### PR TITLE
903 - Accept seeding jobs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/AsyncConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -43,6 +43,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/domain-events-api.yml", permitAll)
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
+        authorize(HttpMethod.POST, "/seed", permitAll)
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.SeedApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.UnauthenticatedProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
+
+@Service
+class SeedController(private val seedService: SeedService) : SeedApiDelegate {
+  override fun seedPost(seedRequest: SeedRequest): ResponseEntity<Unit> {
+    throwIfNotLoopbackRequest()
+
+    seedService.seedData(seedRequest.seedType, seedRequest.fileName)
+
+    return ResponseEntity(HttpStatus.ACCEPTED)
+  }
+
+  private fun throwIfNotLoopbackRequest() {
+    val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+    val remoteAddress = request.remoteAddr
+
+    if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
+      throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
@@ -4,7 +4,7 @@ import org.zalando.problem.AbstractThrowableProblem
 import org.zalando.problem.Exceptional
 import org.zalando.problem.Status
 
-class UnauthenticatedProblem() : AbstractThrowableProblem(null, "Unauthenticated", Status.UNAUTHORIZED, "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") {
+class UnauthenticatedProblem(detail: String = "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") : AbstractThrowableProblem(null, "Unauthenticated", Status.UNAUTHORIZED, detail) {
   override fun getCause(): Exceptional? {
     return null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+
+@Service
+class SeedService {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @Async
+  fun seedData(seedFileType: SeedFileType, filename: String) {
+    log.info("Starting seed request: $seedFileType - $filename")
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1924,6 +1924,24 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /seed:
+    post:
+      summary: Starts the data seeding process, can only be called from a local connection
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SeedRequest'
+        required: true
+      responses:
+        202:
+          description: successfully requested task
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
 components:
   responses:
     401Response:
@@ -3516,3 +3534,17 @@ components:
         - createdAt
         - typeCode
         - typeDescription
+    SeedRequest:
+      type: object
+      properties:
+        seedType:
+          $ref: '#/components/schemas/SeedFileType'
+        fileName:
+          type: string
+      required:
+        - seedType
+        - fileName
+    SeedFileType:
+      type: string
+      enum:
+        - premises

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
+
+class SeedTest : IntegrationTestBase() {
+  @Test
+  fun `Requesting a Seed operation returns 202`() {
+    webTestClient.post()
+      .uri("/seed")
+      .bodyValue(
+        SeedRequest(
+          seedType = SeedFileType.premises,
+          fileName = "file.csv"
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isAccepted
+  }
+}


### PR DESCRIPTION
This adds an endpoint, POST to /seed which can only be called from within the kubernetes pod running the app.  The endpoint a post body with the type of seeding and a filename.  These are passed to a background thread and the call returns a 202 to indicate the work has been accepted.