### PR TITLE
Deploy to preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,18 +34,19 @@ workflows:
           requires:
             - build_docker
             - helm_lint
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          context:
-#            - hmpps-common-vars
-#            - approved-premises-api-preprod
-#          requires:
-#            - request-preprod-approval
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - approved-premises-api-preprod
+          requires:
+            - request-preprod-approval
+
 #      - request-prod-approval:
 #          type: approval
 #          requires:
@@ -97,5 +98,3 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-
-

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,7 +7,20 @@ generic-service:
     tlsSecretName: hmpps-approved-premises-api-preprod-cert
 
   env:
+    SPRING_PROFILES_ACTIVE: preprod
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    SERVICES_COMMUNITY-API_BASE-URL: https://community-api.pre-prod.delius.probation.hmpps.dsd.io
+    SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.pre-prod.delius.probation.hmpps.dsd.io
+    SERVICES_ASSESS-RISKS-AND-NEEDS-API_BASE-URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk
+    SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier-preprod.hmpps.service.justice.gov.uk
+    SERVICES_PRISONS-API_BASE-URL: https://api-preprod.prison.service.justice.gov.uk
+    SERVICES_CASE-NOTES_BASE-URL: https://preprod.offender-case-notes.service.justice.gov.uk
+    SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-preprod.hmpps.service.justice.gov.uk
+    SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all
+    LOG-CLIENT-CREDENTIALS-JWT-INFO: false
+    SENTRY_ENVIRONMENT: preprod
+    CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,7 @@
 generic-service:
   ingress:
     host: approved-premises-api-preprod.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-approved-premises-api-preprod-cert
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json


### PR DESCRIPTION
The new certification name will be provisioned in this other pull request https://github.com/ministryofjustice/cloud-platform-environments/pull/9339.

With a bit of digging most of these preprod hostnames were found https://github.com/ministryofjustice/cloud-platform-environments.

There are 2 outstanding values we need to put in place: 

```
SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: 
SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: 
```

@edavey I wonder if you'd know the preprod hostname is for the Delius API?

@anthony-britton-moj [as the original author of the dev certificate](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/05-certificates.yml) for the OASYS one, you might be able to provide a steer on whether we can add one for preprod too?

I suspect this pull request to drive some conversation so please dive in.
