### PR TITLE
905 - Provide index offence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -67,7 +67,7 @@ class ApplicationsController(
 
     val (offender, inmate) = getPersonDetail(body.crn)
 
-    val application = when (val applicationResult = applicationService.createApplication(body.crn, username, serviceName)) {
+    val application = when (val applicationResult = applicationService.createApplication(body.crn, username, serviceName, body.convictionId, body.deliusEventNumber, body.offenceId)) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = applicationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = applicationResult.validationMessages)
       is ValidatableActionResult.Success -> applicationResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -68,7 +68,10 @@ class ApprovedPremisesApplicationEntity(
   submittedAt: OffsetDateTime?,
   schemaUpToDate: Boolean,
   var isWomensApplication: Boolean?,
-  var isPipeApplication: Boolean?
+  var isPipeApplication: Boolean?,
+  val convictionId: Long,
+  val eventNumber: String,
+  val offenceId: String
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -53,7 +53,7 @@ class ApplicationService(
     return AuthorisableActionResult.Success(jsonSchemaService.checkSchemaOutdated(applicationEntity))
   }
 
-  fun createApplication(crn: String, username: String, service: String) = validated<ApplicationEntity> {
+  fun createApplication(crn: String, username: String, service: String, convictionId: Long?, deliusEventNumber: String?, offenceId: String?) = validated<ApplicationEntity> {
     if (service != ServiceName.approvedPremises.value) {
       "$.service" hasValidationError "onlyCas1Supported"
       return fieldValidationError
@@ -63,6 +63,22 @@ class ApplicationService(
       is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
       is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "userPermission"
       is AuthorisableActionResult.Success -> Unit
+    }
+
+    if (convictionId == null) {
+      "$.convictionId" hasValidationError "empty"
+    }
+
+    if (deliusEventNumber == null) {
+      "$.deliusEventNumber" hasValidationError "empty"
+    }
+
+    if (offenceId == null) {
+      "$.offenceId" hasValidationError "empty"
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
     }
 
     val user = userService.getUserForRequest()
@@ -79,6 +95,9 @@ class ApplicationService(
         submittedAt = null,
         isWomensApplication = null,
         isPipeApplication = null,
+        convictionId = convictionId!!,
+        eventNumber = deliusEventNumber!!,
+        offenceId = offenceId!!,
         schemaUpToDate = true
       )
     )

--- a/src/main/resources/db/migration/all/20221205160719__add_index_offence_fields_to_ap_applications.sql
+++ b/src/main/resources/db/migration/all/20221205160719__add_index_offence_fields_to_ap_applications.sql
@@ -1,0 +1,9 @@
+ALTER TABLE approved_premises_applications ADD COLUMN conviction_id BIGINT;
+ALTER TABLE approved_premises_applications ADD COLUMN event_number TEXT;
+ALTER TABLE approved_premises_applications ADD COLUMN offence_id TEXT;
+
+UPDATE approved_premises_applications SET conviction_id = 0, event_number = '-1', offence_id = '-1';
+
+ALTER TABLE approved_premises_applications ALTER COLUMN conviction_id SET NOT NULL;
+ALTER TABLE approved_premises_applications ALTER COLUMN event_number SET NOT NULL;
+ALTER TABLE approved_premises_applications ALTER COLUMN offence_id SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2765,6 +2765,15 @@ components:
       properties:
         crn:
           type: string
+        convictionId:
+          type: long
+          example: 1502724704
+        deliusEventNumber:
+          type: string
+          example: "7"
+        offenceId:
+          type: string
+          example: "M1502750438"
       required:
         - crn
     UpdateApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -30,6 +31,9 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var isWomensApplication: Yielded<Boolean?> = { null }
   private var isPipeApplication: Yielded<Boolean?> = { null }
+  private var convictionId: Yielded<Long> = { randomInt(0, 1000).toLong() }
+  private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
+  private var offenceId: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -79,6 +83,18 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isPipeApplication = { isPipeApplication }
   }
 
+  fun withConvictionId(convictionId: Long) = apply {
+    this.convictionId = { convictionId }
+  }
+
+  fun withEventNumber(eventNumber: String) = apply {
+    this.eventNumber = { eventNumber }
+  }
+
+  fun withOffenceId(offenceId: String) = apply {
+    this.offenceId = { offenceId }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -90,6 +106,9 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     submittedAt = this.submittedAt(),
     isWomensApplication = this.isWomensApplication(),
     isPipeApplication = this.isPipeApplication(),
+    convictionId = this.convictionId(),
+    eventNumber = this.eventNumber(),
+    offenceId = this.offenceId(),
     schemaUpToDate = false
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -590,7 +590,10 @@ class ApplicationTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewApplication(
-          crn = crn
+          crn = crn,
+          convictionId = 123,
+          deliusEventNumber = "1",
+          offenceId = "789"
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -152,7 +152,7 @@ class ApplicationServiceTest {
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.NotFound()
 
-    val result = applicationService.createApplication(crn, username, "approved-premises")
+    val result = applicationService.createApplication(crn, username, "approved-premises", 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
@@ -166,11 +166,29 @@ class ApplicationServiceTest {
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Unauthorised()
 
-    val result = applicationService.createApplication(crn, username, "approved-premises")
+    val result = applicationService.createApplication(crn, username, "approved-premises", 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
     assertThat(result.validationMessages).containsEntry("$.crn", "userPermission")
+  }
+
+  @Test
+  fun `createApplication returns FieldValidationError when convictionId, eventNumber or offenceId are null`() {
+    val crn = "CRN345"
+    val username = "SOMEPERSON"
+
+    every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
+      OffenderDetailsSummaryFactory().produce()
+    )
+
+    val result = applicationService.createApplication(crn, username, "approved-premises", null, null, null)
+
+    assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
+    result as ValidatableActionResult.FieldValidationError
+    assertThat(result.validationMessages).containsEntry("$.convictionId", "empty")
+    assertThat(result.validationMessages).containsEntry("$.deliusEventNumber", "empty")
+    assertThat(result.validationMessages).containsEntry("$.offenceId", "empty")
   }
 
   @Test
@@ -188,7 +206,7 @@ class ApplicationServiceTest {
     every { mockJsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns schema
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
-    val result = applicationService.createApplication(crn, username, "approved-premises")
+    val result = applicationService.createApplication(crn, username, "approved-premises", 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.Success).isTrue
     result as ValidatableActionResult.Success


### PR DESCRIPTION
Adds convictionId, eventNumber and offenceId properties to the create application endpoint.

The FE can retrieve these from the get active offences endpoint then pass back the correct one when creating the application.