### PR TITLE
Split Premises response body into AP/TA types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,11 +49,27 @@ dependencies {
   testRuntimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
   implementation("com.fasterxml.jackson.core:jackson-databind") {
-    version { strictly("2.14.0-rc1") }
+    version { strictly("2.14.0-rc2") }
   }
 
   testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind") {
-    version { strictly("2.14.0-rc1") }
+    version { strictly("2.14.0-rc2") }
+  }
+
+  implementation("com.fasterxml.jackson.core:jackson-annotations") {
+    version { strictly("2.14.0-rc2") }
+  }
+
+  testRuntimeOnly("com.fasterxml.jackson.core:jackson-annotations") {
+    version { strictly("2.14.0-rc2") }
+  }
+
+  implementation("com.fasterxml.jackson.core:jackson-core") {
+    version { strictly("2.14.0-rc2") }
+  }
+
+  testRuntimeOnly("com.fasterxml.jackson.core:jackson-core") {
+    version { strictly("2.14.0-rc2") }
   }
 
   implementation("org.apache.commons:commons-text") {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1334,9 +1334,6 @@ components:
         name:
           type: string
           example: Hope House
-        apCode:
-          type: string
-          example: NEHOPE1
         addressLine1:
           type: string
           example: one something street
@@ -1365,6 +1362,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Characteristic'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremises'
+          CAS3: '#/components/schemas/TemporaryAccommodationPremises'
       required:
         - id
         - name
@@ -1375,6 +1377,19 @@ components:
         - probationRegion
         - apArea
         - localAuthorityArea
+    ApprovedPremises:
+      allOf:
+        - $ref: '#/components/schemas/Premises'
+        - type: object
+          properties:
+            apCode:
+              type: string
+              example: NEHOPE1
+      required:
+        - apCode
+    TemporaryAccommodationPremises:
+      allOf:
+        - $ref: '#/components/schemas/Premises'
     NewPremises:
       type: object
       properties:


### PR DESCRIPTION
In a nutshell, split the response type from the get all premises and get premises by ID endpoints into 3 entities:
- One containing common properties
- One for AP specific properties that extends the common one
- Another for TA specific properties that extends the common one

Commit messages explain in more detail.