### PR TITLE
Oasys endpoints

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3209,6 +3209,10 @@ components:
             type: string
           answers:
             type: object
+        required:
+          - label
+          - questionNumber
+          - answers
         example:
           - label: "Current offence details"
             questionNumber: "R6.1 FA1"
@@ -3289,4 +3293,7 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         risksToOthers:
           $ref: '#/components/schemas/ArrayOfOASysRisksToOthersQuestions'
+      required:
+        - assessmentId
+        - risksToOthers
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1068,6 +1068,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/rosh-summary:
+    get:
+      tags:
+        - OASys
+      summary: Returns the latest OASys Risk of Serious Harm (RoSH) summary for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys RoSH summary
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRiskOfSeriousHarmSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -3023,6 +3054,40 @@ components:
             questionNumber: "RM31"
             answers:
               - "State they will have secure accommodation for Mr Smith and partner on release, although ..."
+    ArrayOfOASysRiskOfSeriousHarmSummaryQuestions:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          questionNumber:
+            type: string
+          answers:
+            type: object
+        example:
+          - label: "Who is at risk?"
+            questionNumber: "R10.1"
+            answers:
+              - "Males whom Mr Smith believes have wronged him, or strangers with whom he gets...."
+          - label: "What is the nature of the risk?"
+            questionNumber: "R10.2"
+            answers:
+              - "Violence"
+              - "Threats"
+              - "Physical harm"
+          - label: "When is the risk likely to be greatest?"
+            questionNumber: "R10.3"
+            answers:
+              - "Not imminent ? lengthy gap between convictions for violent offences..."
+          - label: "What circumstances are likely to increase the risk?"
+            questionNumber: "R10.4"
+            answers:
+              - "As above ? drug use, need to obtain money for drugs at all costs..."
+          - label: "What factors are likely to reduce the risk?"
+            questionNumber: "R10.5"
+            answers:
+              - "Mr Smith thinking about consequences of his actions and not acting impulsively..."
     OASysOffenceAnalysis:
       type: object
       properties:
@@ -3047,4 +3112,12 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         riskManagementPlan:
           $ref: '#/components/schemas/ArrayOfOASysRiskManagementQuestions'
+    OASysRiskOfSeriousHarmSummary:
+      type: object
+      properties:
+        assessmentId:
+          type: object
+          $ref: '#/components/schemas/OASysAssessmentId'
+        riskOfSeriousHarmSummary:
+          $ref: '#/components/schemas/ArrayOfOASysRiskOfSeriousHarmSummaryQuestions'
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3087,6 +3087,10 @@ components:
             type: string
           answers:
             type: object
+        required:
+          - label
+          - questionNumber
+          - answers
         example:
           - label: "Accommodation issues contributing to risks of offending and harm"
             questionNumber: "3.9"
@@ -3229,6 +3233,9 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         riskContributors:
           $ref: '#/components/schemas/ArrayOfOASysRiskContributorsQuestions'
+      required:
+        - assessmentId
+        - riskContributors
     OASysRiskManagementPlan:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1037,6 +1037,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/risk-management-plan:
+    get:
+      tags:
+        - OASys
+      summary: Returns the latest OASys Risk Management Plan for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys Risk Management Plan
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRiskManagementPlan'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -2968,6 +2999,30 @@ components:
             questionNumber: "4.9"
             answers:
               - "Mr Smith told me that his formal school education was regularly interrupted as he and his family travelled a lot whilst he was growing up..."
+    ArrayOfOASysRiskManagementQuestions:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          questionNumber:
+            type: string
+          answers:
+            type: object
+        example:
+          - label: "Current situation"
+            questionNumber: "RM28.1"
+            answers:
+              - "Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."
+          - label: "Supervision"
+            questionNumber: "RM30"
+            answers:
+              - "Probation Officer, Education training and employment Officer, Prison Offender Supervisor"
+          - label: "Monitoring and control"
+            questionNumber: "RM31"
+            answers:
+              - "State they will have secure accommodation for Mr Smith and partner on release, although ..."
     OASysOffenceAnalysis:
       type: object
       properties:
@@ -2984,4 +3039,12 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         riskContributors:
           $ref: '#/components/schemas/ArrayOfOASysRiskContributorsQuestions'
+    OASysRiskManagementPlan:
+      type: object
+      properties:
+        assessmentId:
+          type: object
+          $ref: '#/components/schemas/OASysAssessmentId'
+        riskManagementPlan:
+          $ref: '#/components/schemas/ArrayOfOASysRiskManagementQuestions'
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1099,6 +1099,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/risks-to-the-individual:
+    get:
+      tags:
+        - OASys
+      summary: Returns the latest OASys risks to the individual (R8, R9) for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys risks to the individual
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRisksToTheIndividual'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -3088,6 +3119,34 @@ components:
             questionNumber: "R10.5"
             answers:
               - "Mr Smith thinking about consequences of his actions and not acting impulsively..."
+    ArrayOfOASysRisksToTheIndividualQuestions:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          questionNumber:
+            type: string
+          answers:
+            type: object
+        example:
+          - label: "Current concerns about self-harm or suicide"
+            questionNumber: "R8.1.1"
+            answers:
+              - "There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody..."
+          - label: "Previous concerns about self-harm or suicide"
+            questionNumber: "R8.1.4"
+            answers:
+              - "During Mr Smith's psr report, he denied having any history of self-harm, however... "
+          - label: "Current concerns about Coping in Custody or Hostel."
+            questionNumber: "R8.2.1"
+            answers:
+              - "Has told prison staff that he swallowed batteries on one occasion due to wanting..."
+          - label: "Previous concerns about Coping in Custody or Hostel."
+            questionNumber: "R8.2.2"
+            answers:
+              - "Reported in 2021 that he will keep himself to himself because he gets discomfiture..."
     OASysOffenceAnalysis:
       type: object
       properties:
@@ -3120,4 +3179,12 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         riskOfSeriousHarmSummary:
           $ref: '#/components/schemas/ArrayOfOASysRiskOfSeriousHarmSummaryQuestions'
+    OASysRisksToTheIndividual:
+      type: object
+      properties:
+        assessmentId:
+          type: object
+          $ref: '#/components/schemas/OASysAssessmentId'
+        risksToTheIndividual:
+          $ref: '#/components/schemas/ArrayOfOASysRisksToTheIndividualQuestions'
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3046,23 +3046,25 @@ components:
       description: The ID of assessment being used. This should always be the latest Layer 3 assessment, regardless of state.
       type: long
       example: 138985987
+    OASysQuestion:
+      type: object
+      properties:
+        label:
+          type: string
+        questionNumber:
+          type: string
+        answers:
+          type: array
+          items:
+            type: string
+      required:
+        - label
+        - questionNumber
+        - answers
     ArrayOfOASysOffenceAnalysisQuestions:
       type: array
       items:
-        type: object
-        properties:
-          label:
-            type: string
-          questionNumber:
-            type: string
-          answers:
-            type: array
-            items:
-              type: string
-        required:
-          - label
-          - questionNumber
-          - answers
+        type: OASysQuestion
         example:
           - label: "Offence summary"
             questionNumber: "2.1"
@@ -3081,20 +3083,7 @@ components:
     ArrayOfOASysRiskContributorsQuestions:
       type: array
       items:
-        type: object
-        properties:
-          label:
-            type: string
-          questionNumber:
-            type: string
-          answers:
-            type: array
-            items:
-              type: string
-        required:
-          - label
-          - questionNumber
-          - answers
+        type: OASysQuestion
         example:
           - label: "Accommodation issues contributing to risks of offending and harm"
             questionNumber: "3.9"
@@ -3107,20 +3096,7 @@ components:
     ArrayOfOASysRiskManagementQuestions:
       type: array
       items:
-        type: object
-        properties:
-          label:
-            type: string
-          questionNumber:
-            type: string
-          answers:
-            type: array
-            items:
-              type: string
-        required:
-          - label
-          - questionNumber
-          - answers
+        type: OASysQuestion
         example:
           - label: "Current situation"
             questionNumber: "RM28.1"
@@ -3137,20 +3113,7 @@ components:
     ArrayOfOASysRiskOfSeriousHarmSummaryQuestions:
       type: array
       items:
-        type: object
-        properties:
-          label:
-            type: string
-          questionNumber:
-            type: string
-          answers:
-            type: array
-            items:
-              type: string
-        required:
-          - label
-          - questionNumber
-          - answers
+        type: OASysQuestion
         example:
           - label: "Who is at risk?"
             questionNumber: "R10.1"
@@ -3175,56 +3138,28 @@ components:
             answers:
               - "Mr Smith thinking about consequences of his actions and not acting impulsively..."
     ArrayOfOASysRisksToTheIndividualQuestions:
-      type: array
-      items:
-        type: object
-        properties:
-          label:
-            type: string
-          questionNumber:
-            type: string
+      type: OASysQuestion
+      example:
+        - label: "Current concerns about self-harm or suicide"
+          questionNumber: "R8.1.1"
           answers:
-            type: array
-            items:
-              type: string
-        required:
-          - label
-          - questionNumber
-          - answers
-        example:
-          - label: "Current concerns about self-harm or suicide"
-            questionNumber: "R8.1.1"
-            answers:
-              - "There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody..."
-          - label: "Previous concerns about self-harm or suicide"
-            questionNumber: "R8.1.4"
-            answers:
-              - "During Mr Smith's psr report, he denied having any history of self-harm, however... "
-          - label: "Current concerns about Coping in Custody or Hostel."
-            questionNumber: "R8.2.1"
-            answers:
-              - "Has told prison staff that he swallowed batteries on one occasion due to wanting..."
-          - label: "Previous concerns about Coping in Custody or Hostel."
-            questionNumber: "R8.2.2"
-            answers:
-              - "Reported in 2021 that he will keep himself to himself because he gets discomfiture..."
+            - "There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody..."
+        - label: "Previous concerns about self-harm or suicide"
+          questionNumber: "R8.1.4"
+          answers:
+            - "During Mr Smith's psr report, he denied having any history of self-harm, however... "
+        - label: "Current concerns about Coping in Custody or Hostel."
+          questionNumber: "R8.2.1"
+          answers:
+            - "Has told prison staff that he swallowed batteries on one occasion due to wanting..."
+        - label: "Previous concerns about Coping in Custody or Hostel."
+          questionNumber: "R8.2.2"
+          answers:
+            - "Reported in 2021 that he will keep himself to himself because he gets discomfiture..."
     ArrayOfOASysRisksToOthersQuestions:
       type: array
       items:
-        type: object
-        properties:
-          label:
-            type: string
-          questionNumber:
-            type: string
-          answers:
-            type: array
-            items:
-              type: string
-        required:
-          - label
-          - questionNumber
-          - answers
+        type: OASysQuestion
         example:
           - label: "Current offence details"
             questionNumber: "R6.1 FA1"

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1006,6 +1006,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/risk-contributors:
+    get:
+      tags:
+        - OASys
+      summary: Returns the latest OASys information on issues contributing to risks of offending or harm for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys information on issues contributing to risks
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRiskContributors'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -2917,6 +2948,26 @@ components:
             questionNumber: "2.3"
             answers:
               - "Iron bar"
+    ArrayOfOASysRiskContributorsQuestions:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          questionNumber:
+            type: string
+          answers:
+            type: object
+        example:
+          - label: "Accommodation issues contributing to risks of offending and harm"
+            questionNumber: "3.9"
+            answers:
+              - "Mr Smith told me that he was renting a room in a shared house, prior to his current remand..."
+          - label: "Education, training and employability issues contributing to risks of offending and harm"
+            questionNumber: "4.9"
+            answers:
+              - "Mr Smith told me that his formal school education was regularly interrupted as he and his family travelled a lot whilst he was growing up..."
     OASysOffenceAnalysis:
       type: object
       properties:
@@ -2925,3 +2976,12 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         offenceAnalysis:
           $ref: '#/components/schemas/ArrayOfOASysOffenceAnalysisQuestions'
+    OASysRiskContributors:
+      type: object
+      properties:
+        assessmentId:
+          type: object
+          $ref: '#/components/schemas/OASysAssessmentId'
+        riskContributors:
+          $ref: '#/components/schemas/ArrayOfOASysRiskContributorsQuestions'
+

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3139,6 +3139,10 @@ components:
             type: string
           answers:
             type: object
+        required:
+          - label
+          - questionNumber
+          - answers
         example:
           - label: "Who is at risk?"
             questionNumber: "R10.1"
@@ -3259,6 +3263,9 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         riskOfSeriousHarmSummary:
           $ref: '#/components/schemas/ArrayOfOASysRiskOfSeriousHarmSummaryQuestions'
+      required:
+        - assessmentId
+        - riskOfSeriousHarmSummary
     OASysRisksToTheIndividual:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3056,7 +3056,9 @@ components:
           questionNumber:
             type: string
           answers:
-            type: object
+            type: array
+            items:
+              type: string
         required:
           - label
           - questionNumber
@@ -3086,7 +3088,9 @@ components:
           questionNumber:
             type: string
           answers:
-            type: object
+            type: array
+            items:
+              type: string
         required:
           - label
           - questionNumber
@@ -3110,7 +3114,9 @@ components:
           questionNumber:
             type: string
           answers:
-            type: object
+            type: array
+            items:
+              type: string
         required:
           - label
           - questionNumber
@@ -3138,7 +3144,9 @@ components:
           questionNumber:
             type: string
           answers:
-            type: object
+            type: array
+            items:
+              type: string
         required:
           - label
           - questionNumber
@@ -3176,7 +3184,9 @@ components:
           questionNumber:
             type: string
           answers:
-            type: object
+            type: array
+            items:
+              type: string
         required:
           - label
           - questionNumber
@@ -3208,7 +3218,9 @@ components:
           questionNumber:
             type: string
           answers:
-            type: object
+            type: array
+            items:
+              type: string
         required:
           - label
           - questionNumber

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1130,6 +1130,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/risks-to-others:
+    get:
+      tags:
+        - OASys
+      summary: Returns the latest OASys current and previous risks to others (R6.1, R6.2) for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys risks to others
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRisksToOthers'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -3147,6 +3178,34 @@ components:
             questionNumber: "R8.2.2"
             answers:
               - "Reported in 2021 that he will keep himself to himself because he gets discomfiture..."
+    ArrayOfOASysRisksToOthersQuestions:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          questionNumber:
+            type: string
+          answers:
+            type: object
+        example:
+          - label: "Current offence details"
+            questionNumber: "R6.1 FA1"
+            answers:
+              - "Mr Smith was released on licence from custody on 12/7/2018.  Between then and 1/8/2018 Mr Smith approached..."
+          - label: "Current where and when"
+            questionNumber: "R6.1 FA2"
+            answers:
+              - "Between 12/7/2018 - 31/7/2018, initially victim in the street putting bins out... "
+          - label: "Previous offence details"
+            questionNumber: "R6.2 FA8"
+            answers:
+              - "Mr Smith is assessed to have committed a number of offences that are considered to have crossed the Threshold of serious harm..."
+          - label: "Previous where and when"
+            questionNumber: "R6.2 FA9"
+            answers:
+              - "Bolton and Bury Districts."
     OASysOffenceAnalysis:
       type: object
       properties:
@@ -3187,4 +3246,12 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         risksToTheIndividual:
           $ref: '#/components/schemas/ArrayOfOASysRisksToTheIndividualQuestions'
+    OASysRisksToOthers:
+      type: object
+      properties:
+        assessmentId:
+          type: object
+          $ref: '#/components/schemas/OASysAssessmentId'
+        risksToOthers:
+          $ref: '#/components/schemas/ArrayOfOASysRisksToOthersQuestions'
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3111,6 +3111,10 @@ components:
             type: string
           answers:
             type: object
+        required:
+          - label
+          - questionNumber
+          - answers
         example:
           - label: "Current situation"
             questionNumber: "RM28.1"
@@ -3244,6 +3248,9 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         riskManagementPlan:
           $ref: '#/components/schemas/ArrayOfOASysRiskManagementQuestions'
+      required:
+        - assessmentId
+        - riskManagementPlan
     OASysRiskOfSeriousHarmSummary:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -974,6 +974,38 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/offence-analysis:
+    get:
+      tags:
+        - OASys
+      summary: Returns the latest OASys offence analysis for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys offence analysis
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: object
+                $ref: '#/components/schemas/OASysOffenceAnalysis'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -2855,3 +2887,41 @@ components:
         - pending
         - active
         - archived
+    OASysAssessmentId:
+      description: The ID of assessment being used. This should always be the latest Layer 3 assessment, regardless of state.
+      type: long
+      example: 138985987
+    ArrayOfOASysOffenceAnalysisQuestions:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          questionNumber:
+            type: string
+          answers:
+            type: object
+        example:
+          - label: "Offence summary"
+            questionNumber: "2.1"
+            answers:
+              - "Mr Smith admits he went to Mr Jones's address on 23rd March 2010..."
+          - label: "Offence involved"
+            questionNumber: "2.2"
+            answers:
+              - "Any violence or threat of violence / coercion"
+              -  "Excessive use of violence / sadistic violence"
+              -  "Carrying or using a weapon"
+          - label: "Specific weapon"
+            questionNumber: "2.3"
+            answers:
+              - "Iron bar"
+    OASysOffenceAnalysis:
+      type: object
+      properties:
+        assessmentId:
+          type: object
+          $ref: '#/components/schemas/OASysAssessmentId'
+        offenceAnalysis:
+          $ref: '#/components/schemas/ArrayOfOASysOffenceAnalysisQuestions'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3057,6 +3057,10 @@ components:
             type: string
           answers:
             type: object
+        required:
+          - label
+          - questionNumber
+          - answers
         example:
           - label: "Offence summary"
             questionNumber: "2.1"
@@ -3214,6 +3218,9 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         offenceAnalysis:
           $ref: '#/components/schemas/ArrayOfOASysOffenceAnalysisQuestions'
+      required:
+        - assessmentId
+        - offenceAnalysis
     OASysRiskContributors:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3177,6 +3177,10 @@ components:
             type: string
           answers:
             type: object
+        required:
+          - label
+          - questionNumber
+          - answers
         example:
           - label: "Current concerns about self-harm or suicide"
             questionNumber: "R8.1.1"
@@ -3274,6 +3278,9 @@ components:
           $ref: '#/components/schemas/OASysAssessmentId'
         risksToTheIndividual:
           $ref: '#/components/schemas/ArrayOfOASysRisksToTheIndividualQuestions'
+      required:
+        - assessmentId
+        - risksToTheIndividual
     OASysRisksToOthers:
       type: object
       properties:


### PR DESCRIPTION
## Draft: interface between CAS UI and CAS API for OASys data

~~This is a first pass at what an ideal interface might look like between our CAS API and the facade to the new OASys ARN API which the integrations team are building for us (`approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk`) on Capita's new OASys ORDS endpoints.~~

~~The same endpoints and response (without the `oaSysIds` element) are intended to be suitable for the CAS API to expose to the CAS1 UI app.~~

For example, the Approved Premises UI app might ask the CAS API for a list of issues contributing to risks of offending or harm: 

`GET /people/{crn}/oasys/risk-contributors:`

and receive:

```json
{
  "assessmentId": 138985987,
  "riskContributors": [
    [
      {
        "label": "Accommodation issues contributing to risks of offending and harm",
        "questionNumber": "3.9",
        "answers": [
          "Mr Smith told me that he was renting a room in a shared house, prior to his current remand..."
        ]
      },
      {
        "label": "Education, training and employability issues contributing to risks of offending and harm",
        "questionNumber": "4.9",
        "answers": [
          "Mr Smith told me that his formal school education was regularly interrupted as he and his family travelled a lot whilst he was growing up..."
        ]
      }
    ]
  ]
}
```

This interface is necessarily tightly coupled to the format of OASys, so to facilitate disambiguation and debugging we provide `label` and `questionNumber` properties to make it transparent how the answers map to the OASys interface and underlying fields.

### Endpoints
- [x] offence analysis section 2
- [x] risk contributors
- [x] risk management plan
- [x] risk of serious harm R10.1 - R10.5
- [x] risk to the individual R8, R9
- [x] risk to others R6.1, R6.2
- [ ] health section 13
- [ ] risk of serious harm to self