### PR TITLE
Add legacy reference codes

### DIFF
--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -748,7 +748,34 @@ components:
       properties:
         description:
           type: string
-          example: Living with family / partner / other
+          enum:
+            - B&B / Temp / Short-Term Housing
+            - Custody
+            - Deported/ Detention Centre/IRC
+            - Housing Association - Rented
+            - Living with Family/ Partner/ Other
+            - Local Authority - Rented
+            - No Fixed Abode
+            - Not Applicable
+            - Owner Occupied
+            - Private Rented
+            - Supported Housing
+            - Transferred to different AP
+        legacyMoveOnCategoryCode:
+          type: string
+          enum:
+            - MC05
+            - MC19
+            - MC10
+            - MC03
+            - MC07
+            - MC02
+            - MC14
+            - MCNA
+            - MC08
+            - MC04
+            - MC06
+            - P
         code:
           type: string
           example: ABC123

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -638,6 +638,8 @@ components:
           type: string
           example: '2022-11-29'
           format: date
+        recordedBy:
+          $ref: '#/components/schemas/StaffMember'
         notes:
           type: string
           example: We learnt that Mr Smith is in hospital.

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -510,9 +510,8 @@ components:
           readOnly: true
         withdrawnBy:
           $ref: '#/components/schemas/StaffMember'
-        reason:
-          type: string
-          example: Parole denied at oral hearing
+        withdrawalReason:
+          $ref: '#/components/schemas/CancellationReason'
 
     ApplicationAssessed:
       type: object
@@ -601,8 +600,7 @@ components:
         cancelledBy:
           $ref: '#/components/schemas/StaffMember'
         cancellationReason:
-          type: string
-          example: Deceased
+          $ref: '#/components/schemas/CancellationReason'
 
     PersonArrived:
       type: object
@@ -742,6 +740,26 @@ components:
           example: Q061
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
+
+    CancellationReason:
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - Custodial disposal - RIC
+            - Offer Withdrawn
+            - Other
+            - Parole Licence not granted
+            - Withdrawn by Referrer
+        legacyCancellationCode:
+          type: string
+          enum:
+            - 1H
+            - B
+            - D
+            - 4I
+            - C
 
     MoveOnCategory:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -659,7 +659,44 @@ components:
           format: date-time
         reason:
           type: string
-          example: Planned move-on
+          enum:
+            - Absconded, still at large
+            - Admitted to Hospital
+            - Arrested, remanded in custody, or sentenced
+            - Bed Withdrawn
+            - Breach / recall (abscond)
+            - Breach / recall (behaviour / increasing risk)
+            - Breach / recall (curfew)
+            - Breach / recall (house rules)
+            - Breach / recall (licence or bail condition)
+            - Breach / recall (other)
+            - Breach / recall (positive drugs test)
+            - Died
+            - End of ROTL
+            - Left of own volition
+            - Order / licence expired
+            - Other
+            - Planned move-on
+        legacyReasonCode:
+          type: string
+          enum:
+            - J
+            - Q
+            - H
+            - X
+            - A
+            - D
+            - F
+            - B
+            - E
+            - G
+            - C
+            - P
+            - V
+            - K
+            - N
+            - W
+            - O
         destination:
           type: object
           properties:


### PR DESCRIPTION
This PR is in response to a number of requests which have come through from the Delius team who will be consuming these Domain Events.

There are some outstanding questions to clarify:

### 1. Representing an "Event"

This identifies a conviction and is important, we understand, when processing `person.not-arrived` and `person.arrived` domain events. The event ID corresponds to a particular `convictionID` and `index` property as exposed by the Community API and perhaps could be represented in a Domain Event in the form:

```json
"convictionEvent": {
    "convictionId": 1502724704,
    "index": "7"
}
```

but we need clarification from the integration team that this is truly essential as at present the AP service is not recording this level of conviction information.

### 2. the "applicant" or "referrer"

It's been suggested that the probation officer who made the application for an AP place needs to be identified in `person.departed`, `person.not-arrived` and `person.arrived` events. Is this the case for all of these Domain Events? e.g. does the probation officer need to be alerted in each case? Once we have this clarified / confirmed we can add staff member information to the Domain Events e.g.

```json
  "referredBy": {
    "staffCode": "N54A999",
    "staffIdentifier": 1501234567,
    "forenames": "John",
    "surname": "Smith",
    "username": "JohnSmithNPS"
},
 
```