### PR TITLE
905 - Split out applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -3,23 +3,41 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 
 @Component
 class ApplicationsTransformer(private val objectMapper: ObjectMapper, private val personTransformer: PersonTransformer) {
-  fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Application(
-    id = jpa.id,
-    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
-    createdByUserId = jpa.createdByUser.id,
-    schemaVersion = jpa.schemaVersion.id,
-    outdatedSchema = !jpa.schemaUpToDate,
-    createdAt = jpa.createdAt,
-    submittedAt = jpa.submittedAt,
-    isWomensApplication = jpa.isWomensApplication,
-    isPipeApplication = jpa.isPipeApplication,
-    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
-    document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null
-  )
+  fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): Application = when (jpa) {
+    is ApprovedPremisesApplicationEntity -> ApprovedPremisesApplication(
+      id = jpa.id,
+      person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+      createdByUserId = jpa.createdByUser.id,
+      schemaVersion = jpa.schemaVersion.id,
+      outdatedSchema = !jpa.schemaUpToDate,
+      createdAt = jpa.createdAt,
+      submittedAt = jpa.submittedAt,
+      isWomensApplication = jpa.isWomensApplication,
+      isPipeApplication = jpa.isPipeApplication,
+      data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+      document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null
+    )
+    is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
+      id = jpa.id,
+      person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+      createdByUserId = jpa.createdByUser.id,
+      schemaVersion = jpa.schemaVersion.id,
+      outdatedSchema = !jpa.schemaUpToDate,
+      createdAt = jpa.createdAt,
+      submittedAt = jpa.submittedAt,
+      data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+      document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null
+    )
+    else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
+  }
 }

--- a/src/main/resources/db/migration/all/20221205134051__split_applications_table.sql
+++ b/src/main/resources/db/migration/all/20221205134051__split_applications_table.sql
@@ -1,0 +1,25 @@
+CREATE TABLE approved_premises_applications (
+    id UUID NOT NULL,
+    is_pipe_application BOOLEAN,
+    is_womens_application BOOLEAN,
+    PRIMARY KEY (id),
+    FOREIGN KEY (id) REFERENCES applications(id)
+);
+
+INSERT INTO approved_premises_applications (id, is_pipe_application, is_womens_application)
+    SELECT id, is_pipe_application, is_womens_application FROM applications;
+
+CREATE TABLE temporary_accommodation_applications (
+    id UUID NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (id) REFERENCES applications(id)
+);
+
+ALTER TABLE applications DROP COLUMN is_pipe_application;
+ALTER TABLE applications DROP COLUMN is_womens_application;
+
+ALTER TABLE applications ADD COLUMN service TEXT;
+
+UPDATE applications SET service = 'approved-premises';
+
+ALTER TABLE applications ALTER COLUMN service SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1185,6 +1185,13 @@ paths:
       tags:
         - Operations on applications
       summary: Creates an application
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: Which service the application will belong to, defaults to approved-premises
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       requestBody:
         description: Information to create a blank application with
         content:
@@ -1222,6 +1229,13 @@ paths:
       tags:
         - Operations on applications
       summary: Lists all applications that the user has created
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: Which service to get applications for, defaults to approved-premises
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation
@@ -2709,10 +2723,6 @@ components:
         createdAt:
           type: string
           format: date-time
-        isWomensApplication:
-          type: boolean
-        isPipeApplication:
-          type: boolean
         submittedAt:
           type: string
           format: date-time
@@ -2720,6 +2730,11 @@ components:
           $ref: '#/components/schemas/AnyValue'
         document:
           $ref: '#/components/schemas/AnyValue'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesApplication'
+          CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - id
         - crn
@@ -2728,6 +2743,21 @@ components:
         - outdatedSchema
         - createdAt
         - person
+        - service
+    ApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+    TemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties: {}
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
     NewApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplicationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var createdByUser: Yielded<UserEntity>? = null
+  private var data: Yielded<String?> = { "{}" }
+  private var document: Yielded<String?> = { "{}" }
+  private var applicationSchema: Yielded<JsonSchemaEntity> = {
+    ApprovedPremisesApplicationJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}",
+      isWomensJsonLogicRule = """{"==": [1, 2]}""",
+      isPipeJsonLogicRule = """{"==": [1, 1]}"""
+    )
+  }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var submittedAt: Yielded<OffsetDateTime?> = { null }
+  private var isWomensApplication: Yielded<Boolean?> = { null }
+  private var isPipeApplication: Yielded<Boolean?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withCreatedByUser(createdByUser: UserEntity) = apply {
+    this.createdByUser = { createdByUser }
+  }
+
+  fun withYieldedCreatedByUser(createdByUser: Yielded<UserEntity>) = apply {
+    this.createdByUser = createdByUser
+  }
+
+  fun withData(data: String?) = apply {
+    this.data = { data }
+  }
+
+  fun withDocument(document: String?) = apply {
+    this.document = { document }
+  }
+
+  fun withApplicationSchema(applicationSchema: JsonSchemaEntity) = apply {
+    this.applicationSchema = { applicationSchema }
+  }
+
+  fun withYieldedApplicationSchema(applicationSchema: Yielded<JsonSchemaEntity>) = apply {
+    this.applicationSchema = applicationSchema
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withSubmittedAt(submittedAt: OffsetDateTime?) = apply {
+    this.submittedAt = { submittedAt }
+  }
+
+  fun withIsWomensApplication(isWomensApplication: Boolean) = apply {
+    this.isWomensApplication = { isWomensApplication }
+  }
+
+  fun withIsPipeApplication(isPipeApplication: Boolean) = apply {
+    this.isPipeApplication = { isPipeApplication }
+  }
+
+  override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
+    id = this.id(),
+    crn = this.crn(),
+    createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
+    data = this.data(),
+    document = this.document(),
+    schemaVersion = this.applicationSchema(),
+    createdAt = this.createdAt(),
+    submittedAt = this.submittedAt(),
+    isWomensApplication = this.isWomensApplication(),
+    isPipeApplication = this.isPipeApplication(),
+    schemaUpToDate = false
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -2,16 +2,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class ApplicationEntityFactory : Factory<ApplicationEntity> {
+class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommodationApplicationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var createdByUser: Yielded<UserEntity>? = null
@@ -71,15 +71,7 @@ class ApplicationEntityFactory : Factory<ApplicationEntity> {
     this.submittedAt = { submittedAt }
   }
 
-  fun withIsWomensApplication(isWomensApplication: Boolean) = apply {
-    this.isWomensApplication = { isWomensApplication }
-  }
-
-  fun withIsPipeApplication(isPipeApplication: Boolean) = apply {
-    this.isPipeApplication = { isPipeApplication }
-  }
-
-  override fun produce(): ApplicationEntity = ApplicationEntity(
+  override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
     createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
@@ -88,8 +80,6 @@ class ApplicationEntityFactory : Factory<ApplicationEntity> {
     schemaVersion = this.applicationSchema(),
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
-    isWomensApplication = this.isWomensApplication(),
-    isPipeApplication = this.isPipeApplication(),
     schemaUpToDate = false
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -68,7 +68,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     assessmentEntityFactory.produceAndPersist {
       withAllocatedToUser(user)
       withApplication(
-        applicationEntityFactory.produceAndPersist {
+        approvedPremisesApplicationEntityFactory.produceAndPersist {
           withCreatedByUser(user)
           withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
@@ -101,7 +102,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
-    val upToDateApplicationEntity = applicationEntityFactory.produceAndPersist {
+    val upToDateApplicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(newestJsonSchema)
       withCrn(offenderDetails.otherIds.crn)
       withCreatedByUser(user)
@@ -114,7 +115,7 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val outdatedApplicationEntity = applicationEntityFactory.produceAndPersist {
+    val outdatedApplicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
       withCreatedByUser(user)
       withCrn(offenderDetails.otherIds.crn)
@@ -263,7 +264,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
-    val applicationEntity = applicationEntityFactory.produceAndPersist {
+    val applicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(newestJsonSchema)
       withCrn(offenderDetails.otherIds.crn)
       withCreatedByUser(userEntity)
@@ -415,7 +416,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
-    val nonUpgradableApplicationEntity = applicationEntityFactory.produceAndPersist {
+    val nonUpgradableApplicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
       withCrn(offenderDetails.otherIds.crn)
       withCreatedByUser(userEntity)
@@ -678,7 +679,7 @@ class ApplicationTest : IntegrationTestBase() {
       withDeliusUsername(username)
     }
 
-    applicationEntityFactory.produceAndPersist {
+    approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn(crn)
       withId(applicationId)
       withApplicationSchema(applicationSchema)
@@ -789,7 +790,7 @@ class ApplicationTest : IntegrationTestBase() {
       withDeliusUsername(username)
     }
 
-    applicationEntityFactory.produceAndPersist {
+    approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn(crn)
       withId(applicationId)
       withApplicationSchema(applicationSchema)
@@ -816,7 +817,7 @@ class ApplicationTest : IntegrationTestBase() {
       .expectStatus()
       .isOk
 
-    val persistedApplication = applicationRepository.findByIdOrNull(applicationId)!!
+    val persistedApplication = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)!! as ApprovedPremisesApplicationEntity
 
     assertThat(persistedApplication.isWomensApplication).isTrue
     assertThat(persistedApplication.isPipeApplication).isTrue
@@ -875,7 +876,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
 
-    val application = applicationEntityFactory.produceAndPersist {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(jsonSchema)
       withCrn(crn)
       withCreatedByUser(userEntity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -71,7 +71,7 @@ class AssessmentTest : IntegrationTestBase() {
       withAddedAt(OffsetDateTime.now())
     }
 
-    val application = applicationEntityFactory.produceAndPersist {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn("CRN123")
       withCreatedByUser(user)
       withApplicationSchema(applicationSchema)
@@ -140,7 +140,7 @@ class AssessmentTest : IntegrationTestBase() {
       withAddedAt(OffsetDateTime.now())
     }
 
-    val application = applicationEntityFactory.produceAndPersist {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn("CRN123")
       withCreatedByUser(user)
       withApplicationSchema(applicationSchema)
@@ -197,7 +197,7 @@ class AssessmentTest : IntegrationTestBase() {
       withPermissiveSchema()
     }
 
-    val application = applicationEntityFactory.produceAndPersist {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn("CRN123")
       withCreatedByUser(user)
       withApplicationSchema(applicationSchema)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -16,7 +16,7 @@ import org.springframework.cache.CacheManager
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
@@ -41,12 +41,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -73,6 +74,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
@@ -84,8 +86,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Staf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationJsonSchemaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesAssessmentJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
@@ -190,7 +192,10 @@ abstract class IntegrationTestBase {
   lateinit var nonArrivalReasonRepository: NonArrivalReasonTestRepository
 
   @Autowired
-  lateinit var applicationRepository: ApplicationTestRepository
+  lateinit var approvedPremisesApplicationRepository: ApprovedPremisesApplicationTestRepository
+
+  @Autowired
+  lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationPremisesTestRepository
 
   @Autowired
   lateinit var approvedPremisesApplicationJsonSchemaRepository: ApprovedPremisesApplicationJsonSchemaTestRepository
@@ -240,7 +245,8 @@ abstract class IntegrationTestBase {
   lateinit var lostBedReasonEntityFactory: PersistedFactory<LostBedReasonEntity, UUID, LostBedReasonEntityFactory>
   lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
-  lateinit var applicationEntityFactory: PersistedFactory<ApplicationEntity, UUID, ApplicationEntityFactory>
+  lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
+  lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
   lateinit var approvedPremisesAssessmentJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesAssessmentJsonSchemaEntity, UUID, ApprovedPremisesAssessmentJsonSchemaEntityFactory>
   lateinit var userEntityFactory: PersistedFactory<UserEntity, UUID, UserEntityFactory>
@@ -292,7 +298,7 @@ abstract class IntegrationTestBase {
     lostBedReasonEntityFactory = PersistedFactory(LostBedReasonEntityFactory(), lostBedReasonRepository)
     extensionEntityFactory = PersistedFactory(ExtensionEntityFactory(), extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory(NonArrivalReasonEntityFactory(), nonArrivalReasonRepository)
-    applicationEntityFactory = PersistedFactory(ApplicationEntityFactory(), applicationRepository)
+    approvedPremisesApplicationEntityFactory = PersistedFactory(ApprovedPremisesApplicationEntityFactory(), approvedPremisesApplicationRepository)
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory(ApprovedPremisesApplicationJsonSchemaEntityFactory(), approvedPremisesApplicationJsonSchemaRepository)
     approvedPremisesAssessmentJsonSchemaEntityFactory = PersistedFactory(ApprovedPremisesAssessmentJsonSchemaEntityFactory(), approvedPremisesAssessmentJsonSchemaRepository)
     userEntityFactory = PersistedFactory(UserEntityFactory(), userRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
@@ -2,8 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import java.util.UUID
 
 @Repository
-interface ApplicationTestRepository : JpaRepository<ApplicationEntity, UUID>
+interface ApprovedPremisesApplicationTestRepository : JpaRepository<ApprovedPremisesApplicationEntity, UUID>
+
+@Repository
+interface TemporaryAccommodationApplicationTestRepository : JpaRepository<TemporaryAccommodationApplicationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -6,7 +6,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -53,7 +53,7 @@ class AssessmentServiceTest {
           UserEntityFactory().produce()
         )
         .withApplication(
-          ApplicationEntityFactory()
+          ApprovedPremisesApplicationEntityFactory()
             .withCreatedByUser(UserEntityFactory().produce())
             .produce()
         )
@@ -79,7 +79,7 @@ class AssessmentServiceTest {
       AssessmentEntityFactory()
         .withAllocatedToUser(user)
         .withApplication(
-          ApplicationEntityFactory()
+          ApprovedPremisesApplicationEntityFactory()
             .withCreatedByUser(UserEntityFactory().produce())
             .produce()
         )
@@ -117,7 +117,7 @@ class AssessmentServiceTest {
           UserEntityFactory().produce()
         )
         .withApplication(
-          ApplicationEntityFactory()
+          ApprovedPremisesApplicationEntityFactory()
             .withCreatedByUser(UserEntityFactory().produce())
             .produce()
         )
@@ -147,7 +147,7 @@ class AssessmentServiceTest {
           UserEntityFactory().produce()
         )
         .withApplication(
-          ApplicationEntityFactory()
+          ApprovedPremisesApplicationEntityFactory()
             .withCreatedByUser(UserEntityFactory().produce())
             .produce()
         )
@@ -201,7 +201,7 @@ class AssessmentServiceTest {
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
-        ApplicationEntityFactory()
+        ApprovedPremisesApplicationEntityFactory()
           .withCreatedByUser(UserEntityFactory().produce())
           .produce()
       )
@@ -232,7 +232,7 @@ class AssessmentServiceTest {
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
-        ApplicationEntityFactory()
+        ApprovedPremisesApplicationEntityFactory()
           .withCreatedByUser(UserEntityFactory().produce())
           .produce()
       )
@@ -262,7 +262,7 @@ class AssessmentServiceTest {
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
-        ApplicationEntityFactory()
+        ApprovedPremisesApplicationEntityFactory()
           .withCreatedByUser(UserEntityFactory().produce())
           .produce()
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -5,11 +5,12 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
@@ -70,7 +71,7 @@ class JsonSchemaServiceTest {
       .withDeliusUsername(distinguishedName)
       .produce()
 
-    val upToDateApplication = ApplicationEntityFactory()
+    val upToDateApplication = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(userEntity)
       .withApplicationSchema(newestJsonSchema)
       .withData(
@@ -82,7 +83,7 @@ class JsonSchemaServiceTest {
       )
       .produce()
 
-    val outdatedApplication = ApplicationEntityFactory()
+    val outdatedApplication = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(userEntity)
       .withApplicationSchema(olderJsonSchema)
       .withData("{}")
@@ -91,7 +92,7 @@ class JsonSchemaServiceTest {
     val applicationEntities = listOf(upToDateApplication, outdatedApplication)
 
     every { mockJsonSchemaRepository.getSchemasForType(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns listOf(newestJsonSchema)
-    every { mockApplicationRepository.findAllByCreatedByUser_Id(userId) } returns applicationEntities
+    every { mockApplicationRepository.findAllByCreatedByUser_Id(userId, ApprovedPremisesApplicationEntity::class.java) } returns applicationEntities
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     assertThat(jsonSchemaService.checkSchemaOutdated(upToDateApplication)).matches {


### PR DESCRIPTION
Split Applications into service specific tables, entities and responses.

Previously isWomensApplication and isPipeApplication existed on the applications table but these properties are not relevant to CAS3.  We have a need to add more CAS1 specific properties, namely selected offence and RoSH data so this is a prerequisite to that work.