### PR TITLE
Fix ap_code migration issue on dev

### DIFF
--- a/src/main/resources/db/migration/local+dev/20220913131811__temp_accommodation_mock_premises.sql
+++ b/src/main/resources/db/migration/local+dev/20220913131811__temp_accommodation_mock_premises.sql
@@ -1,7 +1,0 @@
-INSERT INTO premises (id, name, ap_code, postcode, total_beds, probation_region_id, local_authority_area_id, service)
-VALUES ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Something House', 'HBRDHSE', 'LA9 1DS', 30,
-        'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'temporary-accommodation'),
-       ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Something Court', 'BSLRCRT', 'EC1 3XZ', 10,
-        '6b4a1308-17af-4c1a-a330-6005bec9e27b', '89faa462-7ea6-45ba-b169-93d947d20cae', 'temporary-accommodation'),
-       ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Something Place', 'JSPPLC', 'SA1 1AF', 25,
-        'afee0696-8df3-4d9f-9d0c-268f17772e2c', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'temporary-accommodation');

--- a/src/main/resources/db/migration/local+dev/20221026113526_1__move_address_seed_data_to_own_migration.sql
+++ b/src/main/resources/db/migration/local+dev/20221026113526_1__move_address_seed_data_to_own_migration.sql
@@ -1,3 +1,0 @@
-UPDATE premises SET address_line1 = '1 Somewhere' WHERE id = 'd33006b7-55d9-4a8e-b722-5e18093dbcdf';
-UPDATE premises SET address_line1 = '2 Somewhere' WHERE id = 'ada106c7-e1fb-409a-a38e-0002ea8e7e45';
-UPDATE premises SET address_line1 = '3 Somewhere' WHERE id = '36c7b1f2-5a4b-467b-838c-2970c9c253cf';

--- a/src/main/resources/db/migration/local+dev/20221101100330__temporary_accommodation_premises.sql
+++ b/src/main/resources/db/migration/local+dev/20221101100330__temporary_accommodation_premises.sql
@@ -1,0 +1,7 @@
+INSERT INTO premises (id, name, postcode, total_beds, probation_region_id, local_authority_area_id, service, address_line1)
+VALUES ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Something House', 'LA9 1DS', 30,
+        'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'temporary-accommodation', 'Address 1'),
+       ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Something Court', 'EC1 3XZ', 10,
+        '6b4a1308-17af-4c1a-a330-6005bec9e27b', '89faa462-7ea6-45ba-b169-93d947d20cae', 'temporary-accommodation', 'Address 2'),
+       ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Something Place', 'SA1 1AF', 25,
+        'afee0696-8df3-4d9f-9d0c-268f17772e2c', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'temporary-accommodation', 'Address 3');


### PR DESCRIPTION
We have out of order migrations turned on so that we don't need to adjust timestamps when two branches have both got a migration in them and were worked on at similar times such that the earlier timestamped migration ends up being merged into main after the later one.

The original migration to add temporay accommodation Premises was added with a timestamp in the past (`20220913131811__temp_accommodation_mock_premises.sql`) which works fine when running locally as people will just delete the postgres volume if they hit an error then it will work as the migration will be run where it's been slotted into the timeline.

In the dev environment however, all of the previous migrations have already been run so the new migration that's been inserted in the past will run on its own in the present - leading to issues around missing columns. mismatched constraints etc.  in this case a missing column (ap_code was removed from premises)