### PR TITLE
Fix casing of 'address_line_1' so it's consistent with the rest of the spec

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1310,7 +1310,7 @@ components:
         apCode:
           type: string
           example: NEHOPE1
-        address_line_1:
+        addressLine1:
           type: string
           example: one something street
         postcode:
@@ -1338,7 +1338,7 @@ components:
         - id
         - name
         - apCode
-        - address_line_1
+        - addressLine1
         - postcode
         - bedCount
         - availableBedsForToday

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -63,7 +63,7 @@ class PremisesTest : IntegrationTestBase() {
       .expectStatus()
       .isCreated
       .expectBody()
-      .jsonPath("address_line_1").isEqualTo("1 somewhere")
+      .jsonPath("addressLine1").isEqualTo("1 somewhere")
       .jsonPath("postcode").isEqualTo("AB123CD")
       .jsonPath("service").isEqualTo("CAS3")
       .jsonPath("notes").isEqualTo("some arbitrary notes")


### PR DESCRIPTION
I spotted this whilst doing some work in the UI repo and thought I would fix it upstream.