### PR TITLE
847 - Submit application endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation(kotlin("reflect"))
 
   implementation("com.networknt:json-schema-validator:1.0.73")
+  implementation("io.github.jamsesso:json-logic-java:1.0.7")
 
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonLogicService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonLogicService.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.github.jamsesso.jsonlogic.JsonLogic
+import org.springframework.stereotype.Service
+
+@Service
+class JsonLogicService(private val objectMapper: ObjectMapper) {
+  private val jsonLogic = JsonLogic()
+
+  fun resolveBoolean(jsonLogicRule: String, data: String): Boolean = resolve(jsonLogicRule, data)
+
+  private inline fun <reified T> resolve(jsonLogicRule: String, data: String): T {
+    val suitableData = objectMapper.readValue<Map<*, *>>(data)
+
+    val result = jsonLogic.apply(jsonLogicRule, suitableData)
+
+    if (result !is T) {
+      throw RuntimeException("Expected ${T::class.qualifiedName} but got ${result::class.qualifiedName}")
+    }
+
+    return result
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonLogicServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonLogicServiceTest.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonLogicService
+
+class JsonLogicServiceTest {
+  private val jsonLogicService = JsonLogicService(jacksonObjectMapper())
+
+  @Test
+  fun `resolveBoolean returns true for truthy rule-data combination`() {
+    val rule = """
+      {
+        "==": [
+          { "var": "one" }, 
+          { "var": "two" }
+        ]
+      }
+      """
+
+    val data = SimpleClass(
+      one = 5,
+      two = 5
+    )
+
+    val serializedData = jacksonObjectMapper().writeValueAsString(data)
+
+    assertThat(jsonLogicService.resolveBoolean(rule, serializedData)).isTrue
+  }
+
+  @Test
+  fun `resolveBoolean returns false for falsy rule-data combination`() {
+    val rule = """
+      {
+        "!=": [
+          { "var": "one" }, 
+          { "var": "two" }
+        ]
+      }
+      """
+
+    val data = SimpleClass(
+      one = 5,
+      two = 5
+    )
+
+    val serializedData = jacksonObjectMapper().writeValueAsString(data)
+
+    assertThat(jsonLogicService.resolveBoolean(rule, serializedData)).isFalse
+  }
+}
+
+data class SimpleClass(
+  val one: Int,
+  val two: Int
+)


### PR DESCRIPTION
Use JSON Logic fields to determine first class citizens, store them in the AP Application table and then create/allocate an assessment.