### PR TITLE
Move Address seed data to own migration

### DIFF
--- a/src/main/resources/db/migration/local+dev/20220913131808__mock_premises.sql
+++ b/src/main/resources/db/migration/local+dev/20220913131808__mock_premises.sql
@@ -1,8 +1,4 @@
-INSERT INTO premises (id, name, ap_code, notes, service, address_line1, postcode, total_beds, probation_region_id,
-                      local_authority_area_id)
-VALUES ('3549f9ff-6d58-450f-8ea3-dc2cf196ef2c', 'Habard House', 'HBRDHSE', 'Some notes', 'CAS1', '1 Somewhere',
-        'LA9 1DS', 30, 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'd75ce5b8-fc07-494b-8950-a46a63ac377e'),
-       ('e6d00117-e31c-4332-8c24-8e1432a4c500', 'Basler Court', 'BSLRCRT', 'Some more notes', 'CAS1', '2 Somewhere',
-        'EC1 3XZ', 10, '6b4a1308-17af-4c1a-a330-6005bec9e27b', '89faa462-7ea6-45ba-b169-93d947d20cae'),
-       ('878217f0-6db5-49d8-a5a1-c40fdecd6060', 'Jessopp Pace', 'JSPPLC', 'Some notes again', 'CAS3', '3 Somewhere',
-        'SA1 1AF', 25, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5');
+INSERT INTO premises (id, name, ap_code, postcode, total_beds, probation_region_id, local_authority_area_id) VALUES
+    ('3549f9ff-6d58-450f-8ea3-dc2cf196ef2c', 'Habard House', 'HBRDHSE', 'LA9 1DS', 30, 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'd75ce5b8-fc07-494b-8950-a46a63ac377e'),
+    ('e6d00117-e31c-4332-8c24-8e1432a4c500', 'Basler Court', 'BSLRCRT', 'EC1 3XZ', 10, '6b4a1308-17af-4c1a-a330-6005bec9e27b', '89faa462-7ea6-45ba-b169-93d947d20cae'),
+    ('878217f0-6db5-49d8-a5a1-c40fdecd6060', 'Jessopp Pace', 'JSPPLC', 'SA1 1AF', 25, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5');

--- a/src/main/resources/db/migration/local+dev/20221026113526__move_address_seed_data_to_own_migration.sql
+++ b/src/main/resources/db/migration/local+dev/20221026113526__move_address_seed_data_to_own_migration.sql
@@ -1,0 +1,3 @@
+UPDATE premises SET address_line1 = '1 Somewhere' WHERE id = '3549f9ff-6d58-450f-8ea3-dc2cf196ef2c';
+UPDATE premises SET address_line1 = '2 Somewhere' WHERE id = 'e6d00117-e31c-4332-8c24-8e1432a4c500';
+UPDATE premises SET address_line1 = '3 Somewhere' WHERE id = '878217f0-6db5-49d8-a5a1-c40fdecd6060';


### PR DESCRIPTION
Flyway checks the hash of the migration file on startup, since this migration had already been applied to the dev environment before being modified for address the instances are refusing to startup.