### PR TITLE
Implement bookings for Temporary Accommodation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -261,6 +261,10 @@ class PremisesController(
     if (offenderResult is AuthorisableActionResult.NotFound) validationErrors["crn"] = "Invalid crn"
     inmateDetailResult as AuthorisableActionResult.Success
 
+    if (body.departureDate.isBefore(body.arrivalDate)) {
+      validationErrors["departureDate"] = "departureBeforeArrival"
+    }
+
     if (validationErrors.any()) {
       throw BadRequestProblem(validationErrors)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -267,7 +267,9 @@ class PremisesController(
         nonArrival = null,
         cancellation = null,
         extensions = mutableListOf(),
-        premises = premises
+        premises = premises,
+        bed = null,
+        service = ServiceName.approvedPremises,
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -3,10 +3,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import java.time.LocalDate
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -44,7 +47,12 @@ data class BookingEntity(
   var extensions: MutableList<ExtensionEntity>,
   @ManyToOne
   @JoinColumn(name = "premises_id")
-  var premises: PremisesEntity
+  var premises: PremisesEntity,
+  @ManyToOne
+  @JoinColumn(name = "bed_id")
+  var bed: BedEntity?,
+  @Enumerated(value = EnumType.STRING)
+  var service: ServiceName,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.Exceptional
+import org.zalando.problem.Status
+
+class ConflictProblem(id: Any, entityType: String, conflictReason: String) : AbstractThrowableProblem(null, "Conflict", Status.CONFLICT, "A $entityType already exists for $conflictReason: $id") {
+  override fun getCause(): Exceptional? {
+    return null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
@@ -17,21 +16,23 @@ class BookingTransformer(
   private val departureTransformer: DepartureTransformer,
   private val nonArrivalTransformer: NonArrivalTransformer,
   private val cancellationTransformer: CancellationTransformer,
-  private val extensionTransformer: ExtensionTransformer
+  private val extensionTransformer: ExtensionTransformer,
+  private val bedTransformer: BedTransformer,
 ) {
   fun transformJpaToApi(jpa: BookingEntity, offender: OffenderDetailSummary, inmateDetail: InmateDetail, staffMember: StaffMember?) = Booking(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offender, inmateDetail),
     arrivalDate = jpa.arrivalDate,
     departureDate = jpa.departureDate,
-    serviceName = ServiceName.approvedPremises,
+    serviceName = jpa.service,
     keyWorker = staffMember?.let(staffMemberTransformer::transformDomainToApi),
     status = determineStatus(jpa),
     arrival = arrivalTransformer.transformJpaToApi(jpa.arrival),
     departure = departureTransformer.transformJpaToApi(jpa.departure),
     nonArrival = nonArrivalTransformer.transformJpaToApi(jpa.nonArrival),
     cancellation = cancellationTransformer.transformJpaToApi(jpa.cancellation),
-    extensions = jpa.extensions.map(extensionTransformer::transformJpaToApi)
+    extensions = jpa.extensions.map(extensionTransformer::transformJpaToApi),
+    bed = jpa.bed?.let { bedTransformer.transformJpaToApi(it) },
   )
 
   private fun determineStatus(jpa: BookingEntity) = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
@@ -23,6 +24,7 @@ class BookingTransformer(
     person = personTransformer.transformModelToApi(offender, inmateDetail),
     arrivalDate = jpa.arrivalDate,
     departureDate = jpa.departureDate,
+    serviceName = ServiceName.approvedPremises,
     keyWorker = staffMember?.let(staffMemberTransformer::transformDomainToApi),
     status = determineStatus(jpa),
     arrival = arrivalTransformer.transformJpaToApi(jpa.arrival),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -30,3 +30,30 @@ fun LocalDate.getDaysUntilExclusiveEnd(end: LocalDate): List<LocalDate> {
 }
 
 fun LocalDate.toLocalDateTime(zoneOffset: ZoneOffset = ZoneOffset.UTC) = OffsetDateTime.of(this, LocalTime.MIN, zoneOffset)
+
+infix fun ClosedRange<LocalDate>.overlaps(other: ClosedRange<LocalDate>): Boolean {
+  /*
+  false:  <--A-->             (A entirely before B)
+                    <--B-->
+
+  false:            <--A-->   (A entirely after B)
+          <--B-->
+
+  true:   <--A-->             (A ends after B begins)
+             <--B-->
+
+  true:      <--A-->          (A starts before B ends)
+          <--B-->
+
+  true:   <-------A------->   (A fully contains B)
+            <--B-->
+
+  true:        <--A-->        (B fully contains A)
+          <-------B------->
+  */
+
+  val thisFullyBefore = this.start < other.start && this.endInclusive < other.start
+  val thisFullyAfter = this.endInclusive > other.endInclusive && this.start > other.endInclusive
+
+  return !(thisFullyBefore || thisFullyAfter)
+}

--- a/src/main/resources/db/migration/all/20221115123112__add_bed_id_to_bookings_table.sql
+++ b/src/main/resources/db/migration/all/20221115123112__add_bed_id_to_bookings_table.sql
@@ -1,0 +1,21 @@
+ALTER TABLE bookings ADD COLUMN bed_id UUID;
+ALTER TABLE bookings ADD COLUMN service TEXT;
+ALTER TABLE bookings ADD FOREIGN KEY (bed_id) REFERENCES beds (id);
+
+UPDATE bookings
+SET service = 'approved-premises'
+WHERE premises_id IN (
+    SELECT id
+    FROM premises
+    WHERE service = 'approved-premises'
+);
+
+UPDATE bookings
+SET service = 'temporary-accommodation'
+WHERE premises_id IN (
+    SELECT id
+    FROM premises
+    WHERE service = 'temporary-accommodation'
+);
+
+ALTER TABLE bookings ALTER COLUMN service SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -283,6 +283,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
+        409:
+          description: An existing booking for the given bed has overlapping dates
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
@@ -1998,11 +2004,16 @@ components:
           format: date
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+        bed:
+          $ref: '#/components/schemas/Bed'
       required:
         - id
         - person
         - arrivalDate
         - departureDate
+        - serviceName
     NewBooking:
       type: object
       properties:
@@ -2017,10 +2028,31 @@ components:
           type: string
           format: date
           example: 2022-09-30
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
       required:
         - crn
         - arrivalDate
         - departureDate
+        - serviceName
+      discriminator:
+        propertyName: serviceName
+        mapping:
+          approved-premises: '#/components/schemas/NewApprovedPremisesBooking'
+          temporary-accommodation: '#/components/schemas/NewTemporaryAccommodationBooking'
+    NewApprovedPremisesBooking:
+      allOf:
+        - $ref: '#/components/schemas/NewBooking'
+    NewTemporaryAccommodationBooking:
+      allOf:
+        - $ref: '#/components/schemas/NewBooking'
+        - type: object
+          properties:
+            bedId:
+              type: string
+              format: uuid
+          required:
+            - bedId
     Booking:
       allOf:
         - $ref: '#/components/schemas/BookingBody'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -106,6 +106,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.serviceName = { serviceName }
   }
 
+  fun withYieldedBed(bed: Yielded<BedEntity>) = apply {
+    this.bed = bed
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
@@ -11,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.LocalDate
 import java.util.UUID
@@ -28,6 +31,8 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var cancellation: Yielded<CancellationEntity>? = null
   private var extensions: Yielded<MutableList<ExtensionEntity>>? = null
   private var premises: Yielded<PremisesEntity>? = null
+  private var serviceName: Yielded<ServiceName> = { randomOf(ServiceName.values().asList()) }
+  private var bed: Yielded<BedEntity>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -97,6 +102,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.premises = { premises }
   }
 
+  fun withServiceName(serviceName: ServiceName) = apply {
+    this.serviceName = { serviceName }
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),
@@ -108,6 +117,8 @@ class BookingEntityFactory : Factory<BookingEntity> {
     nonArrival = this.nonArrival?.invoke(),
     cancellation = this.cancellation?.invoke(),
     extensions = this.extensions?.invoke() ?: mutableListOf(),
-    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises")
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
+    bed = this.bed?.invoke(),
+    service = this.serviceName.invoke()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.reactive.server.expectBodyList
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApprovedPremisesBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
@@ -201,10 +202,11 @@ class BookingTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises/${premises.id}/bookings")
       .bodyValue(
-        NewBooking(
+        NewApprovedPremisesBooking(
           crn = "a crn",
           arrivalDate = LocalDate.parse("2022-08-12"),
-          departureDate = LocalDate.parse("2022-08-30")
+          departureDate = LocalDate.parse("2022-08-30"),
+          serviceName = ServiceName.approvedPremises
         )
       )
       .exchange()
@@ -243,10 +245,11 @@ class BookingTest : IntegrationTestBase() {
       .uri("/premises/${premises.id}/bookings")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
-        NewBooking(
+        NewApprovedPremisesBooking(
           crn = "CRN321",
           arrivalDate = LocalDate.parse("2022-08-12"),
-          departureDate = LocalDate.parse("2022-08-30")
+          departureDate = LocalDate.parse("2022-08-30"),
+          serviceName = ServiceName.approvedPremises,
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApprovedPre
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTemporaryAccommodationBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
@@ -31,7 +32,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get a booking for a premises returns OK with the correct body`() {
+  fun `Get a booking for an Approved Premises returns OK with the correct body`() {
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
     mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
@@ -48,6 +49,7 @@ class BookingTest : IntegrationTestBase() {
       withPremises(premises)
       withStaffKeyWorkerCode(keyWorker.code)
       withCrn("CRN123")
+      withServiceName(ServiceName.approvedPremises)
     }
 
     val offenderDetails = OffenderDetailsSummaryFactory()
@@ -72,6 +74,60 @@ class BookingTest : IntegrationTestBase() {
       .json(
         objectMapper.writeValueAsString(
           bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetail, keyWorker)
+        )
+      )
+  }
+
+  @Test
+  fun `Get a booking for an Temporary Accommodation Premises returns OK with the correct body`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+    }
+
+    val bed = bedEntityFactory.produceAndPersist {
+      withName("test-bed")
+      withYieldedRoom {
+        roomEntityFactory.produceAndPersist {
+          withName("test-room")
+          withYieldedPremises { premises }
+        }
+      }
+    }
+
+    val booking = bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withCrn("CRN123")
+      withServiceName(ServiceName.temporaryAccommodation)
+      withYieldedBed { bed }
+    }
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN123")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    webTestClient.get()
+      .uri("/premises/${premises.id}/bookings/${booking.id}")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        objectMapper.writeValueAsString(
+          bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetail, null)
         )
       )
   }
@@ -215,7 +271,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Create Booking returns OK with correct body`() {
+  fun `Create Approved Premises Booking returns OK with correct body`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
@@ -266,6 +322,124 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.departure").isEqualTo(null)
       .jsonPath("$.nonArrival").isEqualTo(null)
       .jsonPath("$.cancellation").isEqualTo(null)
+      .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
+      .jsonPath("$.bed.id").doesNotHaveJsonPath()
+      .jsonPath("$.bed.name").doesNotHaveJsonPath()
+  }
+
+  @Test
+  fun `Create Temporary Accommodation Booking returns OK with correct body`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    val bed = bedEntityFactory.produceAndPersist {
+      withName("test-bed")
+      withYieldedRoom {
+        roomEntityFactory.produceAndPersist {
+          withName("test-room")
+          withYieldedPremises { premises }
+        }
+      }
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN321")
+      .withFirstName("Mock")
+      .withLastName("Person")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    webTestClient.post()
+      .uri("/premises/${premises.id}/bookings")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        NewTemporaryAccommodationBooking(
+          crn = "CRN321",
+          arrivalDate = LocalDate.parse("2022-08-12"),
+          departureDate = LocalDate.parse("2022-08-30"),
+          serviceName = ServiceName.temporaryAccommodation,
+          bedId = bed.id,
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.person.crn").isEqualTo("CRN321")
+      .jsonPath("$.person.name").isEqualTo("Mock Person")
+      .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
+      .jsonPath("$.departureDate").isEqualTo("2022-08-30")
+      .jsonPath("$.keyWorker").isEqualTo(null)
+      .jsonPath("$.status").isEqualTo("awaiting-arrival")
+      .jsonPath("$.arrival").isEqualTo(null)
+      .jsonPath("$.departure").isEqualTo(null)
+      .jsonPath("$.nonArrival").isEqualTo(null)
+      .jsonPath("$.cancellation").isEqualTo(null)
+      .jsonPath("$.serviceName").isEqualTo(ServiceName.temporaryAccommodation.value)
+      .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
+      .jsonPath("$.bed.name").isEqualTo("test-bed")
+  }
+
+  @Test
+  fun `Create Temporary Accommodation Booking returns 400 when bed does not exist on the premises`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN321")
+      .withFirstName("Mock")
+      .withLastName("Person")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    webTestClient.post()
+      .uri("/premises/${premises.id}/bookings")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        NewTemporaryAccommodationBooking(
+          crn = "CRN321",
+          arrivalDate = LocalDate.parse("2022-08-12"),
+          departureDate = LocalDate.parse("2022-08-30"),
+          serviceName = ServiceName.temporaryAccommodation,
+          bedId = UUID.randomUUID(),
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .is4xxClientError
+      .expectBody()
+      .jsonPath("title").isEqualTo("Bad Request")
+      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
@@ -52,6 +53,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
@@ -216,6 +219,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var roomRepository: RoomRepository
 
+  @Autowired
+  lateinit var bedRepository: BedRepository
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
@@ -244,6 +250,7 @@ abstract class IntegrationTestBase {
   lateinit var assessmentClarificationNoteEntityFactory: PersistedFactory<AssessmentClarificationNoteEntity, UUID, AssessmentClarificationNoteEntityFactory>
   lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
   lateinit var roomEntityFactory: PersistedFactory<RoomEntity, UUID, RoomEntityFactory>
+  lateinit var bedEntityFactory: PersistedFactory<BedEntity, UUID, BedEntityFactory>
 
   @BeforeEach
   fun beforeEach() {
@@ -295,6 +302,7 @@ abstract class IntegrationTestBase {
     assessmentClarificationNoteEntityFactory = PersistedFactory(AssessmentClarificationNoteEntityFactory(), assessmentClarificationNoteRepository)
     characteristicEntityFactory = PersistedFactory(CharacteristicEntityFactory(), characteristicRepository)
     roomEntityFactory = PersistedFactory(RoomEntityFactory(), roomRepository)
+    bedEntityFactory = PersistedFactory(BedEntityFactory(), bedRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -108,7 +108,9 @@ class BookingTransformerTest {
     nonArrival = null,
     cancellation = null,
     extensions = mutableListOf(),
-    premises = premisesEntity
+    premises = premisesEntity,
+    bed = null,
+    service = ServiceName.approvedPremises,
   )
 
   private val staffMember = StaffMember(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NonArrivalReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -181,7 +182,8 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         status = Booking.Status.awaitingMinusArrival,
-        extensions = listOf()
+        extensions = listOf(),
+        serviceName = ServiceName.approvedPremises,
       )
     )
   }
@@ -234,7 +236,8 @@ class BookingTransformerTest {
           reason = NonArrivalReason(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true),
           notes = null
         ),
-        extensions = listOf()
+        extensions = listOf(),
+        serviceName = ServiceName.approvedPremises,
       )
     )
   }
@@ -289,7 +292,8 @@ class BookingTransformerTest {
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null
         ),
-        extensions = listOf()
+        extensions = listOf(),
+        serviceName = ServiceName.approvedPremises,
       )
     )
   }
@@ -340,7 +344,8 @@ class BookingTransformerTest {
           reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true),
           notes = null
         ),
-        extensions = listOf()
+        extensions = listOf(),
+        serviceName = ServiceName.approvedPremises,
       )
     )
   }
@@ -460,7 +465,8 @@ class BookingTransformerTest {
           ),
           notes = null
         ),
-        extensions = listOf()
+        extensions = listOf(),
+        serviceName = ServiceName.approvedPremises,
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMemberName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
@@ -55,6 +56,7 @@ class BookingTransformerTest {
   private val mockCancellationTransformer = mockk<CancellationTransformer>()
   private val mockDepartureTransformer = mockk<DepartureTransformer>()
   private val mockExtensionTransformer = mockk<ExtensionTransformer>()
+  private val mockBedTransformer = mockk<BedTransformer>()
 
   private val bookingTransformer = BookingTransformer(
     mockPersonTransformer,
@@ -63,7 +65,8 @@ class BookingTransformerTest {
     mockDepartureTransformer,
     mockNonArrivalTransformer,
     mockCancellationTransformer,
-    mockExtensionTransformer
+    mockExtensionTransformer,
+    mockBedTransformer,
   )
 
   private val premisesEntity = TemporaryAccommodationPremisesEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/DatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/DatesTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.overlaps
+import java.time.LocalDate
+
+class DatesTest {
+  @Test
+  fun `overlaps returns false if one range is fully before another`() {
+    val a = LocalDate.parse("2000-01-01")..LocalDate.parse("2000-12-31")
+    val b = LocalDate.parse("2010-01-01")..LocalDate.parse("2010-12-31")
+
+    assertThat(a overlaps b).isFalse
+    assertThat(b overlaps a).isFalse
+  }
+
+  @Test
+  fun `overlaps returns true if one range ends after another begins`() {
+    val a = LocalDate.parse("2000-01-01")..LocalDate.parse("2010-12-31")
+    val b = LocalDate.parse("2010-01-01")..LocalDate.parse("2020-12-31")
+
+    assertThat(a overlaps b).isTrue
+    assertThat(b overlaps a).isTrue
+  }
+
+  @Test
+  fun `overlaps returns true if one range fully contains another`() {
+    val a = LocalDate.parse("2000-01-01")..LocalDate.parse("2020-12-31")
+    val b = LocalDate.parse("2010-01-01")..LocalDate.parse("2010-12-31")
+
+    assertThat(a overlaps b).isTrue
+    assertThat(b overlaps a).isTrue
+  }
+
+  @Test
+  fun `overlaps considers ranges that share a single day to overlap`() {
+    val a = LocalDate.parse("2000-01-01")..LocalDate.parse("2001-01-01")
+    val b = LocalDate.parse("2001-01-01")..LocalDate.parse("2002-01-01")
+
+    assertThat(a overlaps b).isTrue
+    assertThat(b overlaps a).isTrue
+  }
+}


### PR DESCRIPTION
> See [ticket #467 on the CAS3 Trello board](https://trello.com/c/RqgsUkHV/467-a-user-can-create-a-new-allocated-booking-for-a-person).

This PR implements bookings for a bed in a way that is compatible with the premises-level bookings for the Approved Premises team.

Before creating the booking, it validates that:
- The bed exists on the premises
- The departure date is not before the start date
- A booking does not already exist for that bed during the given dates

A clashing booking results in a `409 Conflict` response from the server.