### PR TITLE
Add support for room characteristics when getting a list of rooms/creating a new room

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -415,7 +415,7 @@ class PremisesController(
     val premises = premisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
 
     val room = extractResultEntityOrThrow(
-      roomService.createRoom(premises, newRoom.name, newRoom.notes)
+      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristics)
     )
 
     return ResponseEntity(roomTransformer.transformJpaToApi(room), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -6,6 +6,8 @@ import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
+import javax.persistence.JoinTable
+import javax.persistence.ManyToMany
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.Table
@@ -25,4 +27,11 @@ data class RoomEntity(
   val premises: PremisesEntity,
   @OneToMany(mappedBy = "room")
   val beds: MutableList<BedEntity>,
+  @ManyToMany
+  @JoinTable(
+    name = "room_characteristics",
+    joinColumns = [JoinColumn(name = "room_id")],
+    inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
+  )
+  val characteristics: MutableList<CharacteristicEntity>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
@@ -42,6 +42,7 @@ class RoomService(
         notes = notes,
         premises = premises,
         beds = mutableListOf(),
+        characteristics = mutableListOf(),
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RoomTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RoomTransformer.kt
@@ -7,11 +7,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 @Component
 class RoomTransformer(
   private val bedTransformer: BedTransformer,
+  private val characteristicTransformer: CharacteristicTransformer,
 ) {
   fun transformJpaToApi(jpa: RoomEntity) = Room(
     id = jpa.id,
     name = jpa.name,
+    notes = jpa.notes ?: "",
     beds = jpa.beds.map(bedTransformer::transformJpaToApi),
-    characteristics = mutableListOf(),
+    characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RoomTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RoomTransformer.kt
@@ -11,6 +11,7 @@ class RoomTransformer(
   fun transformJpaToApi(jpa: RoomEntity) = Room(
     id = jpa.id,
     name = jpa.name,
-    beds = jpa.beds.map(bedTransformer::transformJpaToApi)
+    beds = jpa.beds.map(bedTransformer::transformJpaToApi),
+    characteristics = mutableListOf(),
   )
 }

--- a/src/main/resources/db/migration/all/20221031101732__add_room_characteristics.sql
+++ b/src/main/resources/db/migration/all/20221031101732__add_room_characteristics.sql
@@ -1,0 +1,7 @@
+CREATE TABLE room_characteristics (
+    room_id UUID NOT NULL,
+    characteristic_id UUID NOT NULL,
+    PRIMARY KEY (room_id, characteristic_id),
+    FOREIGN KEY (room_id) REFERENCES rooms(id),
+    FOREIGN KEY (characteristic_id) REFERENCES characteristics(id)
+)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2481,8 +2481,14 @@ components:
           type: string
         notes:
           type: string
+        characteristics:
+          type: array
+          items:
+            type: string
+            format: uuid
       required:
         - name
+        - characteristics
     Room:
       type: object
       properties:
@@ -2497,9 +2503,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Bed'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
       required:
         - id
         - name
+        - characteristics
     Bed:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
@@ -16,6 +16,11 @@ class CharacteristicEntityFactory : Factory<CharacteristicEntity> {
   fun withServiceScope(serviceScope: String) = apply {
     this.serviceScope = { serviceScope }
   }
+
+  fun withModelScope(modelScope: String) = apply {
+    this.modelScope = { modelScope }
+  }
+
   override fun produce(): CharacteristicEntity = CharacteristicEntity(
     id = this.id(),
     name = this.name(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -39,7 +39,8 @@ class RoomEntityFactory : Factory<RoomEntity> {
     name = this.name(),
     notes = this.notes(),
     beds = mutableListOf(),
-    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a premises")
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a premises"),
+    characteristics = mutableListOf(),
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -21,8 +22,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
 class RoomServiceTest {
   private val roomRepository = mockk<RoomRepository>()
   private val bedRepository = mockk<BedRepository>()
+  private val characteristicRepository = mockk<CharacteristicRepository>()
 
-  private val roomService = RoomService(roomRepository, bedRepository)
+  private val roomService = RoomService(roomRepository, bedRepository, characteristicRepository)
 
   @Test
   fun `An empty room name results in a validation error`() {
@@ -35,7 +37,7 @@ class RoomServiceTest {
       .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
       .produce()
 
-    val result = roomService.createRoom(premises, "", "test-notes")
+    val result = roomService.createRoom(premises, "", "test-notes", mutableListOf())
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
@@ -79,7 +81,7 @@ class RoomServiceTest {
 
     every { roomRepository.save(any()) } answers { it.invocation.args[0] as RoomEntity }
 
-    val result = roomService.createRoom(premises, "test-room", "test-notes")
+    val result = roomService.createRoom(premises, "test-room", "test-notes", mutableListOf())
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
     result as ValidatableActionResult.Success
@@ -103,7 +105,7 @@ class RoomServiceTest {
     every { roomRepository.save(any()) } answers { it.invocation.args[0] as RoomEntity }
     every { bedRepository.save(any()) } answers { it.invocation.args[0] as BedEntity }
 
-    val result = roomService.createRoom(premises, "test-room", "test-notes")
+    val result = roomService.createRoom(premises, "test-room", "test-notes", mutableListOf())
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
     result as ValidatableActionResult.Success


### PR DESCRIPTION
> See [ticket #495 on the CAS3 Trello board](https://trello.com/c/YgJCtrWY/495-room-characteristics-can-be-saved).

Currently, when adding a new room to a premises, only a name and some optional notes can be given. To provide additional information about a room, the API will need to provide a way to attach characteristics to a room.

This PR provides support for room characteristics through the following API changes:
- The `NewRoom` schema used to define the request body of the `POST /premises/{premisesId}/rooms` endpoint has been extended to allow the client to specify a list of UUIDS representing characteristics.
- The `Room` schema used in the response body of the `POST /premises/{premisesId/rooms` and the `GET /premises/{premisesId}/rooms` endpoints have been extended to specify the active characteristics of the room.

A characteristic has two ways in which to limit what it can be applied to, known as 'scopes'. The model scope determines which type of entity the characteristic is valid for (currently `"room"` or `"premises"`). The service scope determines which service the characteristic is valid for (currently `"approved-premises"` or `"temporary-accommodation"`). It is possible for a single characteristic to be shared across model or service scopes, although this is beyond the scope of this PR.

To add a characteristic to a room, the `RoomService` enforces that the characteristic has the correct scopes. A characteristic must have a model scope of `"room"`, and the service scope must match the service the premises is for. If these are incorrect, they are reported as validation errors.