### PR TITLE
Make premises name mandatory and unique

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -22,6 +22,9 @@ import javax.persistence.Table
 interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
   @Query("SELECT p FROM PremisesEntity p WHERE TYPE(p) = :type")
   fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesEntity>
+
+  @Query("SELECT COUNT(p) = 0 FROM PremisesEntity p WHERE name = :name AND TYPE(p) = :type")
+  fun <T : PremisesEntity> nameIsUniqueForType(name: String, type: Class<T>): Boolean
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -118,7 +118,7 @@ class PremisesService(
     postcode: String,
     service: String,
     localAuthorityAreaId: UUID,
-    name: String?,
+    name: String,
     notes: String?,
     characteristicIds: List<UUID>
   ) = validated<PremisesEntity> {
@@ -150,7 +150,7 @@ class PremisesService(
 
     var premises = TemporaryAccommodationPremisesEntity(
       id = UUID.randomUUID(),
-      name = if (name.isNullOrEmpty()) "Unknown" else name,
+      name = name,
       addressLine1 = addressLine1,
       postcode = postcode,
       probationRegion = probationRegion,
@@ -180,6 +180,10 @@ class PremisesService(
 
     if (localAuthorityAreaId == null) {
       "$.localAuthorityAreaId" hasValidationError "invalid"
+    }
+
+    if (name.isEmpty()) {
+      "$.name" hasValidationError "empty"
     }
 
     val characteristicEntities = characteristicIds.mapIndexed { index, uuid ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -186,6 +186,10 @@ class PremisesService(
       "$.name" hasValidationError "empty"
     }
 
+    if (!premisesRepository.nameIsUniqueForType(name, TemporaryAccommodationPremisesEntity::class.java)) {
+      "$.name" hasValidationError "notUnique"
+    }
+
     val characteristicEntities = characteristicIds.mapIndexed { index, uuid ->
       val entity = characteristicService.getCharacteristic(uuid)
 

--- a/src/main/resources/db/migration/all/20221103105357__add_unique_constraint_on_premises_name_and_service.sql
+++ b/src/main/resources/db/migration/all/20221103105357__add_unique_constraint_on_premises_name_and_service.sql
@@ -1,0 +1,1 @@
+ALTER TABLE premises ADD CONSTRAINT name_service_unique UNIQUE (name, service);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1528,6 +1528,7 @@ components:
             type: string
             format: uuid
       required:
+        - name
         - addressLine1
         - postcode
         - localAuthorityAreaId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -82,7 +82,7 @@ class PremisesTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `When a new premises is created with no name then it defaults to unknown`() {
+  fun `Trying to create a new premises without a name returns 400`() {
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
 
@@ -102,9 +102,10 @@ class PremisesTest : IntegrationTestBase() {
       )
       .exchange()
       .expectStatus()
-      .isCreated
+      .is4xxClientError
       .expectBody()
-      .jsonPath("name").isEqualTo("Unknown")
+      .jsonPath("title").isEqualTo("Bad Request")
+      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -38,6 +38,7 @@ class PremisesTest : IntegrationTestBase() {
       .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
+          name = "test-premises",
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
@@ -91,6 +92,7 @@ class PremisesTest : IntegrationTestBase() {
       .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewPremises(
+          name = "",
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
           notes = "some arbitrary notes",


### PR DESCRIPTION
> See [ticket #419 on the CAS3 Trello board](https://trello.com/c/jEnXy9cF/491-property-references-are-mandatory).

When creating a new premises, the name is currently optional and if not supplied is set to a default of `"Unknown"`.

This PR removes this default and makes the name mandatory and unique within a service, as from a user perspective enforcing a unique name will assist with identification of premises and reporting metrics.
