### PR TITLE
Get user info from Community API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
 
 @Component
@@ -38,5 +39,9 @@ class CommunityApiClient(
   @Cacheable(value = ["staffMembersCache"], unless = IS_NOT_SUCCESSFUL)
   fun getStaffMembers(deliusTeamCode: String) = getRequest<List<StaffMember>> {
     path = "/secure/teams/$deliusTeamCode/staff"
+  }
+
+  fun getStaffUserDetails(deliusUsername: String) = getRequest<StaffUserDetails> {
+    path = "/secure/staff/username/$deliusUsername"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.Table
 
 @Repository
 interface UserRepository : JpaRepository<UserEntity, UUID> {
-  fun findByDistinguishedName(distinguishedName: String): UserEntity?
+  fun findByDeliusUsername(deliusUsername: String): UserEntity?
 }
 
 @Entity
@@ -19,8 +19,8 @@ data class UserEntity(
   @Id
   val id: UUID,
   val name: String,
-  val distinguishedName: String,
-  var isActive: Boolean,
+  val deliusUsername: String,
+  val deliusStaffIdentifier: Long,
   @OneToMany(mappedBy = "createdByUser")
   val applications: MutableList<ApplicationEntity>
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
+
+data class StaffUserDetails(
+  val username: String,
+  val email: String,
+  val telephoneNumber: String,
+  val staffCode: String,
+  val staffIdentifier: Long,
+  val staff: StaffNames
+)
+
+data class StaffNames(
+  val forenames: String,
+  val surname: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -22,7 +22,7 @@ class ApplicationService(
   private val userService: UserService
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String): List<ApplicationEntity> {
-    val userEntity = userRepository.findByDistinguishedName(userDistinguishedName)
+    val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
       ?: return emptyList()
 
     return applicationRepository.findAllByCreatedByUser_Id(userEntity.id)
@@ -33,7 +33,7 @@ class ApplicationService(
     val applicationEntity = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()
 
-    val userEntity = userRepository.findByDistinguishedName(userDistinguishedName)
+    val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
 
     if (userEntity != applicationEntity.createdByUser) {
       return AuthorisableActionResult.Unauthorised()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import java.util.UUID
@@ -8,23 +10,31 @@ import java.util.UUID
 @Service
 class UserService(
   private val httpAuthService: HttpAuthService,
+  private val communityApiClient: CommunityApiClient,
   private val userRepository: UserRepository
 ) {
   fun getUserForRequest(): UserEntity {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
 
-    // TODO: Make call to Community API for details
+    val existingUser = userRepository.findByDeliusUsername(username)
+    if (existingUser != null) return existingUser
 
-    return userRepository.findByDeliusUsername(username)
-      ?: userRepository.save(
-        UserEntity(
-          id = UUID.randomUUID(),
-          name = "forenames surname",
-          deliusUsername = username,
-          deliusStaffIdentifier = 123,
-          applications = mutableListOf()
-        )
+    val staffUserDetailsResponse = communityApiClient.getStaffUserDetails(username)
+
+    val staffUserDetails = when (staffUserDetailsResponse) {
+      is ClientResult.Success -> staffUserDetailsResponse.body
+      is ClientResult.Failure -> staffUserDetailsResponse.throwException()
+    }
+
+    return userRepository.save(
+      UserEntity(
+        id = UUID.randomUUID(),
+        name = "${staffUserDetails.staff.forenames} ${staffUserDetails.staff.surname}",
+        deliusUsername = username,
+        deliusStaffIdentifier = staffUserDetails.staffIdentifier,
+        applications = mutableListOf()
       )
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -14,13 +14,15 @@ class UserService(
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
 
-    return userRepository.findByDistinguishedName(username)
+    // TODO: Make call to Community API for details
+
+    return userRepository.findByDeliusUsername(username)
       ?: userRepository.save(
         UserEntity(
           id = UUID.randomUUID(),
-          name = username,
-          distinguishedName = username,
-          isActive = true,
+          name = "forenames surname",
+          deliusUsername = username,
+          deliusStaffIdentifier = 123,
           applications = mutableListOf()
         )
       )

--- a/src/main/resources/db/migration/all/20221018133055__extend_users_table.sql
+++ b/src/main/resources/db/migration/all/20221018133055__extend_users_table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "users" DROP COLUMN is_active;
+ALTER TABLE "users" DROP COLUMN distinguished_name;
+ALTER TABLE "users" ADD COLUMN delius_username TEXT NOT NULL;
+ALTER TABLE "users" ADD COLUMN delius_staff_identifier BIGINT NOT NULL;

--- a/src/main/resources/db/migration/local+dev/20221018133054__clear_existing_users.sql
+++ b/src/main/resources/db/migration/local+dev/20221018133054__clear_existing_users.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE "users" CASCADE;

--- a/src/main/resources/db/migration/local+dev/20221018133056__mock_users.sql
+++ b/src/main/resources/db/migration/local+dev/20221018133056__mock_users.sql
@@ -1,0 +1,6 @@
+--These are randomly generated names
+
+INSERT INTO "users" (id, name, delius_username, delius_staff_identifier) VALUES
+    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547),
+    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096),
+    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
@@ -20,6 +20,30 @@ class StaffUserDetailsFactory : Factory<StaffUserDetails> {
     this.username = { username }
   }
 
+  fun withEmail(email: String) = apply {
+    this.email = { email }
+  }
+
+  fun withTelephoneNumber(telephoneNumber: String) = apply {
+    this.telephoneNumber = { telephoneNumber }
+  }
+
+  fun withStaffCode(staffCode: String) = apply {
+    this.staffCode = { staffCode }
+  }
+
+  fun withStaffIdentifier(staffIdentifier: Long) = apply {
+    this.staffIdentifier = { staffIdentifier }
+  }
+
+  fun withForenames(forenames: String) = apply {
+    this.forenames = { forenames }
+  }
+
+  fun withSurname(surname: String) = apply {
+    this.surname = { surname }
+  }
+
   override fun produce(): StaffUserDetails = StaffUserDetails(
     username = this.username(),
     email = this.email(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffNames
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+
+class StaffUserDetailsFactory : Factory<StaffUserDetails> {
+  private var username: Yielded<String> = { randomStringUpperCase(10) }
+  private var email: Yielded<String> = { randomStringUpperCase(8) }
+  private var telephoneNumber: Yielded<String> = { randomStringUpperCase(8) }
+  private var staffCode: Yielded<String> = { randomStringUpperCase(8) }
+  private var staffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
+  private var forenames: Yielded<String> = { randomStringUpperCase(8) }
+  private var surname: Yielded<String> = { randomStringUpperCase(8) }
+
+  fun withUsername(username: String) = apply {
+    this.username = { username }
+  }
+
+  override fun produce(): StaffUserDetails = StaffUserDetails(
+    username = this.username(),
+    email = this.email(),
+    telephoneNumber = this.telephoneNumber(),
+    staffCode = this.staffCode(),
+    staffIdentifier = this.staffIdentifier(),
+    staff = StaffNames(
+      forenames = this.forenames(),
+      surname = this.surname()
+    )
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -4,14 +4,15 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class UserEntityFactory : Factory<UserEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringUpperCase(12) }
-  private var distinguishedName: Yielded<String> = { randomStringUpperCase(12) }
-  private var isActive: Yielded<Boolean> = { false }
+  private var deliusUsername: Yielded<String> = { randomStringUpperCase(12) }
+  private var deliusStaffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
   private var applications: Yielded<MutableList<ApplicationEntity>> = { mutableListOf() }
 
   fun withId(id: UUID) = apply {
@@ -22,12 +23,12 @@ class UserEntityFactory : Factory<UserEntity> {
     this.name = { name }
   }
 
-  fun withDistinguishedName(distinguishedName: String) = apply {
-    this.distinguishedName = { distinguishedName }
+  fun withDeliusUsername(deliusUsername: String) = apply {
+    this.deliusUsername = { deliusUsername }
   }
 
-  fun withIsActive(isActive: Boolean) = apply {
-    this.isActive = { isActive }
+  fun withDeliusStaffIdentifier(deliusStaffIdentifier: Long) = apply {
+    this.deliusStaffIdentifier = { deliusStaffIdentifier }
   }
 
   fun withApplications(applications: MutableList<ApplicationEntity>) = apply {
@@ -37,8 +38,8 @@ class UserEntityFactory : Factory<UserEntity> {
   override fun produce(): UserEntity = UserEntity(
     id = this.id(),
     name = this.name(),
-    distinguishedName = this.distinguishedName(),
-    isActive = this.isActive(),
+    deliusUsername = this.deliusUsername(),
+    deliusStaffIdentifier = this.deliusStaffIdentifier(),
     applications = this.applications()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -94,7 +94,7 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val user = userEntityFactory.produceAndPersist { withDistinguishedName("PROBATIONPERSON") }
+    val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
     val upgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
@@ -272,7 +272,7 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDistinguishedName("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
     val upgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
@@ -424,7 +424,7 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDistinguishedName("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
     val nonUpgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
@@ -657,7 +657,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     val user = userEntityFactory.produceAndPersist {
-      withDistinguishedName(username)
+      withDeliusUsername(username)
     }
 
     applicationEntityFactory.produceAndPersist {
@@ -742,7 +742,7 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDistinguishedName("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
     val application = applicationEntityFactory.produceAndPersist {
       withApplicationSchema(jsonSchema)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import java.time.LocalDate
@@ -562,8 +563,9 @@ class ApplicationTest : IntegrationTestBase() {
   @Test
   fun `Create new application returns 201 with correct body and Location header`() {
     val crn = offenderDetails.otherIds.crn
+    val username = "PROBATIONPERSON"
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt(username)
 
     mockClientCredentialsJwtRequest(username = "username", authSource = "delius")
     mockOffenderDetailsCommunityApiCall(
@@ -578,6 +580,14 @@ class ApplicationTest : IntegrationTestBase() {
         .withReligionOrBelief("Judaism")
         .withGenderIdentity("Prefer to self-describe")
         .withSelfDescribedGenderIdentity("This is a self described identity")
+        .produce()
+    )
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername("PROBATIONPERSON")
+        .withForenames("Jim")
+        .withSurname("Jimmerson")
+        .withStaffIdentifier(5678)
         .produce()
     )
 
@@ -630,6 +640,14 @@ class ApplicationTest : IntegrationTestBase() {
         .withReligionOrBelief("Judaism")
         .withGenderIdentity("Prefer to self-describe")
         .withSelfDescribedGenderIdentity("This is a self described identity")
+        .produce()
+    )
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername("PROBATIONPERSON")
+        .withForenames("Jim")
+        .withSurname("Jimmerson")
+        .withStaffIdentifier(5678)
         .produce()
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
@@ -293,6 +294,18 @@ abstract class IntegrationTestBase {
           .withStatus(200)
           .withBody(
             objectMapper.writeValueAsString(inmateDetail)
+          )
+      )
+  )
+
+  fun mockStaffUserInfoCommunityApiCall(staffUserDetails: StaffUserDetails) = wiremockServer.stubFor(
+    WireMock.get(WireMock.urlEqualTo("/secure/staff/username/${staffUserDetails.username}"))
+      .willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200)
+          .withBody(
+            objectMapper.writeValueAsString(staffUserDetails)
           )
       )
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -41,7 +41,7 @@ class ApplicationServiceTest {
   fun `Get all applications where Probation Officer with provided distinguished name does not exist returns empty list`() {
     val distinguishedName = "SOMEPERSON"
 
-    every { mockUserRepository.findByDistinguishedName(distinguishedName) } returns null
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns null
 
     assertThat(applicationService.getAllApplicationsForUsername(distinguishedName)).isEmpty()
   }
@@ -56,7 +56,7 @@ class ApplicationServiceTest {
     val distinguishedName = "SOMEPERSON"
     val userEntity = UserEntityFactory()
       .withId(userId)
-      .withDistinguishedName(distinguishedName)
+      .withDeliusUsername(distinguishedName)
       .produce()
     val applicationEntities = listOf(
       ApplicationEntityFactory()
@@ -73,7 +73,7 @@ class ApplicationServiceTest {
         .produce()
     )
 
-    every { mockUserRepository.findByDistinguishedName(distinguishedName) } returns userEntity
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
     every { mockApplicationRepository.findAllByCreatedByUser_Id(userId) } returns applicationEntities
     every { mockJsonSchemaService.attemptSchemaUpgrade(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
@@ -95,7 +95,7 @@ class ApplicationServiceTest {
     val distinguishedName = "SOMEPERSON"
     val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
-    every { mockUserRepository.findByDistinguishedName(distinguishedName) } returns UserEntityFactory().produce()
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns UserEntityFactory().produce()
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns ApplicationEntityFactory()
       .withCreatedByUser(UserEntityFactory().produce())
       .produce()
@@ -115,7 +115,7 @@ class ApplicationServiceTest {
 
     val userEntity = UserEntityFactory()
       .withId(userId)
-      .withDistinguishedName(distinguishedName)
+      .withDeliusUsername(distinguishedName)
       .produce()
 
     val applicationEntity = ApplicationEntityFactory()
@@ -125,7 +125,7 @@ class ApplicationServiceTest {
 
     every { mockJsonSchemaService.attemptSchemaUpgrade(any()) } answers { it.invocation.args[0] as ApplicationEntity }
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns applicationEntity
-    every { mockUserRepository.findByDistinguishedName(distinguishedName) } returns userEntity
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
 
     val result = applicationService.getApplicationForUsername(applicationId, distinguishedName)
 
@@ -204,7 +204,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     every { mockUserService.getUserForRequest() } returns UserEntityFactory()
-      .withDistinguishedName(username)
+      .withDeliusUsername(username)
       .produce()
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns ApplicationEntityFactory()
       .withId(applicationId)
@@ -220,7 +220,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     val user = UserEntityFactory()
-      .withDistinguishedName(username)
+      .withDeliusUsername(username)
       .produce()
 
     every { mockUserService.getUserForRequest() } returns user
@@ -247,7 +247,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     val user = UserEntityFactory()
-      .withDistinguishedName(username)
+      .withDeliusUsername(username)
       .produce()
 
     val newestSchema = JsonSchemaEntityFactory().produce()
@@ -278,7 +278,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     val user = UserEntityFactory()
-      .withDistinguishedName(username)
+      .withDeliusUsername(username)
       .produce()
 
     val newestSchema = JsonSchemaEntityFactory().produce()
@@ -310,7 +310,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     val user = UserEntityFactory()
-      .withDistinguishedName(username)
+      .withDeliusUsername(username)
       .produce()
 
     val newestSchema = JsonSchemaEntityFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -67,7 +67,7 @@ class JsonSchemaServiceTest {
     val distinguishedName = "SOMEPERSON"
     val userEntity = UserEntityFactory()
       .withId(userId)
-      .withDistinguishedName(distinguishedName)
+      .withDeliusUsername(distinguishedName)
       .produce()
 
     val upgradableApplication = ApplicationEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -2,9 +2,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
@@ -13,12 +18,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
 class UserServiceTest {
   private val mockHttpAuthService = mockk<HttpAuthService>()
+  private val mockCommunityApiClient = mockk<CommunityApiClient>()
   private val mockUserRepository = mockk<UserRepository>()
 
-  private val userService = UserService(mockHttpAuthService, mockUserRepository)
+  private val userService = UserService(mockHttpAuthService, mockCommunityApiClient, mockUserRepository)
 
   @Test
-  fun `getUserForRequest returns existing User when exists`() {
+  fun `getUserForRequest returns existing User when exists, does not call Community API or save`() {
     val username = "SOMEPERSON"
     val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
 
@@ -30,10 +36,13 @@ class UserServiceTest {
     every { mockUserRepository.findByDeliusUsername(username) } returns user
 
     assertThat(userService.getUserForRequest()).isEqualTo(user)
+
+    verify(exactly = 0) { mockCommunityApiClient.getStaffUserDetails(username) }
+    verify(exactly = 0) { mockUserRepository.save(any()) }
   }
 
   @Test
-  fun `getUserForRequest returns new User when one does not already exist`() {
+  fun `getUserForRequest returns new User when one does not already exist, does call Community API and save`() {
     val username = "SOMEPERSON"
     val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
 
@@ -43,8 +52,21 @@ class UserServiceTest {
     every { mockUserRepository.findByDeliusUsername(username) } returns null
     every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as UserEntity }
 
+    every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
+      HttpStatus.OK,
+      StaffUserDetailsFactory()
+        .withUsername(username)
+        .withForenames("Jim")
+        .withSurname("Jimmerson")
+        .withStaffIdentifier(5678)
+        .produce()
+    )
+
     assertThat(userService.getUserForRequest()).matches {
-      it.name == "forenames surname"
+      it.name == "Jim Jimmerson"
     }
+
+    verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
+    verify(exactly = 1) { mockUserRepository.save(any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -27,7 +27,7 @@ class UserServiceTest {
 
     val user = UserEntityFactory().produce()
 
-    every { mockUserRepository.findByDistinguishedName(username) } returns user
+    every { mockUserRepository.findByDeliusUsername(username) } returns user
 
     assertThat(userService.getUserForRequest()).isEqualTo(user)
   }
@@ -40,11 +40,11 @@ class UserServiceTest {
     every { mockHttpAuthService.getDeliusPrincipalOrThrow() } returns mockPrincipal
     every { mockPrincipal.name } returns username
 
-    every { mockUserRepository.findByDistinguishedName(username) } returns null
+    every { mockUserRepository.findByDeliusUsername(username) } returns null
     every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as UserEntity }
 
     assertThat(userService.getUserForRequest()).matches {
-      it.name == username
+      it.name == "forenames surname"
     }
   }
 }


### PR DESCRIPTION
**Whenever we need a User's details or ID, get their info from Community API if we don't already have it.**

Their name and staff identifier specifically is info that won't change and we will need access to outside the context of them making a request (for allocation.)