### PR TITLE
Remove `cas` prefix from domain

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,7 +5,7 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: cas-approved-premises-api-dev.hmpps.service.justice.gov.uk
+    host: approved-premises-api-dev.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-approved-premises-api-dev-cert
 
   env:


### PR DESCRIPTION
While we were setting up the new `hmpps-community-accommodation-dev` namespace, we had to temporarily change the domains. Now ministryofjustice/cloud-platform-environments#9190 is in, we can safely switch back