### PR TITLE
436 Draft domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -40,6 +40,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/swagger-ui/**", permitAll)
         authorize(HttpMethod.GET, "/v3/api-docs/swagger-config", permitAll)
         authorize(HttpMethod.GET, "/api.yml", permitAll)
+        authorize(HttpMethod.GET, "/domain-events-api.yml", permitAll)
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,11 @@ spring:
 
 springdoc:
   swagger-ui:
-    url: "api.yml"
+    urls:
+      - name: API
+        url: "api.yml"
+      - name: Domain events
+        url: "domain-events-api.yml"
 
 server:
   port: 8080

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -15,6 +15,8 @@ paths:
         schema:
           $ref: '#/components/schemas/EventId'
     get:
+      tags:
+        - Application events
       summary: An application-submitted event
       responses:
         '200':
@@ -38,6 +40,51 @@ paths:
 
         404:
           description: No application-submitted event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /application-withdrawn/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - Application events
+      summary: An application-withdrawn event
+      responses:
+        '200':
+          description: The application-withdrawn event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.application.withdrawn
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/ApplicationWithdrawn'
+
+        404:
+          description: No application-withdrawn event found for the provided `eventId`
           content:
             application/json:
               schema:
@@ -121,6 +168,23 @@ components:
         submittedBy:
           $ref: '#/components/schemas/StaffMember'
 
+    ApplicationWithdrawn:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        withdrawnAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+          readOnly: true
+        withdrawnBy:
+          $ref: '#/components/schemas/StaffMember'
+        reason:
+          type: string
+          example: Parole denied at oral hearing
 
 
     Error:

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1,0 +1,133 @@
+openapi: '3.0.1'
+info:
+  version: '0.1.0'
+  title: 'AP Domain events'
+  description: Get information about events in the Approved Premises domain
+servers:
+  - url: /events
+paths:
+  /application-submitted/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      summary: An application-submitted event
+      responses:
+        '200':
+          description: The application-submitted corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.application.submitted
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/ApplicationSubmitted'
+
+        404:
+          description: No application-submitted event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    EventId:
+      description: The UUID of an event
+      type: string
+      example: 364145f9-0af8-488e-9901-b4c46cd9ba37
+    ApplicationId:
+      description: The UUID of an application for an AP place
+      type: string
+      example: 484b8b5e-6c3b-4400-b200-425bbe410713
+    StaffMember:
+      description: A member of probation or AP staff
+      type: object
+      properties:
+        staffCode:
+          type: string
+          example: N54A999
+          readOnly: true
+        staffIdentifier:
+          type: integer
+          example: 1501234567
+          readOnly: true
+        forenames:
+          type: string
+          example: John
+        surname:
+          type: string
+          example: Smith
+        username:
+          type: string
+          example: JohnSmithNPS
+    ProbationArea:
+      type: object
+      properties:
+        code:
+          type: string
+          example: N54
+          readOnly: true
+        name:
+          type: string
+          example: North East Region
+          readOnly: true
+    PersonReference:
+      type: object
+      properties:
+        crn:
+          type: string
+          example: C123456
+          readOnly: true
+        noms:
+          type: string
+          example: A1234ZX
+          readOnly: true
+    ApplicationSubmitted:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        targetLocation:
+          type: string
+          example: Gateshead
+        probationArea:
+          $ref: '#/components/schemas/ProbationArea'
+        submittedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+          readOnly: true
+        submittedBy:
+          $ref: '#/components/schemas/StaffMember'
+
+
+
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          description: A human readable error message
+          type: string

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -186,6 +186,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /booking-not-made/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Match' events"
+      summary: An 'booking-not-made' event
+      responses:
+        '200':
+          description: The 'booking-not-made' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.booking.not-made
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/BookingNotMade'
+
+        404:
+          description: No 'booking-not-made' event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   schemas:
     EventId:
@@ -340,6 +385,24 @@ components:
           readOnly: true
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
+
+    BookingNotMade:
+      type: object
+      properties:
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        attemptedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+          readOnly: true
+        attemptedBy:
+          $ref: '#/components/schemas/StaffMember'
+        failureDescription:
+          type: string
+          example: No availability
 
     Premises:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -276,6 +276,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /person-arrived/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Mini-manage' events"
+      summary: An 'person-arrived' event
+      responses:
+        '200':
+          description: The 'person-arrived' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.person.arrived
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/PersonArrived'
+
+        404:
+          description: No 'person-arrived' event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   schemas:
     EventId:
@@ -469,6 +514,28 @@ components:
           type: string
           example: Deceased
 
+    PersonArrived:
+      type: object
+      properties:
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        bookingId:
+          $ref: '#/components/schemas/BookingId'
+        premises:
+          $ref: '#/components/schemas/Premises'
+        keyWorker:
+          $ref: '#/components/schemas/StaffMember'
+        arrivedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+        expectedDepartureOn:
+          type: string
+          example: '2023-02-28'
+          format: date
+        notes:
+          type: string
+          example: Arrived a day late due to rail strike. Informed in advance by COM.
 
     Premises:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -366,6 +366,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /person-departed/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Mini-manage' events"
+      summary: A 'person-departed' event
+      responses:
+        '200':
+          description: The 'person-departed' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.person.departed
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/PersonDeparted'
+
+        404:
+          description: No 'person-not-arrived' event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   schemas:
@@ -600,6 +644,33 @@ components:
           type: string
           example: We learnt that Mr Smith is in hospital.
 
+    PersonDeparted:
+      type: object
+      properties:
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        bookingId:
+          $ref: '#/components/schemas/BookingId'
+        premises:
+          $ref: '#/components/schemas/Premises'
+        departedAt:
+          type: string
+          example: '2023-03-30T14:51:30'
+          format: date-time
+        reason:
+          type: string
+          example: Planned move-on
+        destination:
+          type: object
+          properties:
+            premises:
+              $ref: '#/components/schemas/DestinationPremises'
+            moveOnCategory:
+              $ref: '#/components/schemas/MoveOnCategory'
+            destinationProvider:
+              $ref: '#/components/schemas/DestinationProvider'
+
+
     Premises:
       type: object
       properties:
@@ -617,6 +688,43 @@ components:
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
 
+    DestinationPremises:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: New Place
+        apCode:
+          type: string
+          example: NENEW1
+        legacyApCode:
+          type: string
+          example: Q061
+        probationArea:
+          $ref: '#/components/schemas/ProbationArea'
+
+    MoveOnCategory:
+      type: object
+      properties:
+        description:
+          type: string
+          example: Living with family / partner / other
+        code:
+          type: string
+          example: ABC123
+
+    DestinationProvider:
+      type: object
+      properties:
+        description:
+          type: string
+          example: Ext - North East Region
+        code:
+          type: string
+          example: XYZ456
 
     Error:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -186,6 +186,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /booking-cancelled/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Mini-manage' events"
+      summary: An 'booking-cancelled' event
+      responses:
+        '200':
+          description: The 'booking-cancelled' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.booking.cancelled
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/BookingCancelled'
+
+        404:
+          description: No 'booking-made' event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /booking-not-made/{eventId}:
     parameters:
       - name: eventId
@@ -403,6 +448,27 @@ components:
         failureDescription:
           type: string
           example: No availability
+
+    BookingCancelled:
+      type: object
+      properties:
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        bookingId:
+          $ref: '#/components/schemas/BookingId'
+        premises:
+          $ref: '#/components/schemas/Premises'
+        cancelledAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+          readOnly: true
+        cancelledBy:
+          $ref: '#/components/schemas/StaffMember'
+        cancellationReason:
+          type: string
+          example: Deceased
+
 
     Premises:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -95,6 +95,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /application-assessed/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - Application events
+      summary: An 'application-assessed' event
+      responses:
+        '200':
+          description: The 'application-assessed' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.application.assessed
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/ApplicationAssessed'
+
+        404:
+          description: No application-assessed event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     EventId:
@@ -186,6 +231,28 @@ components:
           type: string
           example: Parole denied at oral hearing
 
+    ApplicationAssessed:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        assessedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+          readOnly: true
+        assessedBy:
+          $ref: '#/components/schemas/StaffMember'
+        assessmentArea:
+          $ref: '#/components/schemas/ProbationArea'
+        decision:
+          type: string
+          example: Rejected
+        decisionRationale:
+          type: string
+          example: Risk too low
 
     Error:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -152,7 +152,7 @@ paths:
     get:
       tags:
         - "'Mini-manage' events"
-      summary: An 'booking-made' event
+      summary: A 'booking-made' event
       responses:
         '200':
           description: The 'booking-made' event corresponding to the provided `eventId`
@@ -197,7 +197,7 @@ paths:
     get:
       tags:
         - "'Mini-manage' events"
-      summary: An 'booking-cancelled' event
+      summary: A 'booking-cancelled' event
       responses:
         '200':
           description: The 'booking-cancelled' event corresponding to the provided `eventId`
@@ -242,7 +242,7 @@ paths:
     get:
       tags:
         - "'Match' events"
-      summary: An 'booking-not-made' event
+      summary: A 'booking-not-made' event
       responses:
         '200':
           description: The 'booking-not-made' event corresponding to the provided `eventId`
@@ -287,7 +287,7 @@ paths:
     get:
       tags:
         - "'Mini-manage' events"
-      summary: An 'person-arrived' event
+      summary: A 'person-arrived' event
       responses:
         '200':
           description: The 'person-arrived' event corresponding to the provided `eventId`
@@ -332,7 +332,7 @@ paths:
     get:
       tags:
         - "'Mini-manage' events"
-      summary: An 'person-not-arrived' event
+      summary: A 'person-not-arrived' event
       responses:
         '200':
           description: The 'person-not-arrived' event corresponding to the provided `eventId`

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -321,6 +321,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /person-not-arrived/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Mini-manage' events"
+      summary: An 'person-not-arrived' event
+      responses:
+        '200':
+          description: The 'person-not-arrived' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.person.not-arrived
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/PersonNotArrived'
+
+        404:
+          description: No 'person-not-arrived' event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
 components:
   schemas:
     EventId:
@@ -536,6 +582,23 @@ components:
         notes:
           type: string
           example: Arrived a day late due to rail strike. Informed in advance by COM.
+
+    PersonNotArrived:
+      type: object
+      properties:
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        bookingId:
+          $ref: '#/components/schemas/BookingId'
+        premises:
+          $ref: '#/components/schemas/Premises'
+        expectedArrivalOn:
+          type: string
+          example: '2022-11-29'
+          format: date
+        notes:
+          type: string
+          example: We learnt that Mr Smith is in hospital.
 
     Premises:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -16,7 +16,7 @@ paths:
           $ref: '#/components/schemas/EventId'
     get:
       tags:
-        - Application events
+        - "'Apply' events"
       summary: An application-submitted event
       responses:
         '200':
@@ -61,7 +61,7 @@ paths:
           $ref: '#/components/schemas/EventId'
     get:
       tags:
-        - Application events
+        - "'Apply' events"
       summary: An application-withdrawn event
       responses:
         '200':
@@ -106,7 +106,7 @@ paths:
           $ref: '#/components/schemas/EventId'
     get:
       tags:
-        - Application events
+        - "'Apply' events"
       summary: An 'application-assessed' event
       responses:
         '200':
@@ -151,7 +151,7 @@ paths:
           $ref: '#/components/schemas/EventId'
     get:
       tags:
-        - Booking events
+        - "'Mini-manage' events"
       summary: An 'booking-made' event
       responses:
         '200':

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -140,16 +140,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /booking-made/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - Booking events
+      summary: An 'booking-made' event
+      responses:
+        '200':
+          description: The 'booking-made' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    $ref: '#/components/schemas/EventId'
+                  timestamp:
+                    type: string
+                    example: '2022-11-30T14:53:44'
+                    format: date-time
+                  eventType:
+                    type: string
+                    example: approved-premises.booking.made
+                    readOnly: true
+                  eventDetails:
+                    $ref: '#/components/schemas/BookingMade'
+
+        404:
+          description: No 'booking-made' event found for the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   schemas:
     EventId:
       description: The UUID of an event
       type: string
       example: 364145f9-0af8-488e-9901-b4c46cd9ba37
+
     ApplicationId:
       description: The UUID of an application for an AP place
       type: string
       example: 484b8b5e-6c3b-4400-b200-425bbe410713
+
+    BookingId:
+      description: The UUID of booking for an AP place
+      type: string
+      example: 14c80733-4b6d-4f35-b724-66955aac320c
+
+    LegacyApCode:
+      description: The 'Q code' used in Delius to identify an Approved Premises
+      type: string
+      example: Q057
+
     StaffMember:
       description: A member of probation or AP staff
       type: object
@@ -253,6 +311,53 @@ components:
         decisionRationale:
           type: string
           example: Risk too low
+
+    BookingMade:
+      type: object
+      properties:
+        bookingId:
+          $ref: '#/components/schemas/BookingId'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        createdAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+          readOnly: true
+        bookedBy:
+          $ref: '#/components/schemas/StaffMember'
+        premises:
+          $ref: '#/components/schemas/Premises'
+        arrivalOn:
+          type: string
+          example: '2023-01-30'
+          format: date
+          readOnly: true
+        departureOn:
+          type: string
+          example: '2023-04-30'
+          format: date
+          readOnly: true
+        keyWorker:
+          $ref: '#/components/schemas/StaffMember'
+
+    Premises:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        apCode:
+          type: string
+          example: NEHOPE1
+        legacyApCode:
+          $ref: '#/components/schemas/LegacyApCode'
+        probationArea:
+          $ref: '#/components/schemas/ProbationArea'
+
 
     Error:
       type: object


### PR DESCRIPTION
In order to support the flow of data back to Delius the new AP service will
publish [Domain Events](https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/3732570166/ADR+-+Domain+Event+Schema)

A key design point is that the Domain Event `messages` published via
SNS/SQS should be "skinny" and provide a link (`"detailUrl"`) to full
Event information exposed via our service's API.

In this PR we make a first attempt at designing AP Domain Events which 
can support Delius' needs. Our understanding is that the highest priority
events are:

1. `application.assessed` -> the decision on eligibility for an AP place must be recorded in Delius
2. `person.arrived` -> the address must be updated in Delius 
3. `person.not-arrived` -> the COM needs to be notified within Delius 
4. `person.departed` -> the address must be updated in Delius

We add the specification for the Domain Events API as a separate
OpenAPI spec as for now we don't want to include it in the `openApiGenerate`
code generation gradle task.

Trello: https://trello.com/c/yYzrHuuR/436-move-delius-features-to-new-ap-service

![ap_domain_events](https://user-images.githubusercontent.com/20245/190472043-1fc3bc97-f64a-4fa3-ad9e-9dcb9934ef42.png)

