### PR TITLE
Premises characteristics can be saved

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -105,7 +105,8 @@ class PremisesController(
         service = serviceName,
         localAuthorityAreaId = body.localAuthorityAreaId,
         name = body.name,
-        notes = body.notes
+        notes = body.notes,
+        characteristicIds = body.characteristicIds
       )
     )
     return ResponseEntity(premisesTransformer.transformJpaToApi(premises, premises.totalBeds), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -11,6 +11,8 @@ import javax.persistence.Id
 import javax.persistence.Inheritance
 import javax.persistence.InheritanceType
 import javax.persistence.JoinColumn
+import javax.persistence.JoinTable
+import javax.persistence.ManyToMany
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.PrimaryKeyJoinColumn
@@ -46,6 +48,13 @@ abstract class PremisesEntity(
   val lostBeds: MutableList<LostBedsEntity>,
   @OneToMany(mappedBy = "premises")
   val rooms: MutableList<RoomEntity>,
+  @ManyToMany
+  @JoinTable(
+    name = "premises_characteristics",
+    joinColumns = [JoinColumn(name = "premises_id")],
+    inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
+  )
+  val characteristics: MutableList<CharacteristicEntity>,
 )
 
 @Entity
@@ -67,7 +76,21 @@ class ApprovedPremisesEntity(
   val deliusTeamCode: String,
   val qCode: String,
   rooms: MutableList<RoomEntity>,
-) : PremisesEntity(id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds, rooms)
+  characteristics: MutableList<CharacteristicEntity>,
+) : PremisesEntity(
+  id,
+  name,
+  addressLine1,
+  postcode,
+  totalBeds,
+  notes,
+  probationRegion,
+  localAuthorityArea,
+  bookings,
+  lostBeds,
+  rooms,
+  characteristics
+)
 
 @Entity
 @DiscriminatorValue("temporary-accommodation")
@@ -85,6 +108,18 @@ class TemporaryAccommodationPremisesEntity(
   bookings: MutableList<BookingEntity>,
   lostBeds: MutableList<LostBedsEntity>,
   rooms: MutableList<RoomEntity>,
+  characteristics: MutableList<CharacteristicEntity>,
 ) : PremisesEntity(
-  id, name, addressLine1, postcode, totalBeds, notes, probationRegion, localAuthorityArea, bookings, lostBeds, rooms
+  id,
+  name,
+  addressLine1,
+  postcode,
+  totalBeds,
+  notes,
+  probationRegion,
+  localAuthorityArea,
+  bookings,
+  lostBeds,
+  rooms,
+  characteristics
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -118,7 +118,8 @@ class PremisesService(
     service: String,
     localAuthorityAreaId: UUID,
     name: String?,
-    notes: String?
+    notes: String?,
+    characteristicIds: List<UUID>
   ) = validated<PremisesEntity> {
     /**
      * Start of setting up some dummy data to spike the implementation.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -26,7 +26,8 @@ class PremisesService(
   private val premisesRepository: PremisesRepository,
   private val lostBedsRepository: LostBedsRepository,
   private val bookingRepository: BookingRepository,
-  private val lostBedReasonRepository: LostBedReasonRepository
+  private val lostBedReasonRepository: LostBedReasonRepository,
+  private val characteristicService: CharacteristicService,
 ) {
   private val serviceNameToEntityType = mapOf(
     ServiceName.approvedPremises to ApprovedPremisesEntity::class.java,
@@ -140,6 +141,28 @@ class PremisesService(
     )
     // end of dummy data
 
+    val localAuthorityArea = LocalAuthorityAreaEntity(
+      id = localAuthorityAreaId,
+      identifier = "arbitrary_identifier",
+      name = "arbitrary_local_authority_area",
+      premises = mutableListOf()
+    )
+
+    var premises = TemporaryAccommodationPremisesEntity(
+      id = UUID.randomUUID(),
+      name = if(name.isNullOrEmpty()) "Unknown" else name,
+      addressLine1 = addressLine1,
+      postcode = postcode,
+      probationRegion = probationRegion,
+      localAuthorityArea = localAuthorityArea,
+      bookings = mutableListOf(),
+      lostBeds = mutableListOf(),
+      notes = if(notes.isNullOrEmpty()) "" else notes,
+      totalBeds = 0,
+      rooms = mutableListOf(),
+      characteristics = mutableListOf(),
+    )
+
     // start of validation
     if (addressLine1.isEmpty()) {
       "$.address" hasValidationError "empty"
@@ -159,44 +182,30 @@ class PremisesService(
       "$.localAuthorityAreaId" hasValidationError "invalid"
     }
 
+    val characteristicEntities = characteristicIds.mapIndexed { index, uuid ->
+      val entity = characteristicService.getCharacteristic(uuid)
+
+      if (entity == null) {
+        "$.characteristics[$index]" hasValidationError "doesNotExist"
+      } else {
+        if (!characteristicService.modelScopeMatches(entity, premises)) {
+          "$.characteristics[$index]" hasValidationError "incorrectCharacteristicModelScope"
+        }
+        if (!characteristicService.serviceScopeMatches(entity, premises)) {
+          "$.characteristics[$index]" hasValidationError "incorrectCharacteristicServiceScope"
+        }
+      }
+
+      entity
+    }
+
     if (validationErrors.any()) {
       return fieldValidationError
     }
     // end of validation
+    premises.characteristics.addAll(characteristicEntities.map { it!! })
+    premisesRepository.save(premises)
 
-    val localAuthorityArea = LocalAuthorityAreaEntity(
-      id = localAuthorityAreaId,
-      identifier = "arbitrary_identifier",
-      name = "arbitrary_local_authority_area",
-      premises = mutableListOf()
-    )
-
-    val premisesNotes = when (notes.isNullOrEmpty()) {
-      true -> ""
-      false -> notes
-    }
-
-    val premisesName = when (name.isNullOrEmpty()) {
-      true -> "Unknown"
-      false -> name
-    }
-
-    val premisesEntity = premisesRepository.save(
-      TemporaryAccommodationPremisesEntity(
-        id = UUID.randomUUID(),
-        name = premisesName,
-        addressLine1 = addressLine1,
-        postcode = postcode,
-        probationRegion = probationRegion,
-        localAuthorityArea = localAuthorityArea,
-        bookings = mutableListOf(),
-        lostBeds = mutableListOf(),
-        notes = premisesNotes,
-        totalBeds = 0,
-        rooms = mutableListOf(),
-      )
-    )
-
-    return success(premisesEntity)
+    return success(premises)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -150,14 +150,14 @@ class PremisesService(
 
     var premises = TemporaryAccommodationPremisesEntity(
       id = UUID.randomUUID(),
-      name = if(name.isNullOrEmpty()) "Unknown" else name,
+      name = if (name.isNullOrEmpty()) "Unknown" else name,
       addressLine1 = addressLine1,
       postcode = postcode,
       probationRegion = probationRegion,
       localAuthorityArea = localAuthorityArea,
       bookings = mutableListOf(),
       lostBeds = mutableListOf(),
-      notes = if(notes.isNullOrEmpty()) "" else notes,
+      notes = if (notes.isNullOrEmpty()) "" else notes,
       totalBeds = 0,
       rooms = mutableListOf(),
       characteristics = mutableListOf(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -13,7 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 class PremisesTransformer(
   private val probationRegionTransformer: ProbationRegionTransformer,
   private val apAreaTransformer: ApAreaTransformer,
-  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
+  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer,
+  private val characteristicTransformer: CharacteristicTransformer
 ) {
   fun transformJpaToApi(jpa: PremisesEntity, availableBedsForToday: Int): Premises = when (jpa) {
     is ApprovedPremisesEntity -> ApprovedPremises(
@@ -28,7 +29,8 @@ class PremisesTransformer(
       availableBedsForToday = availableBedsForToday,
       probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
-      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea)
+      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
+      characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
     )
     is TemporaryAccommodationPremisesEntity -> TemporaryAccommodationPremises(
       id = jpa.id,
@@ -41,7 +43,8 @@ class PremisesTransformer(
       availableBedsForToday = availableBedsForToday,
       probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
-      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea)
+      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
+      characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
     )
     else -> throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/resources/db/migration/all/20221102102732__add_premises_characteristics.sql
+++ b/src/main/resources/db/migration/all/20221102102732__add_premises_characteristics.sql
@@ -1,0 +1,8 @@
+CREATE TABLE premises_characteristics
+(
+    premises_id           UUID NOT NULL,
+    characteristic_id UUID NOT NULL,
+    PRIMARY KEY (premises_id, characteristic_id),
+    FOREIGN KEY (premises_id) REFERENCES premises (id),
+    FOREIGN KEY (characteristic_id) REFERENCES characteristics (id)
+)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1522,10 +1522,16 @@ components:
         localAuthorityAreaId:
           type: string
           format: uuid
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
       required:
         - addressLine1
         - postcode
         - localAuthorityAreaId
+        - characteristicIds
     LocalAuthorityArea:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -95,5 +95,6 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     notes = this.notes(),
     qCode = this.qCode(),
     rooms = mutableListOf(),
+    characteristics = mutableListOf()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
@@ -21,6 +21,10 @@ class CharacteristicEntityFactory : Factory<CharacteristicEntity> {
     this.modelScope = { modelScope }
   }
 
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
   override fun produce(): CharacteristicEntity = CharacteristicEntity(
     id = this.id(),
     name = this.name(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -78,5 +78,6 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     addressLine1 = this.addressLine1(),
     notes = this.notes(),
     rooms = mutableListOf(),
+    characteristics = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -618,6 +618,7 @@ class PremisesTest : IntegrationTestBase() {
     val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
       withModelScope("room")
       withServiceScope("temporary-accommodation")
+      withName("Floor level access")
     }.map { it.id }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -641,6 +642,7 @@ class PremisesTest : IntegrationTestBase() {
       .jsonPath("characteristics[*].id").isEqualTo(characteristicIds.map { it.toString() })
       .jsonPath("characteristics[*].modelScope").isEqualTo(MutableList(5) { "room" })
       .jsonPath("characteristics[*].serviceScope").isEqualTo(MutableList(5) { "temporary-accommodation" })
+      .jsonPath("characteristics[*].name").isEqualTo(MutableList(5) { "Floor level access" })
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -40,7 +40,8 @@ class PremisesTest : IntegrationTestBase() {
         NewPremises(
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
+          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()
@@ -63,7 +64,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB123CD",
           notes = "some arbitrary notes",
           name = "some arbitrary name",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
+          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()
@@ -92,7 +94,8 @@ class PremisesTest : IntegrationTestBase() {
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
           notes = "some arbitrary notes",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
+          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()
@@ -116,7 +119,8 @@ class PremisesTest : IntegrationTestBase() {
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
           name = "some arbitrary name",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f")
+          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()
@@ -141,7 +145,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB123CD",
           addressLine1 = "",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          notes = "some notes"
+          notes = "some notes",
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()
@@ -167,7 +172,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "",
           addressLine1 = "FIRST LINE OF THE ADDRESS",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          notes = "some notes"
+          notes = "some notes",
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()
@@ -192,7 +198,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB123CD",
           addressLine1 = "FIRST LINE OF THE ADDRESS",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          notes = "some notes"
+          notes = "some notes",
+          characteristicIds = mutableListOf()
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import java.time.LocalDate
 import java.util.UUID
@@ -34,12 +35,14 @@ class PremisesServiceTest {
   private val lostBedsRepositoryMock = mockk<LostBedsRepository>()
   private val bookingRepositoryMock = mockk<BookingRepository>()
   private val lostBedReasonRepositoryMock = mockk<LostBedReasonRepository>()
+  private val characteristicServiceMock = mockk<CharacteristicService>()
 
   private val premisesService = PremisesService(
     premisesRepositoryMock,
     lostBedsRepositoryMock,
     bookingRepositoryMock,
-    lostBedReasonRepositoryMock
+    lostBedReasonRepositoryMock,
+    characteristicServiceMock
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -91,6 +91,7 @@ class BookingTransformerTest {
     addressLine1 = "1 somewhere",
     notes = "",
     rooms = mutableListOf(),
+    characteristics = mutableListOf(),
   )
 
   private val baseBookingEntity = BookingEntity(


### PR DESCRIPTION
A premises can have characteristics associated with it such e.g Floor Level Access, etc. For a premises these characteristics need to be persisted in a separate link entity table called '**premises_characteristics**'. 

This is so that it can hold an id reference to the premises and an id reference to the particular characteristic. When a client makes a request to GET a premises then the list of characteristics will be included as it joins the tables together. Any entry present in the premises_characteristics table is implied that it is checked on the UI due to its presence in the table. 

