### PR TITLE
865 - Reduce team cache to 20 seconds in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,6 +21,7 @@ generic-service:
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     SENTRY_ENVIRONMENT: dev
+    CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -28,19 +28,19 @@ class RedisConfiguration {
   fun redisCacheManagerBuilderCustomizer(
     buildProperties: BuildProperties,
     objectMapper: ObjectMapper,
-    @Value("\${caches.staffMembers.expiry-minutes}") staffMembersExpiryMinutes: Long,
-    @Value("\${caches.staffMember.expiry-minutes}") staffMemberExpiryMinutes: Long,
-    @Value("\${caches.offenderDetails.expiry-minutes}") offenderDetailsExpiryMinutes: Long,
-    @Value("\${caches.userAccess.expiry-minutes}") userAccessExpiryMinutes: Long,
-    @Value("\${caches.inmateDetails.expiry-minutes}") inmateDetailsExpiryMinutes: Long
+    @Value("\${caches.staffMembers.expiry-seconds}") staffMembersExpirySeconds: Long,
+    @Value("\${caches.staffMember.expiry-seconds}") staffMemberExpirySeconds: Long,
+    @Value("\${caches.userAccess.expiry-minutes}") userAccessExpirySeconds: Long,
+    @Value("\${caches.offenderDetails.expiry-seconds}") offenderDetailsExpirySeconds: Long,
+    @Value("\${caches.inmateDetails.expiry-seconds}") inmateDetailsExpirySeconds: Long
   ): RedisCacheManagerBuilderCustomizer? {
     val version = buildProperties.version
 
     return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManagerBuilder ->
-      builder.clientCacheFor<StaffMembersPage>("qCodeStaffMembersCache", Duration.ofMinutes(staffMembersExpiryMinutes), version, objectMapper)
-        .clientCacheFor<OffenderDetailSummary>("offenderDetailsCache", Duration.ofMinutes(offenderDetailsExpiryMinutes), version, objectMapper)
-        .clientCacheFor<UserOffenderAccess>("userAccessCache", Duration.ofMinutes(userAccessExpiryMinutes), version, objectMapper)
-        .clientCacheFor<InmateDetail>("inmateDetailsCache", Duration.ofMinutes(inmateDetailsExpiryMinutes), version, objectMapper)
+      builder.clientCacheFor<StaffMembersPage>("qCodeStaffMembersCache", Duration.ofSeconds(staffMembersExpirySeconds), version, objectMapper)
+        .clientCacheFor<OffenderDetailSummary>("offenderDetailsCache", Duration.ofSeconds(offenderDetailsExpirySeconds), version, objectMapper)
+        .clientCacheFor<UserOffenderAccess>("userAccessCache", Duration.ofSeconds(userAccessExpirySeconds), version, objectMapper)
+        .clientCacheFor<InmateDetail>("inmateDetailsCache", Duration.ofSeconds(inmateDetailsExpirySeconds), version, objectMapper)
     }
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,12 +141,12 @@ prison-adjudications:
 
 caches:
   staffMembers:
-    expiry-minutes: 360
+    expiry-seconds: 21600
   staffMember:
-    expiry-minutes: 360
+    expiry-seconds: 21600
   offenderDetails:
-    expiry-minutes: 20
+    expiry-seconds: 1200
   userAccess:
-    expiry-minutes: 20
+    expiry-seconds: 1200
   inmateDetails:
-    expiry-minutes: 20
+    expiry-seconds: 1200


### PR DESCRIPTION
**Change cache TTLs to be in seconds rather than minutes**

**Change team member cache to be 20s in dev**
So that the Integrations team can build their E2E test that adds key workers and asserts they exist in our UI