### PR TITLE
Add Temporary Accommodation support to arrivals on a booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -262,7 +262,7 @@ class PremisesController(
     }
 
     if (body.departureDate.isBefore(body.arrivalDate)) {
-      validationErrors["$.departureDate"] = "departureBeforeArrival"
+      validationErrors["$.departureDate"] = "beforeBookingArrivalDate"
     }
 
     if (body is NewTemporaryAccommodationBooking) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2219,7 +2219,6 @@ components:
       required:
         - arrivalDate
         - expectedDepartureDate
-        - keyWorkerStaffCode
     Nonarrival:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -590,6 +590,81 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Create Temporary Accommodation Arrival returns 409 Conflict when another booking for the same bed overlaps with the arrival and expected departure dates`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    val bed = bedEntityFactory.produceAndPersist {
+      withName("test-bed")
+      withYieldedRoom {
+        roomEntityFactory.produceAndPersist {
+          withName("test-room")
+          withYieldedPremises { premises }
+        }
+      }
+    }
+
+    val conflictingBooking = bookingEntityFactory.produceAndPersist {
+      withServiceName(ServiceName.temporaryAccommodation)
+      withCrn("CRN123")
+      withYieldedPremises { premises }
+      withYieldedBed { bed }
+      withArrivalDate(LocalDate.parse("2022-07-15"))
+      withDepartureDate(LocalDate.parse("2022-08-15"))
+    }
+
+    val booking = bookingEntityFactory.produceAndPersist {
+      withServiceName(ServiceName.temporaryAccommodation)
+      withCrn("CRN456")
+      withYieldedPremises { premises }
+      withYieldedBed { bed }
+      withArrivalDate(LocalDate.parse("2022-06-14"))
+      withDepartureDate(LocalDate.parse("2022-07-14"))
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN321")
+      .withFirstName("Mock")
+      .withLastName("Person")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    webTestClient.post()
+      .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        NewArrival(
+          arrivalDate = LocalDate.parse("2022-06-16"),
+          expectedDepartureDate = LocalDate.parse("2022-07-16"),
+          notes = "Moved in late due to sickness",
+          keyWorkerStaffCode = null,
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .is4xxClientError
+      .expectBody()
+      .jsonPath("title").isEqualTo("Conflict")
+      .jsonPath("status").isEqualTo(409)
+      .jsonPath("detail").isEqualTo("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingBooking.id}")
+  }
+
+  @Test
   fun `Create Arrival on Booking returns 200 with correct body`() {
     val keyWorker = ContextStaffMemberFactory().produce()
     mockStaffMembersContextApiCall(keyWorker, "QCODE")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -502,7 +502,7 @@ class BookingTest : IntegrationTestBase() {
       .is4xxClientError
       .expectBody()
       .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("departureBeforeArrival")
+      .jsonPath("invalid-params[0].errorType").isEqualTo("beforeBookingArrivalDate")
   }
 
   @Test


### PR DESCRIPTION
> See [ticket #536 on the CAS3 Trello board](https://trello.com/c/GC1EQ1p0/536-a-user-can-mark-a-confirmed-booking-as-active).

This PR is part of the work to support the Temporary Accommodation booking flow. It allows a booking on a Temporary Accommodation premises to record an arrival.

Changes in this PR:
- The `NewArrival.keyWorkerStaffCode` property has been made optional. Validation has been added to ensure that an Approved Premises arrival still contains this value, and returns a `400 Bad Request` response if not.
- An arrival to a Temporary Accommodation premises will validate the actual arrival date and the expected departure date to make sure that (in case they are different to the booking) there are no conflicts with other bookings for the same bedspace.