### PR TITLE
Fix/docker container errors in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
   database:
     image: "postgres"
-    container_name: approved-premises-postgres-dev
     environment:
       - POSTGRES_USER=localdev
       - POSTGRES_PASSWORD=localdev_password
@@ -14,7 +13,6 @@ services:
 
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
-    container_name: hmpps-auth
     ports:
       - "9091:8080"
     healthcheck:
@@ -27,7 +25,6 @@ services:
 
   community-api:
     image: quay.io/hmpps/community-api:latest
-    container_name: community-api
     ports:
       - "9590:8080"
     healthcheck:
@@ -39,7 +36,6 @@ services:
 
   hmpps-assess-risks-and-needs:
     image: quay.io/hmpps/hmpps-assess-risks-and-needs
-    container_name: assess-risks-and-needs
     ports:
       - "9580:8080"
     healthcheck:
@@ -53,7 +49,6 @@ services:
 
   wiremock:
     image: rodolpheche/wiremock
-    container_name: wiremock
     ports:
       - "9004:8080"
     volumes:
@@ -77,7 +72,6 @@ services:
 
   redis:
     image: "bitnami/redis:5.0"
-    container_name: approved-premises-redis-dev
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
-      - "6379:6379"
+      - "6380:6379"
 
 volumes:
   database-data-development:

--- a/helm_deploy/hmpps-approved-premises-api/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/values.yaml
@@ -25,7 +25,7 @@ generic-service:
     SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
     SPRING_JPA_DATABASE: postgresql
     SPRING_DATASOURCE_URL: "jdbc:postgresql://${DB_HOST}/${DB_NAME}"
-    SPRING_REDIS_PORT: 6379
+    SPRING_REDIS_PORT: 6380
     SPRING_REDIS_SSL: true
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/script/server
+++ b/script/server
@@ -7,6 +7,12 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+cleanup() {
+  echo "==> Tearing down any old containers..."
+  docker-compose down
+}
+trap cleanup EXIT
+
 ./script/development_database
 
 echo "==> Starting server..."

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
     database: postgresql
   redis:
     host: localhost
-    port: 6379
+    port: 6380
     password: ""
 
 log-client-credentials-jwt-info: true


### PR DESCRIPTION
These changes are the ones I found were needed to get both apps running using docker-compose. [There is a similar pull request on the frontend](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/237).

We've got:

- removing container names when not needed to remove name clashes with the frontend
- exposing redis on a non-default port to avoid clashing with the frontend (that still uses the default)
- an addition to the script/server to shut any old containers down when starting up. The script can leave things hanging when we term the process. We found maing changes to the docker-compose and restarting the server was clashing with existing containers running without this

With these changes and a similar set on the frontend both apps work together when running `script/server` which is nice. I'm aware you're experimenting with Tilt right now however I think these changes are still useful.