### PR TITLE
Feature/add characteristics to a property

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -4,18 +4,21 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReferenceDataApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DestinationProvider
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LocalAuthorityArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
@@ -30,13 +33,21 @@ class ReferenceDataController(
   private val cancellationReasonRepository: CancellationReasonRepository,
   private val lostBedReasonRepository: LostBedReasonRepository,
   private val localAuthorityAreaRepository: LocalAuthorityAreaRepository,
+  private val characteristicRepository: CharacteristicRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
   private val destinationProviderTransformer: DestinationProviderTransformer,
   private val cancellationReasonTransformer: CancellationReasonTransformer,
   private val lostBedReasonTransformer: LostBedReasonTransformer,
-  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
+  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer,
+  private val characteristicTransformer: CharacteristicTransformer
 ) : ReferenceDataApiDelegate {
+
+  override fun referenceDataCharacteristicsGet(): ResponseEntity<List<Characteristic>> {
+    val characteristics = characteristicRepository.findAll()
+
+    return ResponseEntity.ok(characteristics.map(characteristicTransformer::transformJpaToApi))
+  }
 
   override fun referenceDataLocalAuthorityAreasGet(): ResponseEntity<List<LocalAuthorityArea>> {
     val localAuthorities = localAuthorityAreaRepository.findAll()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID>
+
+@Entity
+@Table(name = "characteristic")
+data class CharacteristicEntity(
+  @Id
+  var id: UUID,
+  var name: String,
+  var serviceScope: String,
+  var modelScope: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CharacteristicTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CharacteristicTransformer.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+
+@Component
+class CharacteristicTransformer {
+
+  fun transformJpaToApi(jpa: CharacteristicEntity) = Characteristic(
+    id = jpa.id,
+    name = jpa.name,
+    serviceScope = jpa.serviceScope,
+    modelScope = jpa.modelScope
+  )
+}

--- a/src/main/resources/db/migration/all/20220803121541__characteristic_table.sql
+++ b/src/main/resources/db/migration/all/20220803121541__characteristic_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE characteristic (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    service_scope TEXT NOT NULL DEFAULT '*',
+    model_scope TEXT NOT NULL DEFAULT '*',
+    PRIMARY KEY (id)
+);

--- a/src/main/resources/db/migration/local+dev/20220913131809__mock_characteristics.sql
+++ b/src/main/resources/db/migration/local+dev/20220913131809__mock_characteristics.sql
@@ -1,0 +1,10 @@
+INSERT INTO characteristics (id, name, service_scope) VALUES
+('952790c0-21d7-4fd6-a7e1-9018f08d8bb0','Park nearby','CAS3'),
+('199334d3-fabb-432f-84c3-0e92eaf13f24','Pub nearby','CAS3'),
+('1dac11c5-a1b4-4313-b0f7-41b2e57f2404','School nearby','CAS3'),
+('94021062-f692-4877-b6e8-f36c7ff87a18','Not suitable for registered sex offenders (RSO)','CAS3'),
+('16b52729-be75-43b4-b711-77fe5cbcb477','Not suitable for arson offenders','CAS3'),
+('7846fbf2-b423-4ccc-b23b-d8b866f86bde','Men only','CAS3'),
+('7cd8dd2c-a14d-4a78-8d72-48449cc5aaa3','Women only','CAS3'),
+('d9f52ae8-4c01-4751-8975-992efacd5260','Floor level access','CAS3'),
+('a862be08-a96a-4337-9f46-26286db8015f','Wheelchair accessible','CAS3');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1118,6 +1118,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/characteristics:
+    get:
+      tags:
+        - Characteristics
+      summary: Lists all available characteristics
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Characteristic'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -1341,6 +1361,10 @@ components:
           $ref: '#/components/schemas/ApArea'
         localAuthorityArea:
           $ref: '#/components/schemas/LocalAuthorityArea'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
       required:
         - id
         - name
@@ -1422,6 +1446,24 @@ components:
       required:
         - id
         - name
+    Characteristic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        name:
+          type: string
+        serviceScope:
+          type: string
+        modelScope:
+          type: string
+      required:
+        - id
+        - name
+        - serviceScope
+        - modelScope
     BookingBody:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class CharacteristicEntityFactory : Factory<CharacteristicEntity> {
+
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringUpperCase(10) }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
+  private var modelScope: Yielded<String> = { randomStringUpperCase(4) }
+
+  override fun produce(): CharacteristicEntity = CharacteristicEntity(
+    id = this.id(),
+    name = this.name(),
+    serviceScope = this.serviceScope(),
+    modelScope = this.modelScope()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
@@ -48,6 +49,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
@@ -190,6 +193,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var assessmentRepository: AssessmentTestRepository
 
+  @Autowired
+  lateinit var characteristicRepository: CharacteristicRepository
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
@@ -214,6 +220,7 @@ abstract class IntegrationTestBase {
   lateinit var userRoleAssignmentEntityFactory: PersistedFactory<UserRoleAssignmentEntity, UUID, UserRoleAssignmentEntityFactory>
   lateinit var userQualificationAssignmentEntityFactory: PersistedFactory<UserQualificationAssignmentEntity, UUID, UserQualificationAssignmentEntityFactory>
   lateinit var assessmentEntityFactory: PersistedFactory<AssessmentEntity, UUID, AssessmentEntityFactory>
+  lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
 
   @BeforeEach
   fun beforeEach() {
@@ -259,6 +266,7 @@ abstract class IntegrationTestBase {
     userRoleAssignmentEntityFactory = PersistedFactory(UserRoleAssignmentEntityFactory(), userRoleAssignmentRepository)
     userQualificationAssignmentEntityFactory = PersistedFactory(UserQualificationAssignmentEntityFactory(), userQualificationAssignmentRepository)
     assessmentEntityFactory = PersistedFactory(AssessmentEntityFactory(), assessmentRepository)
+    characteristicEntityFactory = PersistedFactory(CharacteristicEntityFactory(), characteristicRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -33,6 +33,19 @@ class ReferenceDataTest : IntegrationTestBase() {
   lateinit var localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
 
   @Test
+  fun `Get Characteristics returns 200`() {
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/characteristics")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  @Test
   fun `Get Local Authorities returns 200 with correct body`() {
     localAuthorityAreaRepository.deleteAll()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
@@ -32,8 +33,17 @@ class ReferenceDataTest : IntegrationTestBase() {
   @Autowired
   lateinit var localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
 
+  @Autowired
+  lateinit var characteristicTransformer: CharacteristicTransformer
+
   @Test
-  fun `Get Characteristics returns 200`() {
+  fun `Get Characteristics returns 200 with correct body`() {
+    characteristicRepository.deleteAll()
+
+    val characteristics = characteristicEntityFactory.produceAndPersistMultiple(10)
+    val expectedJson = objectMapper.writeValueAsString(
+      characteristics.map(characteristicTransformer::transformJpaToApi)
+    )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
@@ -43,6 +53,8 @@ class ReferenceDataTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isOk
+      .expectBody()
+      .json(expectedJson)
   }
 
   @Test


### PR DESCRIPTION
Refers to [this story](https://trello.com/c/CqNOUrof/444-a-user-can-add-additional-characteristics-about-a-property-when-adding-a-property)

A property can have characteristics associated with it. A list of these can be retrieved as reference data so that the client can display them to the end user to select accordingly. 

This PR is a first iteration to set up the necessary infrastructure to be able to persist characteristics (that can be shared across services) and to be able to get a list of them. 

A further iteration on a story being done next is to add a service type param so characteristics can be returned that only a particular service cares about.

This first pass sets up the Characteristic table which will eventually have link entity tables to use it for example with premises. So there would be a link table between this and Premises 