### PR TITLE
717 - Validate json schema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 
   implementation(kotlin("reflect"))
 
+  implementation("com.networknt:json-schema-validator:1.0.73")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.12.5")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -33,7 +33,7 @@ data class ApplicationEntity(
 
   @ManyToOne
   @JoinColumn(name = "schema_version")
-  val schemaVersion: ApplicationSchemaEntity,
+  var schemaVersion: ApplicationSchemaEntity,
   val createdAt: OffsetDateTime,
   val submittedAt: OffsetDateTime?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationSchemaEntity.kt
@@ -9,7 +9,9 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface ApplicationSchemaRepository : JpaRepository<ApplicationSchemaEntity, UUID>
+interface ApplicationSchemaRepository : JpaRepository<ApplicationSchemaEntity, UUID> {
+  fun findFirstByOrderByAddedAtDesc(): ApplicationSchemaEntity
+}
 
 @Entity
 @Table(name = "application_schemas")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -8,16 +8,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationOffi
 @Service
 class ApplicationService(
   private val probationOfficerRepository: ProbationOfficerRepository,
-  private val applicationRepository: ApplicationRepository
+  private val applicationRepository: ApplicationRepository,
+  private val jsonSchemaService: JsonSchemaService
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String): List<ApplicationEntity> {
     val probationOfficerEntity = probationOfficerRepository.findByDistinguishedName(userDistinguishedName)
       ?: return emptyList()
 
     return applicationRepository.findAllByCreatedByProbationOfficer_Id(probationOfficerEntity.id)
-      .map {
-        // TODO: For any entries where schema version is lower than newest - validate against newest and promote if possible
-        it.apply { schemaUpToDate = true }
-      }
+      .map(jsonSchemaService::attemptSchemaUpgrade)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchema
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersionDetector
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSchemaRepository
+import java.util.Collections.synchronizedMap
+import java.util.UUID
+
+@Service
+class JsonSchemaService(
+  private val objectMapper: ObjectMapper,
+  private val applicationSchemaRepository: ApplicationSchemaRepository,
+  private val applicationRepository: ApplicationRepository
+) {
+  private val schemas = synchronizedMap<UUID, JsonSchema>(mutableMapOf())
+
+  private fun validate(schema: ApplicationSchemaEntity, json: String): Boolean {
+    val schemaJsonNode = objectMapper.readTree(schema.schema)
+    val jsonNode = objectMapper.readTree(json)
+
+    if (!schemas.containsKey(schema.id)) {
+      schemas[schema.id] = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaJsonNode))
+        .getSchema(schemaJsonNode)
+    }
+
+    val validationErrors = schemas[schema.id]!!.validate(jsonNode)
+
+    return validationErrors.isEmpty()
+  }
+
+  fun attemptSchemaUpgrade(application: ApplicationEntity): ApplicationEntity {
+    if (application.data == null) return application.apply { schemaUpToDate = true }
+
+    val newestSchema = applicationSchemaRepository.findFirstByOrderByAddedAtDesc()
+
+    if (application.schemaVersion.id != newestSchema.id) {
+      if (!validate(newestSchema, application.data!!)) {
+        return application.apply { schemaUpToDate = false }
+      }
+
+      application.schemaVersion = newestSchema
+      applicationRepository.save(application)
+    }
+
+    application.schemaUpToDate = true
+
+    return application
+  }
+}

--- a/src/main/resources/db/migration/all/20220921104726__missing_application_primary_key.sql
+++ b/src/main/resources/db/migration/all/20220921104726__missing_application_primary_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE applications ADD PRIMARY KEY (id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
+import java.time.OffsetDateTime
 
 class ApplicationTest : IntegrationTestBase() {
   @Autowired
@@ -24,20 +25,65 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get all applications returns 200 with correct body`() {
+  fun `Get all applications returns 200 with correct body, outdated applications upgraded where possible`() {
     applicationSchemaRepository.deleteAll()
 
-    val schemaEntity = applicationSchemaEntityFactory.produceAndPersist()
-    val probationOfficerEntity = probationOfficerEntityFactory.produceAndPersist { withDistinguishedName("PROBATIONPERSON") }
-
-    val applicationEntities = applicationEntityFactory.produceAndPersistMultiple(5) {
-      withApplicationSchema(schemaEntity)
-      withCreatedByProbationOfficer(probationOfficerEntity)
+    val newestJsonSchema = applicationSchemaEntityFactory.produceAndPersist {
+      withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+      withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": {
+            "thingId": {
+              "description": "The unique identifier for a thing",
+              "type": "integer"
+            }
+          },
+          "required": [ "thingId" ]
+        }
+        """
+      )
     }
 
-    applicationEntities.forEach {
-      // Temporary until schema validation is in place
-      it.schemaUpToDate = true
+    val olderJsonSchema = applicationSchemaEntityFactory.produceAndPersist {
+      withAddedAt(OffsetDateTime.parse("2022-09-21T09:45:00+01:00"))
+      withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """
+      )
+    }
+
+    val probationOfficerEntity = probationOfficerEntityFactory.produceAndPersist { withDistinguishedName("PROBATIONPERSON") }
+
+    val upgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
+      withApplicationSchema(olderJsonSchema)
+      withCreatedByProbationOfficer(probationOfficerEntity)
+      withData(
+        """
+          {
+             "thingId": 123
+          }
+          """
+      )
+    }
+
+    val nonUpgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
+      withApplicationSchema(olderJsonSchema)
+      withCreatedByProbationOfficer(probationOfficerEntity)
+      withData("{}")
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
@@ -54,19 +100,33 @@ class ApplicationTest : IntegrationTestBase() {
 
     val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<Application>>() {})
 
-    applicationEntities.map(applicationsTransformer::transformJpaToApi).forEach { expectedApplication ->
-      assertThat(responseBody).anyMatch {
-        expectedApplication.id == it.id &&
-          expectedApplication.crn == it.crn &&
-          expectedApplication.createdAt.toInstant() == it.createdAt.toInstant() &&
-          expectedApplication.createdByProbationOfficerId == it.createdByProbationOfficerId &&
-          expectedApplication.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
-          serializableToJsonNode(expectedApplication.data) == serializableToJsonNode(it.data) &&
-          expectedApplication.schemaVersion == it.schemaVersion &&
-          expectedApplication.outdatedSchema == it.outdatedSchema
-      }
+    assertThat(responseBody).anyMatch {
+      nonUpgradableApplicationEntity.id == it.id &&
+        nonUpgradableApplicationEntity.crn == it.crn &&
+        nonUpgradableApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
+        nonUpgradableApplicationEntity.createdByProbationOfficer.id == it.createdByProbationOfficerId &&
+        nonUpgradableApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
+        serializableToJsonNode(nonUpgradableApplicationEntity.data) == serializableToJsonNode(it.data) &&
+        olderJsonSchema.id == it.schemaVersion &&
+        it.outdatedSchema == true
+    }
+
+    assertThat(responseBody).anyMatch {
+      upgradableApplicationEntity.id == it.id &&
+        upgradableApplicationEntity.crn == it.crn &&
+        upgradableApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
+        upgradableApplicationEntity.createdByProbationOfficer.id == it.createdByProbationOfficerId &&
+        upgradableApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
+        serializableToJsonNode(upgradableApplicationEntity.data) == serializableToJsonNode(it.data) &&
+        newestJsonSchema.id == it.schemaVersion &&
+        it.outdatedSchema == false
     }
   }
 
-  private fun serializableToJsonNode(serializable: Any?): JsonNode = if (serializable == null) NullNode.instance else objectMapper.readTree(objectMapper.writeValueAsString(serializable))
+  private fun serializableToJsonNode(serializable: Any?): JsonNode {
+    if (serializable == null) return NullNode.instance
+    if (serializable is String) return objectMapper.readTree(serializable)
+
+    return objectMapper.readTree(objectMapper.writeValueAsString(serializable))
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -5,17 +5,25 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOfficerEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationOfficerRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import java.util.UUID
 
 class ApplicationServiceTest {
   private val mockProbationOfficerRepository = mockk<ProbationOfficerRepository>()
   private val mockApplicationRepository = mockk<ApplicationRepository>()
+  private val mockJsonSchemaService = mockk<JsonSchemaService>()
 
-  private val applicationService = ApplicationService(mockProbationOfficerRepository, mockApplicationRepository)
+  private val applicationService = ApplicationService(
+    mockProbationOfficerRepository,
+    mockApplicationRepository,
+    mockJsonSchemaService
+  )
 
   @Test
   fun `Get all applications where Probation Officer with provided distinguished name does not exist returns empty list`() {
@@ -28,6 +36,10 @@ class ApplicationServiceTest {
 
   @Test
   fun `Get all applications where Probation Officer exists returns applications returned from repository`() {
+    val newestJsonSchema = ApplicationSchemaEntityFactory()
+      .withSchema("{}")
+      .produce()
+
     val probationOfficerId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
     val distinguishedName = "SOMEPERSON"
     val probationOfficerEntity = ProbationOfficerEntityFactory()
@@ -37,18 +49,21 @@ class ApplicationServiceTest {
     val applicationEntities = listOf(
       ApplicationEntityFactory()
         .withCreatedByProbationOfficer(probationOfficerEntity)
+        .withApplicationSchema(newestJsonSchema)
         .produce(),
       ApplicationEntityFactory()
         .withCreatedByProbationOfficer(probationOfficerEntity)
+        .withApplicationSchema(newestJsonSchema)
         .produce(),
       ApplicationEntityFactory()
         .withCreatedByProbationOfficer(probationOfficerEntity)
+        .withApplicationSchema(newestJsonSchema)
         .produce()
     )
 
     every { mockProbationOfficerRepository.findByDistinguishedName(distinguishedName) } returns probationOfficerEntity
-
     every { mockApplicationRepository.findAllByCreatedByProbationOfficer_Id(probationOfficerId) } returns applicationEntities
+    every { mockJsonSchemaService.attemptSchemaUpgrade(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     assertThat(applicationService.getAllApplicationsForUsername(distinguishedName)).containsAll(applicationEntities)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationSchemaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOfficerEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSchemaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+import java.util.UUID
+
+class JsonSchemaServiceTest {
+  private val mockApplicationSchemaRepository = mockk<ApplicationSchemaRepository>()
+  private val mockApplicationRepository = mockk<ApplicationRepository>()
+
+  private val jsonSchemaService = JsonSchemaService(
+    objectMapper = jacksonObjectMapper(),
+    applicationSchemaRepository = mockApplicationSchemaRepository,
+    applicationRepository = mockApplicationRepository
+  )
+
+  @Test
+  fun `attemptSchemaUpgrade upgrades schema version where possible, marks outdated where not`() {
+    val newestJsonSchema = ApplicationSchemaEntityFactory()
+      .withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": {
+            "thingId": {
+              "description": "The unique identifier for a thing",
+              "type": "integer"
+            }
+          },
+          "required": [ "thingId" ]
+        }
+        """
+      )
+      .produce()
+
+    val olderJsonSchema = ApplicationSchemaEntityFactory()
+      .withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """
+      )
+      .produce()
+
+    val probationOfficerId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
+    val distinguishedName = "SOMEPERSON"
+    val probationOfficerEntity = ProbationOfficerEntityFactory()
+      .withId(probationOfficerId)
+      .withDistinguishedName(distinguishedName)
+      .produce()
+
+    val upgradableApplication = ApplicationEntityFactory()
+      .withCreatedByProbationOfficer(probationOfficerEntity)
+      .withApplicationSchema(olderJsonSchema)
+      .withData(
+        """
+          {
+             "thingId": 123
+          }
+          """
+      )
+      .produce()
+
+    val nonUpgradableApplication = ApplicationEntityFactory()
+      .withCreatedByProbationOfficer(probationOfficerEntity)
+      .withApplicationSchema(olderJsonSchema)
+      .withData("{}")
+      .produce()
+
+    val applicationEntities = listOf(upgradableApplication, nonUpgradableApplication)
+
+    every { mockApplicationSchemaRepository.findFirstByOrderByAddedAtDesc() } returns newestJsonSchema
+    every { mockApplicationRepository.findAllByCreatedByProbationOfficer_Id(probationOfficerId) } returns applicationEntities
+    every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+
+    assertThat(jsonSchemaService.attemptSchemaUpgrade(upgradableApplication)).matches {
+      it.id == upgradableApplication.id &&
+        it.schemaVersion == newestJsonSchema &&
+        it.schemaUpToDate
+    }
+
+    assertThat(jsonSchemaService.attemptSchemaUpgrade(nonUpgradableApplication)).matches {
+      it.id == nonUpgradableApplication.id &&
+        it.schemaVersion == olderJsonSchema &&
+        !it.schemaUpToDate
+    }
+  }
+}


### PR DESCRIPTION
**Validate against JSON schema when fetching applications**

When retrieving all JSON schemas for a user, test any that were created with an earlier version of the applications schema against the newest version of the application schema.  If they pass the validation, bump their version to the newest schema.