### PR TITLE
(Fix) Correctly deserialize service name for bookings from DB

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -314,7 +314,7 @@ class PremisesController(
         extensions = mutableListOf(),
         premises = premises,
         bed = bed,
-        service = body.serviceName,
+        service = body.serviceName.value,
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -3,13 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import java.time.LocalDate
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -51,8 +48,7 @@ data class BookingEntity(
   @ManyToOne
   @JoinColumn(name = "bed_id")
   var bed: BedEntity?,
-  @Enumerated(value = EnumType.STRING)
-  var service: ServiceName,
+  var service: String,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -123,6 +123,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     extensions = this.extensions?.invoke() ?: mutableListOf(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
     bed = this.bed?.invoke(),
-    service = this.serviceName.invoke()
+    service = this.serviceName.invoke().value
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -57,6 +58,7 @@ class BookingTransformerTest {
   private val mockDepartureTransformer = mockk<DepartureTransformer>()
   private val mockExtensionTransformer = mockk<ExtensionTransformer>()
   private val mockBedTransformer = mockk<BedTransformer>()
+  private val enumConverterFactory = EnumConverterFactory()
 
   private val bookingTransformer = BookingTransformer(
     mockPersonTransformer,
@@ -67,6 +69,7 @@ class BookingTransformerTest {
     mockCancellationTransformer,
     mockExtensionTransformer,
     mockBedTransformer,
+    enumConverterFactory,
   )
 
   private val premisesEntity = TemporaryAccommodationPremisesEntity(
@@ -113,7 +116,7 @@ class BookingTransformerTest {
     extensions = mutableListOf(),
     premises = premisesEntity,
     bed = null,
-    service = ServiceName.approvedPremises,
+    service = ServiceName.approvedPremises.value,
   )
 
   private val staffMember = StaffMember(


### PR DESCRIPTION
# Observed behaviour

Retrieving bookings using the `GET /premises/{premisesId}/bookings` or `GET /premises/{premisesId}/bookings/{bookingId}` endpoints results in a problem response such as:

```json
{
	"title": "Internal Server Error",
	"status": 500,
	"detail": "No enum constant uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.approved-premises"
}
```

# Expected behaviour

The endpoints correctly return the booking/list of bookings.

# Solution

- The property `BookingEntity.service` has been changed from an `@Enumerated ServiceName` to a `String`, as Spring does not automatically use `Converter`/`ConverterFactory` implementations to deserialize JPA entities from the database.
- The `BookingTransformer` now uses an `EnumConverterFactory` instance to get the correct enumerated value from the JPA entity's `String` value.