### PR TITLE
Allow convictionDate to be null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Conviction.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Conviction.kt
@@ -11,7 +11,7 @@ data class Conviction(
   val failureToComplyCount: Long,
   val breachEnd: LocalDate?,
   val awaitingPsr: Boolean,
-  val convictionDate: LocalDate,
+  val convictionDate: LocalDate?,
   val referralDate: LocalDate,
   val offences: List<Offence>?
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConvictionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConvictionFactory.kt
@@ -16,7 +16,7 @@ class ConvictionFactory : Factory<Conviction> {
   private var failureToComplyCount: Yielded<Long> = { 0 }
   private var breachEnd: Yielded<LocalDate?> = { null }
   private var awaitingPsr: Yielded<Boolean> = { false }
-  private var convictionDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(10) }
+  private var convictionDate: Yielded<LocalDate?> = { LocalDate.now().randomDateBefore(10) }
   private var referralDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(10) }
   private var offences: Yielded<List<Offence>> = { listOf() }
 
@@ -48,7 +48,7 @@ class ConvictionFactory : Factory<Conviction> {
     this.awaitingPsr = { awaitingPsr }
   }
 
-  fun withConvictionDate(convictionDate: LocalDate) = apply {
+  fun withConvictionDate(convictionDate: LocalDate?) = apply {
     this.convictionDate = { convictionDate }
   }
 


### PR DESCRIPTION
The convictions response from Delius can have a null value for convictionDate.