### PR TITLE
Add 'X-Service-Name' header parameter to allow filtering of premises by service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ConverterConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ConverterConfig.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.format.FormatterRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+
+/**
+ * Allows Spring to correctly deserialize enums coming in as controller parameters when the "public" value (as defined
+ * in the specification) doesn't match the "implementation" value (the name given to it by the generator, which must be
+ * a legal Kotlin identifier).
+ *
+ * This is a workaround, and ideally such conversion logic should be provided by the "kotlin-spring" OpenAPI Generator
+ * profile.
+ *
+ * A PR exists to implement this for the "JavaSpring" profile
+ * [here](https://github.com/OpenAPITools/openapi-generator/pull/13349)
+ * but not for Kotlin as far as I could see.
+ *
+ * @see uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+ */
+@Configuration
+class ConverterConfig : WebMvcConfigurer {
+  override fun addFormatters(registry: FormatterRegistry) = registry.addConverterFactory(EnumConverterFactory())
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -67,8 +67,14 @@ class PremisesController(
   private val staffMemberService: StaffMemberService
 ) : PremisesApiDelegate {
   override fun premisesGet(xServiceName: ServiceName?): ResponseEntity<List<Premises>> {
+    val premises = if (xServiceName == null) {
+      premisesService.getAllPremises()
+    } else {
+      premisesService.getAllPremisesForService(xServiceName)
+    }
+
     return ResponseEntity.ok(
-      premisesService.getAllPremises().map {
+      premises.map {
         val availableBedsForToday = premisesService.getAvailabilityForRange(it, LocalDate.now(), LocalDate.now().plusDays(1))
           .values.first().getFreeCapacity(it.totalBeds)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewNonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
@@ -65,7 +66,7 @@ class PremisesController(
   private val staffMemberTransformer: StaffMemberTransformer,
   private val staffMemberService: StaffMemberService
 ) : PremisesApiDelegate {
-  override fun premisesGet(): ResponseEntity<List<Premises>> {
+  override fun premisesGet(xServiceName: ServiceName?): ResponseEntity<List<Premises>> {
     return ResponseEntity.ok(
       premisesService.getAllPremises().map {
         val availableBedsForToday = premisesService.getAvailabilityForRange(it, LocalDate.now(), LocalDate.now().plusDays(1))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/convert/EnumConverterFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/convert/EnumConverterFactory.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.convert
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.convert.converter.ConverterFactory
+import org.springframework.stereotype.Component
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Allows Spring to correctly deserialize enums coming in as controller parameters when the "public" value (as defined
+ * in the specification) doesn't match the "implementation" value (the name given to it by the generator, which must be
+ * a legal Kotlin identifier).
+ *
+ * This is a workaround, and ideally such conversion logic should be provided by the "kotlin-spring" OpenAPI Generator
+ * profile.
+ *
+ * A PR exists to implement this for the "JavaSpring" profile
+ * [here](https://github.com/OpenAPITools/openapi-generator/pull/13349)
+ * but not for Kotlin as far as I could see.
+ *
+ * @see uk.gov.justice.digital.hmpps.approvedpremisesapi.config.ConverterConfig
+ */
+@Component
+class EnumConverterFactory : ConverterFactory<String, Enum<*>> {
+  class EnumConverter<T : Enum<*>>(private val targetType: Class<T>) : Converter<String, T> {
+    override fun convert(source: String): T? {
+      return targetType.enumConstants.firstOrNull {
+        it.getOpenApiValueOrDefault() == source
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun T.getOpenApiValueOrDefault(): String {
+      // OpenAPI-generated enums will have a field named 'value', but not all enums will.
+      // If it's some other enum then default to the name of the enum value.
+      val valueProperty = this::class.declaredMemberProperties.firstOrNull { it.name == "value" } as KProperty1<T, String>?
+      return if (valueProperty == null) {
+        this.name
+      } else {
+        val access = valueProperty.isAccessible
+        valueProperty.isAccessible = true
+        val result = valueProperty.get(this)
+        valueProperty.isAccessible = access
+        result
+      }
+    }
+  }
+
+  override fun <T : Enum<*>> getConverter(targetType: Class<T>): Converter<String, T> = EnumConverter(targetType)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.DiscriminatorColumn
@@ -16,7 +17,10 @@ import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
 
 @Repository
-interface PremisesRepository : JpaRepository<PremisesEntity, UUID>
+interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
+  @Query("SELECT p FROM PremisesEntity p WHERE TYPE(p) = :type")
+  fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesEntity>
+}
 
 @Entity
 @Table(name = "premises")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
@@ -26,7 +28,17 @@ class PremisesService(
   private val bookingRepository: BookingRepository,
   private val lostBedReasonRepository: LostBedReasonRepository
 ) {
+  private val serviceNameToEntityType = mapOf(
+    ServiceName.approvedPremises to ApprovedPremisesEntity::class.java,
+    ServiceName.temporaryAccommodation to TemporaryAccommodationPremisesEntity::class.java,
+  )
+
   fun getAllPremises(): List<PremisesEntity> = premisesRepository.findAll()
+
+  fun getAllPremisesForService(service: ServiceName) = serviceNameToEntityType[service]?.let {
+    premisesRepository.findAllByType(it)
+  } ?: listOf()
+
   fun getPremises(premisesId: UUID): PremisesEntity? = premisesRepository.findByIdOrNull(premisesId)
 
   fun getLastBookingDate(premises: PremisesEntity) = bookingRepository.getHighestBookingDate(premises.id)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -9,7 +9,14 @@ paths:
     get:
       tags:
         - Premises
-      summary: Lists all approved premises
+      summary: Lists all approved premises, optionally for the given service
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only premises for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation
@@ -2321,3 +2328,11 @@ components:
       enum:
         - womens
         - pipe
+    ServiceName:
+      type: string
+      enum:
+        - approved-premises
+        - temporary-accommodation
+      x-enum-varnames:
+        - approvedPremises
+        - temporaryAccommodation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/convert/EnumConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/convert/EnumConverterTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.convert
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+
+class EnumConverterTest {
+  @Suppress("UNUSED") // Should be accessed by the enum converter under test
+  private enum class OpenApiLike(val value: String) {
+    OPTION_ONE("the-first-option"),
+    OPTION_TWO("the-second-option");
+  }
+  private enum class Standard {
+    OPTION_ONE,
+    OPTION_TWO;
+  }
+
+  @Test
+  fun `The enum converter uses the String value where it is defined`() {
+    val converter = EnumConverterFactory().getConverter(OpenApiLike::class.java)
+
+    assertThat(converter.convert("the-first-option")).isEqualTo(OpenApiLike.OPTION_ONE)
+    assertThat(converter.convert("the-second-option")).isEqualTo(OpenApiLike.OPTION_TWO)
+  }
+
+  @Test
+  fun `The enum converter doesn't use the constant names if the String value is defined`() {
+    val converter = EnumConverterFactory().getConverter(OpenApiLike::class.java)
+
+    assertThat(converter.convert("OPTION_ONE")).isNull()
+    assertThat(converter.convert("OPTION_TWO")).isNull()
+  }
+
+  @Test
+  fun `The enum converter falls back to the constant names if a String value isn't defined`() {
+    val converter = EnumConverterFactory().getConverter(Standard::class.java)
+
+    assertThat(converter.convert("OPTION_ONE")).isEqualTo(Standard.OPTION_ONE)
+    assertThat(converter.convert("OPTION_TWO")).isEqualTo(Standard.OPTION_TWO)
+  }
+
+  @Test
+  fun `The enum converter returns null for all other strings`() {
+    val openApiLikeConverter = EnumConverterFactory().getConverter(OpenApiLike::class.java)
+    val standardConverter = EnumConverterFactory().getConverter(Standard::class.java)
+
+    assertThat(openApiLikeConverter.convert("the-third-option")).isNull()
+    assertThat(standardConverter.convert("the-third-option")).isNull()
+  }
+}


### PR DESCRIPTION
> See [ticket #445 on the CAS3 Trello board](https://trello.com/c/7gUPFXcB/445-cas1-properties-are-not-viewable-in-view-list-of-properties).

Currently the temporary accommodation landing page displays all properties in the database, regardless of whether they are intended for use by the CAS1 or CAS3 service.

~~This PR provides a way for clients of the API to filter premises by the desired service through the use of a query parameter on the `GET /premises/` endpoint:~~
- ~~`/premises/?service=cas1` returns only premises for CAS1~~
- ~~`/premises/?service=cas3` returns only premises for CAS3~~

This PR provides a way for clients of the API to filter premises by the desired service through the use of a header parameter on the `GET /premises/` endpoint:
- `X-Service-Name: approved-premises` returns only premises for CAS1
- `X-Service-Name: temporary-accommodation` returns only premises for CAS3

This ~~query~~ header parameter is optional, and if not supplied, the existing behaviour is kept for backwards compatibility. However, both the CAS1 and the CAS3 frontends should be updated to use this parameter after this PR is merged to avoid premises from the wrong service being displayed.

~~This PR depends on #154 as that adds service information to the premises in the database.~~ #154 has been merged into `main` and this PR has been rebased accordingly.