### PR TITLE
Split out submit endpoint for Applications / Simplify schema version checks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -77,9 +77,8 @@ class ApplicationsController(
     val username = deliusPrincipal.name
 
     val serializedData = objectMapper.writeValueAsString(body.data)
-    val serializedDocument = objectMapper.writeValueAsString(body.document)
 
-    val applicationResult = applicationService.updateApplication(applicationId, serializedData, serializedDocument, body.isWomensApplication, body.isPipeApplication, body.submittedAt, username)
+    val applicationResult = applicationService.updateApplication(applicationId, serializedData, body.isWomensApplication, body.isPipeApplication, username)
 
     val validationResult = when (applicationResult) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -26,7 +26,7 @@ class ApplicationService(
       ?: return emptyList()
 
     return applicationRepository.findAllByCreatedByUser_Id(userEntity.id)
-      .map(jsonSchemaService::attemptSchemaUpgrade)
+      .map(jsonSchemaService::checkSchemaOutdated)
   }
 
   fun getApplicationForUsername(applicationId: UUID, userDistinguishedName: String): AuthorisableActionResult<ApplicationEntity> {
@@ -39,7 +39,7 @@ class ApplicationService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    return AuthorisableActionResult.Success(jsonSchemaService.attemptSchemaUpgrade(applicationEntity))
+    return AuthorisableActionResult.Success(jsonSchemaService.checkSchemaOutdated(applicationEntity))
   }
 
   fun createApplication(crn: String, username: String) = validated<ApplicationEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
@@ -35,23 +35,10 @@ class JsonSchemaService(
     return validationErrors.isEmpty()
   }
 
-  fun attemptSchemaUpgrade(application: ApplicationEntity): ApplicationEntity {
-    if (application.data == null) return application.apply { schemaUpToDate = true }
-
+  fun checkSchemaOutdated(application: ApplicationEntity): ApplicationEntity {
     val newestSchema = jsonSchemaRepository.findFirstByTypeOrderByAddedAtDesc(JsonSchemaType.APPLICATION)
 
-    if (application.schemaVersion.id != newestSchema.id) {
-      if (!validate(newestSchema, application.data!!)) {
-        return application.apply { schemaUpToDate = false }
-      }
-
-      application.schemaVersion = newestSchema
-      applicationRepository.save(application)
-    }
-
-    application.schemaUpToDate = true
-
-    return application
+    return application.apply { application.schemaUpToDate = application.schemaVersion.id == newestSchema.id }
   }
 
   fun getNewestSchema(jsonSchemaType: JsonSchemaType): JsonSchemaEntity = jsonSchemaRepository.findFirstByTypeOrderByAddedAtDesc(jsonSchemaType)

--- a/src/main/resources/db/migration/all/20221114110948__make_application_schema_version_required.sql
+++ b/src/main/resources/db/migration/all/20221114110948__make_application_schema_version_required.sql
@@ -1,0 +1,2 @@
+UPDATE applications SET schema_version = 'f96725f6-27ac-46f2-83e0-00cf4af48370';
+ALTER TABLE applications ALTER COLUMN schema_version SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1169,6 +1169,41 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/submission:
+    post:
+      tags:
+        - Application data
+      summary: Submits an Application
+      parameters:
+        - in: path
+          name: applicationId
+          required: true
+          description: Id of the application
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information needed to submit an application
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SubmitApplication'
+        required: true
+      responses:
+        200:
+          description: successfully submitted the application
+        400:
+          description: application has already been submitted
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /applications/{applicationId}/allocations:
     post:
       tags:
@@ -2529,19 +2564,19 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/AnyValue'
-        document:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
         isWomensApplication:
           type: boolean
         isPipeApplication:
           type: boolean
-        submittedAt:
-          type: string
-          format: date-time
       required:
         - data
+    SubmitApplication:
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+      required:
+        - translatedDocument
     PrisonCaseNote:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -57,7 +57,7 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get all applications returns 200 with correct body, outdated applications upgraded where possible`() {
+  fun `Get all applications returns 200 with correct body`() {
     jsonSchemaRepository.deleteAll()
 
     val newestJsonSchema = jsonSchemaEntityFactory.produceAndPersist {
@@ -100,8 +100,8 @@ class ApplicationTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
-    val upgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
-      withApplicationSchema(olderJsonSchema)
+    val upToDateApplicationEntity = applicationEntityFactory.produceAndPersist {
+      withApplicationSchema(newestJsonSchema)
       withCrn(offenderDetails.otherIds.crn)
       withCreatedByUser(user)
       withData(
@@ -113,7 +113,7 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val nonUpgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
+    val outdatedApplicationEntity = applicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
       withCreatedByUser(user)
       withCrn(offenderDetails.otherIds.crn)
@@ -135,22 +135,22 @@ class ApplicationTest : IntegrationTestBase() {
     val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<Application>>() {})
 
     assertThat(responseBody).anyMatch {
-      nonUpgradableApplicationEntity.id == it.id &&
-        nonUpgradableApplicationEntity.crn == it.person?.crn &&
-        nonUpgradableApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
-        nonUpgradableApplicationEntity.createdByUser.id == it.createdByUserId &&
-        nonUpgradableApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
-        serializableToJsonNode(nonUpgradableApplicationEntity.data) == serializableToJsonNode(it.data) &&
+      outdatedApplicationEntity.id == it.id &&
+        outdatedApplicationEntity.crn == it.person?.crn &&
+        outdatedApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
+        outdatedApplicationEntity.createdByUser.id == it.createdByUserId &&
+        outdatedApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
+        serializableToJsonNode(outdatedApplicationEntity.data) == serializableToJsonNode(it.data) &&
         olderJsonSchema.id == it.schemaVersion && it.outdatedSchema
     }
 
     assertThat(responseBody).anyMatch {
-      upgradableApplicationEntity.id == it.id &&
-        upgradableApplicationEntity.crn == it.person?.crn &&
-        upgradableApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
-        upgradableApplicationEntity.createdByUser.id == it.createdByUserId &&
-        upgradableApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
-        serializableToJsonNode(upgradableApplicationEntity.data) == serializableToJsonNode(it.data) &&
+      upToDateApplicationEntity.id == it.id &&
+        upToDateApplicationEntity.crn == it.person?.crn &&
+        upToDateApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
+        upToDateApplicationEntity.createdByUser.id == it.createdByUserId &&
+        upToDateApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
+        serializableToJsonNode(upToDateApplicationEntity.data) == serializableToJsonNode(it.data) &&
         newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
     }
   }
@@ -235,7 +235,7 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get single application returns 200 with correct body, outdated application upgraded`() {
+  fun `Get single application returns 200 with correct body`() {
     jsonSchemaRepository.deleteAll()
 
     val newestJsonSchema = jsonSchemaEntityFactory.produceAndPersist {
@@ -260,26 +260,10 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val olderJsonSchema = jsonSchemaEntityFactory.produceAndPersist {
-      withAddedAt(OffsetDateTime.parse("2022-09-21T09:45:00+01:00"))
-      withSchema(
-        """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": { }
-        }
-        """
-      )
-    }
-
     val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
-    val upgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
-      withApplicationSchema(olderJsonSchema)
+    val applicationEntity = applicationEntityFactory.produceAndPersist {
+      withApplicationSchema(newestJsonSchema)
       withCrn(offenderDetails.otherIds.crn)
       withCreatedByUser(userEntity)
       withData(
@@ -294,7 +278,7 @@ class ApplicationTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
 
     val rawResponseBody = webTestClient.get()
-      .uri("/applications/${upgradableApplicationEntity.id}")
+      .uri("/applications/${applicationEntity.id}")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -306,12 +290,12 @@ class ApplicationTest : IntegrationTestBase() {
     val responseBody = objectMapper.readValue(rawResponseBody, Application::class.java)
 
     assertThat(responseBody).matches {
-      upgradableApplicationEntity.id == it.id &&
-        upgradableApplicationEntity.crn == it.person.crn &&
-        upgradableApplicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
-        upgradableApplicationEntity.createdByUser.id == it.createdByUserId &&
-        upgradableApplicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
-        serializableToJsonNode(upgradableApplicationEntity.data) == serializableToJsonNode(it.data) &&
+      applicationEntity.id == it.id &&
+        applicationEntity.crn == it.person.crn &&
+        applicationEntity.createdAt.toInstant() == it.createdAt.toInstant() &&
+        applicationEntity.createdByUser.id == it.createdByUserId &&
+        applicationEntity.submittedAt?.toInstant() == it.submittedAt?.toInstant() &&
+        serializableToJsonNode(applicationEntity.data) == serializableToJsonNode(it.data) &&
         newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -78,7 +78,7 @@ class ApplicationServiceTest {
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
     every { mockApplicationRepository.findAllByCreatedByUser_Id(userId) } returns applicationEntities
-    every { mockJsonSchemaService.attemptSchemaUpgrade(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+    every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     assertThat(applicationService.getAllApplicationsForUsername(distinguishedName)).containsAll(applicationEntities)
   }
@@ -126,7 +126,7 @@ class ApplicationServiceTest {
       .withApplicationSchema(newestJsonSchema)
       .produce()
 
-    every { mockJsonSchemaService.attemptSchemaUpgrade(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+    every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns applicationEntity
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
 


### PR DESCRIPTION
**Split out submission endpoint in OpenAPI spec**

No longer use the presence of `submittedAt` on a PUT request to indicate a submission - rather split out a dedicated /submission endpoint for this.  This endpoint also accepts the denormalised JSON document of the application.

**Remove submission logic from PUT endpoint**

Remove the code that creates an assessment when updating an application if `submittedAt` is true.

**Simplify schema outdated checks**

Enforce that all applications must have a schema version.  Do not attempt to upgrade schema versions anymore - this can't work because the JSON blob won't ever pass validation until it is 100% complete.  Instead, on GETs return that the schema is outdated if a new schema version has been released.  

Do not allow updates to applications with an outdated schema - return a 400 instead.