### PR TITLE
819 - Reject Assessment endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -51,6 +51,7 @@ data class AssessmentEntity(
   var submittedAt: OffsetDateTime?,
   @Enumerated(value = EnumType.STRING)
   var decision: AssessmentDecision?,
+  var rejectionRationale: String?,
 
   @OneToMany(mappedBy = "assessment")
   val clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -166,6 +166,53 @@ class AssessmentService(
     )
   }
 
+  fun rejectAssessment(user: UserEntity, assessmentId: UUID, document: String?, rejectionRationale: String): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
+    val assessmentResult = getAssessmentForUser(user, assessmentId)
+    val assessment = when (assessmentResult) {
+      is AuthorisableActionResult.Success -> assessmentResult.entity
+      is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised()
+      is AuthorisableActionResult.NotFound -> return AuthorisableActionResult.NotFound()
+    }
+
+    if (!assessment.schemaUpToDate) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("The schema version is outdated")
+      )
+    }
+
+    if (assessment.submittedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment")
+      )
+    }
+
+    val validationErrors = ValidationErrors()
+    val assessmentData = assessment.data
+
+    if (assessmentData == null) {
+      validationErrors["$.data"] = "empty"
+    } else if (!jsonSchemaService.validate(assessment.schemaVersion, assessmentData)) {
+      validationErrors["$.data"] = "invalid"
+    }
+
+    if (validationErrors.any()) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.FieldValidationError(validationErrors)
+      )
+    }
+
+    assessment.document = document
+    assessment.submittedAt = OffsetDateTime.now()
+    assessment.decision = AssessmentDecision.REJECTED
+    assessment.rejectionRationale = rejectionRationale
+
+    val savedAssessment = assessmentRepository.save(assessment)
+
+    return AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(savedAssessment)
+    )
+  }
+
   fun addAssessmentClarificationNote(user: UserEntity, assessmentId: UUID, text: String): AuthorisableActionResult<AssessmentClarificationNoteEntity> {
     val assessmentResult = getAssessmentForUser(user, assessmentId)
     val assessment = when (assessmentResult) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -85,6 +85,7 @@ class AssessmentService(
         submittedAt = null,
         decision = null,
         schemaUpToDate = true,
+        rejectionRationale = null,
         clarificationNotes = mutableListOf()
       )
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -11,6 +11,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as JpaAssessmentDecision
 
 @Component
 class AssessmentTransformer(
@@ -29,7 +31,9 @@ class AssessmentTransformer(
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
       allocatedToStaffMemberId = jpa.allocatedToUser.id,
-      submittedAt = jpa.submittedAt
+      submittedAt = jpa.submittedAt,
+      decision = transformJpaDecisionToApi(jpa.decision),
+      rejectionRationale = jpa.rejectionRationale
     )
     is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationAssessment(
       id = jpa.id,
@@ -41,8 +45,16 @@ class AssessmentTransformer(
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
       allocatedToStaffMemberId = jpa.allocatedToUser.id,
-      submittedAt = jpa.submittedAt
+      submittedAt = jpa.submittedAt,
+      decision = transformJpaDecisionToApi(jpa.decision),
+      rejectionRationale = jpa.rejectionRationale
     )
     else -> throw RuntimeException("Unsupported Application type when transforming Assessment: ${jpa.application::class.qualifiedName}")
+  }
+
+  private fun transformJpaDecisionToApi(decision: JpaAssessmentDecision?) = when (decision) {
+    JpaAssessmentDecision.ACCEPTED -> ApiAssessmentDecision.accepted
+    JpaAssessmentDecision.REJECTED -> ApiAssessmentDecision.rejected
+    null -> null
   }
 }

--- a/src/main/resources/db/migration/all/20221214105317__assessment_rejected_reason.sql
+++ b/src/main/resources/db/migration/all/20221214105317__assessment_rejected_reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessments ADD COLUMN rejection_rationale TEXT;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3055,6 +3055,8 @@ components:
           format: date-time
         decision:
           $ref: '#/components/schemas/AssessmentDecision'
+        rejectionRationale:
+          type: string
         data:
           $ref: '#/components/schemas/AnyValue'
         clarificationNotes:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
@@ -30,6 +30,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var decision: Yielded<AssessmentDecision> = { AssessmentDecision.ACCEPTED }
   private var allocatedToUser: Yielded<UserEntity>? = null
+  private var rejectionRationale: Yielded<String?> = { null }
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
 
   fun withId(id: UUID) = apply {
@@ -76,6 +77,10 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     this.clarificationNotes = { clarificationNotes }
   }
 
+  fun withRejectionRationale(rejectionRationale: String?) = apply {
+    this.rejectionRationale = { rejectionRationale }
+  }
+
   override fun produce(): AssessmentEntity = AssessmentEntity(
     id = this.id(),
     data = this.data(),
@@ -88,6 +93,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
     allocatedToUser = this.allocatedToUser?.invoke() ?: throw RuntimeException("Must provide an allocatedToUser"),
     allocatedAt = this.allocatedAt(),
+    rejectionRationale = this.rejectionRationale(),
     clarificationNotes = this.clarificationNotes()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
@@ -236,6 +237,74 @@ class AssessmentTest : IntegrationTestBase() {
 
     val persistedAssessment = assessmentRepository.findByIdOrNull(assessment.id)!!
     assertThat(persistedAssessment.decision).isEqualTo(AssessmentDecision.ACCEPTED)
+    assertThat(persistedAssessment.document).isEqualTo("{\"document\":\"value\"}")
+    assertThat(persistedAssessment.submittedAt).isNotNull
+  }
+
+  @Test
+  fun `Reject assessment without JWT returns 401`() {
+    webTestClient.post()
+      .uri("/assessments/6966902f-9b7e-4fc7-96c4-b54ec02d16c9/rejection")
+      .bodyValue(AssessmentRejection(document = "{}", rejectionRationale = "reasoning"))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Reject assessment returns 200, persists decision`() {
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN123")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+
+    val inmateDetails = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockInmateDetailPrisonsApiCall(inmateDetails)
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+      withAddedAt(OffsetDateTime.now())
+    }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCrn("CRN123")
+      withCreatedByUser(user)
+      withApplicationSchema(applicationSchema)
+    }
+
+    val assessment = assessmentEntityFactory.produceAndPersist {
+      withAllocatedToUser(user)
+      withApplication(application)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    assessment.schemaUpToDate = true
+
+    webTestClient.post()
+      .uri("/assessments/${assessment.id}/rejection")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(AssessmentRejection(document = mapOf("document" to "value"), rejectionRationale = "reasoning"))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    val persistedAssessment = assessmentRepository.findByIdOrNull(assessment.id)!!
+    assertThat(persistedAssessment.decision).isEqualTo(AssessmentDecision.REJECTED)
     assertThat(persistedAssessment.document).isEqualTo("{\"document\":\"value\"}")
     assertThat(persistedAssessment.submittedAt).isNotNull
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -589,4 +589,180 @@ class AssessmentServiceTest {
     assertThat(updatedAssessment.submittedAt).isNotNull()
     assertThat(updatedAssessment.document).isEqualTo("{\"test\": \"data\"}")
   }
+
+  @Test
+  fun `rejectAssessment returns unauthorised for Assessment not allocated to user`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withAllocatedToUser(UserEntityFactory().produce())
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
+
+    val result = assessmentService.rejectAssessment(user, assessmentId, "{}", "reasoning")
+
+    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `rejectAssessment returns general validation error for Assessment where schema is outdated`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withSubmittedAt(OffsetDateTime.now())
+      .withDecision(AssessmentDecision.ACCEPTED)
+      .withAllocatedToUser(user)
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
+
+    val result = assessmentService.rejectAssessment(user, assessmentId, "{}", "reasoning")
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+    assertThat(validationResult is ValidatableActionResult.GeneralValidationError)
+    val generalValidationError = validationResult as ValidatableActionResult.GeneralValidationError
+    assertThat(generalValidationError.message).isEqualTo("The schema version is outdated")
+  }
+
+  @Test
+  fun `rejectAssessment returns general validation error for Assessment where decision has already been taken`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}"
+    )
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withSubmittedAt(OffsetDateTime.now())
+      .withDecision(AssessmentDecision.ACCEPTED)
+      .withAllocatedToUser(user)
+      .withAssessmentSchema(schema)
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema
+
+    val result = assessmentService.rejectAssessment(user, assessmentId, "{}", "reasoning")
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+    assertThat(validationResult is ValidatableActionResult.GeneralValidationError)
+    val generalValidationError = validationResult as ValidatableActionResult.GeneralValidationError
+    assertThat(generalValidationError.message).isEqualTo("A decision has already been taken on this assessment")
+  }
+
+  @Test
+  fun `rejectAssessment returns field validation error when JSON schema not satisfied by data`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}"
+    )
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withAllocatedToUser(user)
+      .withAssessmentSchema(schema)
+      .withData("{\"test\": \"data\"}")
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema
+
+    every { jsonSchemaServiceMock.validate(schema, "{\"test\": \"data\"}") } returns false
+
+    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
+
+    val result = assessmentService.rejectAssessment(user, assessmentId, "{\"test\": \"data\"}", "reasoning")
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+    assertThat(validationResult is ValidatableActionResult.FieldValidationError)
+    val fieldValidationError = (validationResult as ValidatableActionResult.FieldValidationError)
+    assertThat(fieldValidationError.validationMessages).contains(
+      entry("$.data", "invalid")
+    )
+  }
+
+  @Test
+  fun `rejectAssessment returns updated assessment`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}"
+    )
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withAllocatedToUser(user)
+      .withAssessmentSchema(schema)
+      .withData("{\"test\": \"data\"}")
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema
+
+    every { jsonSchemaServiceMock.validate(schema, "{\"test\": \"data\"}") } returns true
+
+    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
+
+    val result = assessmentService.rejectAssessment(user, assessmentId, "{\"test\": \"data\"}", "reasoning")
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+    assertThat(validationResult is ValidatableActionResult.Success)
+    val updatedAssessment = (validationResult as ValidatableActionResult.Success).entity
+    assertThat(updatedAssessment.decision).isEqualTo(AssessmentDecision.REJECTED)
+    assertThat(updatedAssessment.rejectionRationale).isEqualTo("reasoning")
+    assertThat(updatedAssessment.submittedAt).isNotNull()
+    assertThat(updatedAssessment.document).isEqualTo("{\"test\": \"data\"}")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+import java.time.OffsetDateTime
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as JpaAssessmentDecision
+
+class AssessmentTransformerTest {
+  private val mockApplicationsTransformer = mockk<ApplicationsTransformer>()
+  private val mockAssessmentClarificationNoteTransformer = mockk<AssessmentClarificationNoteTransformer>()
+  private val assessmentTransformer = AssessmentTransformer(
+    jacksonObjectMapper(),
+    mockApplicationsTransformer,
+    mockAssessmentClarificationNoteTransformer
+  )
+
+  @Test
+  fun `transformJpaToApi transforms correctly`() {
+    val allocatedToUser = UserEntityFactory().produce()
+
+    val assessment = AssessmentEntityFactory()
+      .withApplication(mockk<ApprovedPremisesApplicationEntity>())
+      .withId(UUID.fromString("7d0d3b38-5bc3-45c7-95eb-4d714cbd0db1"))
+      .withAssessmentSchema(
+        ApprovedPremisesAssessmentJsonSchemaEntity(
+          id = UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"),
+          addedAt = OffsetDateTime.now(),
+          schema = "{}"
+        )
+      )
+      .withDecision(JpaAssessmentDecision.REJECTED)
+      .withRejectionRationale("reasoning")
+      .withData("{\"data\": \"something\"}")
+      .withCreatedAt(OffsetDateTime.parse("2022-12-14T12:05:00Z"))
+      .withSubmittedAt(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
+      .withAllocatedToUser(allocatedToUser)
+      .produce()
+
+    every { mockApplicationsTransformer.transformJpaToApi(any(), any(), any()) } returns mockk<ApprovedPremisesApplication>()
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+
+    assertThat(result.id).isEqualTo(UUID.fromString("7d0d3b38-5bc3-45c7-95eb-4d714cbd0db1"))
+    assertThat(result.schemaVersion).isEqualTo(UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"))
+    assertThat(result.decision).isEqualTo(ApiAssessmentDecision.rejected)
+    assertThat(result.rejectionRationale).isEqualTo("reasoning")
+    assertThat(result.createdAt).isEqualTo(OffsetDateTime.parse("2022-12-14T12:05:00Z"))
+    assertThat(result.submittedAt).isEqualTo(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
+    assertThat(result.allocatedToStaffMemberId).isEqualTo(allocatedToUser.id)
+  }
+}


### PR DESCRIPTION
 - Implement the POST `/assessments/{id}/rejection` endpoint
 - Return `rejectionRationale` and `decision` on Assessment endpoints