### PR TITLE
WIP: Generate domain events from the Application service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domain/events/ApplicationEventGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domain/events/ApplicationEventGenerator.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.domain.events
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+
+@Service
+class ApplicationEventGenerator {
+
+  fun generate(eventName: String, application: ApplicationEntity): String {
+    return "Generating an $eventName domain event for application ${application.id}"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.domain.events.ApplicationEventGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -24,7 +25,8 @@ class ApplicationService(
   private val offenderService: OffenderService,
   private val userService: UserService,
   private val assessmentService: AssessmentService,
-  private val jsonLogicService: JsonLogicService
+  private val jsonLogicService: JsonLogicService,
+  private val applicationEventGenerator: ApplicationEventGenerator
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationEntity> {
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
@@ -193,6 +195,7 @@ class ApplicationService(
 
     application = applicationRepository.save(application)
 
+    applicationEventGenerator.generate(eventName = "application.submitted", application = application)
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(application)
     )


### PR DESCRIPTION
In this initial work we tie Domain Event "generators" to services. e.g.:

- `ApplicationService` will use an `ApplicationEventGenerator`, passing in
  an instance of `Application` each time
- `BookingService` will use a `BookingEventGenerator`, passing in an instance
  of `Booking` with each message sent to` generate()`
- `AssessmentService` will send an `Assessment` to its `AssessmentEventGenerator`

etc