### PR TITLE
Send alerts to the events channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: approved-premises-team-dev
+    default: approved-premises-team-events
   releases-slack-channel:
     type: string
-    default: approved-premises-team-dev
+    default: approved-premises-team-events
 
 workflows:
   version: 2


### PR DESCRIPTION
#approved-premises-team-dev is no more, and the events channel seems like a better fit