### PR TITLE
Feature/get list of all local authorities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -3,21 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReferenceDataApiDelegate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DestinationProvider
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.*
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.*
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.*
 
 @Service
 class ReferenceDataController(
@@ -26,12 +14,21 @@ class ReferenceDataController(
   private val destinationProviderRepository: DestinationProviderRepository,
   private val cancellationReasonRepository: CancellationReasonRepository,
   private val lostBedReasonRepository: LostBedReasonRepository,
+  private val localAuthorityAreaRepository: LocalAuthorityAreaRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
+  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
   private val destinationProviderTransformer: DestinationProviderTransformer,
   private val cancellationReasonTransformer: CancellationReasonTransformer,
   private val lostBedReasonTransformer: LostBedReasonTransformer
 ) : ReferenceDataApiDelegate {
+
+  override fun referenceDataLocalAuthoritiesGet(): ResponseEntity<List<LocalAuthorityArea>> {
+    val localAuthorities = localAuthorityAreaRepository.findAll()
+
+    return ResponseEntity.ok(localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi))
+  }
+
   override fun referenceDataDepartureReasonsGet(): ResponseEntity<List<DepartureReason>> {
     val reasons = departureReasonRepository.findAll()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.OneToMany
 import javax.persistence.Table
+
+interface LocalAuthorityAreaRepository : JpaRepository<LocalAuthorityAreaEntity, UUID>
 
 @Entity
 @Table(name = "local_authority_areas")

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1032,6 +1032,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/local-authorities:
+    get:
+      tags:
+        - Local Authorities
+      summary: Lists all local authorities
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocalAuthorityArea'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -2,12 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.*
 
 class ReferenceDataTest : IntegrationTestBase() {
   @Autowired
@@ -28,8 +23,17 @@ class ReferenceDataTest : IntegrationTestBase() {
   @Autowired
   lateinit var staffMemberTransformer: StaffMemberTransformer
 
+  @Autowired
+  lateinit var localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
+
   @Test
-  fun `Get Local Authorities returns 200`() {
+  fun `Get Local Authorities returns 200 with correct body`() {
+    localAuthorityAreaRepository.deleteAll()
+
+    val localAuthorities = localAuthorityEntityFactory.produceAndPersistMultiple(10)
+    val expectedJson = objectMapper.writeValueAsString(
+      localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi)
+    )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
@@ -39,6 +43,8 @@ class ReferenceDataTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isOk
+      .expectBody()
+      .json(expectedJson)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -29,6 +29,19 @@ class ReferenceDataTest : IntegrationTestBase() {
   lateinit var staffMemberTransformer: StaffMemberTransformer
 
   @Test
+  fun `Get Local Authorities returns 200`() {
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/local-authorities")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  @Test
   fun `Get Departure Reasons returns 200 with correct body`() {
     departureReasonRepository.deleteAll()
 


### PR DESCRIPTION
**Context:**

When a user is creating a new temporary accommodation property, they need to be able to select a local authority area from a drop down list with the actual name of the area. When this data is passed on to the server it passes through the ID of that area as a UUID which the server persists against a premises entity.

This just a simple GET request to return those areas as an an array of objects with ID & name attributes.