### PR TITLE
790 - Allow submitting document alongside application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -79,8 +79,9 @@ class ApplicationsController(
     val username = deliusPrincipal.name
 
     val serializedData = objectMapper.writeValueAsString(body.data)
+    val serializedDocument = objectMapper.writeValueAsString(body.document)
 
-    val applicationResult = applicationService.updateApplication(applicationId, serializedData, body.submittedAt, username)
+    val applicationResult = applicationService.updateApplication(applicationId, serializedData, serializedDocument, body.submittedAt, username)
 
     val validationResult = when (applicationResult) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -31,6 +31,9 @@ data class ApplicationEntity(
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   var data: String?,
 
+  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
+  var document: String?,
+
   @ManyToOne
   @JoinColumn(name = "schema_version")
   var schemaVersion: ApplicationSchemaEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -56,6 +56,7 @@ class ApplicationService(
         crn = crn,
         createdByProbationOfficer = probationOfficer,
         data = null,
+        document = null,
         schemaVersion = jsonSchemaService.getNewestSchema(),
         createdAt = OffsetDateTime.now(),
         submittedAt = null,
@@ -66,7 +67,7 @@ class ApplicationService(
     return success(createdApplication)
   }
 
-  fun updateApplication(applicationId: UUID, data: String, submittedAt: OffsetDateTime?, username: String): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
+  fun updateApplication(applicationId: UUID, data: String, document: String?, submittedAt: OffsetDateTime?, username: String): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()
 
@@ -94,6 +95,10 @@ class ApplicationService(
       validationErrors["$.submittedAt"] = "isInFuture"
     }
 
+    if (submittedAt != null && document == null) {
+      validationErrors["$.document"] = "empty"
+    }
+
     if (validationErrors.any()) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.FieldValidationError(validationErrors)
@@ -103,6 +108,7 @@ class ApplicationService(
     application.let {
       it.schemaVersion = latestSchemaVersion
       it.data = data
+      it.document = document
       it.submittedAt = submittedAt
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -17,6 +17,7 @@ class ApplicationsTransformer(private val objectMapper: ObjectMapper, private va
     outdatedSchema = !jpa.schemaUpToDate,
     createdAt = jpa.createdAt,
     submittedAt = jpa.submittedAt,
-    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null
+    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+    document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null
   )
 }

--- a/src/main/resources/db/migration/all/20221013143323__add_document_to_applications.sql
+++ b/src/main/resources/db/migration/all/20221013143323__add_document_to_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE applications ADD COLUMN document JSON;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1767,6 +1767,8 @@ components:
           format: date-time
         data:
           $ref: '#/components/schemas/AnyValue'
+        document:
+          $ref: '#/components/schemas/AnyValue'
       required:
         - id
         - crn
@@ -1788,6 +1790,10 @@ components:
       type: object
       properties:
         data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AnyValue'
+        document:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/AnyValue'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationEntityFactory.kt
@@ -15,6 +15,7 @@ class ApplicationEntityFactory : Factory<ApplicationEntity> {
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var createdByProbationOfficer: Yielded<ProbationOfficerEntity>? = null
   private var data: Yielded<String?> = { "{}" }
+  private var document: Yielded<String?> = { "{}" }
   private var applicationSchema: Yielded<ApplicationSchemaEntity> = {
     ApplicationSchemaEntity(
       id = UUID.randomUUID(),
@@ -45,6 +46,10 @@ class ApplicationEntityFactory : Factory<ApplicationEntity> {
     this.data = { data }
   }
 
+  fun withDocument(document: String?) = apply {
+    this.document = { document }
+  }
+
   fun withApplicationSchema(applicationSchema: ApplicationSchemaEntity) = apply {
     this.applicationSchema = { applicationSchema }
   }
@@ -66,6 +71,7 @@ class ApplicationEntityFactory : Factory<ApplicationEntity> {
     crn = this.crn(),
     createdByProbationOfficer = this.createdByProbationOfficer?.invoke() ?: throw RuntimeException("Must provide a createdByProbationOfficer"),
     data = this.data(),
+    document = this.document(),
     schemaVersion = this.applicationSchema(),
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),


### PR DESCRIPTION
Add a `document` opaque JSON field to applications.

Return this field on the GET endpoints and accept on the PUT.

If `submitted_at` is set, then `document` must also be set.