### PR TITLE
Force org.apache.commons:commons-text to 1.10.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,14 @@ dependencies {
   testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind") {
     version { strictly("2.14.0-rc1") }
   }
+
+  implementation("org.apache.commons:commons-text") {
+    version { strictly("1.10.0") }
+  }
+
+  testRuntimeOnly("org.apache.commons:commons-text") {
+    version { strictly("1.10.0") }
+  }
 }
 
 java {


### PR DESCRIPTION
Due to CVE-2022-42889