### PR TITLE
Add Temporary Accommodation support to extensions on a booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -315,6 +315,8 @@ class PremisesController(
         premises = premises,
         bed = bed,
         service = body.serviceName.value,
+        originalArrivalDate = body.arrivalDate,
+        originalDepartureDate = body.departureDate,
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -435,6 +435,14 @@ class PremisesController(
   ): ResponseEntity<Extension> {
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
+    if (booking.service == ServiceName.temporaryAccommodation.value) {
+      // TODO: Extensions will likely need to check for overlaps once bed-level bookings are implemented for AP
+      val bedId = booking.bed?.id
+        ?: throw InternalServerErrorProblem("No bed ID present on Temporary Accommodation booking: $bookingId")
+
+      throwIfBookingDatesConflict(booking.arrivalDate, body.newDepartureDate, bookingId, bedId, booking.premises)
+    }
+
     val result = bookingService.createExtension(
       booking = booking,
       newDepartureDate = body.newDepartureDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -51,6 +51,8 @@ data class BookingEntity(
   @JoinColumn(name = "bed_id")
   var bed: BedEntity?,
   var service: String,
+  var originalArrivalDate: LocalDate,
+  var originalDepartureDate: LocalDate,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -66,11 +68,13 @@ data class BookingEntity(
     if (nonArrival != other.nonArrival) return false
     if (cancellation != other.cancellation) return false
     if (confirmation != other.confirmation) return false
+    if (originalArrivalDate != other.originalArrivalDate) return false
+    if (originalDepartureDate != other.originalDepartureDate) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, departure, nonArrival, cancellation, confirmation)
+  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, departure, nonArrival, cancellation, confirmation, originalArrivalDate, originalDepartureDate)
 
   override fun toString() = "BookingEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -29,7 +29,7 @@ data class BookingEntity(
   @Id
   val id: UUID,
   var crn: String,
-  val arrivalDate: LocalDate,
+  var arrivalDate: LocalDate,
   var departureDate: LocalDate,
   var keyWorkerStaffCode: String?,
   @OneToOne(mappedBy = "booking")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -94,6 +94,12 @@ class BookingService(
       )
     )
 
+    if (booking.service == ServiceName.temporaryAccommodation.value) {
+      booking.arrivalDate = arrivalDate
+      booking.departureDate = expectedDepartureDate
+      updateBooking(booking)
+    }
+
     return success(arrivalEntity)
   }
 
@@ -250,6 +256,11 @@ class BookingService(
         booking = booking
       )
     )
+
+    if (booking.service == ServiceName.temporaryAccommodation.value) {
+      booking.departureDate = dateTime.toLocalDate()
+      updateBooking(booking)
+    }
 
     return success(departureEntity)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -271,8 +271,13 @@ class BookingService(
     newDepartureDate: LocalDate,
     notes: String?
   ) = validated<ExtensionEntity> {
-    if (booking.departureDate.isAfter(newDepartureDate)) {
-      return "$.newDepartureDate" hasSingleValidationError "beforeExistingDepartureDate"
+    when (booking.service) {
+      ServiceName.approvedPremises.value -> if (booking.departureDate.isAfter(newDepartureDate)) {
+        return "$.newDepartureDate" hasSingleValidationError "beforeExistingDepartureDate"
+      }
+      ServiceName.temporaryAccommodation.value -> if (booking.arrivalDate.isAfter(newDepartureDate)) {
+        return "$.newDepartureDate" hasSingleValidationError "beforeBookingArrivalDate"
+      }
     }
 
     val extensionEntity = ExtensionEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -39,6 +39,8 @@ class BookingTransformer(
     confirmation = confirmationTransformer.transformJpaToApi(jpa.confirmation),
     extensions = jpa.extensions.map(extensionTransformer::transformJpaToApi),
     bed = jpa.bed?.let { bedTransformer.transformJpaToApi(it) },
+    originalArrivalDate = jpa.originalArrivalDate,
+    originalDepartureDate = jpa.originalDepartureDate,
   )
 
   private fun determineStatus(jpa: BookingEntity) = when {

--- a/src/main/resources/db/migration/all/20221207135709__add_original_departure_and_arrival_date_to_a_booking.sql
+++ b/src/main/resources/db/migration/all/20221207135709__add_original_departure_and_arrival_date_to_a_booking.sql
@@ -1,0 +1,10 @@
+ALTER TABLE bookings ADD COLUMN original_arrival_date DATE;
+ALTER TABLE bookings ADD COLUMN original_departure_date DATE;
+
+UPDATE bookings
+SET
+    original_arrival_date = arrival_date,
+    original_departure_date = departure_date;
+
+ALTER TABLE bookings ALTER COLUMN original_arrival_date SET NOT NULL;
+ALTER TABLE bookings ALTER COLUMN original_departure_date SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2025,7 +2025,13 @@ components:
         arrivalDate:
           type: string
           format: date
+        originalArrivalDate:
+          type: string
+          format: date
         departureDate:
+          type: string
+          format: date
+        originalDepartureDate:
           type: string
           format: date
         keyWorker:
@@ -2038,7 +2044,9 @@ components:
         - id
         - person
         - arrivalDate
+        - originalArrivalDate
         - departureDate
+        - originalDepartureDate
         - serviceName
     NewBooking:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -25,6 +25,8 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var departureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
+  private var originalArrivalDate: Yielded<LocalDate>? = null
+  private var originalDepartureDate: Yielded<LocalDate>? = null
   private var keyWorkerStaffCode: Yielded<String?> = { null }
   private var arrival: Yielded<ArrivalEntity>? = null
   private var departure: Yielded<DepartureEntity>? = null
@@ -48,8 +50,16 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.arrivalDate = { arrivalDate }
   }
 
+  fun withOriginalArrivalDate(arrivalDate: LocalDate) = apply {
+    this.originalArrivalDate = { arrivalDate }
+  }
+
   fun withDepartureDate(departureDate: LocalDate) = apply {
     this.departureDate = { departureDate }
+  }
+
+  fun withOriginalDepartureDate(departureDate: LocalDate) = apply {
+    this.originalDepartureDate = { departureDate }
   }
 
   fun withStaffKeyWorkerCode(staffKeyWorkerCode: String?) = apply {
@@ -134,6 +144,8 @@ class BookingEntityFactory : Factory<BookingEntity> {
     extensions = this.extensions?.invoke() ?: mutableListOf(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
     bed = this.bed?.invoke(),
-    service = this.serviceName.invoke().value
+    service = this.serviceName.invoke().value,
+    originalArrivalDate = this.originalArrivalDate?.invoke() ?: this.arrivalDate(),
+    originalDepartureDate = this.originalDepartureDate?.invoke() ?: this.departureDate(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -123,6 +123,8 @@ class BookingTransformerTest {
     premises = premisesEntity,
     bed = null,
     service = ServiceName.approvedPremises.value,
+    originalArrivalDate = LocalDate.parse("2022-08-10"),
+    originalDepartureDate = LocalDate.parse("2022-08-30"),
   )
 
   private val staffMember = StaffMember(
@@ -199,6 +201,8 @@ class BookingTransformerTest {
         status = Booking.Status.awaitingMinusArrival,
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }
@@ -232,6 +236,8 @@ class BookingTransformerTest {
         status = Booking.Status.provisional,
         extensions = listOf(),
         serviceName = ServiceName.temporaryAccommodation,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }
@@ -286,6 +292,8 @@ class BookingTransformerTest {
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }
@@ -342,6 +350,8 @@ class BookingTransformerTest {
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }
@@ -394,6 +404,8 @@ class BookingTransformerTest {
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }
@@ -521,6 +533,8 @@ class BookingTransformerTest {
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }
@@ -576,6 +590,8 @@ class BookingTransformerTest {
         ),
         extensions = listOf(),
         serviceName = ServiceName.temporaryAccommodation,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
       )
     )
   }


### PR DESCRIPTION
> See [ticket #608 on the CAS3 Trello board](https://trello.com/c/C3QYguIW/608-a-user-can-mark-a-booking-as-extended).

This PR is part of the work to support the Temporary Accommodation booking flow. It allows a booking on a Temporary Accommodation premises to record an extension.

Changes in this PR:
- Bookings have been updated to provide original arrival and departure dates, which are set when the booking is created and never changed. This is distinct from the current arrival and departure dates, which can be changed as a booking changes states. These original dates are required by CAS3 for MI reporting.
- Arrival and departure dates are overwritten for all state transitions that can change these values (i.e. arrivals, departures, and extensions). This behaviour is only applied to TA bookings to preserve the current behaviour for AP bookings.
- Extensions for TA bookings can be used to move a departure date to be earlier as well as later.
- Extensions for TA bookings will check for conflicts with other bookings to ensure that an extension can't cause two bookings to overlap.