### PR TITLE
update service name to be approved premises rather than cas1 so that example seeded data is useful

### DIFF
--- a/src/main/resources/db/migration/local+dev/20221101124300__add_ap_service_name_to_mock_premises.sql
+++ b/src/main/resources/db/migration/local+dev/20221101124300__add_ap_service_name_to_mock_premises.sql
@@ -1,0 +1,6 @@
+UPDATE premises
+SET service = 'approved-premises'
+WHERE id in ('3549f9ff-6d58-450f-8ea3-dc2cf196ef2c',
+             'e6d00117-e31c-4332-8c24-8e1432a4c500',
+             '878217f0-6db5-49d8-a5a1-c40fdecd6060');
+


### PR DESCRIPTION
This is a migration script that will update seeded example data so that the service name is 'approved-premises' rather than CAS1. 

By doing so means that example data is more meaningful and useful