### PR TITLE
Validation errors refactor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.shouldNotBeReached
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
@@ -137,7 +138,7 @@ class PremisesController(
     val premises = premisesService.getPremises(premisesId)
       ?: throw NotFoundProblem(premisesId, "Premises")
 
-    val validationErrors = mutableMapOf<String, String>()
+    val validationErrors = ValidationErrors()
 
     val offenderResult = offenderService.getOffenderByCrn(body.crn, httpAuthService.getDeliusPrincipalOrThrow().name)
     if (offenderResult is AuthorisableActionResult.Unauthorised) throw ForbiddenProblem()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidatableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidatableActionResult.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 interface ValidatableActionResult<EntityType> {
   data class Success<EntityType>(val entity: EntityType) : ValidatableActionResult<EntityType>
-  data class FieldValidationError<EntityType>(val validationMessages: Map<String, String>) : ValidatableActionResult<EntityType>
+  data class FieldValidationError<EntityType>(val validationMessages: ValidationErrors) : ValidatableActionResult<EntityType>
   data class GeneralValidationError<EntityType>(val message: String) : ValidatableActionResult<EntityType>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
@@ -5,4 +5,19 @@ value class ValidationErrors(private val errorMap: MutableMap<String, String>) :
   constructor() : this(mutableMapOf())
 }
 
-fun singleValidationErrorOf(propertyNameToMessage: Pair<String, String>) = ValidationErrors().apply { this[propertyNameToMessage.first] = propertyNameToMessage.second }
+private fun singleValidationErrorOf(propertyNameToMessage: Pair<String, String>) = ValidationErrors().apply { this[propertyNameToMessage.first] = propertyNameToMessage.second }
+
+class ValidatedScope<EntityType> {
+  val validationErrors = ValidationErrors()
+
+  val fieldValidationError: ValidatableActionResult.FieldValidationError<EntityType> = ValidatableActionResult.FieldValidationError(validationErrors)
+
+  infix fun success(entity: EntityType) = ValidatableActionResult.Success(entity)
+  infix fun generalError(message: String) = ValidatableActionResult.GeneralValidationError<EntityType>(message)
+  infix fun String.hasValidationError(message: String) = validationErrors.put(this, message)
+  infix fun String.hasSingleValidationError(message: String) = ValidatableActionResult.FieldValidationError<EntityType>(singleValidationErrorOf(this to message))
+}
+
+inline fun <EntityType> validated(scope: ValidatedScope<EntityType>.() -> ValidatableActionResult<EntityType>): ValidatableActionResult<EntityType> {
+  return scope(ValidatedScope())
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
@@ -1,3 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
-typealias ValidationErrors = MutableMap<String, String>
+@JvmInline
+value class ValidationErrors(private val errorMap: MutableMap<String, String>) : MutableMap<String, String> by errorMap {
+  constructor() : this(mutableMapOf())
+}
+
+fun singleValidationErrorOf(propertyNameToMessage: Pair<String, String>) = ValidationErrors().apply { this[propertyNameToMessage.first] = propertyNameToMessage.second }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -7,6 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationOfficerRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.singleValidationErrorOf
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -41,8 +43,8 @@ class ApplicationService(
 
   fun createApplication(crn: String, username: String): ValidatableActionResult<ApplicationEntity> {
     when (offenderService.getOffenderByCrn(crn, username)) {
-      is AuthorisableActionResult.NotFound -> return ValidatableActionResult.FieldValidationError(mapOf("$.crn" to "This CRN does not exist"))
-      is AuthorisableActionResult.Unauthorised -> return ValidatableActionResult.FieldValidationError(mapOf("$.crn" to "You do not have permission to access this CRN"))
+      is AuthorisableActionResult.NotFound -> return ValidatableActionResult.FieldValidationError(singleValidationErrorOf("$.crn" to "This CRN does not exist"))
+      is AuthorisableActionResult.Unauthorised -> return ValidatableActionResult.FieldValidationError(singleValidationErrorOf("$.crn" to "You do not have permission to access this CRN"))
       is AuthorisableActionResult.Success -> Unit
     }
 
@@ -80,7 +82,7 @@ class ApplicationService(
       )
     }
 
-    val validationErrors = mutableMapOf<String, String>()
+    val validationErrors = ValidationErrors()
 
     val latestSchemaVersion = jsonSchemaService.getNewestSchema()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationOffi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.singleValidationErrorOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -41,10 +41,10 @@ class ApplicationService(
     return AuthorisableActionResult.Success(jsonSchemaService.attemptSchemaUpgrade(applicationEntity))
   }
 
-  fun createApplication(crn: String, username: String): ValidatableActionResult<ApplicationEntity> {
+  fun createApplication(crn: String, username: String) = validated<ApplicationEntity> {
     when (offenderService.getOffenderByCrn(crn, username)) {
-      is AuthorisableActionResult.NotFound -> return ValidatableActionResult.FieldValidationError(singleValidationErrorOf("$.crn" to "This CRN does not exist"))
-      is AuthorisableActionResult.Unauthorised -> return ValidatableActionResult.FieldValidationError(singleValidationErrorOf("$.crn" to "You do not have permission to access this CRN"))
+      is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "This CRN does not exist"
+      is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "You do not have permission to access this CRN"
       is AuthorisableActionResult.Success -> Unit
     }
 
@@ -63,7 +63,7 @@ class ApplicationService(
       )
     )
 
-    return ValidatableActionResult.Success(createdApplication)
+    return success(createdApplication)
   }
 
   fun updateApplication(applicationId: UUID, data: String, submittedAt: OffsetDateTime?, username: String): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -20,6 +20,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.singleValidationErrorOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -56,7 +58,7 @@ class BookingService(
     }
 
     if (expectedDepartureDate.isBefore(arrivalDate)) {
-      return ValidatableActionResult.FieldValidationError(mapOf("$.expectedDepartureDate" to "Cannot be before arrivalDate"))
+      return ValidatableActionResult.FieldValidationError(singleValidationErrorOf("$.expectedDepartureDate" to "Cannot be before arrivalDate"))
     }
 
     val arrivalEntity = arrivalRepository.save(
@@ -82,7 +84,7 @@ class BookingService(
       return ValidatableActionResult.GeneralValidationError("This Booking already has a Non Arrival set")
     }
 
-    val validationIssues = mutableMapOf<String, String>()
+    val validationIssues = ValidationErrors()
 
     if (booking.arrivalDate.isAfter(date)) {
       validationIssues["$.date"] = "Cannot be before Booking's arrivalDate"
@@ -120,7 +122,7 @@ class BookingService(
       return ValidatableActionResult.GeneralValidationError("This Booking already has a Cancellation set")
     }
 
-    val validationIssues = mutableMapOf<String, String>()
+    val validationIssues = ValidationErrors()
 
     val reason = cancellationReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
@@ -156,7 +158,7 @@ class BookingService(
       return ValidatableActionResult.GeneralValidationError("This Booking already has a Departure set")
     }
 
-    val validationIssues = mutableMapOf<String, String>()
+    val validationIssues = ValidationErrors()
 
     if (booking.arrivalDate.toLocalDateTime().isAfter(dateTime)) {
       validationIssues["$.dateTime"] = "Must be after the Booking's arrival date (${booking.arrivalDate})"
@@ -203,7 +205,7 @@ class BookingService(
     notes: String?
   ): ValidatableActionResult<ExtensionEntity> {
     if (booking.departureDate.isAfter(newDepartureDate)) {
-      return ValidatableActionResult.FieldValidationError(mapOf("$.newDepartureDate" to "Must be after the Booking's current departure date (${booking.departureDate})"))
+      return ValidatableActionResult.FieldValidationError(singleValidationErrorOf("$.newDepartureDate" to "Must be after the Booking's current departure date (${booking.departureDate})"))
     }
 
     val extensionEntity = ExtensionEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilExclusiveEnd
 import java.time.LocalDate
 import java.util.UUID
@@ -57,38 +57,38 @@ class PremisesService(
     reasonId: UUID,
     referenceNumber: String?,
     notes: String?
-  ): ValidatableActionResult<LostBedsEntity> {
-    val validationIssues = ValidationErrors()
-    if (endDate.isBefore(startDate)) {
-      validationIssues["$.endDate"] = "Cannot be before startDate"
-    }
+  ): ValidatableActionResult<LostBedsEntity> =
+    validated {
+      if (endDate.isBefore(startDate)) {
+        "$.endDate" hasValidationError "Cannot be before startDate"
+      }
 
-    if (numberOfBeds <= 0) {
-      validationIssues["$.numberOfBeds"] = "Must be greater than 0"
-    }
+      if (numberOfBeds <= 0) {
+        "$.numberOfBeds" hasValidationError "Must be greater than 0"
+      }
 
-    val reason = lostBedReasonRepository.findByIdOrNull(reasonId)
-    if (reason == null) {
-      validationIssues["$.reason"] = "This reason does not exist"
-    }
+      val reason = lostBedReasonRepository.findByIdOrNull(reasonId)
+      if (reason == null) {
+        "$.reason" hasValidationError "This reason does not exist"
+      }
 
-    if (validationIssues.any()) {
-      return ValidatableActionResult.FieldValidationError(validationIssues)
-    }
+      if (validationErrors.any()) {
+        return fieldValidationError
+      }
 
-    val lostBedsEntity = lostBedsRepository.save(
-      LostBedsEntity(
-        id = UUID.randomUUID(),
-        premises = premises,
-        startDate = startDate,
-        endDate = endDate,
-        numberOfBeds = numberOfBeds,
-        reason = reason!!,
-        referenceNumber = referenceNumber,
-        notes = notes
+      val lostBedsEntity = lostBedsRepository.save(
+        LostBedsEntity(
+          id = UUID.randomUUID(),
+          premises = premises,
+          startDate = startDate,
+          endDate = endDate,
+          numberOfBeds = numberOfBeds,
+          reason = reason!!,
+          referenceNumber = referenceNumber,
+          notes = notes
+        )
       )
-    )
 
-    return ValidatableActionResult.Success(lostBedsEntity)
-  }
+      return success(lostBedsEntity)
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilExclusiveEnd
 import java.time.LocalDate
 import java.util.UUID
@@ -57,7 +58,7 @@ class PremisesService(
     referenceNumber: String?,
     notes: String?
   ): ValidatableActionResult<LostBedsEntity> {
-    val validationIssues = mutableMapOf<String, String>()
+    val validationIssues = ValidationErrors()
     if (endDate.isBefore(startDate)) {
       validationIssues["$.endDate"] = "Cannot be before startDate"
     }


### PR DESCRIPTION
**Added value type for ValidationErrors**

To make it clear that the MutableMap<String, String> we use in quite a lot of places are for validation errors

**Added a DSL for validation**

Reduces boilerplate around validation somewhat and provides a more semantic syntax.