### PR TITLE
(Chore) Rename IDs named 'characteristic(s)' to 'characteristicId(s)'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -415,7 +415,7 @@ class PremisesController(
     val premises = premisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
 
     val room = extractResultEntityOrThrow(
-      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristics)
+      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristicIds)
     )
 
     return ResponseEntity(roomTransformer.transformJpaToApi(room), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
@@ -25,13 +25,13 @@ class RoomService(
     premises: PremisesEntity,
     roomName: String,
     notes: String?,
-    characteristics: List<UUID>,
+    characteristicIds: List<UUID>,
   ): ValidatableActionResult<RoomEntity> = validated {
     if (roomName.isEmpty()) {
       "$.name" hasValidationError "empty"
     }
 
-    val characteristicEntities = characteristics.mapIndexed { index, uuid ->
+    val characteristicEntities = characteristicIds.mapIndexed { index, uuid ->
       val entity = characteristicRepository.findByIdOrNull(uuid)
 
       if (entity == null) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2488,14 +2488,14 @@ components:
           type: string
         notes:
           type: string
-        characteristics:
+        characteristicIds:
           type: array
           items:
             type: string
             format: uuid
       required:
         - name
-        - characteristics
+        - characteristicIds
     Room:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -608,7 +608,7 @@ class PremisesTest : IntegrationTestBase() {
       }
     }
 
-    val characteristics = characteristicEntityFactory.produceAndPersistMultiple(5) {
+    val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
       withModelScope("room")
       withServiceScope("temporary-accommodation")
     }.map { it.id }
@@ -622,7 +622,7 @@ class PremisesTest : IntegrationTestBase() {
         NewRoom(
           notes = "test notes",
           name = "test-room",
-          characteristics = characteristics
+          characteristicIds = characteristicIds
         )
       )
       .exchange()
@@ -631,7 +631,7 @@ class PremisesTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("name").isEqualTo("test-room")
       .jsonPath("notes").isEqualTo("test notes")
-      .jsonPath("characteristics[*].id").isEqualTo(characteristics.map { it.toString() })
+      .jsonPath("characteristics[*].id").isEqualTo(characteristicIds.map { it.toString() })
       .jsonPath("characteristics[*].modelScope").isEqualTo(MutableList(5) { "room" })
       .jsonPath("characteristics[*].serviceScope").isEqualTo(MutableList(5) { "temporary-accommodation" })
   }
@@ -654,7 +654,7 @@ class PremisesTest : IntegrationTestBase() {
         NewRoom(
           notes = null,
           name = "test-room",
-          characteristics = mutableListOf(),
+          characteristicIds = mutableListOf(),
         )
       )
       .exchange()
@@ -682,7 +682,7 @@ class PremisesTest : IntegrationTestBase() {
         NewRoom(
           notes = "test notes",
           name = "",
-          characteristics = mutableListOf(),
+          characteristicIds = mutableListOf(),
         )
       )
       .exchange()
@@ -711,7 +711,7 @@ class PremisesTest : IntegrationTestBase() {
         NewRoom(
           notes = "test notes",
           name = "test-room",
-          characteristics = mutableListOf(UUID.randomUUID()),
+          characteristicIds = mutableListOf(UUID.randomUUID()),
         )
       )
       .exchange()
@@ -731,7 +731,7 @@ class PremisesTest : IntegrationTestBase() {
       }
     }
 
-    val characteristic = characteristicEntityFactory.produceAndPersist {
+    val characteristicId = characteristicEntityFactory.produceAndPersist {
       withModelScope("room")
       withServiceScope("approved-premises")
     }.id
@@ -745,7 +745,7 @@ class PremisesTest : IntegrationTestBase() {
         NewRoom(
           notes = "test notes",
           name = "test-room",
-          characteristics = mutableListOf(characteristic),
+          characteristicIds = mutableListOf(characteristicId),
         )
       )
       .exchange()
@@ -765,7 +765,7 @@ class PremisesTest : IntegrationTestBase() {
       }
     }
 
-    val characteristic = characteristicEntityFactory.produceAndPersist {
+    val characteristicId = characteristicEntityFactory.produceAndPersist {
       withModelScope("premises")
       withServiceScope("approved-premises")
     }.id
@@ -779,7 +779,7 @@ class PremisesTest : IntegrationTestBase() {
         NewRoom(
           notes = "test notes",
           name = "test-room",
-          characteristics = mutableListOf(characteristic),
+          characteristicIds = mutableListOf(characteristicId),
         )
       )
       .exchange()


### PR DESCRIPTION
The use of `characteristics` to refer to a list of IDs in the `NewRoom` schema is inconsistently named compared to other situations where IDs are accepted as part of a request body.

This PR renames `NewRoom.characteristics` to `NewRoom.characteristicIds` in the API specification and performs similar renaming for adjacent parts of the code.