### PR TITLE
Add Temporary Accommodation support to departures on a booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
@@ -29,7 +29,7 @@ data class DepartureEntity(
   val moveOnCategory: MoveOnCategoryEntity,
   @ManyToOne
   @JoinColumn(name = "destination_provider_id")
-  val destinationProvider: DestinationProviderEntity,
+  val destinationProvider: DestinationProviderEntity?,
   val notes: String?,
   @OneToOne
   @JoinColumn(name = "booking_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureTransformer.kt
@@ -17,7 +17,7 @@ class DepartureTransformer(
       dateTime = jpa.dateTime,
       reason = departureReasonTransformer.transformJpaToApi(jpa.reason),
       moveOnCategory = moveOnCategoryTransformer.transformJpaToApi(jpa.moveOnCategory),
-      destinationProvider = destinationProviderTransformer.transformJpaToApi(jpa.destinationProvider),
+      destinationProvider = jpa.destinationProvider?.let { destinationProviderTransformer.transformJpaToApi(it) },
       notes = jpa.notes
     )
   }

--- a/src/main/resources/db/migration/all/20221129160348__make_departures.destination_provider_id_nullable.sql
+++ b/src/main/resources/db/migration/all/20221129160348__make_departures.destination_provider_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE departures ALTER COLUMN destination_provider_id DROP NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2208,7 +2208,6 @@ components:
         - dateTime
         - reasonId
         - moveOnCategoryId
-        - destinationProviderId
     Departure:
       type: object
       properties:
@@ -2235,7 +2234,6 @@ components:
         - dateTime
         - reason
         - moveOnCategory
-        - destinationProvider
     Confirmation:
       type: object
       properties:


### PR DESCRIPTION
> See [ticket #537 on the CAS3 Trello board](https://trello.com/c/6ey0Kwp2/537-a-user-can-mark-an-occupied-bed-as-closed).

This PR is part of the work to support the Temporary Accommodation booking flow. It allows a booking on a Temporary Accommodation premises to record a departure.

Changes in this PR:
- The `Departure` and `NewDeparture` schemas in the OpenAPI specification have been updated to allow `destinationProvider`/`destinationProviderId` to be optional.
- The `departures.destination_provider_id` column in the database has been set as nullable.
- The `BookingService` now performs additional validation:
  - It ensures departure reasons/move-on categories are of the correct service scope (e.g. for a TA booking, it is either `"temporary-accommodation"` or the wildcard scope `"*"`). If a departure reason or move-on category has the incorrect scope, a validation error of `"incorrectDepartureReasonServiceScope"` or `"incorrectMoveOnCategoryServiceScope"` respectively is returned.
  - If a destination provider is not supplied for an Approved Premises booking, then a validation error of `"empty"` is returned.