### PR TITLE
Add applicationUrl property to Domain Events

### DIFF
--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -428,6 +428,11 @@ components:
       type: string
       example: 484b8b5e-6c3b-4400-b200-425bbe410713
 
+    ApplicationUrl:
+      description: The URL on the Approved Premises service at which a user can view a representation of an AP application and related resources, including bookings
+      type: string
+      example: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713
+
     BookingId:
       description: The UUID of booking for an AP place
       type: string
@@ -486,6 +491,8 @@ components:
       properties:
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         personReference:
           $ref: '#/components/schemas/PersonReference'
         deliusEventNumber:
@@ -508,6 +515,8 @@ components:
       properties:
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         personReference:
           $ref: '#/components/schemas/PersonReference'
         deliusEventNumber:
@@ -527,6 +536,8 @@ components:
       properties:
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         personReference:
           $ref: '#/components/schemas/PersonReference'
         deliusEventNumber:
@@ -552,6 +563,8 @@ components:
       properties:
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
         personReference:
@@ -589,6 +602,8 @@ components:
           $ref: '#/components/schemas/DeliusEventNumber'
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         attemptedAt:
           type: string
           example: '2022-11-30T14:51:30'
@@ -609,6 +624,8 @@ components:
           $ref: '#/components/schemas/DeliusEventNumber'
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
         premises:
@@ -632,6 +649,8 @@ components:
           $ref: '#/components/schemas/DeliusEventNumber'
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
         premises:
@@ -659,6 +678,8 @@ components:
           $ref: '#/components/schemas/DeliusEventNumber'
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
         premises:
@@ -682,6 +703,8 @@ components:
           $ref: '#/components/schemas/DeliusEventNumber'
         applicationId:
           $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
         premises:


### PR DESCRIPTION
It's important that Domain Events provide a link to the UI of the Approved Premises service, to a resource which will allow a human being to explore the "application" for accommodation and its associated resources e.g.:

- the assessment of the application (including clarification notes)
- any bookings related to the application

For example, when a `booking.made` event is consumed by the Delius integration we expect a Delius "contact" to be created. This contact will be of the new (booking) type `EAPB` and will include the `applicationUrl` e.g.

`https://approved-premises/applications/484b8b5e-6c3b-4400-b200-425bbe410713`

Probation officers using Delius will be able to follow this link and view the (possibly multiple) bookings which have been made and explore the AP "application" in full according to their needs.