### PR TITLE
Refactor characteristic scope matching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import java.util.UUID
+
+@Service
+class CharacteristicService(
+  val characteristicRepository: CharacteristicRepository,
+) {
+  fun getCharacteristic(characteristicId: UUID): CharacteristicEntity? =
+    characteristicRepository.findByIdOrNull(characteristicId)
+
+  fun serviceScopeMatches(characteristic: CharacteristicEntity, target: Any): Boolean {
+    val targetService = getServiceForTarget(target) ?: return false
+
+    return when (characteristic.serviceScope) {
+      "*" -> true
+      targetService -> true
+      else -> return false
+    }
+  }
+
+  fun modelScopeMatches(characteristic: CharacteristicEntity, target: Any): Boolean {
+    return when (characteristic.modelScope) {
+      "*" -> true
+      "room" -> target is RoomEntity
+      "premises" -> target is PremisesEntity
+      else -> false
+    }
+  }
+
+  private fun getServiceForTarget(target: Any): String? {
+    return when (target) {
+      is RoomEntity -> getServiceForTarget(target.premises)
+      is ApprovedPremisesEntity -> ServiceName.approvedPremises.value
+      is TemporaryAccommodationPremisesEntity -> ServiceName.temporaryAccommodation.value
+      else -> null
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CharacteristicServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CharacteristicServiceTest.kt
@@ -1,0 +1,249 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+
+class CharacteristicServiceTest {
+  private val characteristicRepository = mockk<CharacteristicRepository>()
+
+  private val characteristicService = CharacteristicService(characteristicRepository)
+
+  @Test
+  fun `serviceScopeMatches returns false if the characteristic has the wrong service scope`() {
+    val characteristicEntityFactory = CharacteristicEntityFactory()
+    val roomEntityFactory = RoomEntityFactory()
+
+    val characteristic1 = characteristicEntityFactory
+      .withModelScope("*")
+      .withServiceScope(ServiceName.approvedPremises.value)
+      .produce()
+
+    val characteristic2 = characteristicEntityFactory
+      .withModelScope("*")
+      .withServiceScope(ServiceName.temporaryAccommodation.value)
+      .produce()
+
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val localAuthorityArea = LocalAuthorityEntityFactory().produce()
+
+    val room1: RoomEntity = roomEntityFactory
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion { probationRegion }
+          .withYieldedLocalAuthorityArea { localAuthorityArea }
+          .produce()
+      }
+      .produce()
+
+    val room2: RoomEntity = roomEntityFactory
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion { probationRegion }
+          .withYieldedLocalAuthorityArea { localAuthorityArea }
+          .produce()
+      }
+      .produce()
+
+    assertThat(characteristicService.serviceScopeMatches(characteristic1, room1)).isFalse
+    assertThat(characteristicService.serviceScopeMatches(characteristic2, room2)).isFalse
+  }
+
+  @Test
+  fun `modelScopeMatches returns false if the characteristic has the wrong model scope`() {
+    val characteristicEntityFactory = CharacteristicEntityFactory()
+
+    val characteristic1 = characteristicEntityFactory
+      .withModelScope("room")
+      .withServiceScope("*")
+      .produce()
+
+    val characteristic2 = characteristicEntityFactory
+      .withModelScope("premises")
+      .withServiceScope("*")
+      .produce()
+
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val localAuthorityArea = LocalAuthorityEntityFactory().produce()
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withYieldedPremises { premises }
+      .produce()
+
+    assertThat(characteristicService.modelScopeMatches(characteristic1, premises)).isFalse
+    assertThat(characteristicService.modelScopeMatches(characteristic2, room)).isFalse
+  }
+
+  @Test
+  fun `serviceScopeMatches returns true if the service scope is correct`() {
+    val characteristicEntityFactory = CharacteristicEntityFactory()
+    val roomEntityFactory = RoomEntityFactory()
+
+    val characteristic1 = characteristicEntityFactory
+      .withModelScope("*")
+      .withServiceScope(ServiceName.approvedPremises.value)
+      .produce()
+
+    val characteristic2 = characteristicEntityFactory
+      .withModelScope("*")
+      .withServiceScope(ServiceName.temporaryAccommodation.value)
+      .produce()
+
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val localAuthorityArea = LocalAuthorityEntityFactory().produce()
+
+    val premises1 = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val premises2 = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val room1: RoomEntity = roomEntityFactory
+      .withYieldedPremises { premises1 }
+      .produce()
+
+    val room2: RoomEntity = roomEntityFactory
+      .withYieldedPremises { premises2 }
+      .produce()
+
+    assertThat(characteristicService.serviceScopeMatches(characteristic1, room1)).isTrue
+    assertThat(characteristicService.serviceScopeMatches(characteristic1, premises1)).isTrue
+    assertThat(characteristicService.serviceScopeMatches(characteristic2, room2)).isTrue
+    assertThat(characteristicService.serviceScopeMatches(characteristic2, premises2)).isTrue
+  }
+
+  @Test
+  fun `modelScopeMatches returns true if the model scope is correct`() {
+    val characteristicEntityFactory = CharacteristicEntityFactory()
+    val roomEntityFactory = RoomEntityFactory()
+
+    val characteristic1 = characteristicEntityFactory
+      .withModelScope("room")
+      .withServiceScope("*")
+      .produce()
+
+    val characteristic2 = characteristicEntityFactory
+      .withModelScope("premises")
+      .withServiceScope("*")
+      .produce()
+
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val localAuthorityArea = LocalAuthorityEntityFactory().produce()
+
+    val premises1 = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val premises2 = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val room: RoomEntity = roomEntityFactory
+      .withYieldedPremises { premises1 }
+      .produce()
+
+    assertThat(characteristicService.modelScopeMatches(characteristic1, room)).isTrue
+    assertThat(characteristicService.modelScopeMatches(characteristic2, premises1)).isTrue
+    assertThat(characteristicService.modelScopeMatches(characteristic2, premises2)).isTrue
+  }
+
+  @Test
+  fun `serviceScopeMatches always matches on wildcard scopes`() {
+    val characteristic = CharacteristicEntityFactory()
+      .withModelScope("*")
+      .withServiceScope("*")
+      .produce()
+
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val localAuthorityArea = LocalAuthorityEntityFactory().produce()
+
+    val premises1 = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val premises2 = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val room: RoomEntity = RoomEntityFactory()
+      .withYieldedPremises { premises1 }
+      .produce()
+
+    assertThat(characteristicService.serviceScopeMatches(characteristic, room)).isTrue
+    assertThat(characteristicService.serviceScopeMatches(characteristic, premises1)).isTrue
+    assertThat(characteristicService.serviceScopeMatches(characteristic, premises1)).isTrue
+    assertThat(characteristicService.serviceScopeMatches(characteristic, premises2)).isTrue
+  }
+
+  @Test
+  fun `modelScopeMatches always matches on wildcard scopes`() {
+    val characteristic = CharacteristicEntityFactory()
+      .withModelScope("*")
+      .withServiceScope("*")
+      .produce()
+
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val localAuthorityArea = LocalAuthorityEntityFactory().produce()
+
+    val premises1 = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val premises2 = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion { probationRegion }
+      .withYieldedLocalAuthorityArea { localAuthorityArea }
+      .produce()
+
+    val room: RoomEntity = RoomEntityFactory()
+      .withYieldedPremises { premises1 }
+      .produce()
+
+    assertThat(characteristicService.modelScopeMatches(characteristic, room)).isTrue
+    assertThat(characteristicService.modelScopeMatches(characteristic, premises1)).isTrue
+    assertThat(characteristicService.modelScopeMatches(characteristic, premises1)).isTrue
+    assertThat(characteristicService.modelScopeMatches(characteristic, premises2)).isTrue
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
@@ -13,18 +13,18 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
 
 class RoomServiceTest {
   private val roomRepository = mockk<RoomRepository>()
   private val bedRepository = mockk<BedRepository>()
-  private val characteristicRepository = mockk<CharacteristicRepository>()
+  private val characteristicService = mockk<CharacteristicService>()
 
-  private val roomService = RoomService(roomRepository, bedRepository, characteristicRepository)
+  private val roomService = RoomService(roomRepository, bedRepository, characteristicService)
 
   @Test
   fun `An empty room name results in a validation error`() {


### PR DESCRIPTION
> See [ticket #505 on the CAS3 Trello board](https://trello.com/c/ikNfvcs7/505-refactor-characteristics-to-support-wildcards).

Currently, the logic to validate a characteristic is the responsibility of the `RoomService`, and upcoming work to add characteristics to premises intends to add very similar validation to the `PremisesService`.

Additionally, when a new room is created, any characteristics it is given are only successfully applied if the model scope is `"room"` and the service scope is equal to the value of the `service` column on the relevant premises's table. Characteristics with wildcard scopes (which should always be considered valid) fail to apply.

This PR creates a single point of access for characteristic matching for entities. To do this, the current characteristic validation logic from `RoomService` has been moved into its own `CharacteristicService` and modified to support the upcoming premises characteristics work. As the canonical implementation of characteristic matching, it also adds support for `"*"` as a wildcard in either the model or service scope (or both).