### PR TITLE
710 - Add Delius Team Code to Premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -22,6 +22,7 @@ data class PremisesEntity(
   val apCode: String,
   var postcode: String,
   var totalBeds: Int,
+  val deliusTeamCode: String,
   @ManyToOne
   @JoinColumn(name = "probation_region_id")
   val probationRegion: ProbationRegionEntity,

--- a/src/main/resources/db/migration/all/20220928150557__add_delius_team_code.sql
+++ b/src/main/resources/db/migration/all/20220928150557__add_delius_team_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE premises ADD COLUMN delius_team_code TEXT NOT NULL DEFAULT '';

--- a/src/main/resources/db/migration/local+dev/20220928153424__seed_delius_team_codes.sql
+++ b/src/main/resources/db/migration/local+dev/20220928153424__seed_delius_team_codes.sql
@@ -1,0 +1,3 @@
+UPDATE premises SET delius_team_code = 'CMBUAT' WHERE id = '3549f9ff-6d58-450f-8ea3-dc2cf196ef2c';
+UPDATE premises SET delius_team_code = 'DBSUAT' WHERE id = 'e6d00117-e31c-4332-8c24-8e1432a4c500';
+UPDATE premises SET delius_team_code = 'GWTUAT' WHERE id = '878217f0-6db5-49d8-a5a1-c40fdecd6060';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
@@ -19,6 +19,7 @@ class PremisesEntityFactory : Factory<PremisesEntity> {
   private var apCode: Yielded<String> = { randomStringUpperCase(5) }
   private var postcode: Yielded<String> = { randomPostCode() }
   private var totalBeds: Yielded<Int> = { randomInt(1, 100) }
+  private var deliusTeamCode: Yielded<String> = { randomStringUpperCase(6) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -56,12 +57,17 @@ class PremisesEntityFactory : Factory<PremisesEntity> {
     this.localAuthorityArea = localAuthorityAreaEntity
   }
 
+  fun withDeliusTeamCode(deliusTeamCode: String) = apply {
+    this.deliusTeamCode = { deliusTeamCode }
+  }
+
   override fun produce(): PremisesEntity = PremisesEntity(
     id = this.id(),
     name = this.name(),
     apCode = this.apCode(),
     postcode = this.postcode(),
     totalBeds = this.totalBeds(),
+    deliusTeamCode = this.deliusTeamCode(),
     probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("Must provide a probation region"),
     localAuthorityArea = this.localAuthorityArea?.invoke() ?: throw RuntimeException("Must provide a local authority area"),
     bookings = mutableListOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -70,6 +70,7 @@ class BookingTransformerTest {
     apCode = "APCODE",
     postcode = "ST8ST8",
     totalBeds = 50,
+    deliusTeamCode = "ABCDEFG",
     probationRegion = ProbationRegionEntity(
       id = UUID.fromString("4eae0059-af28-4436-a4d8-7106523866d9"),
       name = "region",


### PR DESCRIPTION
**Add Delius Team code to the Premises Entity and add seed values for local+dev.**

This will allow us to query the staff for that team from Delius to support fetching key workers from Delius.