### PR TITLE
Use probation regions when creating or updating a premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -90,9 +90,13 @@ class PremisesController(
 
     val updatePremisesResult = premisesService
       .updatePremises(
-        premisesId, body.addressLine1,
-        body.postcode, body.localAuthorityAreaId,
-        body.characteristicIds, body.notes,
+        premisesId,
+        body.addressLine1,
+        body.postcode,
+        body.localAuthorityAreaId,
+        body.probationRegionId,
+        body.characteristicIds,
+        body.notes,
         body.status
       )
 
@@ -141,6 +145,7 @@ class PremisesController(
         postcode = body.postcode,
         service = serviceName,
         localAuthorityAreaId = body.localAuthorityAreaId,
+        probationRegionId = body.probationRegionId,
         name = body.name,
         notes = body.notes,
         characteristicIds = body.characteristicIds,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DestinationPro
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LocalAuthorityArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationPr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
@@ -25,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 
 @Service
 class ReferenceDataController(
@@ -35,13 +38,15 @@ class ReferenceDataController(
   private val lostBedReasonRepository: LostBedReasonRepository,
   private val localAuthorityAreaRepository: LocalAuthorityAreaRepository,
   private val characteristicRepository: CharacteristicRepository,
+  private val probationRegionRepository: ProbationRegionRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
   private val destinationProviderTransformer: DestinationProviderTransformer,
   private val cancellationReasonTransformer: CancellationReasonTransformer,
   private val lostBedReasonTransformer: LostBedReasonTransformer,
   private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer,
-  private val characteristicTransformer: CharacteristicTransformer
+  private val characteristicTransformer: CharacteristicTransformer,
+  private val probationRegionTransformer: ProbationRegionTransformer,
 ) : ReferenceDataApiDelegate {
 
   override fun referenceDataCharacteristicsGet(xServiceName: ServiceName?): ResponseEntity<List<Characteristic>> {
@@ -94,5 +99,11 @@ class ReferenceDataController(
     val lostBedReasons = lostBedReasonRepository.findAll()
 
     return ResponseEntity.ok(lostBedReasons.map(lostBedReasonTransformer::transformJpaToApi))
+  }
+
+  override fun referenceDataProbationRegionsGet(): ResponseEntity<List<ProbationRegion>> {
+    val probationRegions = probationRegionRepository.findAll()
+
+    return ResponseEntity.ok(probationRegions.map(probationRegionTransformer::transformJpaToApi))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -44,7 +44,7 @@ abstract class PremisesEntity(
   var notes: String,
   @ManyToOne
   @JoinColumn(name = "probation_region_id")
-  val probationRegion: ProbationRegionEntity,
+  var probationRegion: ProbationRegionEntity,
   @ManyToOne
   @JoinColumn(name = "local_authority_area_id")
   var localAuthorityArea: LocalAuthorityAreaEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -7,6 +9,9 @@ import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.Table
+
+@Repository
+interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID>
 
 @Entity
 @Table(name = "probation_regions")

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1852,6 +1852,9 @@ components:
         localAuthorityAreaId:
           type: string
           format: uuid
+        probationRegionId:
+          type: string
+          format: uuid
         characteristicIds:
           type: array
           items:
@@ -1864,6 +1867,7 @@ components:
         - addressLine1
         - postcode
         - localAuthorityAreaId
+        - probationRegionId
         - characteristicIds
         - status
     LocalAuthorityArea:
@@ -2833,6 +2837,9 @@ components:
         localAuthorityAreaId:
           type: string
           format: uuid
+        probationRegionId:
+          type: string
+          format: uuid
         characteristicIds:
           type: array
           items:
@@ -2844,6 +2851,7 @@ components:
         - addressLine1
         - postcode
         - localAuthorityAreaId
+        - probationRegionId
         - characteristicIds
         - status
     UpdateAssessment:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1535,6 +1535,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/probation-regions:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all probation regions
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProbationRegion'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /reference-data/characteristics:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
 
 class ReferenceDataTest : IntegrationTestBase() {
@@ -36,6 +37,9 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var characteristicTransformer: CharacteristicTransformer
+
+  @Autowired
+  lateinit var probationRegionTransformer: ProbationRegionTransformer
 
   @Test
   fun `Get Characteristics returns 200 with correct body`() {
@@ -332,6 +336,29 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     webTestClient.get()
       .uri("/reference-data/lost-bed-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Probation Regions returns 200 with correct body`() {
+    probationRegionRepository.deleteAll()
+
+    val probationRegions = probationRegionEntityFactory.produceAndPersistMultiple(10) {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+    val expectedJson = objectMapper.writeValueAsString(
+      probationRegions.map(probationRegionTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/probation-regions")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
@@ -37,6 +38,7 @@ class PremisesServiceTest {
   private val bookingRepositoryMock = mockk<BookingRepository>()
   private val lostBedReasonRepositoryMock = mockk<LostBedReasonRepository>()
   private val localAuthorityAreaRepositoryMock = mockk<LocalAuthorityAreaRepository>()
+  private val probationRegionRepositoryMock = mockk<ProbationRegionRepository>()
   private val characteristicServiceMock = mockk<CharacteristicService>()
 
   private val premisesService = PremisesService(
@@ -45,6 +47,7 @@ class PremisesServiceTest {
     bookingRepositoryMock,
     lostBedReasonRepositoryMock,
     localAuthorityAreaRepositoryMock,
+    probationRegionRepositoryMock,
     characteristicServiceMock
   )
 


### PR DESCRIPTION
> See [ticket #529 on the CAS3 Trello board](https://trello.com/c/Jnqzc0pE/529-users-can-assign-a-property-to-a-region).

Currently, when creating or updating a premises, a mock probation region is used that does not correspond to any real location. This PR allows for the probation region a premises is in to be specified when creating or updating it.

Changes in this PR:
- A `GET /reference-data/probation-regions` endpoint has been implemented to provide a list of all available probation regions.
- The `NewPremises` and `UpdatePremises` schemas in the OpenAPI specification have been updated to require a UUID for the `probationRegionId` property.
- The `PremisesService` validates that the provided `probationRegionId` corresponds to an actual probation region in the database.