### PR TITLE
819 - Get all assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.AssessmentsApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+
+@Service
+class AssessmentController(
+  private val assessmentService: AssessmentService,
+  private val userService: UserService,
+  private val offenderService: OffenderService,
+  private val assessmentTransformer: AssessmentTransformer
+) : AssessmentsApiDelegate {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun assessmentsGet(): ResponseEntity<List<Assessment>> {
+    val user = userService.getUserForRequest()
+
+    val assessments = assessmentService.getVisibleAssessmentsForUser(user)
+
+    return ResponseEntity.ok(
+      assessments.mapNotNull {
+        val applicationCrn = it.application.crn
+
+        val offenderDetailsResult = offenderService.getOffenderByCrn(applicationCrn, user.deliusUsername)
+        val offenderDetails = when (offenderDetailsResult) {
+          is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+          is AuthorisableActionResult.NotFound -> {
+            log.error("Could not get Offender Details for CRN: $applicationCrn")
+            return@mapNotNull null
+          }
+          is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
+        }
+
+        if (offenderDetails.otherIds.nomsNumber == null) {
+          log.error("No NOMS number for CRN: $applicationCrn")
+          return@mapNotNull null
+        }
+
+        val inmateDetailsResult = offenderService.getInmateDetailByNomsNumber(offenderDetails.otherIds.nomsNumber)
+        val inmateDetails = when (inmateDetailsResult) {
+          is AuthorisableActionResult.Success -> inmateDetailsResult.entity
+          is AuthorisableActionResult.NotFound -> {
+            log.error("Could not get Inmate Details for NOMS number: ${offenderDetails.otherIds.nomsNumber}")
+            return@mapNotNull null
+          }
+          is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
+        }
+
+        assessmentTransformer.transformJpaToApi(it, offenderDetails, inmateDetails)
+      }
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -11,6 +11,7 @@ import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.Table
 
@@ -49,6 +50,9 @@ data class AssessmentEntity(
   @Enumerated(value = EnumType.STRING)
   var decision: AssessmentDecision?,
 
+  @OneToMany(mappedBy = "assessment")
+  val clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
+
   @Transient
   var schemaUpToDate: Boolean
 )
@@ -57,3 +61,24 @@ enum class AssessmentDecision {
   ACCEPTED,
   REJECTED
 }
+
+@Repository
+interface AssessmentClarificationNoteRepository : JpaRepository<AssessmentClarificationNoteEntity, UUID>
+
+@Entity
+@Table(name = "assessment_clarification_notes")
+data class AssessmentClarificationNoteEntity(
+  @Id
+  val id: UUID,
+
+  @ManyToOne
+  @JoinColumn(name = "assessment_id")
+  val assessment: AssessmentEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdByUser: UserEntity,
+  val createdAt: OffsetDateTime,
+
+  val text: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -16,7 +16,9 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Repository
-interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID>
+interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
+  fun findAllByAllocatedToUser_Id(id: UUID): List<AssessmentEntity>
+}
 
 @Entity
 @Table(name = "assessments")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -48,7 +48,9 @@ data class UserEntity(
   val roles: MutableList<UserRoleAssignmentEntity>,
   @OneToMany(mappedBy = "user")
   val qualifications: MutableList<UserQualificationAssignmentEntity>
-)
+) {
+  fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
+}
 
 @Repository
 interface UserRoleAssignmentRepository : JpaRepository<UserRoleAssignmentEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -35,7 +35,8 @@ class AssessmentService(
         createdAt = dateTimeNow,
         submittedAt = null,
         decision = null,
-        schemaUpToDate = true
+        schemaUpToDate = true,
+        clarificationNotes = mutableListOf()
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaTyp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -17,6 +18,22 @@ class AssessmentService(
   private val assessmentRepository: AssessmentRepository,
   private val jsonSchemaService: JsonSchemaService
 ) {
+  fun getVisibleAssessmentsForUser(user: UserEntity): List<AssessmentEntity> {
+    val latestSchema = jsonSchemaService.getNewestSchema(JsonSchemaType.ASSESSMENT)
+
+    val assessments = if (user.hasRole(UserRole.WORKFLOW_MANAGER)) {
+      assessmentRepository.findAll()
+    } else {
+      assessmentRepository.findAllByAllocatedToUser_Id(user.id)
+    }
+
+    assessments.forEach {
+      it.schemaUpToDate = it.schemaVersion.id == latestSchema.id
+    }
+
+    return assessments
+  }
+
   fun createAssessment(application: ApplicationEntity): AssessmentEntity {
     val requiredQualifications = getRequiredQualifications(application)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+
+@Component
+class AssessmentTransformer(private val objectMapper: ObjectMapper, private val applicationsTransformer: ApplicationsTransformer) {
+  fun transformJpaToApi(jpa: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Assessment(
+    id = jpa.id,
+    application = applicationsTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail),
+    schemaVersion = jpa.schemaVersion.id,
+    outdatedSchema = jpa.schemaUpToDate,
+    createdAt = jpa.createdAt,
+    allocatedAt = jpa.allocatedAt,
+    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+    clarificationNotes = jpa.clarificationNotes.map {
+      ClarificationNote(
+        id = it.id,
+        createdAt = it.createdAt,
+        createdByStaffMemberId = it.createdByUser.id,
+        text = it.text
+      )
+    },
+    allocatedToStaffMemberId = jpa.allocatedToUser.id,
+    submittedAt = jpa.submittedAt
+  )
+}

--- a/src/main/resources/db/migration/all/20221102125322__clarification_notes.sql
+++ b/src/main/resources/db/migration/all/20221102125322__clarification_notes.sql
@@ -1,0 +1,10 @@
+CREATE TABLE assessment_clarification_notes (
+    id UUID NOT NULL,
+    assessment_id UUID NOT NULL,
+    created_by_user_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    text TEXT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (assessment_id) REFERENCES assessments(id),
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2491,13 +2491,9 @@ components:
     NewClarificationNote:
       type: object
       properties:
-        createdAt:
-          type: string
-          format: date-time
         text:
           type: string
       required:
-        - createdAt
         - text
     Reallocation:
       type: object

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2446,7 +2446,6 @@ components:
         - outdatedSchema
         - createdAt
         - allocatedAt
-        - data
         - clarificationNotes
     AssessmentDecision:
       type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2478,11 +2478,15 @@ components:
         createdAt:
           type: string
           format: date-time
+        createdByStaffMemberId:
+          type: string
+          format: uuid
         text:
           type: string
       required:
         - id
         - createdAt
+        - createdByStaffMemberId
         - text
     NewClarificationNote:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarificationNoteEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var assessment: Yielded<AssessmentEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var createdBy: Yielded<UserEntity>? = null
+  private var text: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAssessment(assessment: AssessmentEntity) = apply {
+    this.assessment = { assessment }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  fun withText(text: String) = apply {
+    this.text = { text }
+  }
+
+  override fun produce(): AssessmentClarificationNoteEntity = AssessmentClarificationNoteEntity(
+    id = this.id(),
+    assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
+    createdAt = this.createdAt(),
+    createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
+    text = this.text()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
@@ -30,6 +31,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var decision: Yielded<AssessmentDecision> = { AssessmentDecision.ACCEPTED }
   private var allocatedToUser: Yielded<UserEntity>? = null
+  private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -71,6 +73,10 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     this.allocatedToUser = { allocatedToUser }
   }
 
+  fun withClarificationNotes(clarificationNotes: MutableList<AssessmentClarificationNoteEntity>) = apply {
+    this.clarificationNotes = { clarificationNotes }
+  }
+
   override fun produce(): AssessmentEntity = AssessmentEntity(
     id = this.id(),
     data = this.data(),
@@ -82,6 +88,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     schemaUpToDate = false,
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
     allocatedToUser = this.allocatedToUser?.invoke() ?: throw RuntimeException("Must provide an allocatedToUser"),
-    allocatedAt = this.allocatedAt()
+    allocatedAt = this.allocatedAt(),
+    clarificationNotes = this.clarificationNotes()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/JsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/JsonSchemaEntityFactory.kt
@@ -30,6 +30,21 @@ class JsonSchemaEntityFactory : Factory<JsonSchemaEntity> {
     this.type = { type }
   }
 
+  fun withPermissiveSchema() = apply {
+    withSchema(
+      """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """
+    )
+  }
+
   override fun produce(): JsonSchemaEntity = JsonSchemaEntity(
     id = this.id(),
     addedAt = this.addedAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -35,7 +35,7 @@ class ApplicationTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    applicationSchemaRepository.deleteAll()
+    jsonSchemaRepository.deleteAll()
 
     val inmateDetail = InmateDetailFactory()
       .withOffenderNo("NOMS321")
@@ -58,7 +58,7 @@ class ApplicationTest : IntegrationTestBase() {
 
   @Test
   fun `Get all applications returns 200 with correct body, outdated applications upgraded where possible`() {
-    applicationSchemaRepository.deleteAll()
+    jsonSchemaRepository.deleteAll()
 
     val newestJsonSchema = jsonSchemaEntityFactory.produceAndPersist {
       withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
@@ -236,7 +236,7 @@ class ApplicationTest : IntegrationTestBase() {
 
   @Test
   fun `Get single application returns 200 with correct body, outdated application upgraded`() {
-    applicationSchemaRepository.deleteAll()
+    jsonSchemaRepository.deleteAll()
 
     val newestJsonSchema = jsonSchemaEntityFactory.produceAndPersist {
       withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
@@ -388,7 +388,7 @@ class ApplicationTest : IntegrationTestBase() {
 
   @Test
   fun `Get single application returns 200 with correct body, non-upgradable outdated application marked as such`() {
-    applicationSchemaRepository.deleteAll()
+    jsonSchemaRepository.deleteAll()
 
     jsonSchemaEntityFactory.produceAndPersist {
       withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+
+class AssessmentTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var assessmentTransformer: AssessmentTransformer
+
+  private val offenderDetails = OffenderDetailsSummaryFactory()
+    .withCrn("CRN123")
+    .withNomsNumber("NOMS321")
+    .produce()
+
+  @BeforeEach
+  fun setup() {
+    jsonSchemaRepository.deleteAll()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+  }
+
+  @Test
+  fun `Get all assessments without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/assessments")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get all assessments returns 200 with correct body`() {
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN123")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+
+    val inmateDetails = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockInmateDetailPrisonsApiCall(inmateDetails)
+
+    val applicationSchema = jsonSchemaEntityFactory.produceAndPersist {
+      withType(JsonSchemaType.APPLICATION)
+      withPermissiveSchema()
+    }
+
+    val assessmentSchema = jsonSchemaEntityFactory.produceAndPersist {
+      withType(JsonSchemaType.ASSESSMENT)
+      withPermissiveSchema()
+    }
+
+    val application = applicationEntityFactory.produceAndPersist {
+      withCrn("CRN123")
+      withCreatedByUser(user)
+      withApplicationSchema(applicationSchema)
+    }
+
+    val assessment = assessmentEntityFactory.produceAndPersist {
+      withAllocatedToUser(user)
+      withApplication(application)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    assessment.schemaUpToDate = true
+
+    webTestClient.get()
+      .uri("/assessments")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        objectMapper.writeValueAsString(
+          listOf(
+            assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
+          )
+        )
+      )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -186,7 +186,7 @@ abstract class IntegrationTestBase {
   lateinit var applicationRepository: ApplicationTestRepository
 
   @Autowired
-  lateinit var applicationSchemaRepository: ApplicationSchemaTestRepository
+  lateinit var jsonSchemaRepository: ApplicationSchemaTestRepository
 
   @Autowired
   lateinit var userRepository: UserTestRepository
@@ -278,7 +278,7 @@ abstract class IntegrationTestBase {
     extensionEntityFactory = PersistedFactory(ExtensionEntityFactory(), extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory(NonArrivalReasonEntityFactory(), nonArrivalReasonRepository)
     applicationEntityFactory = PersistedFactory(ApplicationEntityFactory(), applicationRepository)
-    jsonSchemaEntityFactory = PersistedFactory(JsonSchemaEntityFactory(), applicationSchemaRepository)
+    jsonSchemaEntityFactory = PersistedFactory(JsonSchemaEntityFactory(), jsonSchemaRepository)
     userEntityFactory = PersistedFactory(UserEntityFactory(), userRepository)
     userRoleAssignmentEntityFactory = PersistedFactory(UserRoleAssignmentEntityFactory(), userRoleAssignmentRepository)
     userQualificationAssignmentEntityFactory = PersistedFactory(UserQualificationAssignmentEntityFactory(), userQualificationAssignmentRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
@@ -46,6 +47,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
@@ -80,6 +82,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationSc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentClarificationNoteTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
@@ -198,6 +201,9 @@ abstract class IntegrationTestBase {
   lateinit var assessmentRepository: AssessmentTestRepository
 
   @Autowired
+  lateinit var assessmentClarificationNoteRepository: AssessmentClarificationNoteTestRepository
+
+  @Autowired
   lateinit var characteristicRepository: CharacteristicRepository
 
   @Autowired
@@ -227,6 +233,7 @@ abstract class IntegrationTestBase {
   lateinit var userRoleAssignmentEntityFactory: PersistedFactory<UserRoleAssignmentEntity, UUID, UserRoleAssignmentEntityFactory>
   lateinit var userQualificationAssignmentEntityFactory: PersistedFactory<UserQualificationAssignmentEntity, UUID, UserQualificationAssignmentEntityFactory>
   lateinit var assessmentEntityFactory: PersistedFactory<AssessmentEntity, UUID, AssessmentEntityFactory>
+  lateinit var assessmentClarificationNoteEntityFactory: PersistedFactory<AssessmentClarificationNoteEntity, UUID, AssessmentClarificationNoteEntityFactory>
   lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
   lateinit var roomEntityFactory: PersistedFactory<RoomEntity, UUID, RoomEntityFactory>
 
@@ -276,6 +283,7 @@ abstract class IntegrationTestBase {
     userRoleAssignmentEntityFactory = PersistedFactory(UserRoleAssignmentEntityFactory(), userRoleAssignmentRepository)
     userQualificationAssignmentEntityFactory = PersistedFactory(UserQualificationAssignmentEntityFactory(), userQualificationAssignmentRepository)
     assessmentEntityFactory = PersistedFactory(AssessmentEntityFactory(), assessmentRepository)
+    assessmentClarificationNoteEntityFactory = PersistedFactory(AssessmentClarificationNoteEntityFactory(), assessmentClarificationNoteRepository)
     characteristicEntityFactory = PersistedFactory(CharacteristicEntityFactory(), characteristicRepository)
     roomEntityFactory = PersistedFactory(RoomEntityFactory(), roomRepository)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentClarificationNoteTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentClarificationNoteTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import java.util.UUID
+
+@Repository
+interface AssessmentClarificationNoteTestRepository : JpaRepository<AssessmentClarificationNoteEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.JsonSchemaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+
+class AssessmentServiceTest {
+  private val userRepositoryMock = mockk<UserRepository>()
+  private val assessmentRepositoryMock = mockk<AssessmentRepository>()
+  private val jsonSchemaServiceMock = mockk<JsonSchemaService>()
+
+  private val assessmentService = AssessmentService(userRepositoryMock, assessmentRepositoryMock, jsonSchemaServiceMock)
+
+  @Test
+  fun `getVisibleAssessmentsForUser fetches all assessments for workflow managers`() {
+    val user = UserEntityFactory()
+      .produce()
+
+    user.roles.add(
+      UserRoleAssignmentEntityFactory()
+        .withRole(UserRole.WORKFLOW_MANAGER)
+        .withUser(user)
+        .produce()
+    )
+
+    val allAssessments = listOf(
+      AssessmentEntityFactory()
+        .withAllocatedToUser(
+          UserEntityFactory().produce()
+        )
+        .withApplication(
+          ApplicationEntityFactory()
+            .withCreatedByUser(UserEntityFactory().produce())
+            .produce()
+        )
+        .produce()
+    )
+
+    every { assessmentRepositoryMock.findAll() } returns allAssessments
+    every { jsonSchemaServiceMock.getNewestSchema(JsonSchemaType.ASSESSMENT) } returns JsonSchemaEntityFactory().produce()
+
+    val result = assessmentService.getVisibleAssessmentsForUser(user)
+
+    assertThat(result).containsAll(allAssessments)
+
+    verify(exactly = 1) { assessmentRepositoryMock.findAll() }
+  }
+
+  @Test
+  fun `getVisibleAssessmentsForUser fetches only allocated assessments`() {
+    val user = UserEntityFactory()
+      .produce()
+
+    val allocatedAssessments = listOf(
+      AssessmentEntityFactory()
+        .withAllocatedToUser(user)
+        .withApplication(
+          ApplicationEntityFactory()
+            .withCreatedByUser(UserEntityFactory().produce())
+            .produce()
+        )
+        .produce()
+    )
+
+    every { assessmentRepositoryMock.findAllByAllocatedToUser_Id(user.id) } returns allocatedAssessments
+    every { jsonSchemaServiceMock.getNewestSchema(JsonSchemaType.ASSESSMENT) } returns JsonSchemaEntityFactory().produce()
+
+    val result = assessmentService.getVisibleAssessmentsForUser(user)
+
+    assertThat(result).containsAll(allocatedAssessments)
+
+    verify(exactly = 1) { assessmentRepositoryMock.findAllByAllocatedToUser_Id(user.id) }
+  }
+}


### PR DESCRIPTION
**Few small changes to the Assessments Open API spec**

- Add a createdByUserId to clarification notes, so we can tell who has created each note in cases where assessment is reallocated or an admin adds a note to an assessment they are not allocated to
- Remove createdAt from NewClarificationNote - this should be determined by the API rather than trusting user input
- Make data optional on Assessment - this would be null until the first section of the assessment has been completed



**Groundwork for Application Clarification Notes**
Adds a table, entity etc. since these need to be returned with the assessment responses

**Implement GET /assessments**
Returns all assessments if the user is a workflow manager, otherwise returns the ones that are allocated to the user.  If any problems are encountered fetching futher info on individual assessments log an error and omit that assessment from the response to prevent a single issue breaking the endpoint entirely.