### PR TITLE
Assessments oapi changes

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2484,13 +2484,9 @@ components:
     NewClarificationNote:
       type: object
       properties:
-        createdAt:
-          type: string
-          format: date-time
         text:
           type: string
       required:
-        - createdAt
         - text
     Reallocation:
       type: object

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2439,7 +2439,6 @@ components:
         - outdatedSchema
         - createdAt
         - allocatedAt
-        - data
         - clarificationNotes
     AssessmentDecision:
       type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2471,11 +2471,15 @@ components:
         createdAt:
           type: string
           format: date-time
+        createdByStaffMemberId:
+          type: string
+          format: uuid
         text:
           type: string
       required:
         - id
         - createdAt
+        - createdByStaffMemberId
         - text
     NewClarificationNote:
       type: object


### PR DESCRIPTION
A few small changes to the Assessments Open API spec:
 - Add a `createdByUserId` to clarification notes, so we can tell who has created each note in cases where assessment is reallocated or an admin adds a note to an assessment they are not allocated to
 - Remove `createdAt` from NewClarificationNote - this should be determined by the API rather than trusting user input
 - Make `data` optional on Assessment - this would be null until the first section of the assessment has been completed