### PR TITLE
Add 'status' property to Premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -82,7 +82,9 @@ class PremisesController(
     val updatePremisesResult = premisesService
       .updatePremises(
         premisesId, body.addressLine1,
-        body.postcode, body.localAuthorityAreaId, body.characteristicIds, body.notes
+        body.postcode, body.localAuthorityAreaId,
+        body.characteristicIds, body.notes,
+        body.status
       )
 
     val validationResult = when (updatePremisesResult) {
@@ -132,7 +134,8 @@ class PremisesController(
         localAuthorityAreaId = body.localAuthorityAreaId,
         name = body.name,
         notes = body.notes,
-        characteristicIds = body.characteristicIds
+        characteristicIds = body.characteristicIds,
+        status = body.status
       )
     )
     return ResponseEntity(premisesTransformer.transformJpaToApi(premises, premises.totalBeds), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -3,10 +3,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import java.util.UUID
 import javax.persistence.DiscriminatorColumn
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.Inheritance
 import javax.persistence.InheritanceType
@@ -58,6 +61,8 @@ abstract class PremisesEntity(
     inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
   )
   var characteristics: MutableList<CharacteristicEntity>,
+  @Enumerated(value = EnumType.STRING)
+  var status: PropertyStatus
 )
 
 @Entity
@@ -79,6 +84,7 @@ class ApprovedPremisesEntity(
   val qCode: String,
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
+  status: PropertyStatus
 ) : PremisesEntity(
   id,
   name,
@@ -91,7 +97,8 @@ class ApprovedPremisesEntity(
   bookings,
   lostBeds,
   rooms,
-  characteristics
+  characteristics,
+  status
 )
 
 @Entity
@@ -111,6 +118,7 @@ class TemporaryAccommodationPremisesEntity(
   lostBeds: MutableList<LostBedsEntity>,
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
+  status: PropertyStatus
 ) : PremisesEntity(
   id,
   name,
@@ -123,5 +131,6 @@ class TemporaryAccommodationPremisesEntity(
   bookings,
   lostBeds,
   rooms,
-  characteristics
+  characteristics,
+  status
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -124,7 +125,8 @@ class PremisesService(
     localAuthorityAreaId: UUID,
     name: String,
     notes: String?,
-    characteristicIds: List<UUID>
+    characteristicIds: List<UUID>,
+    status: PropertyStatus
   ) = validated<PremisesEntity> {
     /**
      * Start of setting up some dummy data to spike the implementation.
@@ -165,6 +167,7 @@ class PremisesService(
       totalBeds = 0,
       rooms = mutableListOf(),
       characteristics = mutableListOf(),
+      status = status
     )
 
     // start of validation
@@ -227,7 +230,8 @@ class PremisesService(
     postcode: String,
     localAuthorityAreaId: UUID,
     characteristicIds: List<UUID>,
-    notes: String?
+    notes: String?,
+    status: PropertyStatus
   ): AuthorisableActionResult<ValidatableActionResult<PremisesEntity>> {
 
     val premises = premisesRepository.findByIdOrNull(premisesId)
@@ -272,6 +276,7 @@ class PremisesService(
       }
       it.characteristics = characteristicEntities.map { it!! }.toMutableList()
       it.notes = if (notes.isNullOrEmpty()) "" else notes
+      it.status = status
     }
 
     val savedPremises = premisesRepository.save(premises)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -31,6 +31,7 @@ class PremisesTransformer(
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
       localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
+      status = jpa.status,
     )
     is TemporaryAccommodationPremisesEntity -> TemporaryAccommodationPremises(
       id = jpa.id,
@@ -45,6 +46,7 @@ class PremisesTransformer(
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
       localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
+      status = jpa.status,
     )
     else -> throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/resources/db/migration/all/20221110102259__add_status_column_to_premises_table.sql
+++ b/src/main/resources/db/migration/all/20221110102259__add_status_column_to_premises_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE premises ADD COLUMN status TEXT NOT NULL DEFAULT 'active';

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1635,6 +1635,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Characteristic'
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
       discriminator:
         propertyName: service
         mapping:
@@ -1650,6 +1652,7 @@ components:
         - probationRegion
         - apArea
         - localAuthorityArea
+        - status
     ApprovedPremises:
       allOf:
         - $ref: '#/components/schemas/Premises'
@@ -1683,12 +1686,15 @@ components:
           items:
             type: string
             format: uuid
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
       required:
         - name
         - addressLine1
         - postcode
         - localAuthorityAreaId
         - characteristicIds
+        - status
     LocalAuthorityArea:
       type: object
       properties:
@@ -2652,11 +2658,14 @@ components:
           items:
             type: string
             format: uuid
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
       required:
         - addressLine1
         - postcode
         - localAuthorityAreaId
         - characteristicIds
+        - status
     UpdateAssessment:
       type: object
       properties:
@@ -2805,3 +2814,9 @@ components:
       required:
         - id
         - name
+    PropertyStatus:
+      type: string
+      enum:
+        - pending
+        - active
+        - archived

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -23,6 +25,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
   private var service: Yielded<String> = { "CAS1" }
   private var qCode: Yielded<String> = { randomStringUpperCase(4) }
+  private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.values().asList()) }
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
@@ -75,6 +78,10 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.qCode = { qCode }
   }
 
+  fun withStatus(status: PropertyStatus) = apply {
+    this.status = { status }
+  }
+
   override fun produce(): ApprovedPremisesEntity = ApprovedPremisesEntity(
     id = this.id(),
     name = this.name(),
@@ -89,6 +96,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     notes = this.notes(),
     qCode = this.qCode(),
     rooms = mutableListOf(),
-    characteristics = mutableListOf()
+    characteristics = mutableListOf(),
+    status = this.status()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -22,6 +24,8 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   private var addressLine1: Yielded<String> = { randomStringUpperCase(10) }
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
   private var service: Yielded<String> = { ServiceName.temporaryAccommodation.value }
+  private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.values().asList()) }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
@@ -66,6 +70,9 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     this.localAuthorityArea = localAuthorityAreaEntity
   }
 
+  fun withStatus(status: PropertyStatus) = apply {
+    this.status = { status }
+  }
   override fun produce(): TemporaryAccommodationPremisesEntity = TemporaryAccommodationPremisesEntity(
     id = this.id(),
     name = this.name(),
@@ -79,5 +86,6 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     notes = this.notes(),
     rooms = mutableListOf(),
     characteristics = mutableListOf(),
+    status = this.status()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateRoom
@@ -44,7 +45,8 @@ class PremisesTest : IntegrationTestBase() {
           addressLine1 = "1 somewhere",
           postcode = "AB123CD",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.pending
         )
       )
       .exchange()
@@ -67,7 +69,8 @@ class PremisesTest : IntegrationTestBase() {
           notes = "some arbitrary notes",
           name = "some arbitrary name",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.pending
         )
       )
       .exchange()
@@ -80,6 +83,7 @@ class PremisesTest : IntegrationTestBase() {
       .jsonPath("notes").isEqualTo("some arbitrary notes")
       .jsonPath("name").isEqualTo("some arbitrary name")
       .jsonPath("localAuthorityArea.id").isEqualTo("a5f52443-6b55-498c-a697-7c6fad70cc3f")
+      .jsonPath("status").isEqualTo("pending")
   }
 
   @Test
@@ -105,7 +109,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB456CD",
           notes = "some arbitrary notes updated",
           localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.archived
         )
       )
       .exchange()
@@ -117,6 +122,7 @@ class PremisesTest : IntegrationTestBase() {
       .jsonPath("notes").isEqualTo("some arbitrary notes updated")
       .jsonPath("localAuthorityArea.id").isEqualTo("d1bd139b-7b90-4aae-87aa-9f93e183a7ff")
       .jsonPath("localAuthorityArea.name").isEqualTo("Allerdale")
+      .jsonPath("status").isEqualTo("archived")
   }
 
   @Test
@@ -134,7 +140,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB123CD",
           notes = "some arbitrary notes",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()
@@ -167,7 +174,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB456CD",
           notes = "some arbitrary notes updated",
           localAuthorityAreaId = UUID.fromString("878217f0-6db5-49d8-a5a1-c40fdecd6060"), // not in db
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()
@@ -201,7 +209,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB123CD",
           notes = "some arbitrary notes",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()
@@ -226,7 +235,8 @@ class PremisesTest : IntegrationTestBase() {
           postcode = "AB123CD",
           name = "some arbitrary name",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()
@@ -251,7 +261,8 @@ class PremisesTest : IntegrationTestBase() {
           addressLine1 = "",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
           notes = "some notes",
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()
@@ -277,7 +288,8 @@ class PremisesTest : IntegrationTestBase() {
           addressLine1 = "FIRST LINE OF THE ADDRESS",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
           notes = "some notes",
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()
@@ -302,7 +314,8 @@ class PremisesTest : IntegrationTestBase() {
           addressLine1 = "FIRST LINE OF THE ADDRESS",
           localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
           notes = "some notes",
-          characteristicIds = mutableListOf()
+          characteristicIds = mutableListOf(),
+          status = PropertyStatus.active
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NonArrivalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -92,6 +93,7 @@ class BookingTransformerTest {
     notes = "",
     rooms = mutableListOf(),
     characteristics = mutableListOf(),
+    status = PropertyStatus.active
   )
 
   private val baseBookingEntity = BookingEntity(


### PR DESCRIPTION
> See [ticket #482 on the CAS3 Trello board](https://trello.com/c/ewdT1APV/482-properties-can-have-a-status).

Currently, there is no way to distinguish between premises that are in active service from those that are not yet or no longer active.

This PR modifies the request bodies of the `POST /premises/` and `PUT /premises/{premisesId}/` endpoints to require a `status` field containing one of the following values:
- `"active"`
- `"pending"`
- `"archived"`

The `Premises` schema has also been updated to include this status with the effect that any endpoint that includes a `Premises` in its response body will include the provided status. In the case of premises that already exist on the database, this is given a default value of `"active"`.