### PR TITLE
Add service scopes to departure reasons and move-on categories

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -60,14 +60,20 @@ class ReferenceDataController(
     return ResponseEntity.ok(localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi))
   }
 
-  override fun referenceDataDepartureReasonsGet(): ResponseEntity<List<DepartureReason>> {
-    val reasons = departureReasonRepository.findAll()
+  override fun referenceDataDepartureReasonsGet(xServiceName: ServiceName?): ResponseEntity<List<DepartureReason>> {
+    val reasons = when (xServiceName != null) {
+      true -> departureReasonRepository.findAllByServiceScope(xServiceName.value)
+      false -> departureReasonRepository.findAll()
+    }
 
     return ResponseEntity.ok(reasons.map(departureReasonTransformer::transformJpaToApi))
   }
 
-  override fun referenceDataMoveOnCategoriesGet(): ResponseEntity<List<MoveOnCategory>> {
-    val moveOnCategories = moveOnCategoryRepository.findAll()
+  override fun referenceDataMoveOnCategoriesGet(xServiceName: ServiceName?): ResponseEntity<List<MoveOnCategory>> {
+    val moveOnCategories = when (xServiceName != null) {
+      true -> moveOnCategoryRepository.findAllByServiceScope(xServiceName.value)
+      false -> moveOnCategoryRepository.findAll()
+    }
 
     return ResponseEntity.ok(moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -8,7 +9,10 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface DepartureReasonRepository : JpaRepository<DepartureReasonEntity, UUID>
+interface DepartureReasonRepository : JpaRepository<DepartureReasonEntity, UUID> {
+  @Query("SELECT d FROM DepartureReasonEntity d WHERE d.serviceScope = :serviceName OR d.serviceScope = '*'")
+  fun findAllByServiceScope(serviceName: String): List<DepartureReasonEntity>
+}
 
 @Entity
 @Table(name = "departure_reasons")
@@ -16,7 +20,8 @@ data class DepartureReasonEntity(
   @Id
   val id: UUID,
   val name: String,
-  val isActive: Boolean
+  val isActive: Boolean,
+  val serviceScope: String,
 ) {
   override fun toString() = "DepartureReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -8,7 +9,10 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface MoveOnCategoryRepository : JpaRepository<MoveOnCategoryEntity, UUID>
+interface MoveOnCategoryRepository : JpaRepository<MoveOnCategoryEntity, UUID> {
+  @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*'")
+  fun findAllByServiceScope(serviceName: String): List<MoveOnCategoryEntity>
+}
 
 @Entity
 @Table(name = "move_on_categories")
@@ -16,7 +20,8 @@ data class MoveOnCategoryEntity(
   @Id
   val id: UUID,
   val name: String,
-  val isActive: Boolean
+  val isActive: Boolean,
+  val serviceScope: String,
 ) {
   override fun toString() = "MoveOnCategoryEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureReasonTransformer.kt
@@ -9,6 +9,7 @@ class DepartureReasonTransformer() {
   fun transformJpaToApi(jpa: DepartureReasonEntity) = DepartureReason(
     id = jpa.id,
     name = jpa.name,
-    isActive = jpa.isActive
+    isActive = jpa.isActive,
+    serviceScope = jpa.serviceScope,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/MoveOnCategoryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/MoveOnCategoryTransformer.kt
@@ -9,6 +9,7 @@ class MoveOnCategoryTransformer() {
   fun transformJpaToApi(jpa: MoveOnCategoryEntity) = MoveOnCategory(
     id = jpa.id,
     name = jpa.name,
-    isActive = jpa.isActive
+    isActive = jpa.isActive,
+    serviceScope = jpa.serviceScope,
   )
 }

--- a/src/main/resources/db/migration/all/20221128171437__add_service_scopes_to_departure_reasons.sql
+++ b/src/main/resources/db/migration/all/20221128171437__add_service_scopes_to_departure_reasons.sql
@@ -1,0 +1,26 @@
+ALTER TABLE departure_reasons ADD COLUMN service_scope TEXT;
+
+UPDATE departure_reasons SET service_scope = 'approved-premises';
+
+UPDATE departure_reasons
+SET service_scope = '*'
+WHERE id IN (
+    '6589f8fb-d377-4bc4-ace9-d3a2ce02f97b', -- Left of own volition
+    '5bb2a91b-a33a-425e-8503-2ba69d7cabe7', -- Admitted to Hospital
+    '9a68687d-944b-4960-9de2-7645635910f3', -- Bed Withdrawn
+    'c81c42fe-f7af-4d16-b67d-93f0b4cbd338', -- Breach / recall (abscond)
+    'f5b57d36-1b3c-4777-93a2-72ff59cf7674', -- Breach / recall (behaviour / increasing risk)
+    'b80cbd68-c223-40af-b82b-5f7cee6f6fd7', -- Breach / recall (curfew)
+    'ff751e28-f957-4941-8049-5b44c6da878e', -- Breach / recall (house rules)
+    'd6e3f1db-01a7-4ce4-b7cb-f1ff5454d62e', -- Breach / recall (licence or bail condition)
+    'd86b6e2e-0b95-459a-a85a-065729149f0a', -- Breach / recall (other)
+    '761cfbe1-c102-4fe9-b943-bf131d550c90', -- Breach / recall (positive drugs test)
+    '69eac20f-c3b9-4ea3-87fd-814c3f1fd117', -- Died
+    'f4d00e1c-8bfd-40e9-8241-a7d0f744e737', -- Planned move-on
+    '60d030db-ce2d-4f1a-b24f-42ce15d268f7'  -- Other
+);
+
+ALTER TABLE departure_reasons ALTER COLUMN service_scope SET NOT NULL;
+
+INSERT INTO departure_reasons (id, name, is_active, service_scope) VALUES
+    ('ae93ec2c-157a-49fd-a4c9-b67f1a9457d8', 'Further custodial sentence imposed', true, 'temporary-accommodation');

--- a/src/main/resources/db/migration/all/20221128172629__add_service_scopes_to_move-on_categories.sql
+++ b/src/main/resources/db/migration/all/20221128172629__add_service_scopes_to_move-on_categories.sql
@@ -1,0 +1,25 @@
+ALTER TABLE move_on_categories ADD COLUMN service_scope TEXT;
+
+UPDATE move_on_categories SET service_scope = 'approved-premises';
+
+UPDATE move_on_categories
+SET service_scope = '*'
+WHERE id IN (
+    '0d8dee49-f49a-4e0e-a20e-80e0c18645ce' -- Supported Housing
+);
+
+ALTER TABLE move_on_categories ALTER COLUMN service_scope SET NOT NULL;
+
+INSERT INTO move_on_categories (id, name, is_active, service_scope) VALUES
+    ('d8e04fa1-9757-4681-bfab-6c61913c8463', 'Approved Premises', true, 'temporary-accommodation'),
+    ('247ae3f4-7958-4c59-97ed-272a39ad411c', 'Friends/Family (settled)', true, 'temporary-accommodation'),
+    ('2236cd7e-32c5-4784-a461-8f0aead1d386', 'Householder (Owner - freehold or leasehold)', true, 'temporary-accommodation'),
+    ('d3b9f02e-c3a5-475b-a5dd-124c058900d9', 'Long Term Residential Healthcare', true, 'temporary-accommodation'),
+    ('587dc0dc-9073-4992-9d58-5576753050e9', 'Rental accommodation - private rental', true, 'temporary-accommodation'),
+    ('12c739fa-7bb1-416d-bbf2-71362578a7f3', 'Rental accommodation - social rental', true, 'temporary-accommodation'),
+    ('3de4665a-c848-4797-ba80-502cacc6f7d7', 'Friends/Family (transient)', true, 'temporary-accommodation'),
+    ('a90a77a3-5662-4fa8-85ab-07d0c085052f', 'Homeless - Shelter/Emergency Hostel/Campsite', true, 'temporary-accommodation'),
+    ('33244330-87e9-4cc6-9940-f78586585436', 'Homeless - Rough Sleeping', true, 'temporary-accommodation'),
+    ('15fb0af2-3406-49c9-81ed-5e42bddf9fc2', 'Homeless - Squat', true, 'temporary-accommodation'),
+    ('91158ed5-467e-4ee8-90d9-4f17a5dac82f', 'Transient/short term accommodation', true, 'temporary-accommodation'),
+    ('9e18dc4d-297b-4a9c-86cc-31238d339b3a', 'AfEO Funded', true, 'temporary-accommodation');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1494,6 +1494,13 @@ paths:
       tags:
         - Reference Data
       summary: Lists all departure reasons
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only departure reasons for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation
@@ -1514,6 +1521,13 @@ paths:
       tags:
         - Reference Data
       summary: Lists all move-on categories for departures
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only move-on categories for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation
@@ -2487,11 +2501,14 @@ components:
         name:
           type: string
           example: Admitted to Hospital
+        serviceScope:
+          type: string
         isActive:
           type: boolean
       required:
         - id
         - name
+        - serviceScope
         - isActive
     MoveOnCategory:
       type: object
@@ -2502,11 +2519,14 @@ components:
         name:
           type: string
           example: Housing Association - Rented
+        serviceScope:
+          type: string
         isActive:
           type: boolean
       required:
         - id
         - name
+        - serviceScope
         - isActive
     DestinationProvider:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
@@ -4,12 +4,14 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class DepartureReasonEntityFactory : Factory<DepartureReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -23,9 +25,14 @@ class DepartureReasonEntityFactory : Factory<DepartureReasonEntity> {
     this.isActive = { isActive }
   }
 
+  fun withServiceScope(serviceScope: String) = apply {
+    this.serviceScope = { serviceScope }
+  }
+
   override fun produce(): DepartureReasonEntity = DepartureReasonEntity(
     id = this.id(),
     name = this.name(),
-    isActive = this.isActive()
+    isActive = this.isActive(),
+    serviceScope = this.serviceScope(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
@@ -4,12 +4,14 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class MoveOnCategoryEntityFactory : Factory<MoveOnCategoryEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -23,9 +25,14 @@ class MoveOnCategoryEntityFactory : Factory<MoveOnCategoryEntity> {
     this.isActive = { isActive }
   }
 
+  fun withServiceScope(serviceScope: String) = apply {
+    this.serviceScope = { serviceScope }
+  }
+
   override fun produce(): MoveOnCategoryEntity = MoveOnCategoryEntity(
     id = this.id(),
     name = this.name(),
-    isActive = this.isActive()
+    isActive = this.isActive(),
+    serviceScope = this.serviceScope(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -149,6 +149,60 @@ class ReferenceDataTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get Departure Reasons for only approved premises returns 200 with correct body`() {
+    departureReasonRepository.deleteAll()
+
+    departureReasonEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedDepartureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.approvedPremises.value)
+    }
+
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedDepartureReasons.map(departureReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/departure-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "approved-premises")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Departure Reasons for only temporary accommodation returns 200 with correct body`() {
+    departureReasonRepository.deleteAll()
+
+    departureReasonEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedDepartureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.temporaryAccommodation.value)
+    }
+
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedDepartureReasons.map(departureReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/departure-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "temporary-accommodation")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
   fun `Get Move on Categories returns 200 with correct body`() {
     moveOnCategoryRepository.deleteAll()
 
@@ -162,6 +216,60 @@ class ReferenceDataTest : IntegrationTestBase() {
     webTestClient.get()
       .uri("/reference-data/move-on-categories")
       .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Move on Categories for only approved premises returns 200 with correct body`() {
+    moveOnCategoryRepository.deleteAll()
+
+    moveOnCategoryEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedMoveOnCategories = moveOnCategoryEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.approvedPremises.value)
+    }
+
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedMoveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/move-on-categories")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "approved-premises")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Move on Categories for only temporary accommodation returns 200 with correct body`() {
+    moveOnCategoryRepository.deleteAll()
+
+    moveOnCategoryEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedMoveOnCategories = moveOnCategoryEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.temporaryAccommodation.value)
+    }
+
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedMoveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/move-on-categories")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "temporary-accommodation")
       .exchange()
       .expectStatus()
       .isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -415,12 +415,14 @@ class BookingTransformerTest {
         reason = DepartureReasonEntity(
           id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
           name = "Departure Reason",
-          isActive = true
+          isActive = true,
+          serviceScope = "*",
         ),
         moveOnCategory = MoveOnCategoryEntity(
           id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
           name = "Move on Category",
-          isActive = true
+          isActive = true,
+          serviceScope = "*",
         ),
         destinationProvider = DestinationProviderEntity(
           id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
@@ -446,12 +448,14 @@ class BookingTransformerTest {
       reason = DepartureReason(
         id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
         name = "Departure Reason",
-        isActive = true
+        isActive = true,
+        serviceScope = "*",
       ),
       moveOnCategory = MoveOnCategory(
         id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
         name = "Move on Category",
-        isActive = true
+        isActive = true,
+        serviceScope = "*",
       ),
       destinationProvider = DestinationProvider(
         id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
@@ -499,12 +503,14 @@ class BookingTransformerTest {
           reason = DepartureReason(
             id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
             name = "Departure Reason",
-            isActive = true
+            isActive = true,
+            serviceScope = "*",
           ),
           moveOnCategory = MoveOnCategory(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
             name = "Move on Category",
-            isActive = true
+            isActive = true,
+            serviceScope = "*",
           ),
           destinationProvider = DestinationProvider(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),


### PR DESCRIPTION
> See ticket [#537 on the CAS3 Trello board](https://trello.com/c/6ey0Kwp2/537-a-user-can-mark-an-occupied-bed-as-closed).

This PR is part of the work to support the Temporary Accommodation booking flow. It allows departure reasons and move-on categories to be service-specific.

Changes in this PR:
- The `DepartureReason` and `MoveOnCategory` OpenAPI schemas have had a `serviceScope` property added, to be used in a similar way to `Characteristic.serviceScope`.
- A `service_scope` column has been added to the `departure_reasons` and `move_on_categories` tables. Existing rows in these tables have been assigned either a scope of `"approved-premises"` or `"*"` (the wildcard scope) depending on whether they are specific to AP or will also be used by TA. New rows have been assigned a scope of `"temporary-accommodation"`. ~~**NB: Some departure reasons are still TBC, so these are subject to change.**~~ *We've made the decision on the CAS3 team to reuse AP's departure reasons for 'bed withdrawn' and 'breach/recall' provisionally and to update these as necessary in the future.*
- The `GET /reference-data/departure-reasons` and `GET /reference-data/move-on-categories` endpoints now accept `X-Service-Name` as a header, which if provided, provides only the items which match the given scope. The behaviour if no header is supplied is to return all items to maintain backwards compatibility.