### PR TITLE
Add confirmations to bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -311,6 +311,7 @@ class PremisesController(
         departure = null,
         nonArrival = null,
         cancellation = null,
+        confirmation = null,
         extensions = mutableListOf(),
         premises = premises,
         bed = bed,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PremisesApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DateCapacity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Departure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Extension
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewDeparture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
@@ -49,6 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
@@ -58,6 +61,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RoomTransfor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.overlaps
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
@@ -72,6 +76,7 @@ class PremisesController(
   private val arrivalTransformer: ArrivalTransformer,
   private val nonArrivalTransformer: NonArrivalTransformer,
   private val cancellationTransformer: CancellationTransformer,
+  private val confirmationTransformer: ConfirmationTransformer,
   private val departureTransformer: DepartureTransformer,
   private val extensionTransformer: ExtensionTransformer,
   private val staffMemberTransformer: StaffMemberTransformer,
@@ -378,6 +383,24 @@ class PremisesController(
     val cancellation = extractResultEntityOrThrow(result)
 
     return ResponseEntity.ok(cancellationTransformer.transformJpaToApi(cancellation))
+  }
+
+  override fun premisesPremisesIdBookingsBookingIdConfirmationsPost(
+    premisesId: UUID,
+    bookingId: UUID,
+    body: NewConfirmation,
+  ): ResponseEntity<Confirmation> {
+    val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
+
+    val result = bookingService.createConfirmation(
+      booking = booking,
+      dateTime = OffsetDateTime.now(),
+      notes = body.notes,
+    )
+
+    val confirmation = extractResultEntityOrThrow(result)
+
+    return ResponseEntity.ok(confirmationTransformer.transformJpaToApi(confirmation))
   }
 
   override fun premisesPremisesIdBookingsBookingIdDeparturesPost(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -40,6 +40,8 @@ data class BookingEntity(
   var nonArrival: NonArrivalEntity?,
   @OneToOne(mappedBy = "booking")
   var cancellation: CancellationEntity?,
+  @OneToOne(mappedBy = "booking")
+  var confirmation: ConfirmationEntity?,
   @OneToMany(mappedBy = "booking")
   var extensions: MutableList<ExtensionEntity>,
   @ManyToOne
@@ -63,11 +65,12 @@ data class BookingEntity(
     if (departure != other.departure) return false
     if (nonArrival != other.nonArrival) return false
     if (cancellation != other.cancellation) return false
+    if (confirmation != other.confirmation) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, departure, nonArrival, cancellation)
+  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, departure, nonArrival, cancellation, confirmation)
 
   override fun toString() = "BookingEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ConfirmationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ConfirmationEntity.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Repository
+interface ConfirmationRepository : JpaRepository<ConfirmationEntity, UUID>
+
+@Entity
+@Table(name = "confirmations")
+data class ConfirmationEntity(
+  @Id
+  val id: UUID,
+  val dateTime: OffsetDateTime,
+  val notes: String?,
+  @OneToOne
+  @JoinColumn(name = "booking_id")
+  var booking: BookingEntity
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is ConfirmationEntity) return false
+
+    if (id != other.id) return false
+    if (dateTime != other.dateTime) return false
+    if (notes != other.notes) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(dateTime, notes)
+
+  override fun toString() = "ConfirmationEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -10,6 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingReposi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureRepository
@@ -35,6 +37,7 @@ class BookingService(
   private val bookingRepository: BookingRepository,
   private val arrivalRepository: ArrivalRepository,
   private val cancellationRepository: CancellationRepository,
+  private val confirmationRepository: ConfirmationRepository,
   private val extensionRepository: ExtensionRepository,
   private val departureRepository: DepartureRepository,
   private val departureReasonRepository: DepartureReasonRepository,
@@ -156,6 +159,27 @@ class BookingService(
     )
 
     return success(cancellationEntity)
+  }
+
+  fun createConfirmation(
+    booking: BookingEntity,
+    dateTime: OffsetDateTime,
+    notes: String?,
+  ) = validated<ConfirmationEntity> {
+    if (booking.confirmation != null) {
+      return generalError("This Booking already has a Confirmation set")
+    }
+
+    val confirmationEntity = confirmationRepository.save(
+      ConfirmationEntity(
+        id = UUID.randomUUID(),
+        dateTime = dateTime,
+        notes = notes,
+        booking = booking,
+      )
+    )
+
+    return success(confirmationEntity)
   }
 
   fun createDeparture(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ConfirmationTransformer.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+
+@Component
+class ConfirmationTransformer {
+  fun transformJpaToApi(jpa: ConfirmationEntity?): Confirmation? = jpa?.let {
+    Confirmation(
+      id = it.id,
+      bookingId = it.booking.id,
+      dateTime = it.dateTime,
+      notes = it.notes,
+    )
+  }
+}

--- a/src/main/resources/db/migration/all/20221123150057__add_booking_confirmation_table.sql
+++ b/src/main/resources/db/migration/all/20221123150057__add_booking_confirmation_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE confirmations (
+    id UUID NOT NULL,
+    booking_id UUID NOT NULL,
+    date_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    notes TEXT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (booking_id) REFERENCES bookings(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -630,6 +630,59 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /premises/{premisesId}/bookings/{bookingId}/confirmations:
+    post:
+      tags:
+        - Operations on bookings
+      summary: Posts a confirmation to a specified Temporary Accommodation booking
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the confirmation is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bookingId
+          in: path
+          description: ID of the booking
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the confirmation
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewConfirmation'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Confirmation'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /premises/{premisesId}/rooms:
     get:
       tags:
@@ -2066,6 +2119,8 @@ components:
               - not-arrived
               - departed
               - cancelled
+              - provisional
+              - confirmed
             extensions:
               type: array
               items:
@@ -2086,6 +2141,10 @@ components:
               nullable: true
               allOf:
               - $ref: '#/components/schemas/Cancellation'
+            confirmation:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Confirmation'
           required:
             - status
             - extensions
@@ -2308,6 +2367,30 @@ components:
         - reason
         - moveOnCategory
         - destinationProvider
+    Confirmation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - bookingId
+        - dateTime
+    NewConfirmation:
+      type: object
+      properties:
+        notes:
+          type: string
+      required: []
     Problem:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
@@ -29,6 +30,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var departure: Yielded<DepartureEntity>? = null
   private var nonArrival: Yielded<NonArrivalEntity>? = null
   private var cancellation: Yielded<CancellationEntity>? = null
+  private var confirmation: Yielded<ConfirmationEntity>? = null
   private var extensions: Yielded<MutableList<ExtensionEntity>>? = null
   private var premises: Yielded<PremisesEntity>? = null
   private var serviceName: Yielded<ServiceName> = { randomOf(ServiceName.values().asList()) }
@@ -86,6 +88,14 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.cancellation = { cancellation }
   }
 
+  fun withYieldedConfirmation(confirmation: Yielded<ConfirmationEntity>) = apply {
+    this.confirmation = confirmation
+  }
+
+  fun withConfirmation(confirmation: ConfirmationEntity) = apply {
+    this.confirmation = { confirmation }
+  }
+
   fun withYieldedExtensions(extensions: Yielded<MutableList<ExtensionEntity>>) = apply {
     this.extensions = extensions
   }
@@ -120,6 +130,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
     departure = this.departure?.invoke(),
     nonArrival = this.nonArrival?.invoke(),
     cancellation = this.cancellation?.invoke(),
+    confirmation = this.confirmation?.invoke(),
     extensions = this.extensions?.invoke() ?: mutableListOf(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
     bed = this.bed?.invoke(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConfirmationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConfirmationEntityFactory.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ConfirmationEntityFactory : Factory<ConfirmationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore() }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<BookingEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDateTime(dateTime: OffsetDateTime) = apply {
+    this.dateTime = { dateTime }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedBooking(booking: Yielded<BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  override fun produce(): ConfirmationEntity = ConfirmationEntity(
+    id = this.id(),
+    notes = this.notes(),
+    dateTime = this.dateTime(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -113,6 +113,7 @@ class BookingTransformerTest {
     departure = null,
     nonArrival = null,
     cancellation = null,
+    confirmation = null,
     extensions = mutableListOf(),
     premises = premisesEntity,
     bed = null,


### PR DESCRIPTION
> See [ticket #472 on the CAS3 Trello board](https://trello.com/c/Le89Hfzk/472-a-user-can-confirm-a-provisional-booking).

This PR is the first piece of work to support the Temporary Accommodation booking flow. It allows for a provisional booking to be confirmed.

For the Temporary Accommodation service, a booking is provisional when it is first created. This is analogous to the `"awaiting-arrival"` status in Approved Premises bookings. Provisional bookings become confirmed once an HPT has approved the booking.

This PR adds:
- `"provisional"` and `"confirmed"` statuses as well as a `confirmation` property to the booking API schema
- A `POST /premises/{premisesId}/bookings/{bookingId}/confirmations` endpoint to confirm a booking