### PR TITLE
765 - Redis caching for Staff and Offender data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.vladmihalcea:hibernate-types-55:2.19.2")
   implementation("org.flywaydb:flyway-core")
+  implementation("org.springframework.boot:spring-boot-starter-data-redis")
+  implementation("org.springframework.boot:spring-boot-starter-cache")
 
   runtimeOnly("org.postgresql:postgresql")
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,3 +8,11 @@ services:
       - POSTGRES_DB=approved_premises_integration_test
     ports:
       - "5433:5432"
+
+  integration_test_redis:
+    image: "bitnami/redis:5.0"
+    container_name: approved-premises-redis-test
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "6377:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,5 +75,13 @@ services:
     volumes:
       - ./nomis-db:/nomis-db
 
+  redis:
+    image: "bitnami/redis:5.0"
+    container_name: approved-premises-redis-dev
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "6379:6379"
+
 volumes:
   database-data-development:

--- a/helm_deploy/hmpps-approved-premises-api/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/values.yaml
@@ -25,6 +25,7 @@ generic-service:
     SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
     SPRING_JPA_DATABASE: postgresql
     SPRING_DATASOURCE_URL: "jdbc:postgresql://${DB_HOST}/${DB_NAME}"
+    SPRING_REDIS_PORT: 6379
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -45,6 +46,9 @@ generic-service:
       SPRING_DATASOURCE_PASSWORD: "database_password"
       DB_HOST: "rds_instance_endpoint"
       DB_NAME: "database_name"
+    elasticache-redis:
+      SPRING_REDIS_HOST: "primary_endpoint_address"
+      SPRING_REDIS_PASSWORD: "auth_token"
 
   allowlist:
     office: "217.33.148.210/32"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
@@ -26,10 +27,12 @@ class CommunityApiClient(
     path = "/secure/offenders/crn/$crn/registrations?activeOnly=true"
   }
 
+  @Cacheable(value = ["staffMemberCache"])
   fun getStaffMember(staffId: Long) = getRequest<StaffMember> {
     path = "/secure/staff/staffIdentifier/$staffId"
   }
 
+  @Cacheable(value = ["staffMembersCache"])
   fun getStaffMembers(deliusTeamCode: String) = getRequest<List<StaffMember>> {
     path = "/secure/teams/$deliusTeamCode/staff"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -15,10 +15,12 @@ class CommunityApiClient(
   @Qualifier("communityApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper
 ) : BaseHMPPSClient(webClient, objectMapper) {
+  @Cacheable(value = ["offenderDetailsCache"])
   fun getOffenderDetailSummary(crn: String) = getRequest<OffenderDetailSummary> {
     path = "/secure/offenders/crn/$crn"
   }
 
+  @Cacheable(value = ["userAccessCache"])
   fun getUserAccessForOffenderCrn(userDistinguishedName: String, crn: String) = getRequest<UserOffenderAccess> {
     path = "/secure/offenders/crn/$crn/user/$userDistinguishedName/userAccess"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.CaseNotesPage
@@ -13,6 +14,7 @@ class PrisonsApiClient(
   @Qualifier("prisonsApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper
 ) : BaseHMPPSClient(webClient, objectMapper) {
+  @Cacheable(value = ["inmateDetailsCache"])
   fun getInmateDetails(nomsNumber: String) = getRequest<InmateDetail> {
     path = "/api/offenders/$nomsNumber"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer
 import org.springframework.boot.info.BuildProperties
 import org.springframework.cache.annotation.EnableCaching
@@ -27,16 +28,21 @@ class RedisConfiguration {
   @Bean
   fun redisCacheManagerBuilderCustomizer(
     buildProperties: BuildProperties,
-    objectMapper: ObjectMapper
+    objectMapper: ObjectMapper,
+    @Value("\${caches.staffMembers.expiry-minutes}") staffMembersExpiryMinutes: Long,
+    @Value("\${caches.staffMember.expiry-minutes}") staffMemberExpiryMinutes: Long,
+    @Value("\${caches.offenderDetails.expiry-minutes}") offenderDetailsExpiryMinutes: Long,
+    @Value("\${caches.userAccess.expiry-minutes}") userAccessExpiryMinutes: Long,
+    @Value("\${caches.inmateDetails.expiry-minutes}") inmateDetailsExpiryMinutes: Long
   ): RedisCacheManagerBuilderCustomizer? {
     val version = buildProperties.version
 
     return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManagerBuilder ->
-      builder.clientCacheFor<List<StaffMember>>("staffMembersCache", Duration.ofHours(6), version, objectMapper)
-        .clientCacheFor<StaffMember>("staffMemberCache", Duration.ofHours(6), version, objectMapper)
-        .clientCacheFor<OffenderDetailSummary>("offenderDetailsCache", Duration.ofMinutes(20), version, objectMapper)
-        .clientCacheFor<UserOffenderAccess>("userAccessCache", Duration.ofMinutes(20), version, objectMapper)
-        .clientCacheFor<InmateDetail>("inmateDetailsCache", Duration.ofMinutes(20), version, objectMapper)
+      builder.clientCacheFor<List<StaffMember>>("staffMembersCache", Duration.ofMinutes(staffMembersExpiryMinutes), version, objectMapper)
+        .clientCacheFor<StaffMember>("staffMemberCache", Duration.ofMinutes(staffMemberExpiryMinutes), version, objectMapper)
+        .clientCacheFor<OffenderDetailSummary>("offenderDetailsCache", Duration.ofMinutes(offenderDetailsExpiryMinutes), version, objectMapper)
+        .clientCacheFor<UserOffenderAccess>("userAccessCache", Duration.ofMinutes(userAccessExpiryMinutes), version, objectMapper)
+        .clientCacheFor<InmateDetail>("inmateDetailsCache", Duration.ofMinutes(inmateDetailsExpiryMinutes), version, objectMapper)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+
+@Configuration
+class RedisConfiguration {
+  @Bean
+  fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
+    val template = RedisTemplate<String, String>()
+    template.connectionFactory = connectionFactory
+    return template
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -1,16 +1,138 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer
+import org.springframework.boot.info.BuildProperties
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair
+import org.springframework.data.redis.serializer.RedisSerializer
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.shouldNotBeReached
+import java.time.Duration
 
 @Configuration
+@EnableCaching
 class RedisConfiguration {
   @Bean
-  fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
-    val template = RedisTemplate<String, String>()
-    template.connectionFactory = connectionFactory
-    return template
+  fun redisCacheManagerBuilderCustomizer(
+    buildProperties: BuildProperties,
+    objectMapper: ObjectMapper
+  ): RedisCacheManagerBuilderCustomizer? {
+    val version = buildProperties.version
+
+    return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManagerBuilder ->
+      builder.clientCacheFor<List<StaffMember>>("staffMembersCache", Duration.ofHours(6), version, objectMapper)
+        .clientCacheFor<StaffMember>("staffMemberCache", Duration.ofHours(6), version, objectMapper)
+    }
   }
+
+  private inline fun <reified T> RedisCacheManagerBuilder.clientCacheFor(cacheName: String, duration: Duration, version: String, objectMapper: ObjectMapper) =
+    this.withCacheConfiguration(
+      cacheName,
+      RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(duration)
+        .serializeValuesWith(SerializationPair.fromSerializer(ClientResultRedisSerializer(objectMapper, object : TypeReference<T>() {})))
+        .prefixCacheNameWith(version)
+    )
+}
+
+class ClientResultRedisSerializer(
+  private val objectMapper: ObjectMapper,
+  private val typeReference: TypeReference<*>
+) : RedisSerializer<ClientResult<Any>> {
+  override fun serialize(clientResult: ClientResult<Any>?): ByteArray? {
+    val toSerialize = when (clientResult) {
+      is ClientResult.StatusCodeFailure -> {
+        SerializableClientResult(
+          discriminator = ClientResultDiscriminator.STATUS_CODE_FAILURE,
+          status = clientResult.status,
+          body = clientResult.body,
+          exceptionMessage = null,
+          type = null,
+          method = clientResult.method,
+          path = clientResult.path
+        )
+      }
+      is ClientResult.OtherFailure -> {
+        SerializableClientResult(
+          discriminator = ClientResultDiscriminator.OTHER_FAILURE,
+          status = null,
+          body = null,
+          exceptionMessage = clientResult.exception.message,
+          type = null,
+          method = clientResult.method,
+          path = clientResult.path
+        )
+      }
+      is ClientResult.Success -> {
+        SerializableClientResult(
+          discriminator = ClientResultDiscriminator.SUCCESS,
+          status = clientResult.status,
+          body = objectMapper.writeValueAsString(clientResult.body),
+          exceptionMessage = null,
+          type = clientResult.body::class.java.typeName,
+          method = null,
+          path = null
+        )
+      }
+      else -> shouldNotBeReached()
+    }
+
+    return objectMapper.writeValueAsBytes(toSerialize)
+  }
+
+  override fun deserialize(bytes: ByteArray?): ClientResult<Any>? {
+    val deserializedWrapper = objectMapper.readValue(bytes, SerializableClientResult::class.java)
+
+    if (deserializedWrapper.discriminator == ClientResultDiscriminator.SUCCESS) {
+      return ClientResult.Success(
+        status = deserializedWrapper.status!!,
+        body = objectMapper.readValue(deserializedWrapper.body, typeReference)
+      )
+    }
+
+    if (deserializedWrapper.discriminator == ClientResultDiscriminator.STATUS_CODE_FAILURE) {
+      return ClientResult.StatusCodeFailure(
+        method = deserializedWrapper.method!!,
+        path = deserializedWrapper.path!!,
+        status = deserializedWrapper.status!!,
+        body = deserializedWrapper.body
+      )
+    }
+
+    if (deserializedWrapper.discriminator == ClientResultDiscriminator.OTHER_FAILURE) {
+      return ClientResult.StatusCodeFailure(
+        method = deserializedWrapper.method!!,
+        path = deserializedWrapper.path!!,
+        status = deserializedWrapper.status!!,
+        body = deserializedWrapper.body
+      )
+    }
+
+    throw RuntimeException("Unhandled discriminator type: ${deserializedWrapper.discriminator}")
+  }
+}
+
+data class SerializableClientResult(
+  val discriminator: ClientResultDiscriminator,
+  val type: String?,
+  val status: HttpStatus?,
+  val body: String?,
+  val exceptionMessage: String?,
+  val method: HttpMethod?,
+  val path: String?
+)
+
+enum class ClientResultDiscriminator {
+  SUCCESS,
+  STATUS_CODE_FAILURE,
+  OTHER_FAILURE
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,5 +8,9 @@ spring:
     locations: classpath:db/migration/all,classpath:db/migration/local+dev
   jpa:
     database: postgresql
+  redis:
+    host: localhost
+    port: 6379
+    password: ""
 
 log-client-credentials-jwt-info: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,3 +125,15 @@ prison-case-notes:
       subcategory: null
     - category: PRISON
       subcategory: RELEASE
+
+caches:
+  staffMembers:
+    expiry-minutes: 360
+  staffMember:
+    expiry-minutes: 360
+  offenderDetails:
+    expiry-minutes: 20
+  userAccess:
+    expiry-minutes: 20
+  inmateDetails:
+    expiry-minutes: 20

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,10 @@ spring:
     hibernate:
       ddl-auto: none
 
+  redis:
+    database: 5
+    timeout: 60000
+
   security:
     oauth2:
       resourceserver:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.cache.CacheManager
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -94,6 +95,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   private lateinit var flyway: Flyway
+
+  @Autowired
+  private lateinit var cacheManager: CacheManager
 
   @Autowired
   lateinit var objectMapper: ObjectMapper
@@ -189,6 +193,10 @@ abstract class IntegrationTestBase {
 
     flyway.clean()
     flyway.migrate()
+
+    cacheManager.cacheNames.forEach {
+      cacheManager.getCache(it)!!.clear()
+    }
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.exactly
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffMemberFactory
@@ -215,5 +218,59 @@ class PremisesTest : IntegrationTestBase() {
           staffMembers.map(staffMemberTransformer::transformDomainToApi)
         )
       )
+  }
+
+  @Test
+  fun `Get Premises Staff caches response`() {
+    val deliusTeamCode = "FOUND"
+
+    val premises = premisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+      withDeliusTeamCode(deliusTeamCode)
+    }
+
+    val staffMembers = listOf(
+      StaffMemberFactory().produce(),
+      StaffMemberFactory().produce(),
+      StaffMemberFactory().produce(),
+      StaffMemberFactory().produce(),
+      StaffMemberFactory().produce()
+    )
+
+    mockClientCredentialsJwtRequest()
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    wiremockServer.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/teams/$deliusTeamCode/staff"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              objectMapper.writeValueAsString(staffMembers)
+            )
+        )
+    )
+
+    repeat(2) {
+      webTestClient.get()
+        .uri("/premises/${premises.id}/staff")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            staffMembers.map(staffMemberTransformer::transformDomainToApi)
+          )
+        )
+    }
+
+    wiremockServer.verify(exactly(1), getRequestedFor(urlEqualTo("/secure/teams/$deliusTeamCode/staff")))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/ClientResultRedisSerializerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/ClientResultRedisSerializerTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.config
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.ClientResultRedisSerializer
+
+class ClientResultRedisSerializerTest {
+  private val objectMapper = jacksonObjectMapper()
+  private val clientResponseRedisSerializer = ClientResultRedisSerializer(objectMapper, object : TypeReference<ClientResponseBody>() {})
+
+  @Test
+  fun `ClientResult-StatusCodeFailure responses are serialized and deserialized correctly`() {
+    val clientResult = ClientResult.StatusCodeFailure<ClientResponseBody>(
+      method = HttpMethod.GET,
+      path = "/an/endpoint",
+      status = HttpStatus.BAD_REQUEST,
+      body = "Something went wrong"
+    )
+
+    val cachedByteArray = clientResponseRedisSerializer.serialize(clientResult)
+    val deserializedCacheValue = clientResponseRedisSerializer.deserialize(cachedByteArray)
+
+    assertThat(deserializedCacheValue is ClientResult.StatusCodeFailure).isTrue
+    deserializedCacheValue as ClientResult.StatusCodeFailure
+    assertThat(deserializedCacheValue.method).isEqualTo(HttpMethod.GET)
+    assertThat(deserializedCacheValue.path).isEqualTo("/an/endpoint")
+    assertThat(deserializedCacheValue.status).isEqualTo(HttpStatus.BAD_REQUEST)
+    assertThat(deserializedCacheValue.body).isEqualTo("Something went wrong")
+  }
+
+  @Test
+  fun `ClientResult-OtherFailure responses are serialized and deserialized correctly`() {
+    val clientResult = ClientResult.OtherFailure<ClientResponseBody>(
+      method = HttpMethod.GET,
+      path = "/an/endpoint",
+      exception = RuntimeException("Something went wrong")
+    )
+
+    val cachedByteArray = clientResponseRedisSerializer.serialize(clientResult)
+    val deserializedCacheValue = clientResponseRedisSerializer.deserialize(cachedByteArray)
+
+    assertThat(deserializedCacheValue is ClientResult.OtherFailure).isTrue
+    deserializedCacheValue as ClientResult.OtherFailure
+    assertThat(deserializedCacheValue.method).isEqualTo(HttpMethod.GET)
+    assertThat(deserializedCacheValue.path).isEqualTo("/an/endpoint")
+    assertThat(deserializedCacheValue.exception.message).isEqualTo(clientResult.exception.message)
+  }
+
+  @Test
+  fun `ClientResult-Success responses are serialized and deserialized correctly`() {
+    val clientResult = ClientResult.Success(
+      status = HttpStatus.OK,
+      body = ClientResponseBody(
+        property = "hello"
+      )
+    )
+
+    val cachedByteArray = clientResponseRedisSerializer.serialize(clientResult)
+    val cachedString = String(cachedByteArray)
+    val deserializedCacheValue = clientResponseRedisSerializer.deserialize(cachedByteArray)
+
+    assertThat(deserializedCacheValue is ClientResult.Success).isTrue
+    deserializedCacheValue as ClientResult.Success
+    assertThat(deserializedCacheValue.status).isEqualTo(HttpStatus.OK)
+    assertThat(deserializedCacheValue.body).isEqualTo(clientResult.body)
+  }
+}
+
+data class ClientResponseBody(
+  val property: String
+)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -63,3 +63,15 @@ prison-case-notes:
       subcategory: null
     - category: PRISON
       subcategory: RELEASE
+
+caches:
+  staffMembers:
+    expiry-minutes: 360
+  staffMember:
+    expiry-minutes: 360
+  offenderDetails:
+    expiry-minutes: 20
+  userAccess:
+    expiry-minutes: 20
+  inmateDetails:
+    expiry-minutes: 20

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,10 @@ spring:
     locations: classpath:db/migration/all
   jpa:
     database: postgresql
+  redis:
+    host: localhost
+    port: 6377
+    password: ""
   security:
     oauth2:
       client:


### PR DESCRIPTION
**Add a distributed cache backed by Redis that sits over the Client layer**

The ClientResult values are serialized and stored in Redis.  The cache name is prefixed with the version of the application so that we don't have any issues when deploying a new version where the models we're deserializing into may have changed etc.

 - Add a cache over Staff info for 6 hours
 - Add a cache over Offender Details (Community API), User Access (Community API), Inmate Details (Prisons API) for 20 minutes