### PR TITLE
831 - Service specific Premises types

### DIFF
--- a/doc/architecture/decisions/0007-storing-service-specific-properties.md
+++ b/doc/architecture/decisions/0007-storing-service-specific-properties.md
@@ -1,0 +1,54 @@
+# 7. storing-service-specific-properties
+
+Date: 2022-10-26
+
+## Status
+
+Accepted
+
+## Context
+
+Whilst many of the properties of a Premises are shared between CAS1 (Approved Premises) 
+and CAS3 (Temporary Accommodation) there are some known divergences (e.g. Ap Code being
+specific to CAS1).  There are also likely to be unknown divergences.
+
+This requires us to have a way of sharing most properties but allowing for service specific 
+properties too.
+
+## Decision
+
+- We will use JPA's inheritance support[1] to create a common base class (PremisesEntity) from 
+  which a class for each service (`ApprovedPremisesEntity` and `TemporaryAccommodationPremisesEntity`) 
+  will derive.
+- We will use the `JOINED` strategy to model this in the database (i.e. one `premises` table storing 
+  the common fields with an additional table for each of the derived classes `approved_premises` and 
+  `temporary_accommodation_premises`) to store their specialised fields.
+  - There is a performance impact from using this approach as JPA must generate a JOIN instead of 
+    a single table select.  It's unlikely that this will be significant enough to cause an issue at 
+    our anticipated level of load.
+  - The `SINGLE_TABLE` approach was also considered but decided against as:
+    - The properties of derived classes must be nullable in the table, but potentially not-nullable in 
+      the Kotlin entity models.  Consistency between the two is preferable.
+    - A single table with mixed fields becomes harder to reason about over time
+  - The `TABLE_PER_CLASS` approach was also considered but decided against as:
+    - Database level referential integrity must be abandoned for tables that currently have foreign keys 
+      to the `premises` table as it's not possible to have a foreign key that references more than one table
+    - Maintenance becomes harder (e.g. forgetting to add a new shared property to one of the tables)
+- The existing `service` field will be used as the discriminator value (`CAS1` or `CAS3`) by which JPA knows 
+  which type of Premises to return for a given ID
+
+[1] [Overview of JPA Inheritance support](https://thorben-janssen.com/complete-guide-inheritance-strategies-jpa-hibernate)
+
+## Consequences
+
+- Adding new service specific properties is straight forward
+- Determining the type of Premises (and switching behaviour as appropriate) can be done by type assertion
+  ```
+    when (premisesEntity) {
+      is ApprovedPremisesEntity -> cas1SpecificBehaviour()
+      is TemporaryAccommodationPremisesEntity -> cas3SpecificBehaviour()
+      else -> unsupportedPremisesType()
+    }
+  ```
+- Tests must use either `ApprovedPremisesEntityFactory` or `TemporaryAccommodationPremisesEntityFactory` to
+  produce one of the concrete types rather than the previously used `PremisesEntityFactory` which covered both

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -3,11 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
+import javax.persistence.DiscriminatorColumn
+import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
 import javax.persistence.Id
+import javax.persistence.Inheritance
+import javax.persistence.InheritanceType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
+import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
 
 @Repository
@@ -15,7 +20,9 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID>
 
 @Entity
 @Table(name = "premises")
-data class PremisesEntity(
+@DiscriminatorColumn(name = "service")
+@Inheritance(strategy = InheritanceType.JOINED)
+abstract class PremisesEntity(
   @Id
   val id: UUID,
   val name: String,
@@ -24,7 +31,6 @@ data class PremisesEntity(
   var postcode: String,
   var totalBeds: Int,
   val deliusTeamCode: String,
-  val service: String,
   val notes: String,
   @ManyToOne
   @JoinColumn(name = "probation_region_id")
@@ -36,4 +42,45 @@ data class PremisesEntity(
   val bookings: MutableList<BookingEntity>,
   @OneToMany(mappedBy = "premises")
   var lostBeds: MutableList<LostBedsEntity>
+)
+
+@Entity
+@DiscriminatorValue("CAS1")
+@Table(name = "approved_premises")
+@PrimaryKeyJoinColumn(name = "premises_id")
+class ApprovedPremisesEntity(
+  id: UUID,
+  name: String,
+  apCode: String,
+  addressLine1: String,
+  postcode: String,
+  totalBeds: Int,
+  deliusTeamCode: String,
+  notes: String,
+  probationRegion: ProbationRegionEntity,
+  localAuthorityArea: LocalAuthorityAreaEntity,
+  bookings: MutableList<BookingEntity>,
+  lostBeds: MutableList<LostBedsEntity>,
+  val qCode: String?
+) : PremisesEntity(id, name, apCode, addressLine1, postcode, totalBeds, deliusTeamCode, notes, probationRegion, localAuthorityArea, bookings, lostBeds)
+
+@Entity
+@DiscriminatorValue("CAS3")
+@Table(name = "temporary_accommodation_premises")
+@PrimaryKeyJoinColumn(name = "premises_id")
+class TemporaryAccommodationPremisesEntity(
+  id: UUID,
+  name: String,
+  apCode: String,
+  addressLine1: String,
+  postcode: String,
+  totalBeds: Int,
+  deliusTeamCode: String,
+  notes: String,
+  probationRegion: ProbationRegionEntity,
+  localAuthorityArea: LocalAuthorityAreaEntity,
+  bookings: MutableList<BookingEntity>,
+  lostBeds: MutableList<LostBedsEntity>
+) : PremisesEntity(
+  id, name, apCode, addressLine1, postcode, totalBeds, deliusTeamCode, notes, probationRegion, localAuthorityArea, bookings, lostBeds
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -107,7 +108,6 @@ class PremisesService(
     name: String?,
     notes: String?
   ) = validated<PremisesEntity> {
-
     /**
      * Start of setting up some dummy data to spike the implementation.
      * TODO: This will be removed once it's established how to dynamically get this data
@@ -140,6 +140,10 @@ class PremisesService(
       "$.service" hasValidationError "empty"
     }
 
+    if (service != "CAS3") {
+      "$.service" hasValidationError "onlyCas3Supported"
+    }
+
     if (localAuthorityAreaId == null) {
       "$.localAuthorityAreaId" hasValidationError "invalid"
     }
@@ -167,7 +171,7 @@ class PremisesService(
     }
 
     val premisesEntity = premisesRepository.save(
-      PremisesEntity(
+      TemporaryAccommodationPremisesEntity(
         id = UUID.randomUUID(),
         name = premisesName,
         apCode = "UNKNOWN",
@@ -178,7 +182,6 @@ class PremisesService(
         localAuthorityArea = localAuthorityArea,
         bookings = mutableListOf(),
         lostBeds = mutableListOf(),
-        service = service,
         notes = premisesNotes,
         totalBeds = 0
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -138,9 +138,7 @@ class PremisesService(
 
     if (service.isEmpty()) {
       "$.service" hasValidationError "empty"
-    }
-
-    if (service != "CAS3") {
+    } else if (service != "CAS3") {
       "$.service" hasValidationError "onlyCas3Supported"
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 
 @Component
 class PremisesTransformer(
@@ -17,7 +18,7 @@ class PremisesTransformer(
     addressLine1 = jpa.addressLine1,
     postcode = jpa.postcode,
     bedCount = jpa.totalBeds,
-    service = jpa.service,
+    service = if (jpa is TemporaryAccommodationPremisesEntity) "CAS3" else "CAS1",
     notes = jpa.notes,
     availableBedsForToday = availableBedsForToday,
     probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),

--- a/src/main/resources/db/migration/all/20221025120723__service_specific_properties.sql
+++ b/src/main/resources/db/migration/all/20221025120723__service_specific_properties.sql
@@ -1,0 +1,12 @@
+CREATE TABLE approved_premises (
+    premises_id UUID NOT NULL,
+    q_code TEXT,
+    PRIMARY KEY (premises_id),
+    FOREIGN KEY (premises_id) REFERENCES premises(id)
+);
+
+CREATE TABLE temporary_accommodation_premises (
+    premises_id UUID NOT NULL,
+    PRIMARY KEY (premises_id),
+    FOREIGN KEY (premises_id) REFERENCES premises(id)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
-class PremisesEntityFactory : Factory<PremisesEntity> {
+class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
   private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
   private var id: Yielded<UUID> = { UUID.randomUUID() }
@@ -23,6 +23,7 @@ class PremisesEntityFactory : Factory<PremisesEntity> {
   private var addressLine1: Yielded<String> = { randomStringUpperCase(10) }
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
   private var service: Yielded<String> = { "CAS1" }
+  private var qCode: Yielded<String> = { randomStringUpperCase(4) }
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
@@ -75,7 +76,11 @@ class PremisesEntityFactory : Factory<PremisesEntity> {
     this.deliusTeamCode = { deliusTeamCode }
   }
 
-  override fun produce(): PremisesEntity = PremisesEntity(
+  fun withQCode(qCode: String) = apply {
+    this.qCode = { qCode }
+  }
+
+  override fun produce(): ApprovedPremisesEntity = ApprovedPremisesEntity(
     id = this.id(),
     name = this.name(),
     apCode = this.apCode(),
@@ -88,6 +93,6 @@ class PremisesEntityFactory : Factory<PremisesEntity> {
     lostBeds = mutableListOf(),
     addressLine1 = this.addressLine1(),
     notes = this.notes(),
-    service = this.service()
+    qCode = this.qCode()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
@@ -22,7 +22,7 @@ class PremisesEntityFactory : Factory<PremisesEntity> {
   private var deliusTeamCode: Yielded<String> = { randomStringUpperCase(6) }
   private var addressLine1: Yielded<String> = { randomStringUpperCase(10) }
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
-  private var service: Yielded<String> = { randomStringUpperCase(4) }
+  private var service: Yielded<String> = { "CAS1" }
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodationPremisesEntity> {
+  private var probationRegion: Yielded<ProbationRegionEntity>? = null
+  private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var apCode: Yielded<String> = { randomStringUpperCase(5) }
+  private var postcode: Yielded<String> = { randomPostCode() }
+  private var totalBeds: Yielded<Int> = { randomInt(1, 100) }
+  private var deliusTeamCode: Yielded<String> = { randomStringUpperCase(6) }
+  private var addressLine1: Yielded<String> = { randomStringUpperCase(10) }
+  private var notes: Yielded<String> = { randomStringUpperCase(15) }
+  private var service: Yielded<String> = { "CAS3" }
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withApCode(apCode: String) = apply {
+    this.apCode = { apCode }
+  }
+
+  fun withAddressLine1(addressLine1: String) = apply {
+    this.addressLine1 = { addressLine1 }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withService(service: String) = apply {
+    this.service = { service }
+  }
+
+  fun withPostcode(postcode: String) = apply {
+    this.postcode = { postcode }
+  }
+
+  fun withTotalBeds(totalBeds: Int) = apply {
+    this.totalBeds = { totalBeds }
+  }
+
+  fun withProbationRegion(probationRegion: ProbationRegionEntity) = apply {
+    this.probationRegion = { probationRegion }
+  }
+
+  fun withYieldedProbationRegion(probationRegion: Yielded<ProbationRegionEntity>) = apply {
+    this.probationRegion = probationRegion
+  }
+
+  fun withLocalAuthorityArea(localAuthorityAreaEntity: LocalAuthorityAreaEntity) = apply {
+    this.localAuthorityArea = { localAuthorityAreaEntity }
+  }
+
+  fun withYieldedLocalAuthorityArea(localAuthorityAreaEntity: Yielded<LocalAuthorityAreaEntity>) = apply {
+    this.localAuthorityArea = localAuthorityAreaEntity
+  }
+
+  fun withDeliusTeamCode(deliusTeamCode: String) = apply {
+    this.deliusTeamCode = { deliusTeamCode }
+  }
+
+  override fun produce(): TemporaryAccommodationPremisesEntity = TemporaryAccommodationPremisesEntity(
+    id = this.id(),
+    name = this.name(),
+    apCode = this.apCode(),
+    postcode = this.postcode(),
+    totalBeds = this.totalBeds(),
+    deliusTeamCode = this.deliusTeamCode(),
+    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("Must provide a probation region"),
+    localAuthorityArea = this.localAuthorityArea?.invoke() ?: throw RuntimeException("Must provide a local authority area"),
+    bookings = mutableListOf(),
+    lostBeds = mutableListOf(),
+    addressLine1 = this.addressLine1(),
+    notes = this.notes()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -35,7 +35,7 @@ class BookingTest : IntegrationTestBase() {
 
     mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
 
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
     }
@@ -98,7 +98,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings on Premises without any Bookings returns empty list`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
     }
@@ -117,7 +117,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings returns OK with correct body`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -191,7 +191,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking without JWT returns 401`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -214,7 +214,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking returns OK with correct body`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -289,7 +289,7 @@ class BookingTest : IntegrationTestBase() {
 
     val booking = bookingEntityFactory.produceAndPersist {
       withYieldedPremises {
-        premisesEntityFactory.produceAndPersist {
+        approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
             probationRegionEntityFactory.produceAndPersist {
@@ -343,7 +343,7 @@ class BookingTest : IntegrationTestBase() {
   fun `Create Cancellation on Booking returns OK with correct body`() {
     val booking = bookingEntityFactory.produceAndPersist {
       withYieldedPremises {
-        premisesEntityFactory.produceAndPersist {
+        approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
             probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -402,7 +402,7 @@ class BookingTest : IntegrationTestBase() {
       withDepartureDate(LocalDate.parse("2022-08-20"))
       withStaffKeyWorkerId(keyWorker.staffIdentifier)
       withYieldedPremises {
-        premisesEntityFactory.produceAndPersist {
+        approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
             probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 class CapacityTest : IntegrationTestBase() {
   @Test
   fun `Get Capacity without JWT returns 401`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -37,7 +37,7 @@ class CapacityTest : IntegrationTestBase() {
 
   @Test
   fun `Get Capacity with no bookings or lost beds returns OK with empty list body`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withTotalBeds(30)
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
@@ -61,7 +61,7 @@ class CapacityTest : IntegrationTestBase() {
 
   @Test
   fun `Get Capacity with booking in past returns OK with empty list body`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withTotalBeds(30)
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
@@ -92,7 +92,7 @@ class CapacityTest : IntegrationTestBase() {
 
   @Test
   fun `Get Capacity with booking in future returns OK with list entry for each day until the booking ends`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withTotalBeds(30)
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -17,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
@@ -34,13 +35,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
@@ -57,8 +59,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
@@ -70,6 +72,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
@@ -85,8 +88,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.MoveOnCategoryTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserTestRepository
@@ -125,7 +128,10 @@ abstract class IntegrationTestBase {
   lateinit var localAuthorityAreaRepository: LocalAuthorityAreaTestRepository
 
   @Autowired
-  lateinit var premisesRepository: PremisesTestRepository
+  lateinit var approvedPremisesRepository: ApprovedPremisesTestRepository
+
+  @Autowired
+  lateinit var temporaryAccommodationPremisesRepository: TemporaryAccommodationPremisesTestRepository
 
   @Autowired
   lateinit var bookingRepository: BookingTestRepository
@@ -187,7 +193,8 @@ abstract class IntegrationTestBase {
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
-  lateinit var premisesEntityFactory: PersistedFactory<PremisesEntity, UUID, PremisesEntityFactory>
+  lateinit var approvedPremisesEntityFactory: PersistedFactory<ApprovedPremisesEntity, UUID, ApprovedPremisesEntityFactory>
+  lateinit var temporaryAccommodationPremisesEntityFactory: PersistedFactory<TemporaryAccommodationPremisesEntity, UUID, TemporaryAccommodationPremisesEntityFactory>
   lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
   lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
   lateinit var departureEntityFactory: PersistedFactory<DepartureEntity, UUID, DepartureEntityFactory>
@@ -231,7 +238,8 @@ abstract class IntegrationTestBase {
     probationRegionEntityFactory = PersistedFactory(ProbationRegionEntityFactory(), probationRegionRepository)
     apAreaEntityFactory = PersistedFactory(ApAreaEntityFactory(), apAreaRepository)
     localAuthorityEntityFactory = PersistedFactory(LocalAuthorityEntityFactory(), localAuthorityAreaRepository)
-    premisesEntityFactory = PersistedFactory(PremisesEntityFactory(), premisesRepository)
+    approvedPremisesEntityFactory = PersistedFactory(ApprovedPremisesEntityFactory(), approvedPremisesRepository)
+    temporaryAccommodationPremisesEntityFactory = PersistedFactory(TemporaryAccommodationPremisesEntityFactory(), temporaryAccommodationPremisesRepository)
     bookingEntityFactory = PersistedFactory(BookingEntityFactory(), bookingRepository)
     arrivalEntityFactory = PersistedFactory(ArrivalEntityFactory(), arrivalRepository)
     departureEntityFactory = PersistedFactory(DepartureEntityFactory(), departureRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -13,7 +13,7 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `List Lost Beds without JWT returns 401`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -41,7 +41,7 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `List Lost Beds returns OK with correct body`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -72,7 +72,7 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds without JWT returns 401`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -98,7 +98,7 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds returns OK with correct body`() {
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withTotalBeds(3)
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -198,7 +198,7 @@ class PremisesTest : IntegrationTestBase() {
   }
   @Test
   fun `Get all Premises returns OK with correct body`() {
-    val premises = premisesEntityFactory.produceAndPersistMultiple(10) {
+    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(10) {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -226,7 +226,7 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Get Premises by ID returns OK with correct body`() {
-    val premises = premisesEntityFactory.produceAndPersistMultiple(5) {
+    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -251,7 +251,7 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Get Premises by ID returns OK with correct body when capacity is used`() {
-    val premises = premisesEntityFactory.produceAndPersistMultiple(5) {
+    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -316,7 +316,7 @@ class PremisesTest : IntegrationTestBase() {
   fun `Get Premises Staff where delius team cannot be found returns 500`() {
     val deliusTeamCode = "NOTFOUND"
 
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -351,7 +351,7 @@ class PremisesTest : IntegrationTestBase() {
   fun `Get Premises Staff returns 200 with correct body`() {
     val deliusTeamCode = "FOUND"
 
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
@@ -401,7 +401,7 @@ class PremisesTest : IntegrationTestBase() {
   fun `Get Premises Staff caches response`() {
     val deliusTeamCode = "FOUND"
 
-    val premises = premisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PremisesTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PremisesTestRepository.kt
@@ -2,8 +2,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import java.util.UUID
 
 @Repository
 interface PremisesTestRepository : JpaRepository<PremisesEntity, UUID>
+
+@Repository
+interface ApprovedPremisesTestRepository : JpaRepository<ApprovedPremisesEntity, UUID>
+
+@Repository
+interface TemporaryAccommodationPremisesTestRepository : JpaRepository<TemporaryAccommodationPremisesEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
@@ -18,7 +19,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
@@ -95,7 +95,7 @@ class BookingServiceTest {
     val premisesId = UUID.fromString("8461d08b-0e3f-426a-a941-0ada4160e6db")
     val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
 
-    every { mockPremisesService.getPremises(premisesId) } returns PremisesEntityFactory()
+    every { mockPremisesService.getPremises(premisesId) } returns ApprovedPremisesEntityFactory()
       .withId(premisesId)
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -116,7 +116,7 @@ class BookingServiceTest {
     val premisesId = UUID.fromString("8461d08b-0e3f-426a-a941-0ada4160e6db")
     val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
 
-    val premisesEntityFactory = PremisesEntityFactory()
+    val premisesEntityFactory = ApprovedPremisesEntityFactory()
       .withId(premisesId)
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -144,7 +144,7 @@ class BookingServiceTest {
     val premisesId = UUID.fromString("8461d08b-0e3f-426a-a941-0ada4160e6db")
     val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
 
-    val premisesEntity = PremisesEntityFactory()
+    val premisesEntity = ApprovedPremisesEntityFactory()
       .withId(premisesId)
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -176,7 +176,7 @@ class BookingServiceTest {
 
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -221,7 +221,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-25"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -263,7 +263,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-25"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -305,7 +305,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-25"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -347,7 +347,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-25"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -389,7 +389,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-22"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -435,7 +435,7 @@ class BookingServiceTest {
   fun `createArrival returns GeneralValidationError with correct message when Booking already has an Arrival`() {
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -471,7 +471,7 @@ class BookingServiceTest {
 
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -503,7 +503,7 @@ class BookingServiceTest {
 
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -537,7 +537,7 @@ class BookingServiceTest {
   fun `createNonArrival returns GeneralValidationError with correct message when Booking already has a NonArrival`() {
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -573,7 +573,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-26"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -607,7 +607,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-24"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -641,7 +641,7 @@ class BookingServiceTest {
   fun `createCancellation returns GeneralValidationError with correct message when Booking already has a Cancellation`() {
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -677,7 +677,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-26"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -709,7 +709,7 @@ class BookingServiceTest {
 
     val bookingEntity = BookingEntityFactory()
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -744,7 +744,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withDepartureDate(LocalDate.parse("2022-08-26"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -772,7 +772,7 @@ class BookingServiceTest {
     val bookingEntity = BookingEntityFactory()
       .withDepartureDate(LocalDate.parse("2022-08-24"))
       .withYieldedPremises {
-        PremisesEntityFactory()
+        ApprovedPremisesEntityFactory()
           .withYieldedProbationRegion {
             ProbationRegionEntityFactory()
               .withYieldedApArea { ApAreaEntityFactory().produce() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
@@ -16,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
@@ -47,7 +47,7 @@ class PremisesServiceTest {
     val startDate = LocalDate.now()
     val endDate = LocalDate.now().plusDays(3)
 
-    val premises = PremisesEntityFactory()
+    val premises = ApprovedPremisesEntityFactory()
       .withTotalBeds(30)
       .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
       .withYieldedProbationRegion {
@@ -71,7 +71,7 @@ class PremisesServiceTest {
     val startDate = LocalDate.now()
     val endDate = LocalDate.now().plusDays(6)
 
-    val premises = PremisesEntityFactory()
+    val premises = ApprovedPremisesEntityFactory()
       .withTotalBeds(30)
       .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
       .withYieldedProbationRegion {
@@ -158,7 +158,7 @@ class PremisesServiceTest {
 
   @Test
   fun `createLostBeds returns FieldValidationError with correct param to message map when invalid parameters supplied`() {
-    val premisesEntity = PremisesEntityFactory()
+    val premisesEntity = ApprovedPremisesEntityFactory()
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
           .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -191,7 +191,7 @@ class PremisesServiceTest {
 
   @Test
   fun `createLostBeds returns Success with correct result when validation passed`() {
-    val premisesEntity = PremisesEntityFactory()
+    val premisesEntity = ApprovedPremisesEntityFactory()
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
           .withYieldedApArea { ApAreaEntityFactory().produce() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -29,8 +29,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
@@ -64,7 +64,7 @@ class BookingTransformerTest {
     mockExtensionTransformer
   )
 
-  private val premisesEntity = PremisesEntity(
+  private val premisesEntity = TemporaryAccommodationPremisesEntity(
     id = UUID.fromString("9703eaaf-164f-4f35-b038-f4de79e4847b"),
     name = "AP",
     apCode = "APCODE",
@@ -91,7 +91,6 @@ class BookingTransformerTest {
     bookings = mutableListOf(),
     lostBeds = mutableListOf(),
     addressLine1 = "1 somewhere",
-    service = "CAS3",
     notes = ""
   )
 


### PR DESCRIPTION
**Split out PremisesEntity into abstract base class + concrete derived classes**

Common properties remain on PremisesEntity but two derived classes `ApprovedPremisesEntity` and `TemporaryAccommodationPremisesEntity` are created.

There are several ways of achieving this as outlined here: https://thorben-janssen.com/complete-guide-inheritance-strategies-jpa-hibernate

Ultimately went with the `JOINED` option as:
 - It allows us to keep referential integrity at the database level for other tables with foreign keys to the premises table - the `TABLE_PER_CLASS` option would have forced us to abandon the FK constraints
 - It's neater to navigate and reason about than the `SINGLE_TABLE` option as you can easily see which properties belong to which type
 - Performance impact of the join should be acceptable given the number of users/traffic is not particularly high in the scheme of things.

We store the additional properties in two new tables, when JPA retrieves the data it joins to the relevant table as determined by the `service` field.

We can then distinguish between the types of property via type assertion, e.g.

```
when(somePremises) {
   is ApprovedPremisesEntity -> cas1SpecificStuff()
   is TemporaryAccommodationEntity -> cas3SpecificStuff()
}
```

From the perspective of the actual code, the same `PremisesRepository` that we know and love can be used.  It will return the correct subclass based on the value of the `service` column.  The extra properties can then be accessed through type assertion as above when required or treated as the base class when behaviour is the same for both types of Premises.

In the test code, we need to deal with concrete classes when inserting so we now have two distinct factories for producing & persisting Premises entities.  e.g. 

```
approvedPremisesEntityFactory.produceAndPersist { ... }
temporaryAccommodationEntityFactory.produceAndPersist { ... }
```

_The next step would be to move deliusTeamCode from PremisesEntity down into ApprovedPremisesEntity, however we're not 100% sure that CAS3 won't need this for some publicly run Premises yet in which case a staff-details strategy would be more appropriate so will leave that for now_

_I've also made the POST Premises endpoint only work for CAS3 Premises for now, will sort this in a subsequent PR_