### PR TITLE
819 - Accept Assessment endpoint

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1831,6 +1831,13 @@ paths:
           schema:
             type: string
             format: uuid
+      requestBody:
+        description: Information needed to accept an assessment
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/AssessmentAcceptance'
+        required: true
       responses:
         200:
           description: successfully accepted the assessment
@@ -3100,12 +3107,22 @@ components:
             $ref: '#/components/schemas/AnyValue'
       required:
         - data
+    AssessmentAcceptance:
+      type: object
+      properties:
+        document:
+          $ref: '#/components/schemas/AnyValue'
+      required:
+        - document
     AssessmentRejection:
       type: object
       properties:
+        document:
+          $ref: '#/components/schemas/AnyValue'
         rejectionRationale:
           type: string
       required:
+        - document
         - rejectionRationale
     ClarificationNote:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import java.time.OffsetDateTime
 
@@ -166,6 +170,74 @@ class AssessmentTest : IntegrationTestBase() {
           assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
         )
       )
+  }
+
+  @Test
+  fun `Accept assessment without JWT returns 401`() {
+    webTestClient.post()
+      .uri("/assessments/6966902f-9b7e-4fc7-96c4-b54ec02d16c9/acceptance")
+      .bodyValue(AssessmentAcceptance(document = "{}"))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Accept assessment returns 200, persists decision`() {
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN123")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+
+    val inmateDetails = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockInmateDetailPrisonsApiCall(inmateDetails)
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+      withAddedAt(OffsetDateTime.now())
+    }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCrn("CRN123")
+      withCreatedByUser(user)
+      withApplicationSchema(applicationSchema)
+    }
+
+    val assessment = assessmentEntityFactory.produceAndPersist {
+      withAllocatedToUser(user)
+      withApplication(application)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    assessment.schemaUpToDate = true
+
+    webTestClient.post()
+      .uri("/assessments/${assessment.id}/acceptance")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(AssessmentAcceptance(document = mapOf("document" to "value")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    val persistedAssessment = assessmentRepository.findByIdOrNull(assessment.id)!!
+    assertThat(persistedAssessment.decision).isEqualTo(AssessmentDecision.ACCEPTED)
+    assertThat(persistedAssessment.document).isEqualTo("{\"document\":\"value\"}")
+    assertThat(persistedAssessment.submittedAt).isNotNull
   }
 
   @Test


### PR DESCRIPTION
This PR implements the POST `/assessments/{id}/acceptance` endpoint.

Assuming that:
 - Schema validation passes
 - The Assessment has not already been approved or rejected

Then the `document` value is persisted and the Assessment is marked as accepted.