### PR TITLE
(762) Add person detail to Application responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -7,31 +7,38 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ApplicationsApiDeleg
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.shouldNotBeReached
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import java.net.URI
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
 class ApplicationsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
   private val applicationsTransformer: ApplicationsTransformer,
-  private val objectMapper: ObjectMapper
+  private val objectMapper: ObjectMapper,
+  private val offenderService: OffenderService
 ) : ApplicationsApiDelegate {
   override fun applicationsGet(): ResponseEntity<List<Application>> {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
     val applications = applicationService.getAllApplicationsForUsername(username)
 
-    return ResponseEntity.ok(applications.map(applicationsTransformer::transformJpaToApi))
+    return ResponseEntity.ok(applications.map { getPersonDetailAndTransform(it) })
   }
 
   override fun applicationsApplicationIdGet(applicationId: UUID): ResponseEntity<Application> {
@@ -45,12 +52,15 @@ class ApplicationsController(
       else -> shouldNotBeReached()
     }
 
-    return ResponseEntity.ok(applicationsTransformer.transformJpaToApi(application))
+    return ResponseEntity.ok(getPersonDetailAndTransform(application))
   }
 
+  @Transactional
   override fun applicationsPost(body: NewApplication): ResponseEntity<Application> {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
+
+    val (offender, inmate) = getPersonDetail(body.crn)
 
     val application = when (val applicationResult = applicationService.createApplication(body.crn, username)) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = applicationResult.message)
@@ -61,7 +71,7 @@ class ApplicationsController(
 
     return ResponseEntity
       .created(URI.create("/applications/${application.id}"))
-      .body(applicationsTransformer.transformJpaToApi(application))
+      .body(applicationsTransformer.transformJpaToApi(application, offender, inmate))
   }
 
   override fun applicationsApplicationIdPut(applicationId: UUID, body: UpdateApplication): ResponseEntity<Application> {
@@ -86,6 +96,35 @@ class ApplicationsController(
       else -> shouldNotBeReached()
     }
 
-    return ResponseEntity.ok(applicationsTransformer.transformJpaToApi(updatedApplication))
+    return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication))
+  }
+
+  private fun getPersonDetail(crn: String): Pair<OffenderDetailSummary, InmateDetail> {
+    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
+    val username = deliusPrincipal.name
+
+    val offenderResult = offenderService.getOffenderByCrn(crn, username)
+
+    if (offenderResult !is AuthorisableActionResult.Success) {
+      throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
+    }
+
+    if (offenderResult.entity.otherIds.nomsNumber == null) {
+      throw InternalServerErrorProblem("No nomsNumber present for CRN")
+    }
+
+    val inmateDetailResult = offenderService.getInmateDetailByNomsNumber(offenderResult.entity.otherIds.nomsNumber)
+
+    if (inmateDetailResult !is AuthorisableActionResult.Success) {
+      throw InternalServerErrorProblem("Unable to get InmateDetail via crn: $crn")
+    }
+
+    return Pair(offenderResult.entity, inmateDetailResult.entity)
+  }
+
+  private fun getPersonDetailAndTransform(application: ApplicationEntity): Application {
+    val (offender, inmate) = getPersonDetail(application.crn)
+
+    return applicationsTransformer.transformJpaToApi(application, offender, inmate)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 
 @Component
-class ApplicationsTransformer(private val objectMapper: ObjectMapper) {
-  fun transformJpaToApi(jpa: ApplicationEntity) = Application(
+class ApplicationsTransformer(private val objectMapper: ObjectMapper, private val personTransformer: PersonTransformer) {
+  fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Application(
     id = jpa.id,
-    crn = jpa.crn,
+    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdByProbationOfficerId = jpa.createdByProbationOfficer.id,
     schemaVersion = jpa.schemaVersion.id,
     outdatedSchema = !jpa.schemaUpToDate,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1710,8 +1710,8 @@ components:
         id:
           type: string
           format: uuid
-        crn:
-          type: string
+        person:
+          $ref: '#/components/schemas/Person'
         createdByProbationOfficerId:
           type: string
           format: uuid
@@ -1735,6 +1735,7 @@ components:
         - schemaVersion
         - outdatedSchema
         - createdAt
+        - person
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
     NewApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
@@ -19,7 +19,7 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
   private var firstName: Yielded<String> = { randomStringUpperCase(6) }
   private var lastName: Yielded<String> = { randomStringUpperCase(10) }
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
-  private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var gender: Yielded<String> = { randomOf(listOf("Male", "Female", "Other")) }
   private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore() }
   private var currentRestriction: Yielded<Boolean> = { false }
@@ -51,6 +51,10 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
 
   fun withNomsNumber(nomsNumber: String) = apply {
     this.nomsNumber = { nomsNumber }
+  }
+
+  fun withoutNomsNumber() = apply {
+    this.nomsNumber = { null }
   }
 
   fun withGender(gender: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
-import com.github.tomakehurst.wiremock.client.WireMock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,7 +11,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import java.time.LocalDate
 import java.util.UUID
@@ -477,16 +475,4 @@ class BookingTest : IntegrationTestBase() {
 
     assertThat(bookingRepository.findByIdOrNull(booking.id)!!.departureDate).isEqualTo(LocalDate.parse("2022-08-22"))
   }
-
-  private fun mockInmateDetailPrisonsApiCall(inmateDetail: InmateDetail) = wiremockServer.stubFor(
-    WireMock.get(WireMock.urlEqualTo("/api/offenders/${inmateDetail.offenderNo}"))
-      .willReturn(
-        WireMock.aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(200)
-          .withBody(
-            objectMapper.writeValueAsString(inmateDetail)
-          )
-      )
-  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -59,6 +59,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationOffi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTestRepository
@@ -267,6 +268,18 @@ abstract class IntegrationTestBase {
           .withStatus(200)
           .withBody(
             objectMapper.writeValueAsString(offenderDetails)
+          )
+      )
+  )
+
+  fun mockInmateDetailPrisonsApiCall(inmateDetail: InmateDetail) = wiremockServer.stubFor(
+    WireMock.get(WireMock.urlEqualTo("/api/offenders/${inmateDetail.offenderNo}"))
+      .willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200)
+          .withBody(
+            objectMapper.writeValueAsString(inmateDetail)
           )
       )
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import java.time.LocalDate
 
 class PersonSearchTest : IntegrationTestBase() {
@@ -141,16 +140,4 @@ class PersonSearchTest : IntegrationTestBase() {
         )
       )
   }
-
-  private fun mockInmateDetailPrisonsApiCall(inmateDetail: InmateDetail) = wiremockServer.stubFor(
-    WireMock.get(WireMock.urlEqualTo("/api/offenders/${inmateDetail.offenderNo}"))
-      .willReturn(
-        WireMock.aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(200)
-          .withBody(
-            objectMapper.writeValueAsString(inmateDetail)
-          )
-      )
-  )
 }


### PR DESCRIPTION
This adds the detail of a specific person to all of the Application responses. This involves us having to call the Community and Prisons APIs, so we have guards in place for if either API has problems returning the person detail(s).

This is done using a private method in the controller, the implementation of which is nicked from the BookingsController. I do wonder if this would be better placed in a service, but I think this is fine for now.

I’ve also added the `mockInmateDetailPrisonsApiCall` function, which is used in some other integration tests to the IntegrationTestBase file, so we can use it everywhere.