### PR TITLE
Add Temporary Accommodation support for cancellations on a booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -89,8 +89,11 @@ class ReferenceDataController(
     return ResponseEntity.ok(destinationProviders.map(destinationProviderTransformer::transformJpaToApi))
   }
 
-  override fun referenceDataCancellationReasonsGet(): ResponseEntity<List<CancellationReason>> {
-    val cancellationReasons = cancellationReasonRepository.findAll()
+  override fun referenceDataCancellationReasonsGet(xServiceName: ServiceName?): ResponseEntity<List<CancellationReason>> {
+    val cancellationReasons = when (xServiceName != null) {
+      true -> cancellationReasonRepository.findAllByServiceScope(xServiceName.value)
+      false -> cancellationReasonRepository.findAll()
+    }
 
     return ResponseEntity.ok(cancellationReasons.map(cancellationReasonTransformer::transformJpaToApi))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -16,7 +16,8 @@ data class CancellationReasonEntity(
   @Id
   val id: UUID,
   val name: String,
-  val isActive: Boolean
+  val isActive: Boolean,
+  val serviceScope: String,
 ) {
   override fun toString() = "CancellationReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -8,7 +9,10 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity, UUID>
+interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity, UUID> {
+  @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*'")
+  fun findAllByServiceScope(serviceName: String): List<CancellationReasonEntity>
+}
 
 @Entity
 @Table(name = "cancellation_reasons")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -152,6 +152,8 @@ class BookingService(
     val reason = cancellationReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
       "$.reason" hasValidationError "doesNotExist"
+    } else if (!serviceScopeMatches(reason.serviceScope, booking)) {
+      "$.reason" hasValidationError "incorrectCancellationReasonServiceScope"
     }
 
     if (validationErrors.any()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationReasonTransformer.kt
@@ -9,6 +9,7 @@ class CancellationReasonTransformer() {
   fun transformJpaToApi(jpa: CancellationReasonEntity) = CancellationReason(
     id = jpa.id,
     name = jpa.name,
-    isActive = jpa.isActive
+    isActive = jpa.isActive,
+    serviceScope = jpa.serviceScope,
   )
 }

--- a/src/main/resources/db/migration/all/20221209161455__add_service_scope_to_cancellation_reasons.sql
+++ b/src/main/resources/db/migration/all/20221209161455__add_service_scope_to_cancellation_reasons.sql
@@ -1,0 +1,6 @@
+ALTER TABLE cancellation_reasons ADD COLUMN service_scope TEXT;
+
+UPDATE cancellation_reasons
+SET service_scope = 'approved-premises';
+
+ALTER TABLE cancellation_reasons ALTER COLUMN service_scope SET NOT NULL;

--- a/src/main/resources/db/migration/all/20221209162642__add_cancellation_reasons_for_temporary_accommodation.sql
+++ b/src/main/resources/db/migration/all/20221209162642__add_cancellation_reasons_for_temporary_accommodation.sql
@@ -1,0 +1,8 @@
+INSERT INTO cancellation_reasons (id, name, is_active, service_scope)
+VALUES
+    ('3d57413f-ca94-424a-b026-bf9e99ed28fe', 'Alternative suitable accommodation provided by LHA', true, 'temporary-accommodation'),
+    ('f023aab7-4bd8-42a3-9f80-7aab3d4f40b8', 'Alternative suitable accommodation provided (Other)', true, 'temporary-accommodation'),
+    ('edd09efb-ef83-42da-a15c-750afd057eb3', 'Person on probation rejected placement (Out of area)', true, 'temporary-accommodation'),
+    ('7c54c8f5-14df-4836-af9c-c66a6021a375', 'Person on probation failed to arrive', true, 'temporary-accommodation'),
+    ('8afe2dc8-f024-4ab1-a98d-0e321e317b19', 'Withdrawn by referrer', true, 'temporary-accommodation'),
+    ('d2a0d037-53db-4bb2-b9f7-afa07948a3f5', 'Administrative error', true, 'temporary-accommodation');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1618,6 +1618,13 @@ paths:
       tags:
         - Reference Data
       summary: Lists all cancellation reasons
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only departure reasons for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2679,10 +2679,13 @@ components:
           example: Recall
         isActive:
           type: boolean
+        serviceScope:
+          type: string
       required:
         - id
         - name
         - isActive
+        - serviceScope
     NonArrivalReason:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
@@ -4,12 +4,14 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class CancellationReasonEntityFactory : Factory<CancellationReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -23,9 +25,14 @@ class CancellationReasonEntityFactory : Factory<CancellationReasonEntity> {
     this.isActive = { isActive }
   }
 
+  fun withServiceScope(serviceScope: String) = apply {
+    this.serviceScope = { serviceScope }
+  }
+
   override fun produce(): CancellationReasonEntity = CancellationReasonEntity(
     id = this.id(),
     name = this.name(),
-    isActive = this.isActive()
+    isActive = this.isActive(),
+    serviceScope = this.serviceScope(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1081,7 +1081,9 @@ class BookingTest : IntegrationTestBase() {
       }
     }
 
-    val cancellationReason = cancellationReasonEntityFactory.produceAndPersist()
+    val cancellationReason = cancellationReasonEntityFactory.produceAndPersist {
+      withServiceScope("*")
+    }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -324,6 +324,60 @@ class ReferenceDataTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get Cancellation Reasons for only approved premises returns 200 with correct body`() {
+    cancellationReasonRepository.deleteAll()
+
+    cancellationReasonEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedCancellationReasons = cancellationReasonEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.approvedPremises.value)
+    }
+
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/cancellation-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "approved-premises")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Cancellation Reasons for only temporary accommodation returns 200 with correct body`() {
+    cancellationReasonRepository.deleteAll()
+
+    cancellationReasonEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedCancellationReasons = cancellationReasonEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.temporaryAccommodation.value)
+    }
+
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/cancellation-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "temporary-accommodation")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
   fun `Get Lost Bed Reasons returns 200 with correct body`() {
     lostBedReasonRepository.deleteAll()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -362,7 +362,7 @@ class BookingTransformerTest {
       cancellation = CancellationEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         date = LocalDate.parse("2022-08-10"),
-        reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true),
+        reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
         notes = null,
         booking = this
       )
@@ -372,7 +372,7 @@ class BookingTransformerTest {
       bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
       notes = null,
       date = LocalDate.parse("2022-08-10"),
-      reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true)
+      reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises")
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(cancellationBooking, offenderDetails, inmateDetail, null)
@@ -399,7 +399,7 @@ class BookingTransformerTest {
         cancellation = Cancellation(
           bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
           date = LocalDate.parse("2022-08-10"),
-          reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true),
+          reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
           notes = null
         ),
         extensions = listOf(),


### PR DESCRIPTION
> See [ticket #471 on the CAS3 Trello board](https://trello.com/c/Rkqzx3HH/471-a-user-can-mark-a-booking-as-cancelled).

This PR is part of the work to support the Temporary Accommodation booking flow. It allows a booking on a Temporary Accommodation premises to record a cancellation.

Changes in this PR:
- Cancellation reasons now have a service scope associated with them, which can be either `"approved-premises"`, `"temporary-accommodation"`, or the wildcard `"*"`.
- The `BookingService.createCancellation` method will validate that the supplied reason ID corresponds to a cancellation reason with the correct scope. If the scope is incorrect, the method will return a `"incorrectCancellationReasonServiceScope"` validation error.
- The `GET /reference-data/cancellation-reasons` endpoint now filters by the value of the `X-Service-Name` header if it's provided.
- The TA-specific cancellation reasons have been seeded into the database through a Flyway migration.