### PR TITLE
(Fix) Remove mock Temporary Accommodation characteristics

### DIFF
--- a/src/main/resources/db/migration/local+dev/20221206114543__remove_mock_characteristics_for_temporary_accommodation.sql
+++ b/src/main/resources/db/migration/local+dev/20221206114543__remove_mock_characteristics_for_temporary_accommodation.sql
@@ -1,2 +1,0 @@
-DELETE FROM characteristics
-WHERE service_scope = 'temporary-accommodation';

--- a/src/main/resources/db/migration/local+dev/20221213124429__remove_mock_characteristics_for_temporary_accommodation.sql
+++ b/src/main/resources/db/migration/local+dev/20221213124429__remove_mock_characteristics_for_temporary_accommodation.sql
@@ -1,0 +1,61 @@
+-- Migrate premises characteristics to the real ones.
+-- All mock characteristics defined correspond to premises-specific or shared real characteristics,
+-- so no loss of data.
+
+-- Migrate 'Park nearby' characteristic
+UPDATE premises_characteristics
+SET characteristic_id = 'fffb3004-5f0a-4e88-8350-fb89a0168296'
+WHERE characteristic_id = '952790c0-21d7-4fd6-a7e1-9018f08d8bb0';
+
+-- Migrate 'School nearby' characteristic
+UPDATE premises_characteristics
+SET characteristic_id = '78c5d99b-9702-4bf2-a23d-c2a0cf3a017d'
+WHERE characteristic_id = '1dac11c5-a1b4-4313-b0f7-41b2e57f2404';
+
+-- Migrate 'Not suitable for arson offenders' characteristic
+UPDATE premises_characteristics
+SET characteristic_id = '62c4d8cf-b612-4110-9e27-5c29982f9fcf'
+WHERE characteristic_id = '16b52729-be75-43b4-b711-77fe5cbcb477';
+
+-- Migrate 'Women only' characteristic
+UPDATE premises_characteristics
+SET characteristic_id = '8221f1ad-3aaf-406a-b918-dbdef956ea17'
+WHERE characteristic_id = '7cd8dd2c-a14d-4a78-8d72-48449cc5aaa3';
+
+-- Migrate 'Floor level access' characteristic
+UPDATE premises_characteristics
+SET characteristic_id = '99bb0f33-ff92-4606-9d1c-43bcf0c42ef4'
+WHERE characteristic_id = 'd9f52ae8-4c01-4751-8975-992efacd5260';
+
+-- Migrate room characteristics where possible.
+-- Otherwise, delete the link entry.
+-- This is fine, as this is a non-production Flyway migration.
+
+-- 'Park nearby', 'School nearby', and 'Women only' characteristics are premises-specific, and have
+-- no corresponding room characteristic to migrate to.
+DELETE FROM room_characteristics
+WHERE characteristic_id IN (
+    '952790c0-21d7-4fd6-a7e1-9018f08d8bb0',
+    '1dac11c5-a1b4-4313-b0f7-41b2e57f2404',
+    '7cd8dd2c-a14d-4a78-8d72-48449cc5aaa3'
+);
+
+-- Migrate 'Not suitable for arson offenders' characteristic
+UPDATE room_characteristics
+SET characteristic_id = '62c4d8cf-b612-4110-9e27-5c29982f9fcf'
+WHERE characteristic_id = '16b52729-be75-43b4-b711-77fe5cbcb477';
+
+-- Migrate 'Floor level access' characteristic
+UPDATE room_characteristics
+SET characteristic_id = '99bb0f33-ff92-4606-9d1c-43bcf0c42ef4'
+WHERE characteristic_id = 'd9f52ae8-4c01-4751-8975-992efacd5260';
+
+-- Remove mock TA characteristics.
+DELETE FROM characteristics
+WHERE id IN (
+    '952790c0-21d7-4fd6-a7e1-9018f08d8bb0',
+    '1dac11c5-a1b4-4313-b0f7-41b2e57f2404',
+    '16b52729-be75-43b4-b711-77fe5cbcb477',
+    '7cd8dd2c-a14d-4a78-8d72-48449cc5aaa3',
+    'd9f52ae8-4c01-4751-8975-992efacd5260'
+);


### PR DESCRIPTION
# Observed behaviour

The e2e tests for the Temporary Accommodation UI fail as some characteristics are missing:

![Failed end-to-end test from CircleCI showing an expected item in the radio list of characteristics was not found](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/artifacts/e84ccffc-55f5-4498-8341-8c51ebe593c2/402116c5-b7e4-46ee-9a28-1f358a068bcc/0/screenshots/premises.feature/Manage%20Temporary%20Accommodation%20-%20Premieses%20--%20Creating%20a%20premises%20%28failed%29.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQVFQINEOLMP2LA5K%2F20221213%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221213T131258Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJX%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCIA4cWu1aEir213I7VsW%2FeVcgwPZIMxvyv1iGC9xBRb%2FKAiAWgUr8nY%2FNik%2BrGTRBaGNz3fO4UJdP1psm%2Bl9JkbDkTiq0Agi%2B%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAMaDDA0NTQ2NjgwNjU1NiIMaYfIr5yA6k1tbeiIKogCO%2BGL4y1D7Rn7nchyRB%2BgC545odyNfotylXkmsLAxvwPoAH6489QF5fqlAYrQy%2BZKlso%2FfrXQQN4548pHBQptwDxyLeVlCHCaAcAIdsUKuDrnfQQhAjxI70OBQoZahwEWgscbECwBl5MzA6EzavCh2LfXHW3OBoolw43VJZfrHblJ1nI7UyibBwbk1YQMyiemBJ%2Bi61SaX0MJ03Bn%2FNH7KGYIPNfgm4aH37zkbExuHtSduTVupOIjG2WRlYxRaSSnnY9dUOmRnnqsL0GTGu9Z6y8WQmbJNKlV513XlnEYJqBp860fBgHDaTpzTg234bGxIyaKfgSP95BXvsz9nUfRb4vJ%2BHhVZ1pJMMzw4ZwGOp4B55UApFHRyGEFuaAuEM%2F52EPSgXgnOFgFpgWZYQ4x0UaQqn6OmPUYWaDqFd6g1QFLIUx8ozjCFhA4bWtFveeTCB22GrQSiodyobTloILiulI1Yg6Z5PTvt4MJZaqR9w8lfSmS0QlXMSjRvnlnuMAXdGbW15hO0xEclofAfOP6OzI4LqfoWkdc34cN7oVikw1vbFrqBlC50DGo%2F5AeYLE%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=3500dff8c036a8567afea1b2f8cccbc97f623c986ac134601f1e12fe8d77c9df)

It seemed like an old version of the API existed in the dev environment, as some Flyway migrations to add real Temporary Accommodation characteristics and to remove mock ones had been merged in some time ago. However, deploying the API to the dev environment results in the following failure when running Flyway migrations:

```
ERROR: update or delete on table "characteristics" violates foreign key constraint "premises_characteristics_characteristic_id_fkey" on table "premises_characteristics"
[12:35](https://mojdt.slack.com/archives/D04D2MMTT24/p1670934935786429)
key (id)=(9527...8bb0) is still referenced from table "premises_characteristics"
```

# Expected behaviour

The Flyway migrations run successfully and the Temporary Accommodation UI displays the correct set of characteristics.

# Solution

The `local+dev` Flyway migration to remove mock characteristics now updates rows on the `premises_characteristics` and `room_characteristics` tables to use the new IDs where possible. Where no suitable real characteristic exists, these rows are instead deleted.