### PR TITLE
Fix Offender Case Notes Service path

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CaseNotesClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CaseNotesClient.kt
@@ -13,6 +13,6 @@ class CaseNotesClient(
   objectMapper: ObjectMapper
 ) : BaseHMPPSClient(webClient, objectMapper) {
   fun getCaseNotesPage(nomsNumber: String, from: LocalDate, page: Int, pageSize: Int) = getRequest<CaseNotesPage> {
-    path = "/$nomsNumber?startDate=$from&page=$page&size=$pageSize"
+    path = "/case-notes/$nomsNumber?startDate=$from&page=$page&size=$pageSize"
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,7 +118,7 @@ services:
   prisons-api:
     base-url: http://localhost:9570
   case-notes:
-    base-url: http://localhost:9004/case-notes
+    base-url: http://localhost:9004
   ap-delius-context-api:
     base-url: http://localhost:9004
   ap-oasys-context-api:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -51,7 +51,7 @@ services:
   prisons-api:
     base-url: http://localhost:57839
   case-notes:
-    base-url: http://localhost:57839/case-notes
+    base-url: http://localhost:57839
   ap-delius-context-api:
     base-url: http://localhost:57839
   ap-oasys-context-api:


### PR DESCRIPTION
The real path actually has /case-notes at the start of it.  Coincidentally we were using this as a qualifier for Wiremock anyway so the change is a small one.