### PR TITLE
Fix for OffsetDateTime issue in tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -98,6 +98,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.JwtAuthHelper
 import java.time.Duration
+import java.util.TimeZone
 import java.util.UUID
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -224,6 +225,8 @@ abstract class IntegrationTestBase {
 
   @BeforeEach
   fun beforeEach() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
     wiremockServer = WireMockServer(57839)
     wiremockServer.start()
 


### PR DESCRIPTION
The `Get All Bookings returns OK with correct body` test sometimes fails locally due to an equality failure:
```
[id=3d953164-7318-4920-aa6e-485747e372d3].departure.dateTime
Expected: 2022-10-30T20:20:34+01:00
     got: 2022-10-30T19:20:34Z
```

Whilst these two OffsetDateTimes represent the same point in time - they are not equal as the comparison for OffsetDateTime compares the date-time and the offset parts individually.

This is happening because we are creating OffsetDateTimes in test setup code, then persisting them to the database.  Postgres `TIMESTAMP WITH TIME ZONE` does not actually store the offset but rather uses it to convert the date-time to UTC then discards it.  Consequently, when the application retrieves the values from the database during the test they will be in UTC rather than the system time zone.

This alleviates the issue by setting the JVM's time zone to UTC during test execution.  A subsequent improvement would be to switch to using `Instant` rather than `OffsetDateTime` in the JPA entities.