### PR TITLE
897 - List Documents endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Conviction
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
@@ -37,5 +38,9 @@ class CommunityApiClient(
 
   fun getConvictions(crn: String) = getRequest<List<Conviction>> {
     path = "/secure/offenders/crn/$crn/convictions"
+  }
+
+  fun getDocuments(crn: String) = getRequest<GroupedDocuments> {
+    path = "/secure/offenders/crn/$crn/documents/grouped"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class GroupedDocuments(
+  val documents: List<OffenderLevelDocument>,
+  val convictions: List<ConvictionDocuments>
+)
+
+data class OffenderLevelDocument(
+  val id: UUID,
+  val documentName: String,
+  val author: String,
+  val type: DocumentType,
+  val extendedDescription: String?,
+  val createdAt: LocalDateTime,
+  val lastModifiedAt: LocalDateTime?,
+  val parentPrimaryKeyId: Long?
+)
+
+data class ConvictionDocuments(
+  val convictionId: String,
+  val documents: List<ConvictionLevelDocument>
+)
+
+data class ConvictionLevelDocument(
+  val id: UUID,
+  val documentName: String,
+  val author: String,
+  val type: DocumentType,
+  val extendedDescription: String?,
+  val lastModifiedAt: LocalDateTime?,
+  val createdAt: LocalDateTime,
+  val parentPrimaryKeyId: Long?
+)
+
+data class DocumentType(
+  val code: String,
+  val description: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Document
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DocumentLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
+import java.time.ZoneOffset
+
+@Component
+class DocumentTransformer {
+  fun transformToApi(groupedDocuments: GroupedDocuments, convictionId: Long): List<Document> {
+    val offenderDocuments = groupedDocuments.documents.map {
+      Document(
+        id = it.id,
+        level = DocumentLevel.offender,
+        fileName = it.documentName,
+        createdAt = it.createdAt.atOffset(ZoneOffset.UTC),
+        typeCode = it.type.code,
+        typeDescription = it.type.description,
+        description = it.extendedDescription
+      )
+    }
+
+    val convictionDocuments = groupedDocuments.convictions
+      .firstOrNull { it.convictionId == convictionId.toString() }
+      ?.documents
+      ?.map {
+        Document(
+          id = it.id,
+          level = DocumentLevel.conviction,
+          fileName = it.documentName,
+          createdAt = it.createdAt.atOffset(ZoneOffset.UTC),
+          typeCode = it.type.code,
+          typeDescription = it.type.description,
+          description = it.extendedDescription
+        )
+      } ?: emptyList()
+
+    return offenderDocuments + convictionDocuments
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1316,6 +1316,40 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/documents:
+    get:
+      tags:
+        - Application data
+      summary: Returns meta info on documents at the person level or at the Conviction level for the index Offence of this application.
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Document'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /applications/{applicationId}/submission:
     post:
       tags:
@@ -3319,3 +3353,36 @@ components:
         - offenceId
         - convictionId
         - offenceDate
+    DocumentLevel:
+      type: string
+      description: The level at which a Document is associated - i.e. to the Offender or to a specific Conviction
+      enum:
+        - Offender
+        - Conviction
+    Document:
+      type: object
+      description: Meta Info about a file relating to an Offender
+      properties:
+        id:
+          type: string
+          format: uuid
+        level:
+          $ref: '#/components/schemas/DocumentLevel'
+        fileName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        typeCode:
+          type: string
+        typeDescription:
+          type: string
+        description:
+          type: string
+      required:
+        - id
+        - level
+        - fileName
+        - createdAt
+        - typeCode
+        - typeDescription

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConvictionLevelDocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConvictionLevelDocumentFactory.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.ConvictionLevelDocument
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.DocumentType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ConvictionLevelDocumentFactory : Factory<ConvictionLevelDocument> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var documentName: Yielded<String> = { "${randomStringMultiCaseWithNumbers(5)}.pdf" }
+  private var author: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
+  private var typeCode: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
+  private var typeDescription: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
+  private var extendedDescription: Yielded<String?> = { randomStringMultiCaseWithNumbers(10) }
+  private var lastModifiedAt: Yielded<LocalDateTime?> = { null }
+  private var createdAt: Yielded<LocalDateTime> = { LocalDateTime.now().randomDateTimeBefore(5) }
+  private var parentPrimaryKeyId: Yielded<Long?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDocumentName(documentName: String) = apply {
+    this.documentName = { documentName }
+  }
+
+  fun withAuthor(author: String) = apply {
+    this.author = { author }
+  }
+
+  fun withTypeCode(typeCode: String) = apply {
+    this.typeCode = { typeCode }
+  }
+
+  fun withTypeDescription(typeDescription: String) = apply {
+    this.typeDescription = { typeDescription }
+  }
+
+  fun withExtendedDescription(extendedDescription: String?) = apply {
+    this.extendedDescription = { extendedDescription }
+  }
+
+  fun withLastModifiedAt(lastModifiedAt: LocalDateTime?) = apply {
+    this.lastModifiedAt = { lastModifiedAt }
+  }
+
+  fun withCreatedAt(createdAt: LocalDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withParentPrimaryKeyId(parentPrimaryKeyId: Long?) = apply {
+    this.parentPrimaryKeyId = { parentPrimaryKeyId }
+  }
+
+  override fun produce(): ConvictionLevelDocument = ConvictionLevelDocument(
+    id = this.id(),
+    documentName = this.documentName(),
+    author = this.author(),
+    type = DocumentType(
+      code = this.typeCode(),
+      description = this.typeDescription()
+    ),
+    extendedDescription = this.extendedDescription(),
+    lastModifiedAt = this.lastModifiedAt(),
+    createdAt = this.createdAt(),
+    parentPrimaryKeyId = this.parentPrimaryKeyId()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/GroupedDocumentsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/GroupedDocumentsFactory.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.ConvictionDocuments
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.ConvictionLevelDocument
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLevelDocument
+
+class GroupedDocumentsFactory : Factory<GroupedDocuments> {
+  private val offenderLevelDocuments = mutableListOf<OffenderLevelDocument>()
+  private val convictionLevelDocuments = mutableMapOf<String, MutableList<ConvictionLevelDocument>>()
+
+  fun withOffenderLevelDocument(offenderLevelDocument: OffenderLevelDocument) = apply {
+    this.offenderLevelDocuments += offenderLevelDocument
+  }
+
+  fun withConvictionLevelDocument(convictionId: String, convictionLevelDocument: ConvictionLevelDocument) = apply {
+    if (! this.convictionLevelDocuments.containsKey(convictionId)) {
+      this.convictionLevelDocuments[convictionId] = mutableListOf()
+    }
+
+    this.convictionLevelDocuments[convictionId]!! += convictionLevelDocument
+  }
+
+  override fun produce(): GroupedDocuments = GroupedDocuments(
+    documents = offenderLevelDocuments,
+    convictions = convictionLevelDocuments.map {
+      ConvictionDocuments(
+        convictionId = it.key,
+        documents = it.value
+      )
+    }
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderLevelDocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderLevelDocumentFactory.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.DocumentType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLevelDocument
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDateTime
+import java.util.UUID
+
+class OffenderLevelDocumentFactory : Factory<OffenderLevelDocument> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var documentName: Yielded<String> = { "${randomStringMultiCaseWithNumbers(5)}.pdf" }
+  private var author: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
+  private var typeCode: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
+  private var typeDescription: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
+  private var extendedDescription: Yielded<String?> = { randomStringMultiCaseWithNumbers(10) }
+  private var lastModifiedAt: Yielded<LocalDateTime?> = { null }
+  private var createdAt: Yielded<LocalDateTime> = { LocalDateTime.now().randomDateTimeBefore(5) }
+  private var parentPrimaryKeyId: Yielded<Long?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDocumentName(documentName: String) = apply {
+    this.documentName = { documentName }
+  }
+
+  fun withAuthor(author: String) = apply {
+    this.author = { author }
+  }
+
+  fun withTypeCode(typeCode: String) = apply {
+    this.typeCode = { typeCode }
+  }
+
+  fun withTypeDescription(typeDescription: String) = apply {
+    this.typeDescription = { typeDescription }
+  }
+
+  fun withExtendedDescription(extendedDescription: String?) = apply {
+    this.extendedDescription = { extendedDescription }
+  }
+
+  fun withLastModifiedAt(lastModifiedAt: LocalDateTime?) = apply {
+    this.lastModifiedAt = { lastModifiedAt }
+  }
+
+  fun withCreatedAt(createdAt: LocalDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withParentPrimaryKeyId(parentPrimaryKeyId: Long?) = apply {
+    this.parentPrimaryKeyId = { parentPrimaryKeyId }
+  }
+
+  override fun produce(): OffenderLevelDocument = OffenderLevelDocument(
+    id = this.id(),
+    documentName = this.documentName(),
+    author = this.author(),
+    type = DocumentType(
+      code = this.typeCode(),
+      description = this.typeDescription()
+    ),
+    extendedDescription = this.extendedDescription(),
+    lastModifiedAt = this.lastModifiedAt(),
+    createdAt = this.createdAt(),
+    parentPrimaryKeyId = this.parentPrimaryKeyId()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
@@ -1,0 +1,122 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConvictionLevelDocumentFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.GroupedDocumentsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderLevelDocumentFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ApplicationDocumentsTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var documentTransformer: DocumentTransformer
+
+  private val offenderDetails = OffenderDetailsSummaryFactory()
+    .withCrn("CRN123")
+    .withNomsNumber("NOMS321")
+    .produce()
+
+  private val inmateDetail = InmateDetailFactory()
+    .withOffenderNo("NOMS321")
+    .produce()
+
+  @Test
+  fun `Get application documents without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/applications/1e63735c-64dd-4904-a808-fc11e4feded3/documents")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get application documents where application was not created by user returns 403`() {
+    val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+    val owner = userEntityFactory.produceAndPersist { withDeliusUsername("DIFFERENTPROBATIONPERSON") }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCreatedByUser(owner)
+      withCrn("CRN123")
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaRepository.findAll().first())
+    }
+
+    webTestClient.get()
+      .uri("/applications/${application.id}/documents")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Get application documents returns 200`() {
+    val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCreatedByUser(user)
+      withCrn("CRN123")
+      withConvictionId(12345)
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaRepository.findAll().first())
+    }
+
+    val groupedDocuments = GroupedDocumentsFactory()
+      .withOffenderLevelDocument(
+        OffenderLevelDocumentFactory()
+          .withId(UUID.fromString("b0df5ec4-5685-4b02-8a95-91b6da80156f"))
+          .withDocumentName("offender_level_doc.pdf")
+          .withTypeCode("TYPE-1")
+          .withTypeDescription("Type 1 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
+          .withExtendedDescription("Extended Description 1")
+          .produce()
+      )
+      .withConvictionLevelDocument(
+        "12345",
+        ConvictionLevelDocumentFactory()
+          .withId(UUID.fromString("457af8a5-82b1-449a-ad03-032b39435865"))
+          .withDocumentName("conviction_level_doc.pdf")
+          .withTypeCode("TYPE-2")
+          .withTypeDescription("Type 2 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
+          .withExtendedDescription("Extended Description 2")
+          .produce()
+      )
+      .produce()
+
+    mockClientCredentialsJwtRequest()
+    mockCommunityApiDocumentsCall("CRN123", groupedDocuments)
+
+    webTestClient.get()
+      .uri("/applications/${application.id}/documents")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        objectMapper.writeValueAsString(
+          documentTransformer.transformToApi(groupedDocuments, 12345)
+        )
+      )
+  }
+
+  private fun mockCommunityApiDocumentsCall(crn: String, groupedDocuments: GroupedDocuments) = wiremockServer.stubFor(
+    WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/$crn/documents/grouped"))
+      .willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200)
+          .withBody(
+            objectMapper.writeValueAsString(groupedDocuments)
+          )
+      )
+  )
+}


### PR DESCRIPTION
Adds a `/applications/{applicationId}/documents` endpoint that returns meta data about the documents associated to:
 - The Offender the Application is for
 - The Conviction the Application is associated with