### PR TITLE
rename characteristic table to characteristics

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -9,7 +9,7 @@ import javax.persistence.Table
 interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID>
 
 @Entity
-@Table(name = "characteristic")
+@Table(name = "characteristics")
 data class CharacteristicEntity(
   @Id
   var id: UUID,

--- a/src/main/resources/db/migration/all/20220803121541__characteristics_table.sql
+++ b/src/main/resources/db/migration/all/20220803121541__characteristics_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE characteristic (
+CREATE TABLE characteristics (
     id UUID NOT NULL,
     name TEXT NOT NULL,
     service_scope TEXT NOT NULL DEFAULT '*',


### PR DESCRIPTION
The creation of the table 'characteristic' should actually be 'characteristics'