### PR TITLE
Use keys for error messages

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -43,8 +43,8 @@ class ApplicationService(
 
   fun createApplication(crn: String, username: String) = validated<ApplicationEntity> {
     when (offenderService.getOffenderByCrn(crn, username)) {
-      is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "This CRN does not exist"
-      is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "You do not have permission to access this CRN"
+      is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
+      is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "userPermission"
       is AuthorisableActionResult.Success -> Unit
     }
 
@@ -87,11 +87,11 @@ class ApplicationService(
     val latestSchemaVersion = jsonSchemaService.getNewestSchema()
 
     if (!jsonSchemaService.validate(latestSchemaVersion, data)) {
-      validationErrors["$.data"] = "This data does not conform to the newest application schema"
+      validationErrors["$.data"] = "invalid"
     }
 
     if (submittedAt?.isAfter(OffsetDateTime.now()) == true) {
-      validationErrors["$.submittedAt"] = "Submitted at must be in the past"
+      validationErrors["$.submittedAt"] = "isInFuture"
     }
 
     if (validationErrors.any()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -56,7 +56,7 @@ class BookingService(
     }
 
     if (expectedDepartureDate.isBefore(arrivalDate)) {
-      return "$.expectedDepartureDate" hasSingleValidationError "Cannot be before arrivalDate"
+      return "$.expectedDepartureDate" hasSingleValidationError "beforeBookingArrivalDate"
     }
 
     val arrivalEntity = arrivalRepository.save(
@@ -83,12 +83,12 @@ class BookingService(
     }
 
     if (booking.arrivalDate.isAfter(date)) {
-      "$.date" hasValidationError "Cannot be before Booking's arrivalDate"
+      "$.date" hasValidationError "afterBookingArrivalDate"
     }
 
     val reason = nonArrivalReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      "$.reason" hasValidationError "This reason does not exist"
+      "$.reason" hasValidationError "doesNotExist"
     }
 
     if (validationErrors.any()) {
@@ -120,7 +120,7 @@ class BookingService(
 
     val reason = cancellationReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      "$.reason" hasValidationError "This reason does not exist"
+      "$.reason" hasValidationError "doesNotExist"
     }
 
     if (validationErrors.any()) {
@@ -153,22 +153,22 @@ class BookingService(
     }
 
     if (booking.arrivalDate.toLocalDateTime().isAfter(dateTime)) {
-      "$.dateTime" hasValidationError "Must be after the Booking's arrival date (${booking.arrivalDate})"
+      "$.dateTime" hasValidationError "beforeBookingArrivalDate"
     }
 
     val reason = departureReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      "$.reasonId" hasValidationError "Reason does not exist"
+      "$.reasonId" hasValidationError "doesNotExist"
     }
 
     val moveOnCategory = moveOnCategoryRepository.findByIdOrNull(moveOnCategoryId)
     if (reason == null) {
-      "$.moveOnCategoryId" hasValidationError "Move on Category does not exist"
+      "$.moveOnCategoryId" hasValidationError "doesNotExist"
     }
 
     val destinationProvider = destinationProviderRepository.findByIdOrNull(destinationProviderId)
     if (destinationProvider == null) {
-      "$.destinationProviderId" hasValidationError "Destination Provider does not exist"
+      "$.destinationProviderId" hasValidationError "doesNotExist"
     }
 
     if (validationErrors.any()) {
@@ -197,7 +197,7 @@ class BookingService(
     notes: String?
   ) = validated<ExtensionEntity> {
     if (booking.departureDate.isAfter(newDepartureDate)) {
-      return "$.newDepartureDate" hasSingleValidationError "Must be after the Booking's current departure date (${booking.departureDate})"
+      return "$.newDepartureDate" hasSingleValidationError "beforeExistingDepartureDate"
     }
 
     val extensionEntity = ExtensionEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
@@ -23,7 +23,7 @@ class DeserializationValidationService {
       jsonArray.forEachIndexed { index, jsonNode ->
         val expectedJsonPrimitiveType = getExpectedJsonPrimitiveType(targetType.java)
         if (jsonNode.nodeType != expectedJsonPrimitiveType) {
-          result["$path[$index]"] = "Expected a ${expectedJsonPrimitiveType!!.name.lowercase()}"
+          result["$path[$index]"] = "expected${expectedJsonPrimitiveType!!.name.lowercase().replaceFirstChar(Char::uppercase)}"
         }
       }
 
@@ -33,7 +33,7 @@ class DeserializationValidationService {
     jsonArray.forEachIndexed { index, jsonNode ->
       if (nullOrNullNode(jsonNode)) {
         if (!elementsNullable) {
-          result["$path[$index]"] = "Expected an object"
+          result["$path[$index]"] = "expectedObject"
         }
         return@forEachIndexed
       }
@@ -53,14 +53,14 @@ class DeserializationValidationService {
       }
 
       if (!it.returnType.isMarkedNullable && nullOrNullNode(jsonNode)) {
-        result["$path.${it.name}"] = "A value must be provided for this property"
+        result["$path.${it.name}"] = "empty"
         return@forEach
       }
 
       if (!nullOrNullNode(jsonNode)) {
         if (isArrayType(it.returnType.jvmErasure.java)) {
           if (jsonObject.get(it.name) !is ArrayNode) {
-            result["$path.${it.name}"] = "Expected an array"
+            result["$path.${it.name}"] = "expectedArray"
             return@forEach
           }
 
@@ -71,7 +71,7 @@ class DeserializationValidationService {
 
         if (getExpectedJsonPrimitiveType(it.returnType.jvmErasure.java) == null) {
           if (jsonObject.get(it.name) !is ObjectNode) {
-            result["$path.${it.name}"] = "Expected an object"
+            result["$path.${it.name}"] = "expectedObject"
             return@forEach
           }
 
@@ -83,7 +83,7 @@ class DeserializationValidationService {
 
         val expectedJsonPrimitiveType = getExpectedJsonPrimitiveType(it.returnType.jvmErasure.java)
         if (jsonNode.nodeType != expectedJsonPrimitiveType) {
-          result["$path.${it.name}"] = "Expected a ${expectedJsonPrimitiveType!!.name.lowercase()}"
+          result["$path.${it.name}"] = "expected${expectedJsonPrimitiveType!!.name.lowercase().replaceFirstChar(Char::uppercase)}"
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -60,16 +60,16 @@ class PremisesService(
   ): ValidatableActionResult<LostBedsEntity> =
     validated {
       if (endDate.isBefore(startDate)) {
-        "$.endDate" hasValidationError "Cannot be before startDate"
+        "$.endDate" hasValidationError "beforeStartDate"
       }
 
       if (numberOfBeds <= 0) {
-        "$.numberOfBeds" hasValidationError "Must be greater than 0"
+        "$.numberOfBeds" hasValidationError "isZero"
       }
 
       val reason = lostBedReasonRepository.findByIdOrNull(reasonId)
       if (reason == null) {
-        "$.reason" hasValidationError "This reason does not exist"
+        "$.reason" hasValidationError "doesNotExist"
       }
 
       if (validationErrors.any()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
@@ -75,7 +75,7 @@ class ProblemResponsesTest : IntegrationTestBase() {
                   "requiredString": null,
                   "optionalBoolean": 1234,
                   "optionalLocalDate": false
-               }, 
+               },
                null]
           }
         """
@@ -89,19 +89,19 @@ class ProblemResponsesTest : IntegrationTestBase() {
 
     assertThat(validationResult!!.invalidParams).containsAll(
       listOf(
-        InvalidParam(propertyName = "$.optionalListOfObjects[0].optionalBoolean", errorType = "Expected a boolean"),
-        InvalidParam(propertyName = "$.optionalListOfObjects[0].optionalLocalDate", errorType = "Expected a string"),
-        InvalidParam(propertyName = "$.optionalListOfObjects[0].requiredString", errorType = "A value must be provided for this property"),
-        InvalidParam(propertyName = "$.optionalListOfObjects[1]", errorType = "Expected an object"),
-        InvalidParam(propertyName = "$.optionalObject", errorType = "Expected an object"),
-        InvalidParam(propertyName = "$.requiredInt", errorType = "A value must be provided for this property"),
-        InvalidParam(propertyName = "$.requiredListOfInts[0]", errorType = "Expected a number"),
-        InvalidParam(propertyName = "$.requiredListOfInts[1]", errorType = "Expected a number"),
-        InvalidParam(propertyName = "$.requiredListOfInts[2]", errorType = "Expected a number"),
-        InvalidParam(propertyName = "$.requiredListOfObjects", errorType = "A value must be provided for this property"),
-        InvalidParam(propertyName = "$.requiredObject.optionalBoolean", errorType = "Expected a boolean"),
-        InvalidParam(propertyName = "$.requiredObject.optionalLocalDate", errorType = "Expected a string"),
-        InvalidParam(propertyName = "$.requiredObject.requiredString", errorType = "A value must be provided for this property")
+        InvalidParam(propertyName = "$.optionalListOfObjects[0].optionalBoolean", errorType = "expectedBoolean"),
+        InvalidParam(propertyName = "$.optionalListOfObjects[0].optionalLocalDate", errorType = "expectedString"),
+        InvalidParam(propertyName = "$.optionalListOfObjects[0].requiredString", errorType = "empty"),
+        InvalidParam(propertyName = "$.optionalListOfObjects[1]", errorType = "expectedObject"),
+        InvalidParam(propertyName = "$.optionalObject", errorType = "expectedObject"),
+        InvalidParam(propertyName = "$.requiredInt", errorType = "empty"),
+        InvalidParam(propertyName = "$.requiredListOfInts[0]", errorType = "expectedNumber"),
+        InvalidParam(propertyName = "$.requiredListOfInts[1]", errorType = "expectedNumber"),
+        InvalidParam(propertyName = "$.requiredListOfInts[2]", errorType = "expectedNumber"),
+        InvalidParam(propertyName = "$.requiredListOfObjects", errorType = "empty"),
+        InvalidParam(propertyName = "$.requiredObject.optionalBoolean", errorType = "expectedBoolean"),
+        InvalidParam(propertyName = "$.requiredObject.optionalLocalDate", errorType = "expectedString"),
+        InvalidParam(propertyName = "$.requiredObject.requiredString", errorType = "empty")
       )
     )
   }
@@ -131,7 +131,7 @@ class ProblemResponsesTest : IntegrationTestBase() {
                   "requiredString": null,
                   "optionalBoolean": 1234,
                   "optionalLocalDate": false
-               }, 
+               },
                null]
           }]
         """
@@ -145,19 +145,19 @@ class ProblemResponsesTest : IntegrationTestBase() {
 
     assertThat(validationResult!!.invalidParams).containsAll(
       listOf(
-        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].optionalBoolean", errorType = "Expected a boolean"),
-        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].optionalLocalDate", errorType = "Expected a string"),
-        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].requiredString", errorType = "A value must be provided for this property"),
-        InvalidParam(propertyName = "$[0].optionalListOfObjects[1]", errorType = "Expected an object"),
-        InvalidParam(propertyName = "$[0].optionalObject", errorType = "Expected an object"),
-        InvalidParam(propertyName = "$[0].requiredInt", errorType = "A value must be provided for this property"),
-        InvalidParam(propertyName = "$[0].requiredListOfInts[0]", errorType = "Expected a number"),
-        InvalidParam(propertyName = "$[0].requiredListOfInts[1]", errorType = "Expected a number"),
-        InvalidParam(propertyName = "$[0].requiredListOfInts[2]", errorType = "Expected a number"),
-        InvalidParam(propertyName = "$[0].requiredListOfObjects", errorType = "A value must be provided for this property"),
-        InvalidParam(propertyName = "$[0].requiredObject.optionalBoolean", errorType = "Expected a boolean"),
-        InvalidParam(propertyName = "$[0].requiredObject.optionalLocalDate", errorType = "Expected a string"),
-        InvalidParam(propertyName = "$[0].requiredObject.requiredString", errorType = "A value must be provided for this property")
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].optionalBoolean", errorType = "expectedBoolean"),
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].optionalLocalDate", errorType = "expectedString"),
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].requiredString", errorType = "empty"),
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[1]", errorType = "expectedObject"),
+        InvalidParam(propertyName = "$[0].optionalObject", errorType = "expectedObject"),
+        InvalidParam(propertyName = "$[0].requiredInt", errorType = "empty"),
+        InvalidParam(propertyName = "$[0].requiredListOfInts[0]", errorType = "expectedNumber"),
+        InvalidParam(propertyName = "$[0].requiredListOfInts[1]", errorType = "expectedNumber"),
+        InvalidParam(propertyName = "$[0].requiredListOfInts[2]", errorType = "expectedNumber"),
+        InvalidParam(propertyName = "$[0].requiredListOfObjects", errorType = "empty"),
+        InvalidParam(propertyName = "$[0].requiredObject.optionalBoolean", errorType = "expectedBoolean"),
+        InvalidParam(propertyName = "$[0].requiredObject.optionalLocalDate", errorType = "expectedString"),
+        InvalidParam(propertyName = "$[0].requiredObject.requiredString", errorType = "empty")
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -145,7 +145,7 @@ class ApplicationServiceTest {
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
-    assertThat(result.validationMessages).containsEntry("$.crn", "This CRN does not exist")
+    assertThat(result.validationMessages).containsEntry("$.crn", "doesNotExist")
   }
 
   @Test
@@ -159,7 +159,7 @@ class ApplicationServiceTest {
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
-    assertThat(result.validationMessages).containsEntry("$.crn", "You do not have permission to access this CRN")
+    assertThat(result.validationMessages).containsEntry("$.crn", "userPermission")
   }
 
   @Test
@@ -267,8 +267,8 @@ class ApplicationServiceTest {
     assertThat(result.entity is ValidatableActionResult.FieldValidationError).isTrue
     val validatableActionResult = result.entity as ValidatableActionResult.FieldValidationError
 
-    assertThat(validatableActionResult.validationMessages).containsEntry("$.data", "This data does not conform to the newest application schema")
-    assertThat(validatableActionResult.validationMessages).containsEntry("$.submittedAt", "Submitted at must be in the past")
+    assertThat(validatableActionResult.validationMessages).containsEntry("$.data", "invalid")
+    assertThat(validatableActionResult.validationMessages).containsEntry("$.submittedAt", "isInFuture")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -236,10 +236,10 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.dateTime", "Must be after the Booking's arrival date (2022-08-25)"),
-      entry("$.reasonId", "Reason does not exist"),
-      entry("$.moveOnCategoryId", "Move on Category does not exist"),
-      entry("$.destinationProviderId", "Destination Provider does not exist")
+      entry("$.dateTime", "beforeBookingArrivalDate"),
+      entry("$.reasonId", "doesNotExist"),
+      entry("$.moveOnCategoryId", "doesNotExist"),
+      entry("$.destinationProviderId", "doesNotExist")
     )
   }
 
@@ -352,7 +352,7 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.expectedDepartureDate", "Cannot be before arrivalDate")
+      entry("$.expectedDepartureDate", "beforeBookingArrivalDate")
     )
   }
 
@@ -452,8 +452,8 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.date", "Cannot be before Booking's arrivalDate"),
-      entry("$.reason", "This reason does not exist")
+      entry("$.date", "afterBookingArrivalDate"),
+      entry("$.reason", "doesNotExist")
     )
   }
 
@@ -559,7 +559,7 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "This reason does not exist")
+      entry("$.reason", "doesNotExist")
     )
   }
 
@@ -625,7 +625,7 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.newDepartureDate", "Must be after the Booking's current departure date (2022-08-26)")
+      entry("$.newDepartureDate", "beforeExistingDepartureDate")
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -184,9 +184,9 @@ class PremisesServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.endDate", "Cannot be before startDate"),
-      entry("$.numberOfBeds", "Must be greater than 0"),
-      entry("$.reason", "This reason does not exist")
+      entry("$.endDate", "beforeStartDate"),
+      entry("$.numberOfBeds", "isZero"),
+      entry("$.reason", "doesNotExist")
     )
   }
 


### PR DESCRIPTION
Rather than using sentences for error messages, this updates the error response `errorType`s  to return keys. This makes translating messages in the frontend easier, and gives us more flexibility. 