### PR TITLE
Add creation time to bookings and state transitions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -317,6 +317,7 @@ class PremisesController(
         service = body.serviceName.value,
         originalArrivalDate = body.arrivalDate,
         originalDepartureDate = body.departureDate,
+        createdAt = OffsetDateTime.now(),
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
@@ -22,6 +23,7 @@ data class ArrivalEntity(
   val arrivalDate: LocalDate,
   val expectedDepartureDate: LocalDate,
   val notes: String?,
+  val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity
@@ -34,11 +36,12 @@ data class ArrivalEntity(
     if (arrivalDate != other.arrivalDate) return false
     if (expectedDepartureDate != other.expectedDepartureDate) return false
     if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(arrivalDate, expectedDepartureDate, notes)
+  override fun hashCode() = Objects.hash(arrivalDate, expectedDepartureDate, notes, createdAt)
 
   override fun toString() = "ArrivalEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
@@ -53,6 +54,7 @@ data class BookingEntity(
   var service: String,
   var originalArrivalDate: LocalDate,
   var originalDepartureDate: LocalDate,
+  val createdAt: OffsetDateTime,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -70,11 +72,12 @@ data class BookingEntity(
     if (confirmation != other.confirmation) return false
     if (originalArrivalDate != other.originalArrivalDate) return false
     if (originalDepartureDate != other.originalDepartureDate) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, departure, nonArrival, cancellation, confirmation, originalArrivalDate, originalDepartureDate)
+  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, departure, nonArrival, cancellation, confirmation, originalArrivalDate, originalDepartureDate, createdAt)
 
   override fun toString() = "BookingEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
@@ -25,6 +26,7 @@ data class CancellationEntity(
   @JoinColumn(name = "cancellation_reason_id")
   val reason: CancellationReasonEntity,
   val notes: String?,
+  val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity
@@ -37,11 +39,12 @@ data class CancellationEntity(
     if (date != other.date) return false
     if (reason != other.reason) return false
     if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(date, reason, notes)
+  override fun hashCode() = Objects.hash(date, reason, notes, createdAt)
 
   override fun toString() = "CancellationEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ConfirmationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ConfirmationEntity.kt
@@ -21,6 +21,7 @@ data class ConfirmationEntity(
   val id: UUID,
   val dateTime: OffsetDateTime,
   val notes: String?,
+  val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity
@@ -32,11 +33,12 @@ data class ConfirmationEntity(
     if (id != other.id) return false
     if (dateTime != other.dateTime) return false
     if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(dateTime, notes)
+  override fun hashCode() = Objects.hash(dateTime, notes, createdAt)
 
   override fun toString() = "ConfirmationEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
@@ -31,6 +31,7 @@ data class DepartureEntity(
   @JoinColumn(name = "destination_provider_id")
   val destinationProvider: DestinationProviderEntity?,
   val notes: String?,
+  val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity
@@ -45,11 +46,12 @@ data class DepartureEntity(
     if (moveOnCategory != other.moveOnCategory) return false
     if (destinationProvider != other.destinationProvider) return false
     if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(dateTime, reason, moveOnCategory, destinationProvider, notes)
+  override fun hashCode() = Objects.hash(dateTime, reason, moveOnCategory, destinationProvider, notes, createdAt)
 
   override fun toString() = "DepartureEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExtensionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExtensionEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
@@ -22,6 +23,7 @@ data class ExtensionEntity(
   val previousDepartureDate: LocalDate,
   val newDepartureDate: LocalDate,
   val notes: String?,
+  val createdAt: OffsetDateTime,
   @ManyToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity
@@ -34,11 +36,12 @@ data class ExtensionEntity(
     if (previousDepartureDate != other.previousDepartureDate) return false
     if (newDepartureDate != other.newDepartureDate) return false
     if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(id, previousDepartureDate, newDepartureDate, notes)
+  override fun hashCode() = Objects.hash(id, previousDepartureDate, newDepartureDate, notes, createdAt)
 
   override fun toString() = "ExtensionEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
@@ -25,6 +26,7 @@ data class NonArrivalEntity(
   @JoinColumn(name = "non_arrival_reason_id")
   val reason: NonArrivalReasonEntity,
   val notes: String?,
+  val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity
@@ -37,11 +39,12 @@ data class NonArrivalEntity(
     if (date != other.date) return false
     if (reason != other.reason) return false
     if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(id, date, reason, notes)
+  override fun hashCode() = Objects.hash(id, date, reason, notes, createdAt)
 
   override fun toString() = "NonArrivalEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -90,7 +90,8 @@ class BookingService(
         arrivalDate = arrivalDate,
         expectedDepartureDate = expectedDepartureDate,
         notes = notes,
-        booking = booking
+        booking = booking,
+        createdAt = OffsetDateTime.now(),
       )
     )
 
@@ -132,7 +133,8 @@ class BookingService(
         date = date,
         notes = notes,
         reason = reason!!,
-        booking = booking
+        booking = booking,
+        createdAt = OffsetDateTime.now(),
       )
     )
 
@@ -166,7 +168,8 @@ class BookingService(
         date = date,
         reason = reason!!,
         notes = notes,
-        booking = booking
+        booking = booking,
+        createdAt = OffsetDateTime.now(),
       )
     )
 
@@ -188,6 +191,7 @@ class BookingService(
         dateTime = dateTime,
         notes = notes,
         booking = booking,
+        createdAt = OffsetDateTime.now(),
       )
     )
 
@@ -255,7 +259,8 @@ class BookingService(
         moveOnCategory = moveOnCategory!!,
         destinationProvider = destinationProvider,
         notes = notes,
-        booking = booking
+        booking = booking,
+        createdAt = OffsetDateTime.now(),
       )
     )
 
@@ -287,7 +292,8 @@ class BookingService(
       previousDepartureDate = booking.departureDate,
       newDepartureDate = newDepartureDate,
       notes = notes,
-      booking = booking
+      booking = booking,
+      createdAt = OffsetDateTime.now(),
     )
 
     val extension = extensionRepository.save(extensionEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ArrivalTransformer.kt
@@ -11,7 +11,8 @@ class ArrivalTransformer() {
       bookingId = jpa.booking.id,
       arrivalDate = jpa.arrivalDate,
       expectedDepartureDate = jpa.expectedDepartureDate,
-      notes = jpa.notes
+      notes = jpa.notes,
+      createdAt = jpa.createdAt,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -41,6 +41,7 @@ class BookingTransformer(
     bed = jpa.bed?.let { bedTransformer.transformJpaToApi(it) },
     originalArrivalDate = jpa.originalArrivalDate,
     originalDepartureDate = jpa.originalDepartureDate,
+    createdAt = jpa.createdAt,
   )
 
   private fun determineStatus(jpa: BookingEntity) = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationTransformer.kt
@@ -12,7 +12,8 @@ class CancellationTransformer(private val cancellationReasonTransformer: Cancell
       bookingId = jpa.booking.id,
       date = jpa.date,
       reason = cancellationReasonTransformer.transformJpaToApi(jpa.reason),
-      notes = jpa.notes
+      notes = jpa.notes,
+      createdAt = jpa.createdAt,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ConfirmationTransformer.kt
@@ -12,6 +12,7 @@ class ConfirmationTransformer {
       bookingId = it.booking.id,
       dateTime = it.dateTime,
       notes = it.notes,
+      createdAt = jpa.createdAt,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureTransformer.kt
@@ -18,7 +18,8 @@ class DepartureTransformer(
       reason = departureReasonTransformer.transformJpaToApi(jpa.reason),
       moveOnCategory = moveOnCategoryTransformer.transformJpaToApi(jpa.moveOnCategory),
       destinationProvider = jpa.destinationProvider?.let { destinationProviderTransformer.transformJpaToApi(it) },
-      notes = jpa.notes
+      notes = jpa.notes,
+      createdAt = jpa.createdAt,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExtensionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExtensionTransformer.kt
@@ -11,6 +11,7 @@ class ExtensionTransformer() {
     bookingId = jpa.booking.id,
     previousDepartureDate = jpa.previousDepartureDate,
     newDepartureDate = jpa.newDepartureDate,
-    notes = jpa.notes
+    notes = jpa.notes,
+    createdAt = jpa.createdAt,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NonArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NonArrivalTransformer.kt
@@ -12,7 +12,8 @@ class NonArrivalTransformer(private val nonArrivalReasonTransformer: NonArrivalR
       bookingId = jpa.booking.id,
       date = jpa.date,
       reason = nonArrivalReasonTransformer.transformJpaToApi(jpa.reason),
-      notes = jpa.notes
+      notes = jpa.notes,
+      createdAt = jpa.createdAt,
     )
   }
 }

--- a/src/main/resources/db/migration/all/20221214123407__add_creation_time_to_booking_tables.sql
+++ b/src/main/resources/db/migration/all/20221214123407__add_creation_time_to_booking_tables.sql
@@ -1,0 +1,64 @@
+-- Bookings
+-- Use the original arrival date as the best guess, as the booking must have been created no later than this.
+ALTER TABLE bookings ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE bookings
+SET created_at = original_arrival_date::timestamp;
+
+ALTER TABLE bookings ALTER COLUMN created_at SET NOT NULL;
+
+-- Extensions
+-- Extensions don't have a suitable column to use as a best guess, so use the booking's created_at.
+ALTER TABLE extensions ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE extensions
+SET created_at = bookings.created_at
+FROM bookings
+WHERE extensions.booking_id = bookings.id;
+
+ALTER TABLE extensions ALTER COLUMN created_at SET NOT NULL;
+
+-- Arrivals
+-- Use the arrival date as the best guess, as the arrival would have been logged after this time.
+ALTER TABLE arrivals ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE arrivals
+SET created_at = arrival_date::timestamp;
+
+ALTER TABLE arrivals ALTER COLUMN created_at SET NOT NULL;
+
+-- Departures
+-- Use the departure date as the best guess, as the departure would have been logged after this time.
+ALTER TABLE departures ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE departures
+SET created_at = date_time;
+
+ALTER TABLE departures ALTER COLUMN created_at SET NOT NULL;
+
+-- Non-arrivals
+-- Use the expected arrival date as the best guess, as the non-arrival would have been logged after this time.
+ALTER TABLE non_arrivals ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE non_arrivals
+SET created_at = date::timestamp;
+
+ALTER TABLE non_arrivals ALTER COLUMN created_at SET NOT NULL;
+
+-- Cancellations
+-- Use the cancellation date as the best guess, as the cancellation would have been logged after this time.
+ALTER TABLE cancellations ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE cancellations
+SET created_at = date::timestamp;
+
+ALTER TABLE cancellations ALTER COLUMN created_at SET NOT NULL;
+
+-- Confirmations
+-- Use the confirmation datetime, as this is currently set to the current time when creating the confirmation row.
+ALTER TABLE confirmations ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE confirmations
+SET created_at = date_time;
+
+ALTER TABLE confirmations ALTER COLUMN created_at SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2138,6 +2138,9 @@ components:
         originalDepartureDate:
           type: string
           format: date
+        createdAt:
+          type: string
+          format: date-time
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
         serviceName:
@@ -2151,6 +2154,7 @@ components:
         - originalArrivalDate
         - departureDate
         - originalDepartureDate
+        - createdAt
         - serviceName
     NewBooking:
       type: object
@@ -2280,10 +2284,14 @@ components:
           format: date
         notes:
           type: string
+        createdAt:
+          type: string
+          format: date-time
       required:
         - bookingId
         - arrivalDate
         - expectedDepartureDate
+        - createdAt
     NewArrival:
       type: object
       properties:
@@ -2316,11 +2324,15 @@ components:
           $ref: '#/components/schemas/NonArrivalReason'
         notes:
           type: string
+        createdAt:
+          type: string
+          format: date-time
       required:
         - id
         - bookingId
         - date
         - reason
+        - createdAt
     NewNonarrival:
       type: object
       properties:
@@ -2366,10 +2378,14 @@ components:
           $ref: '#/components/schemas/CancellationReason'
         notes:
           type: string
+        createdAt:
+          type: string
+          format: date-time
       required:
         - bookingId
         - date
         - reason
+        - createdAt
     Extension:
       type: object
       properties:
@@ -2387,11 +2403,15 @@ components:
           format: date
         notes:
           type: string
+        createdAt:
+          type: string
+          format: date-time
       required:
         - id
         - bookingId
         - previousDepartureDate
         - newDepartureDate
+        - createdAt
     NewExtension:
       type: object
       properties:
@@ -2443,12 +2463,16 @@ components:
           $ref: '#/components/schemas/MoveOnCategory'
         destinationProvider:
           $ref: '#/components/schemas/DestinationProvider'
+        createdAt:
+          type: string
+          format: date-time
       required:
         - id
         - bookingId
         - dateTime
         - reason
         - moveOnCategory
+        - createdAt
     Confirmation:
       type: object
       properties:
@@ -2463,10 +2487,14 @@ components:
           format: date-time
         notes:
           type: string
+        createdAt:
+          type: string
+          format: date-time
       required:
         - id
         - bookingId
         - dateTime
+        - createdAt
     NewConfirmation:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -6,8 +6,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ArrivalEntityFactory : Factory<ArrivalEntity> {
@@ -16,6 +18,7 @@ class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -41,11 +44,16 @@ class ArrivalEntityFactory : Factory<ArrivalEntity> {
     this.booking = { booking }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): ArrivalEntity = ArrivalEntity(
     id = this.id(),
     arrivalDate = this.arrivalDate(),
     expectedDepartureDate = this.expectedDepartureDate(),
     notes = this.notes(),
-    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided")
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -14,9 +14,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.RuntimeException
 
@@ -37,6 +39,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var premises: Yielded<PremisesEntity>? = null
   private var serviceName: Yielded<ServiceName> = { randomOf(ServiceName.values().asList()) }
   private var bed: Yielded<BedEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -130,6 +133,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.bed = bed
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),
@@ -147,5 +154,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     service = this.serviceName.invoke().value,
     originalArrivalDate = this.originalArrivalDate?.invoke() ?: this.arrivalDate(),
     originalDepartureDate = this.originalDepartureDate?.invoke() ?: this.departureDate(),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -6,8 +6,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class CancellationEntityFactory : Factory<CancellationEntity> {
@@ -16,6 +18,7 @@ class CancellationEntityFactory : Factory<CancellationEntity> {
   private var reason: Yielded<CancellationReasonEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -45,11 +48,16 @@ class CancellationEntityFactory : Factory<CancellationEntity> {
     this.booking = { booking }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): CancellationEntity = CancellationEntity(
     id = this.id(),
     notes = this.notes(),
     date = this.date(),
     reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
-    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided")
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConfirmationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConfirmationEntityFactory.kt
@@ -14,6 +14,7 @@ class ConfirmationEntityFactory : Factory<ConfirmationEntity> {
   private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -35,10 +36,15 @@ class ConfirmationEntityFactory : Factory<ConfirmationEntity> {
     this.booking = { booking }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): ConfirmationEntity = ConfirmationEntity(
     id = this.id(),
     notes = this.notes(),
     dateTime = this.dateTime(),
     booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -20,6 +21,7 @@ class DepartureEntityFactory : Factory<DepartureEntity> {
   private var destinationProvider: Yielded<DestinationProviderEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -65,6 +67,10 @@ class DepartureEntityFactory : Factory<DepartureEntity> {
     this.booking = { booking }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): DepartureEntity = DepartureEntity(
     id = this.id(),
     dateTime = this.dateTime(),
@@ -72,6 +78,7 @@ class DepartureEntityFactory : Factory<DepartureEntity> {
     moveOnCategory = this.moveOnCategory?.invoke() ?: throw RuntimeException("MoveOnCategory must be provided"),
     destinationProvider = this.destinationProvider?.invoke() ?: throw RuntimeException("DestinationProvider must be provided"),
     notes = this.notes(),
-    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided")
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
@@ -5,8 +5,10 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ExtensionEntityFactory : Factory<ExtensionEntity> {
@@ -15,6 +17,7 @@ class ExtensionEntityFactory : Factory<ExtensionEntity> {
   private var newDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -40,11 +43,16 @@ class ExtensionEntityFactory : Factory<ExtensionEntity> {
     this.booking = { booking }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): ExtensionEntity = ExtensionEntity(
     id = this.id(),
     previousDepartureDate = this.previousDepartureDate(),
     newDepartureDate = this.newDepartureDate(),
     notes = this.notes(),
-    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided")
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
@@ -6,8 +6,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class NonArrivalEntityFactory : Factory<NonArrivalEntity> {
@@ -16,6 +18,7 @@ class NonArrivalEntityFactory : Factory<NonArrivalEntity> {
   private var reason: Yielded<NonArrivalReasonEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -45,11 +48,16 @@ class NonArrivalEntityFactory : Factory<NonArrivalEntity> {
     this.booking = { booking }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): NonArrivalEntity = NonArrivalEntity(
     id = this.id(),
     date = this.date(),
     reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
     notes = this.notes(),
-    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided")
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -331,6 +331,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.nonArrival").isEqualTo(null)
       .jsonPath("$.cancellation").isEqualTo(null)
       .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
       .jsonPath("$.bed.id").doesNotHaveJsonPath()
       .jsonPath("$.bed.name").doesNotHaveJsonPath()
   }
@@ -402,6 +403,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.cancellation").isEqualTo(null)
       .jsonPath("$.confirmation").isEqualTo(null)
       .jsonPath("$.serviceName").isEqualTo(ServiceName.temporaryAccommodation.value)
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
       .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
       .jsonPath("$.bed.name").isEqualTo("test-bed")
   }
@@ -709,6 +711,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
       .jsonPath("$.expectedDepartureDate").isEqualTo("2022-08-14")
       .jsonPath("$.notes").isEqualTo("Hello")
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
   }
 
   @Test
@@ -730,6 +733,7 @@ class BookingTest : IntegrationTestBase() {
       }
       withArrivalDate(LocalDate.parse("2022-08-10"))
       withDepartureDate(LocalDate.parse("2022-08-30"))
+      withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -774,6 +778,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.departureDate").isEqualTo("2022-08-30")
       .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-10")
       .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+      .jsonPath("$.createdAt").isEqualTo("2022-07-01T12:34:56.789Z")
   }
 
   @Test
@@ -804,6 +809,7 @@ class BookingTest : IntegrationTestBase() {
       withServiceName(ServiceName.temporaryAccommodation)
       withArrivalDate(LocalDate.parse("2022-08-10"))
       withDepartureDate(LocalDate.parse("2022-08-30"))
+      withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -848,6 +854,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.departureDate").isEqualTo("2022-08-14")
       .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-10")
       .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+      .jsonPath("$.createdAt").isEqualTo("2022-07-01T12:34:56.789Z")
   }
 
   @Test
@@ -903,6 +910,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.moveOnCategory.id").isEqualTo(moveOnCategory.id.toString())
       .jsonPath("$.destinationProvider.id").isEqualTo(destinationProvider.id.toString())
       .jsonPath("$.notes").isEqualTo("Hello")
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
   }
 
   @Test
@@ -925,6 +933,7 @@ class BookingTest : IntegrationTestBase() {
       withServiceName(ServiceName.approvedPremises)
       withArrivalDate(LocalDate.parse("2022-08-10"))
       withDepartureDate(LocalDate.parse("2022-08-30"))
+      withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
     }
 
     val reason = departureReasonEntityFactory.produceAndPersist {
@@ -977,6 +986,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.departureDate").isEqualTo("2022-08-30")
       .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-10")
       .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+      .jsonPath("$.createdAt").isEqualTo("2022-07-01T12:34:56.789Z")
   }
 
   @Test
@@ -998,6 +1008,7 @@ class BookingTest : IntegrationTestBase() {
       withServiceName(ServiceName.temporaryAccommodation)
       withArrivalDate(LocalDate.parse("2022-08-10"))
       withDepartureDate(LocalDate.parse("2022-08-30"))
+      withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
     }
 
     val reason = departureReasonEntityFactory.produceAndPersist {
@@ -1050,6 +1061,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath("$.departureDate").isEqualTo("2022-09-01")
       .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-10")
       .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+      .jsonPath("$.createdAt").isEqualTo("2022-07-01T12:34:56.789Z")
   }
 
   @Test
@@ -1107,6 +1119,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath(".reason.id").isEqualTo(cancellationReason.id.toString())
       .jsonPath(".reason.name").isEqualTo(cancellationReason.name)
       .jsonPath(".reason.isActive").isEqualTo(true)
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
   }
 
   @Test
@@ -1235,6 +1248,7 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath(".previousDepartureDate").isEqualTo("2022-08-20")
       .jsonPath(".newDepartureDate").isEqualTo("2022-08-22")
       .jsonPath(".notes").isEqualTo("notes")
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
 
     val actualBooking = bookingRepository.findByIdOrNull(booking.id)!!
 
@@ -1272,26 +1286,6 @@ class BookingTest : IntegrationTestBase() {
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
-    val matcher: Matcher<OffsetDateTime> = object : BaseMatcher<OffsetDateTime>() {
-      override fun describeTo(description: Description?) {
-        description?.appendText("within the last five seconds")
-      }
-
-      override fun matches(actual: Any?): Boolean {
-        val actualDateTime = when (actual) {
-          is String -> OffsetDateTime.parse(actual)
-          is OffsetDateTime -> actual
-          else -> return false
-        }
-
-        val now = OffsetDateTime.now()
-
-        if (now.isBefore(actualDateTime)) return false
-
-        return actualDateTime.plusSeconds(5L).isAfter(now)
-      }
-    }
-
     webTestClient.post()
       .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
       .header("Authorization", "Bearer $jwt")
@@ -1305,7 +1299,32 @@ class BookingTest : IntegrationTestBase() {
       .isOk
       .expectBody()
       .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
-      .jsonPath("$.dateTime").value(matcher, OffsetDateTime::class.java)
+      .jsonPath("$.dateTime").value(withinSeconds(5L), OffsetDateTime::class.java)
       .jsonPath("$.notes").isEqualTo(null)
+      .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+  }
+
+  fun withinSeconds(seconds: Long): Matcher<OffsetDateTime> {
+    val matcher: Matcher<OffsetDateTime> = object : BaseMatcher<OffsetDateTime>() {
+      private val now: OffsetDateTime = OffsetDateTime.now()
+
+      override fun describeTo(description: Description?) {
+        description?.appendText("within the last $seconds seconds (now: $now)")
+      }
+
+      override fun matches(actual: Any?): Boolean {
+        val actualDateTime = when (actual) {
+          is String -> OffsetDateTime.parse(actual)
+          is OffsetDateTime -> actual
+          else -> return false
+        }
+
+        if (now.isBefore(actualDateTime)) return false
+
+        return actualDateTime.plusSeconds(seconds).isAfter(now)
+      }
+    }
+
+    return matcher
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -125,6 +125,7 @@ class BookingTransformerTest {
     service = ServiceName.approvedPremises.value,
     originalArrivalDate = LocalDate.parse("2022-08-10"),
     originalDepartureDate = LocalDate.parse("2022-08-30"),
+    createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
   )
 
   private val staffMember = StaffMember(
@@ -203,6 +204,7 @@ class BookingTransformerTest {
         serviceName = ServiceName.approvedPremises,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }
@@ -238,6 +240,7 @@ class BookingTransformerTest {
         serviceName = ServiceName.temporaryAccommodation,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }
@@ -250,7 +253,8 @@ class BookingTransformerTest {
         date = LocalDate.parse("2022-08-10"),
         reason = NonArrivalReasonEntity(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true),
         notes = null,
-        booking = this
+        booking = this,
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     }
 
@@ -259,7 +263,8 @@ class BookingTransformerTest {
       bookingId = UUID.fromString("655f72ba-51eb-4965-b6ac-45bcc6271b19"),
       date = LocalDate.parse("2022-08-10"),
       reason = NonArrivalReason(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true),
-      notes = null
+      notes = null,
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(nonArrivalBooking, offenderDetails, inmateDetail, null)
@@ -288,12 +293,14 @@ class BookingTransformerTest {
           bookingId = UUID.fromString("655f72ba-51eb-4965-b6ac-45bcc6271b19"),
           date = LocalDate.parse("2022-08-10"),
           reason = NonArrivalReason(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true),
-          notes = null
+          notes = null,
+          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }
@@ -306,7 +313,8 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         expectedDepartureDate = LocalDate.parse("2022-08-16"),
         notes = null,
-        booking = this
+        booking = this,
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     }
 
@@ -314,7 +322,8 @@ class BookingTransformerTest {
       bookingId = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
-      notes = null
+      notes = null,
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(arrivalBooking, offenderDetails, inmateDetail, staffMember)
@@ -346,12 +355,14 @@ class BookingTransformerTest {
           bookingId = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
-          notes = null
+          notes = null,
+          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }
@@ -364,7 +375,8 @@ class BookingTransformerTest {
         date = LocalDate.parse("2022-08-10"),
         reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
         notes = null,
-        booking = this
+        booking = this,
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     }
 
@@ -372,7 +384,8 @@ class BookingTransformerTest {
       bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
       notes = null,
       date = LocalDate.parse("2022-08-10"),
-      reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises")
+      reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(cancellationBooking, offenderDetails, inmateDetail, null)
@@ -400,12 +413,14 @@ class BookingTransformerTest {
           bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
-          notes = null
+          notes = null,
+          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }
@@ -419,7 +434,8 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         expectedDepartureDate = LocalDate.parse("2022-08-16"),
         notes = null,
-        booking = this
+        booking = this,
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
       departure = DepartureEntity(
         id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
@@ -442,7 +458,8 @@ class BookingTransformerTest {
           isActive = true
         ),
         notes = null,
-        booking = this
+        booking = this,
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     }
 
@@ -450,7 +467,8 @@ class BookingTransformerTest {
       bookingId = bookingId,
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
-      notes = null
+      notes = null,
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     )
 
     every { mockDepartureTransformer.transformJpaToApi(departedBooking.departure) } returns Departure(
@@ -474,7 +492,8 @@ class BookingTransformerTest {
         name = "Destination Provider",
         isActive = true
       ),
-      notes = null
+      notes = null,
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
@@ -506,7 +525,8 @@ class BookingTransformerTest {
           bookingId = bookingId,
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
-          notes = null
+          notes = null,
+          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
         departure = Departure(
           id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
@@ -529,12 +549,14 @@ class BookingTransformerTest {
             name = "Destination Provider",
             isActive = true
           ),
-          notes = null
+          notes = null,
+          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }
@@ -549,7 +571,8 @@ class BookingTransformerTest {
         id = UUID.fromString("69fc6350-b2ec-4e99-9a2f-e829e83535e8"),
         dateTime = OffsetDateTime.parse("2022-11-23T12:34:56.789Z"),
         notes = null,
-        booking = this
+        booking = this,
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     }
 
@@ -558,6 +581,7 @@ class BookingTransformerTest {
       bookingId = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
       notes = null,
       dateTime = OffsetDateTime.parse("2022-11-23T12:34:56.789Z"),
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(confirmationBooking, offenderDetails, inmateDetail, null)
@@ -587,11 +611,13 @@ class BookingTransformerTest {
           bookingId = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
           notes = null,
           dateTime = OffsetDateTime.parse("2022-11-23T12:34:56.789Z"),
+          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
         serviceName = ServiceName.temporaryAccommodation,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
     )
   }


### PR DESCRIPTION
> See [ticket #622 on the CAS3 Trello board](https://trello.com/c/6aHYZoZT/622-record-when-bookings-change-states).

This PR is part of the work to support the Temporary Accommodation booking flow. It allows for the history of a booking as it changes states to be captured.

Changes in this PR:
- The `BookingBody` schema and the booking state sub-schemas (`Arrival`, `Departure`, `Cancellation`, etc.) all have a `createdAt` property defined in the OpenAPI specification.
- The `bookings` table and associated state tables have a `created_at` column created and seeded through a Flyway migration.
- When creating a booking or a state entity, the `BookingService` uses the current system time as the `created_at` time.