### PR TITLE
Implement 'add new room' endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -19,8 +19,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewNonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewRoom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Room
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -391,6 +393,10 @@ class PremisesController(
     }
 
     return ResponseEntity.ok(staffMembers.map(staffMemberTransformer::transformDomainToApi))
+  }
+
+  override fun premisesPremisesIdRoomsPost(premisesId: UUID, newRoom: NewRoom): ResponseEntity<Room> {
+    return super.premisesPremisesIdRoomsPost(premisesId, newRoom)
   }
 
   private fun getBookingForPremisesOrThrow(premisesId: UUID, bookingId: UUID) = when (val result = bookingService.getBookingForPremises(premisesId, bookingId)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface BedRepository : JpaRepository<BedEntity, UUID>
+
+@Entity
+@Table(name = "beds")
+data class BedEntity(
+  @Id
+  val id: UUID,
+  val name: String,
+  @ManyToOne
+  @JoinColumn(name = "room_id")
+  val room: RoomEntity,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -43,7 +43,9 @@ abstract class PremisesEntity(
   @OneToMany(mappedBy = "premises")
   val bookings: MutableList<BookingEntity>,
   @OneToMany(mappedBy = "premises")
-  var lostBeds: MutableList<LostBedsEntity>
+  val lostBeds: MutableList<LostBedsEntity>,
+  @OneToMany(mappedBy = "premises")
+  val rooms: MutableList<RoomEntity>,
 )
 
 @Entity
@@ -63,8 +65,9 @@ class ApprovedPremisesEntity(
   lostBeds: MutableList<LostBedsEntity>,
   val apCode: String,
   val deliusTeamCode: String,
-  val qCode: String
-) : PremisesEntity(id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds)
+  val qCode: String,
+  rooms: MutableList<RoomEntity>,
+) : PremisesEntity(id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds, rooms)
 
 @Entity
 @DiscriminatorValue("CAS3")
@@ -80,7 +83,8 @@ class TemporaryAccommodationPremisesEntity(
   probationRegion: ProbationRegionEntity,
   localAuthorityArea: LocalAuthorityAreaEntity,
   bookings: MutableList<BookingEntity>,
-  lostBeds: MutableList<LostBedsEntity>
+  lostBeds: MutableList<LostBedsEntity>,
+  rooms: MutableList<RoomEntity>,
 ) : PremisesEntity(
-  id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds
+  id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds, rooms
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Repository
+interface RoomRepository : JpaRepository<RoomEntity, UUID>
+
+@Entity
+@Table(name = "rooms")
+data class RoomEntity(
+  @Id
+  val id: UUID,
+  val name: String,
+  val notes: String?,
+  @ManyToOne
+  @JoinColumn(name = "premises_id")
+  val premises: PremisesEntity,
+  @OneToMany(mappedBy = "room")
+  val beds: MutableList<BedEntity>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -191,7 +191,8 @@ class PremisesService(
         bookings = mutableListOf(),
         lostBeds = mutableListOf(),
         notes = premisesNotes,
-        totalBeds = 0
+        totalBeds = 0,
+        rooms = mutableListOf(),
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.util.UUID
+
+@Service
+class RoomService(
+  private val roomRepository: RoomRepository,
+  private val bedRepository: BedRepository,
+) {
+
+  fun createRoom(
+    premises: PremisesEntity,
+    roomName: String,
+    notes: String?,
+  ): ValidatableActionResult<RoomEntity> = validated {
+    if (roomName.isEmpty()) {
+      "$.name" hasValidationError "empty"
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    val automaticallyCreateBed = when (premises) {
+      is TemporaryAccommodationPremisesEntity -> true
+      else -> false
+    }
+
+    val room = roomRepository.save(
+      RoomEntity(
+        id = UUID.randomUUID(),
+        name = roomName,
+        notes = notes,
+        premises = premises,
+        beds = mutableListOf(),
+      )
+    )
+
+    if (automaticallyCreateBed) {
+      val bed = createBedInternal(room, "default-bed")
+      room.beds.add(bed)
+    }
+
+    return success(room)
+  }
+
+  fun createBed(
+    room: RoomEntity,
+    bedName: String,
+  ): ValidatableActionResult<BedEntity> = validated {
+    if (bedName.isEmpty()) {
+      "$.name" hasValidationError "empty"
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    return success(createBedInternal(room, bedName))
+  }
+
+  private fun createBedInternal(
+    room: RoomEntity,
+    bedName: String,
+  ): BedEntity = bedRepository.save(
+    BedEntity(
+      id = UUID.randomUUID(),
+      name = bedName,
+      room = room,
+    )
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedTransformer.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Bed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+
+@Component
+class BedTransformer {
+  fun transformJpaToApi(jpa: BedEntity) = Bed(
+    id = jpa.id,
+    name = jpa.name
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RoomTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RoomTransformer.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Room
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+
+@Component
+class RoomTransformer(
+  private val bedTransformer: BedTransformer,
+) {
+  fun transformJpaToApi(jpa: RoomEntity) = Room(
+    id = jpa.id,
+    name = jpa.name,
+    beds = jpa.beds.map(bedTransformer::transformJpaToApi)
+  )
+}

--- a/src/main/resources/db/migration/all/20221027144656__room_tables.sql
+++ b/src/main/resources/db/migration/all/20221027144656__room_tables.sql
@@ -1,0 +1,16 @@
+CREATE TABLE rooms (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    notes TEXT,
+    premises_id UUID NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (premises_id) REFERENCES premises(id)
+);
+
+CREATE TABLE beds (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    room_id UUID NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (room_id) REFERENCES rooms(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -578,6 +578,51 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /premises/{premisesId}/rooms:
+    post:
+      tags:
+        - Rooms
+      summary: Adds a new room for an approved premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the room is in
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the new room
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewRoom'
+        required: true
+      responses:
+        201:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Room'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /people/search:
     get:
       summary: Searches for a Person by their CRN
@@ -2399,3 +2444,40 @@ components:
       x-enum-varnames:
         - approvedPremises
         - temporaryAccommodation
+    NewRoom:
+      type: object
+      properties:
+        name:
+          type: string
+        notes:
+          type: string
+      required:
+        - name
+    Room:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        notes:
+          type: string
+        beds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bed'
+      required:
+        - id
+        - name
+    Bed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -93,6 +93,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     lostBeds = mutableListOf(),
     addressLine1 = this.addressLine1(),
     notes = this.notes(),
-    qCode = this.qCode()
+    qCode = this.qCode(),
+    rooms = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+class RoomEntityFactory : Factory<RoomEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+  private var premises: Yielded<PremisesEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  fun withPremises(premises: PremisesEntity) = apply {
+    this.premises = { premises }
+  }
+
+  fun withYieldedPremises(premises: Yielded<PremisesEntity>) = apply {
+    this.premises = premises
+  }
+
+  override fun produce() = RoomEntity(
+    id = this.id(),
+    name = this.name(),
+    notes = this.notes(),
+    beds = mutableListOf(),
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a premises")
+  )
+}
+
+class BedEntityFactory : Factory<BedEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var room: Yielded<RoomEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withRoom(room: RoomEntity) = apply {
+    this.room = { room }
+  }
+
+  fun withYieldedRoom(room: Yielded<RoomEntity>) = apply {
+    this.room = room
+  }
+  override fun produce() = BedEntity(
+    id = this.id(),
+    name = this.name(),
+    room = this.room?.invoke() ?: throw java.lang.RuntimeException("Must provide a room")
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -75,6 +75,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     bookings = mutableListOf(),
     lostBeds = mutableListOf(),
     addressLine1 = this.addressLine1(),
-    notes = this.notes()
+    notes = this.notes(),
+    rooms = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
+
+class RoomServiceTest {
+  private val roomRepository = mockk<RoomRepository>()
+  private val bedRepository = mockk<BedRepository>()
+
+  private val roomService = RoomService(roomRepository, bedRepository)
+
+  @Test
+  fun `An empty room name results in a validation error`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val result = roomService.createRoom(premises, "", "test-notes")
+
+    assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+    assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+      entry("$.name", "empty")
+    )
+  }
+
+  @Test
+  fun `An empty bed name results in a validation error`() {
+    val room = RoomEntityFactory()
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val result = roomService.createBed(room, "")
+
+    assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+    assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+      entry("$.name", "empty")
+    )
+  }
+
+  @Test
+  fun `An Approved Premises does not automatically create a bed for the new room`() {
+    val premises = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    every { roomRepository.save(any()) } answers { it.invocation.args[0] as RoomEntity }
+
+    val result = roomService.createRoom(premises, "test-room", "test-notes")
+
+    assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+    result as ValidatableActionResult.Success
+    assertThat(result.entity.premises).isEqualTo(premises)
+    assertThat(result.entity.name).isEqualTo("test-room")
+    assertThat(result.entity.notes).isEqualTo("test-notes")
+    assertThat(result.entity.beds).isEmpty()
+  }
+
+  @Test
+  fun `A Temporary Accommodation Premises automatically creates a bed for the new room`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    every { roomRepository.save(any()) } answers { it.invocation.args[0] as RoomEntity }
+    every { bedRepository.save(any()) } answers { it.invocation.args[0] as BedEntity }
+
+    val result = roomService.createRoom(premises, "test-room", "test-notes")
+
+    assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+    result as ValidatableActionResult.Success
+    assertThat(result.entity.premises).isEqualTo(premises)
+    assertThat(result.entity.name).isEqualTo("test-room")
+    assertThat(result.entity.notes).isEqualTo("test-notes")
+    assertThat(result.entity.beds).hasSize(1)
+    assertThat(result.entity.beds[0].room).isEqualTo(result.entity)
+    assertThat(result.entity.beds[0].name).isEqualTo("default-bed")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -89,7 +89,8 @@ class BookingTransformerTest {
     bookings = mutableListOf(),
     lostBeds = mutableListOf(),
     addressLine1 = "1 somewhere",
-    notes = ""
+    notes = "",
+    rooms = mutableListOf(),
   )
 
   private val baseBookingEntity = BookingEntity(


### PR DESCRIPTION
> See [ticket 418 on the CAS3 Trello board](https://trello.com/c/4qwDVVVa/418-add-a-bedspace-to-a-property).

This PR introduces the `POST /premises/{premisesId}/rooms` endpoint to allow clients to add rooms to a premises.

For CAS3, the concept of a room and a bed have been collapsed into a single concept known as a "bedspace", but are considered distinct for CAS1. To simplify the API interaction from a client's perspective, the `RoomService.createRoom` method will automatically create a bed at the same time as its containing room if the premises is a `TemporaryAccommodationPremisesEntity`. Otherwise, no beds will be created, but `RoomService` also exposes a `createBed` method to allow adding beds to a room at a later time.