### PR TITLE
Feature/447 implement get list of all local authorities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -6,16 +6,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReferenceDataApiDele
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DestinationProvider
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LocalAuthorityArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
 
@@ -26,12 +29,21 @@ class ReferenceDataController(
   private val destinationProviderRepository: DestinationProviderRepository,
   private val cancellationReasonRepository: CancellationReasonRepository,
   private val lostBedReasonRepository: LostBedReasonRepository,
+  private val localAuthorityAreaRepository: LocalAuthorityAreaRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
   private val destinationProviderTransformer: DestinationProviderTransformer,
   private val cancellationReasonTransformer: CancellationReasonTransformer,
-  private val lostBedReasonTransformer: LostBedReasonTransformer
+  private val lostBedReasonTransformer: LostBedReasonTransformer,
+  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
 ) : ReferenceDataApiDelegate {
+
+  override fun referenceDataLocalAuthorityAreasGet(): ResponseEntity<List<LocalAuthorityArea>> {
+    val localAuthorities = localAuthorityAreaRepository.findAll()
+
+    return ResponseEntity.ok(localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi))
+  }
+
   override fun referenceDataDepartureReasonsGet(): ResponseEntity<List<DepartureReason>> {
     val reasons = departureReasonRepository.findAll()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.OneToMany
 import javax.persistence.Table
+
+interface LocalAuthorityAreaRepository : JpaRepository<LocalAuthorityAreaEntity, UUID>
 
 @Entity
 @Table(name = "local_authority_areas")

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1032,6 +1032,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/local-authority-areas:
+    get:
+      tags:
+        - Local Authorities
+      summary: Lists all local authorities
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocalAuthorityArea'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
@@ -27,6 +28,22 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var staffMemberTransformer: StaffMemberTransformer
+
+  @Autowired
+  lateinit var localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
+
+  @Test
+  fun `Get Local Authorities returns 200`() {
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/local-authority-areas")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
 
   @Test
   fun `Get Departure Reasons returns 200 with correct body`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -33,7 +33,13 @@ class ReferenceDataTest : IntegrationTestBase() {
   lateinit var localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
 
   @Test
-  fun `Get Local Authorities returns 200`() {
+  fun `Get Local Authorities returns 200 with correct body`() {
+    localAuthorityAreaRepository.deleteAll()
+
+    val localAuthorities = localAuthorityEntityFactory.produceAndPersistMultiple(10)
+    val expectedJson = objectMapper.writeValueAsString(
+      localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi)
+    )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
@@ -43,6 +49,8 @@ class ReferenceDataTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isOk
+      .expectBody()
+      .json(expectedJson)
   }
 
   @Test


### PR DESCRIPTION
**Context:**

When a user is creating a new temporary accommodation property, they need to be able to select a local authority area from a list. This list of course needs to be the actual names of the areas. When all of the data is passed to the server to create a new property, it will include the ID of the area which will be persisted.

This change exposes a new endpoint that the client can call to retrieve a full list of area objects with all of their attributes.