### PR TITLE
Store service name against a property

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -92,11 +92,17 @@ class PremisesController(
   }
 
   override fun premisesPost(body: NewPremises, xServiceName: ServiceName?): ResponseEntity<Premises> {
+
+    val serviceName = when (xServiceName == null) {
+      true -> ServiceName.approvedPremises.value
+      false -> xServiceName.value
+    }
+
     val premises = extractResultEntityOrThrow(
       premisesService.createNewPremises(
         addressLine1 = body.addressLine1,
         postcode = body.postcode,
-        service = xServiceName?.value,
+        service = serviceName,
         localAuthorityAreaId = body.localAuthorityAreaId,
         name = body.name,
         notes = body.notes

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -91,12 +91,12 @@ class PremisesController(
     )
   }
 
-  override fun premisesPost(body: NewPremises): ResponseEntity<Premises> {
+  override fun premisesPost(body: NewPremises, xServiceName: ServiceName?): ResponseEntity<Premises> {
     val premises = extractResultEntityOrThrow(
       premisesService.createNewPremises(
         addressLine1 = body.addressLine1,
         postcode = body.postcode,
-        service = body.service,
+        service = xServiceName?.value,
         localAuthorityAreaId = body.localAuthorityAreaId,
         name = body.name,
         notes = body.notes

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -49,7 +49,7 @@ abstract class PremisesEntity(
 )
 
 @Entity
-@DiscriminatorValue("CAS1")
+@DiscriminatorValue("approved-premises")
 @Table(name = "approved_premises")
 @PrimaryKeyJoinColumn(name = "premises_id")
 class ApprovedPremisesEntity(
@@ -70,7 +70,7 @@ class ApprovedPremisesEntity(
 ) : PremisesEntity(id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds, rooms)
 
 @Entity
-@DiscriminatorValue("CAS3")
+@DiscriminatorValue("temporary-accommodation")
 @Table(name = "temporary_accommodation_premises")
 @PrimaryKeyJoinColumn(name = "premises_id")
 class TemporaryAccommodationPremisesEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -115,7 +115,7 @@ class PremisesService(
   fun createNewPremises(
     addressLine1: String,
     postcode: String,
-    service: String,
+    service: String?,
     localAuthorityAreaId: UUID,
     name: String?,
     notes: String?
@@ -148,7 +148,7 @@ class PremisesService(
       "$.postcode" hasValidationError "empty"
     }
 
-    if (service.isEmpty()) {
+    if (service == null) {
       "$.service" hasValidationError "empty"
     } else if (service != "CAS3") {
       "$.service" hasValidationError "onlyCas3Supported"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -115,7 +115,7 @@ class PremisesService(
   fun createNewPremises(
     addressLine1: String,
     postcode: String,
-    service: String?,
+    service: String,
     localAuthorityAreaId: UUID,
     name: String?,
     notes: String?
@@ -148,9 +148,9 @@ class PremisesService(
       "$.postcode" hasValidationError "empty"
     }
 
-    if (service == null) {
+    if (service.isEmpty()) {
       "$.service" hasValidationError "empty"
-    } else if (service != "CAS3") {
+    } else if (service != ServiceName.temporaryAccommodation.value) {
       "$.service" hasValidationError "onlyCas3Supported"
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -22,7 +23,7 @@ class PremisesTransformer(
       addressLine1 = jpa.addressLine1,
       postcode = jpa.postcode,
       bedCount = jpa.totalBeds,
-      service = "CAS1",
+      service = ServiceName.approvedPremises.value,
       notes = jpa.notes,
       availableBedsForToday = availableBedsForToday,
       probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
@@ -35,7 +36,7 @@ class PremisesTransformer(
       addressLine1 = jpa.addressLine1,
       postcode = jpa.postcode,
       bedCount = jpa.totalBeds,
-      service = "CAS3",
+      service = ServiceName.temporaryAccommodation.value,
       notes = jpa.notes,
       availableBedsForToday = availableBedsForToday,
       probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),

--- a/src/main/resources/db/migration/all/20220803121542__revise_service_column_default_value.sql
+++ b/src/main/resources/db/migration/all/20220803121542__revise_service_column_default_value.sql
@@ -1,0 +1,7 @@
+UPDATE premises
+SET service = 'approved-premises'
+WHERE service = 'CAS1';
+
+UPDATE premises
+SET service='temporary-accommodation'
+WHERE service = 'CAS3';

--- a/src/main/resources/db/migration/local+dev/20220913131811__temp_accommodation_mock_premises.sql
+++ b/src/main/resources/db/migration/local+dev/20220913131811__temp_accommodation_mock_premises.sql
@@ -1,0 +1,7 @@
+INSERT INTO premises (id, name, ap_code, postcode, total_beds, probation_region_id, local_authority_area_id, service)
+VALUES ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Something House', 'HBRDHSE', 'LA9 1DS', 30,
+        'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'temporary-accommodation'),
+       ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Something Court', 'BSLRCRT', 'EC1 3XZ', 10,
+        '6b4a1308-17af-4c1a-a330-6005bec9e27b', '89faa462-7ea6-45ba-b169-93d947d20cae', 'temporary-accommodation'),
+       ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Something Place', 'JSPPLC', 'SA1 1AF', 25,
+        'afee0696-8df3-4d9f-9d0c-268f17772e2c', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'temporary-accommodation');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -36,6 +36,13 @@ paths:
       tags:
         - Premises
       summary: Add a new premises
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, persist the service name against this property
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       requestBody:
         content:
           'application/json':
@@ -1478,9 +1485,6 @@ components:
           type: string
         postcode:
           type: string
-        service:
-          type: string
-          example: CAS3
         notes:
           type: string
           example: some notes about this property
@@ -1490,7 +1494,6 @@ components:
       required:
         - addressLine1
         - postcode
-        - service
         - localAuthorityAreaId
     LocalAuthorityArea:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
@@ -20,7 +21,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   private var totalBeds: Yielded<Int> = { randomInt(1, 100) }
   private var addressLine1: Yielded<String> = { randomStringUpperCase(10) }
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
-  private var service: Yielded<String> = { "CAS3" }
+  private var service: Yielded<String> = { ServiceName.temporaryAccommodation.value }
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -71,7 +71,7 @@ class PremisesTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("addressLine1").isEqualTo("1 somewhere")
       .jsonPath("postcode").isEqualTo("AB123CD")
-      .jsonPath("service").isEqualTo("CAS3")
+      .jsonPath("service").isEqualTo(ServiceName.temporaryAccommodation.value)
       .jsonPath("notes").isEqualTo("some arbitrary notes")
       .jsonPath("name").isEqualTo("some arbitrary name")
       .jsonPath("localAuthorityArea.id").isEqualTo("a5f52443-6b55-498c-a697-7c6fad70cc3f")
@@ -185,7 +185,6 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises?service=temporary-accommodation")
       .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           name = "arbitrary_test_name",
@@ -200,7 +199,7 @@ class PremisesTest : IntegrationTestBase() {
       .is4xxClientError
       .expectBody()
       .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+      .jsonPath("invalid-params[0].errorType").isEqualTo("onlyCas3Supported")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RoomTransformer
@@ -33,11 +34,11 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
-          service = "CAS3",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
         )
       )
@@ -54,11 +55,11 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
-          service = "CAS3",
           notes = "some arbitrary notes",
           name = "some arbitrary name",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
@@ -84,11 +85,11 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
-          service = "CAS3",
           notes = "some arbitrary notes",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
         )
@@ -108,11 +109,11 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
-          service = "CAS3",
           name = "some arbitrary name",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
         )
@@ -132,14 +133,14 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises?service=temporary-accommodation")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           name = "arbitrary_test_name",
           postcode = "AB123CD",
           addressLine1 = "",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          notes = "some notes",
-          service = "CAS3"
+          notes = "some notes"
         )
       )
       .exchange()
@@ -158,14 +159,14 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises?service=temporary-accommodation")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           name = "arbitrary_test_name",
           postcode = "",
           addressLine1 = "FIRST LINE OF THE ADDRESS",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          notes = "some notes",
-          service = "CAS3"
+          notes = "some notes"
         )
       )
       .exchange()
@@ -184,14 +185,14 @@ class PremisesTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises?service=temporary-accommodation")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
           name = "arbitrary_test_name",
           postcode = "AB123CD",
           addressLine1 = "FIRST LINE OF THE ADDRESS",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          notes = "some notes",
-          service = ""
+          notes = "some notes"
         )
       )
       .exchange()


### PR DESCRIPTION
So that properties can be differentiated, a service name is required to be stored against them on creation of a new one. 

This was a little more involved than just passing down the service name, that is now in the header rather than the body, as there has been some work done previously to split out the concrete implementations of a TA property or an AP property.

Where the POST method deals with the service name in the header, is calls down to the service layer which calls a save method on the repo, creating specifically an instance of a TA premises. At this point there's no need to tell it what service to persist as it knows it's a TA instance and so it saves the relevant service name by default. 