### PR TITLE
Config flag to log authorities & scopes

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ generic-service:
     SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
     SERVICES_PRISONS-API_BASE-URL: https://api-dev.prison.service.justice.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev
+    LOG-CLIENT-CREDENTIALS-JWT-INFO: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.core.convert.converter.Converter
 import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AbstractAuthenticationToken
@@ -10,13 +13,19 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.config.web.servlet.invoke
+import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import java.util.Base64
 
 @EnableWebSecurity
 class OAuth2ResourceServerSecurityConfiguration {
@@ -68,7 +77,7 @@ class OAuth2ResourceServerSecurityConfiguration {
   }
 }
 
-class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
+class AuthAwareTokenConverter() : Converter<Jwt, AbstractAuthenticationToken> {
   private val jwtGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>> =
     JwtGrantedAuthoritiesConverter()
 
@@ -118,3 +127,53 @@ class AuthAwareAuthenticationToken(
     return aPrincipal
   }
 }
+
+@Configuration
+class AuthorizedClientServiceConfiguration(
+  @Value("\${log-client-credentials-jwt-info}") private val logClintCredentialsJwtInfo: Boolean,
+  private val clientRegistrationRepository: ClientRegistrationRepository,
+  private val objectMapper: ObjectMapper
+) {
+  @Bean
+  fun inMemoryOAuth2AuthorizedClientService(): OAuth2AuthorizedClientService {
+    if (logClintCredentialsJwtInfo) return LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository, objectMapper)
+
+    return InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository)
+  }
+}
+
+class LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository: ClientRegistrationRepository, private val objectMapper: ObjectMapper) : OAuth2AuthorizedClientService {
+  private val backingImplementation = InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository)
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+    clientRegistrationId: String?,
+    principalName: String?
+  ): T = backingImplementation.loadAuthorizedClient<T>(clientRegistrationId, principalName)
+
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient?, principal: Authentication?) {
+    val tokenValue = authorizedClient?.accessToken?.tokenValue
+
+    if (tokenValue != null) {
+      try {
+        val tokenBodyBase64 = tokenValue.split(".")[1]
+        val tokenBodyRaw = Base64.getDecoder().decode(tokenBodyBase64)
+        val info = objectMapper.readValue(tokenBodyRaw, JwtLogInfo::class.java)
+        log.info("Retrieved a client_credentials JWT for service->service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")
+      } catch (exception: Exception) {
+        // Deliberately not logging exception message
+        log.error("Unable to get token info to log, exception of type: ${exception::class.java.name}")
+      }
+    }
+
+    backingImplementation.saveAuthorizedClient(authorizedClient, principal)
+  }
+
+  override fun removeAuthorizedClient(clientRegistrationId: String?, principalName: String?) = backingImplementation.removeAuthorizedClient(clientRegistrationId, principalName)
+}
+
+data class JwtLogInfo(
+  val authorities: List<String>,
+  val scope: List<String>,
+  val exp: Long
+)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,3 +8,5 @@ spring:
     locations: classpath:db/migration/all,classpath:db/migration/local+dev
   jpa:
     database: postgresql
+
+log-client-credentials-jwt-info: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,3 +102,5 @@ services:
 hmpps:
   auth:
     url: http://localhost:9091/auth
+
+log-client-credentials-jwt-info: false


### PR DESCRIPTION
Add configuration option `log-client-credentials-jwt-info` which logs the authorities, scope and expiry of client_credentials tokens retrieved from HMPPS Auth.

This is useful for troubleshooting as we have no way currently of knowing for certain which authorities/scopes our service accounts have been given.