### PR TITLE
Refactor OpenAPI specification for Assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -2,8 +2,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 
@@ -13,16 +18,31 @@ class AssessmentTransformer(
   private val applicationsTransformer: ApplicationsTransformer,
   private val assessmentClarificationNoteTransformer: AssessmentClarificationNoteTransformer
 ) {
-  fun transformJpaToApi(jpa: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Assessment(
-    id = jpa.id,
-    application = applicationsTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail),
-    schemaVersion = jpa.schemaVersion.id,
-    outdatedSchema = jpa.schemaUpToDate,
-    createdAt = jpa.createdAt,
-    allocatedAt = jpa.allocatedAt,
-    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
-    clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
-    allocatedToStaffMemberId = jpa.allocatedToUser.id,
-    submittedAt = jpa.submittedAt
-  )
+  fun transformJpaToApi(jpa: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = when (jpa.application) {
+    is ApprovedPremisesApplicationEntity -> ApprovedPremisesAssessment(
+      id = jpa.id,
+      application = applicationsTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail) as ApprovedPremisesApplication,
+      schemaVersion = jpa.schemaVersion.id,
+      outdatedSchema = jpa.schemaUpToDate,
+      createdAt = jpa.createdAt,
+      allocatedAt = jpa.allocatedAt,
+      data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+      clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
+      allocatedToStaffMemberId = jpa.allocatedToUser.id,
+      submittedAt = jpa.submittedAt
+    )
+    is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationAssessment(
+      id = jpa.id,
+      application = applicationsTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail) as TemporaryAccommodationApplication,
+      schemaVersion = jpa.schemaVersion.id,
+      outdatedSchema = jpa.schemaUpToDate,
+      createdAt = jpa.createdAt,
+      allocatedAt = jpa.allocatedAt,
+      data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+      clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
+      allocatedToStaffMemberId = jpa.allocatedToUser.id,
+      submittedAt = jpa.submittedAt
+    )
+    else -> throw RuntimeException("Unsupported Application type when transforming Assessment: ${jpa.application::class.qualifiedName}")
+  }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3001,8 +3001,6 @@ components:
         id:
           type: string
           format: uuid
-        application:
-            $ref: '#/components/schemas/Application'
         allocatedToStaffMemberId:
           type: string
           format: uuid
@@ -3028,15 +3026,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClarificationNote'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesAssessment'
+          CAS3: '#/components/schemas/TemporaryAccommodationAssessment'
       required:
         - id
-        - application
         - allocatedToUser
         - schemaVersion
         - outdatedSchema
         - createdAt
         - allocatedAt
         - clarificationNotes
+    ApprovedPremisesAssessment:
+      allOf:
+        - $ref: '#/components/schemas/Assessment'
+        - type: object
+          properties:
+            application:
+              $ref: '#/components/schemas/ApprovedPremisesApplication'
+          required:
+            - application
+    TemporaryAccommodationAssessment:
+      allOf:
+        - $ref: '#/components/schemas/Assessment'
+        - type: object
+          properties:
+            application:
+              $ref: '#/components/schemas/TemporaryAccommodationApplication'
+          required:
+            - application
     AssessmentDecision:
       type: string
       enum:


### PR DESCRIPTION
Break out Assessment into two subtypes so that the frontend can use the correct one since polymorphism on the `application` property isn't working with the OpenAPI->TS generator.