### PR TITLE
905 - Select index offence OApi spec

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1167,6 +1167,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/offences:
+    get:
+      summary: Returns the active Offences for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch active Offences for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActiveOffence'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -3340,3 +3371,19 @@ components:
       enum:
         - Completed
         - Incomplete
+    ActiveOffence:
+      type: object
+      properties:
+        deliusEventNumber:
+          type: string
+        offenceDescription:
+          type: string
+        offenceId:
+          type: string
+        convictionId:
+          type: long
+      required:
+        - deliusEventNumber
+        - offenceDescription
+        - offenceId
+        - convictionId

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2805,8 +2805,17 @@ components:
       properties:
         crn:
           type: string
+        convictionId:
+          type: long
+        eventNumber:
+          type: string
+        offenceId:
+          type: string
       required:
         - crn
+        - convictionId
+        - eventNumber
+        - offenceId
     UpdateApplication:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -474,7 +474,10 @@ class ApplicationTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewApplication(
-          crn = crn
+          crn = crn,
+          convictionId = 123,
+          eventNumber = "123",
+          offenceId = "123"
         )
       )
       .exchange()
@@ -508,7 +511,10 @@ class ApplicationTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewApplication(
-          crn = crn
+          crn = crn,
+          convictionId = 123,
+          eventNumber = "123",
+          offenceId = "123"
         )
       )
       .exchange()
@@ -538,7 +544,10 @@ class ApplicationTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewApplication(
-          crn = crn
+          crn = crn,
+          convictionId = 123,
+          eventNumber = "123",
+          offenceId = "123"
         )
       )
       .exchange()
@@ -589,7 +598,10 @@ class ApplicationTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewApplication(
-          crn = crn
+          crn = crn,
+          convictionId = 123,
+          eventNumber = "123",
+          offenceId = "123"
         )
       )
       .exchange()


### PR DESCRIPTION
This would alter the flow such that:

- When rendering the confirm identity screen, frontend also makes a call to the `/people/{crn}/offences` endpoint
- If there is more than one active offence, a selector is displayed
- When creating the application, the `convictionId`, `eventNumber` & `offenceId` for the selected entry are passed back to the API - these can then be stored on the `applications` table and used by the backend later when generating events, finding documents etc.

**If we merge this, it will break creating an application on the frontend until values are provided for convictionId, eventNumber, offenceId**

Perhaps we could provide some placeholder values until the designs are done to allow me to continue with the backend?