### PR TITLE
Fix for 500 when requesting Limited Access Offender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/UserOffenderAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/UserOffenderAccess.kt
@@ -2,5 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
 
 data class UserOffenderAccess(
   val userRestricted: Boolean,
-  val userExcluded: Boolean
+  val userExcluded: Boolean,
+  val restrictionMessage: String?
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -109,7 +109,7 @@ class OffenderServiceTest {
       .withCurrentExclusion(true)
       .produce()
 
-    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true)
+    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true, restrictionMessage = null)
 
     every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)
@@ -126,7 +126,7 @@ class OffenderServiceTest {
       .withCurrentExclusion(true)
       .produce()
 
-    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true)
+    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true, restrictionMessage = null)
 
     every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Failure.StatusCode(
@@ -169,7 +169,7 @@ class OffenderServiceTest {
       .withCurrentRestriction(true)
       .produce()
 
-    val accessBody = UserOffenderAccess(userRestricted = true, userExcluded = false)
+    val accessBody = UserOffenderAccess(userRestricted = true, userExcluded = false, restrictionMessage = null)
 
     every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)
@@ -186,7 +186,7 @@ class OffenderServiceTest {
       .withCurrentRestriction(true)
       .produce()
 
-    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = false)
+    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = false, restrictionMessage = null)
 
     every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)
@@ -226,7 +226,7 @@ class OffenderServiceTest {
       .withCurrentExclusion(true)
       .produce()
 
-    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true)
+    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true, restrictionMessage = null)
 
     every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)


### PR DESCRIPTION
Failing to deserialize because of additional property and default Jackon object mapper - the easiest route is just to include the missing property