### PR TITLE
Use new cloud platform namespace

### DIFF
--- a/helm_deploy/hmpps-approved-premises-api/Chart.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: '1.0'
 description: A Helm chart for Kubernetes
-name: approved-premises-api
+name: hmpps-approved-premises-api
 version: 0.2.0
 dependencies:
   - name: generic-service

--- a/helm_deploy/hmpps-approved-premises-api/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/values.yaml
@@ -1,18 +1,18 @@
 ---
 generic-service:
-  nameOverride: approved-premises-api
+  nameOverride: hmpps-approved-premises-api
 
   replicaCount: 4
 
   image:
-    repository: quay.io/hmpps/approved-premises-api
+    repository: quay.io/hmpps/hmpps-approved-premises-api
     tag: app_version    # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
     host: app-hostname.local    # override per environment
-    tlsSecretName: approved-premises-api-cert
+    tlsSecretName: hmpps-approved-premises-api-cert
     contextColour: green
 
   # Environment variables to load into the deployment
@@ -32,7 +32,7 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
-    approved-premises-api:
+    hmpps-approved-premises-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_COMMUNITY-API_CLIENT-ID: "SYSTEM_CLIENT_DELIUS_ID"
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_COMMUNITY-API_CLIENT-SECRET: "SYSTEM_CLIENT_DELIUS_SECRET"
@@ -57,4 +57,4 @@ generic-service:
     cloudplatform-live-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
-  targetApplication: approved-premises-api
+  targetApplication: hmpps-approved-premises-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,7 +6,7 @@ generic-service:
 
   ingress:
     host: approved-premises-api-dev.hmpps.service.justice.gov.uk
-    tlsSecretName: approved-premises-api-dev-cert
+    tlsSecretName: hmpps-approved-premises-api-dev-cert
 
   env:
     SPRING_PROFILES_ACTIVE: dev


### PR DESCRIPTION
Since we updated the repo name, the deploys have been failing, rather than put in a bunch of fixes that will hang around forever, I thought it best to create a whole new namespace that fits the naming conventions and allows us to host both services in the same namespace. I’ve copied the secrets over from our old namespace to the new one too.