### PR TITLE
(Fix) Allow DeserializationValidationService.validateObject to validate an enum as a string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import com.fasterxml.jackson.databind.node.NullNode
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -72,6 +73,13 @@ class DeserializationValidationService {
 
           val genericType = it.returnType.arguments.first().type!!.jvmErasure
           result.putAll(validateArray("$path.${it.name}", genericType, jsonObject.get(it.name) as ArrayNode, it.returnType.arguments.first().type!!.isMarkedNullable))
+          return@forEach
+        }
+
+        if ((it.returnType.jvmErasure.java as Class<*>).isEnum) {
+          if (jsonObject.get(it.name) !is TextNode) {
+            result["$path.${it.name}"] = "expectedString"
+          }
           return@forEach
         }
 


### PR DESCRIPTION
When creating or updating a Premises, if invalid data is supplied, an extra unwanted error is returned on the `status` property, even if it has a valid value.

Similarly, as part of the work on [adding bookings for Temporary Accommodation](https://trello.com/c/kEBk1zvf/540-spike-how-might-we-extend-the-existing-api-logic-for-bookings) a similar issue has been seen on the `serviceName` property when creating an invalid booking.

# Observed behaviour
A `POST` request to `/premises` with the following body:

```json
{
  "name": "Borgia House",
  "addressLine1": "57 Northbrook Road",
  "postcode": null,
  "service": "temporary-accommodation",
  "notes": "some notes about this property",
  "localAuthorityAreaId": "d75ce5b8-fc07-494b-8950-a46a63ac377e",
  "characteristicIds": [],
  "status": "active"
}
```

returns the following response:

```json
{
  "title": "Bad Request",
  "status": 400,
  "detail": "There is a problem with your request",
  "invalid-params": [
    {
      "propertyName": "$.postcode",
      "errorType": "empty"
    },
    {
      "propertyName": "$.status",
      "errorType": "expectedObject"
    }
  ]
}
```

# Expected behaviour
A `POST` request to `/premises` with the above request body should return the following response:

```json
{
  "title": "Bad Request",
  "status": 400,
  "detail": "There is a problem with your request",
  "invalid-params": [
    {
      "propertyName": "$.postcode",
      "errorType": "empty"
    }
  ]
}
```

# Solution
This PR updates the `DeserializationValidationService.validateObject` method to be aware of enumerated types, and handle them separately by checking whether or not their node is a `TextNode`. If not, then the `"expectedString"` error is returned.