### PR TITLE
Implement PUT `/assessments/{assessmentId}` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -7,19 +8,24 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.AssessmentsApiDelega
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
 class AssessmentController(
+  private val objectMapper: ObjectMapper,
   private val assessmentService: AssessmentService,
   private val userService: UserService,
   private val offenderService: OffenderService,
@@ -75,6 +81,48 @@ class AssessmentController(
       is AuthorisableActionResult.Success -> assessmentResult.entity
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    }
+
+    val applicationCrn = assessment.application.crn
+
+    val offenderDetailsResult = offenderService.getOffenderByCrn(applicationCrn, user.deliusUsername)
+    val offenderDetails = when (offenderDetailsResult) {
+      is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+      else -> throw InternalServerErrorProblem("Could not get Offender Details for CRN: $applicationCrn")
+    }
+
+    if (offenderDetails.otherIds.nomsNumber == null) {
+      throw InternalServerErrorProblem("No NOMS number for CRN: $applicationCrn")
+    }
+
+    val inmateDetailsResult = offenderService.getInmateDetailByNomsNumber(offenderDetails.otherIds.nomsNumber)
+    val inmateDetails = when (inmateDetailsResult) {
+      is AuthorisableActionResult.Success -> inmateDetailsResult.entity
+      else -> throw InternalServerErrorProblem("Could not get Inmate Details for NOMS: ${offenderDetails.otherIds.nomsNumber}")
+    }
+
+    return ResponseEntity.ok(
+      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
+    )
+  }
+
+  @Transactional
+  override fun assessmentsAssessmentIdPut(assessmentId: UUID, updateAssessment: UpdateAssessment): ResponseEntity<Assessment> {
+    val user = userService.getUserForRequest()
+
+    val serializedData = objectMapper.writeValueAsString(updateAssessment.data)
+
+    val assessmentAuthResult = assessmentService.updateAssessment(user, assessmentId, serializedData)
+    val assessmentValidationResult = when (assessmentAuthResult) {
+      is AuthorisableActionResult.Success -> assessmentAuthResult.entity
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    }
+
+    val assessment = when (assessmentValidationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = assessmentValidationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = assessmentValidationResult.validationMessages)
+      is ValidatableActionResult.Success -> assessmentValidationResult.entity
     }
 
     val applicationCrn = assessment.application.crn


### PR DESCRIPTION
This endpoint follows the same pattern as the update endpoint for Applications:
 - Must either be assigned to the assessment or a WORKFLOW_MANAGER in order to update it (this is subject to future changes pending outcome of auth conversations)
 - The schema version of the assessment must be the latest
 - The assessment must not have already been accepted or rejected