### PR TITLE
Add a basic application schema

### DIFF
--- a/src/main/resources/db/migration/all/20221005143000__add_placeholder_application_schema.sql
+++ b/src/main/resources/db/migration/all/20221005143000__add_placeholder_application_schema.sql
@@ -1,0 +1,2 @@
+INSERT INTO application_schemas (id, added_at, "schema") VALUES
+	('f96725f6-27ac-46f2-83e0-00cf4af48370', NOW() ,'{}');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -31,6 +31,8 @@ class ApplicationTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
+    applicationSchemaRepository.deleteAll()
+
     val inmateDetail = InmateDetailFactory()
       .withOffenderNo("NOMS321")
       .produce()


### PR DESCRIPTION
At the moment, we don’t have a schema to match applications against, so the service fails. This adds a very basic one to get things moving while we define the shape of the schema.