### PR TITLE
Implement an 'update room' endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Room
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateRoom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
@@ -420,6 +421,14 @@ class PremisesController(
     )
 
     return ResponseEntity(roomTransformer.transformJpaToApi(room), HttpStatus.CREATED)
+  }
+
+  override fun premisesPremisesIdRoomsRoomIdPut(
+    premisesId: UUID,
+    roomId: UUID,
+    updateRoom: UpdateRoom
+  ): ResponseEntity<Room> {
+    return super.premisesPremisesIdRoomsRoomIdPut(premisesId, roomId, updateRoom)
   }
 
   private fun getBookingForPremisesOrThrow(premisesId: UUID, bookingId: UUID) = when (val result = bookingService.getBookingForPremises(premisesId, bookingId)) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -657,6 +657,56 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/rooms/{roomId}:
+    put:
+      summary: Updates a room
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the room is in
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: roomId
+          in: path
+          description: ID of the room to update
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information to update the room with
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateRoom'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Room'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or room ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /people/search:
     get:
       summary: Searches for a Person by their CRN
@@ -2554,6 +2604,18 @@ components:
             format: uuid
       required:
         - name
+        - characteristicIds
+    UpdateRoom:
+      type: object
+      properties:
+        notes:
+          type: string
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
         - characteristicIds
     Room:
       type: object


### PR DESCRIPTION
> See [ticket #422 on the CAS3 Trello board](https://trello.com/c/WCaf76xE/422-a-user-can-edit-details-of-a-bedspace).

Currently, the API does not allow rooms to be modified after they have been created. However, a user may wish to update the notes on a room or alter its characteristics.

This PR implements the `PUT /premises/{premisesId}/rooms/{roomId}` endpoint to allow existing rooms to be modified. It accepts an `UpdateRoom` schema in the request body and returns the updated room.

Note that the name of the room is not able to be changed. The CAS3 team believe that this value should be immutable to avoid confusion caused by a change of name (such as in reporting, correspondence, etc.).