### PR TITLE
Remove persistent volume from test Postgres container

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,10 +6,5 @@ services:
       - POSTGRES_USER=integration_test
       - POSTGRES_PASSWORD=integration_test_password
       - POSTGRES_DB=approved_premises_integration_test
-    volumes:
-      - database-data-integration-test:/var/lib/postgresql/data/
     ports:
       - "5433:5432"
-
-volumes:
-  database-data-integration-test:


### PR DESCRIPTION
This sometimes causes failures when switching between branches with different migrations.  Since there's no real utility in having this data be persistent across test runs (it is cleared at the start of every integration test anyway), best to simply remove the volume.