### PR TITLE
903 - Seeding scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ sonar-project.properties
 .trivyignore
 
 nomis-db/
+
+test-seed-csvs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 WORKDIR /app
 ADD . .
-RUN ./gradlew --no-daemon assemble
+RUN ./gradlew -v --no-daemon assemble
 
 FROM openjdk:17-slim
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
@@ -29,6 +29,9 @@ COPY --from=builder --chown=appuser:appgroup /app/build/libs/approved-premises-a
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
+
+COPY --from=builder --chown=appuser:appgroup /app/script/run_seed_job /app
+RUN mkdir /seed
 
 USER 2000
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,12 @@ dependencies {
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")
   testRuntimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
   testRuntimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+  testImplementation("org.springframework.boot:spring-boot-starter-test") {
+    exclude(module = "mockito-core")
+  }
+
+  testImplementation("com.ninja-squad:springmockk:4.0.0")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
   implementation("com.networknt:json-schema-validator:1.0.73")
   implementation("io.github.jamsesso:json-logic-java:1.0.7")
 
+  implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.7.0")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.3")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/doc/how-to/run_seed_job_remotely.md
+++ b/doc/how-to/run_seed_job_remotely.md
@@ -1,0 +1,22 @@
+# How to run a seed job remotely
+
+To process a seed CSV against a non-local environment:
+
+- Ensure nobody is deploying a change (or is going to deploy a change shortly.)
+- Run `kubectl get pod` against the namespace for the environment you wish to run the seed job in.
+- Copy the name of one of the running `hmpps-approved-premises-api` pods.
+- Transfer the CSV to the `/seed` directory in the container via kubectl, e.g.
+  ```
+  kubectl cp /local/path/ap_seed_file.csv {pod name}:/seed/ap_seed_file.csv
+  ```
+- Run the helper script from within the container to trigger the seed job:
+  ```
+  kubectl exec --stdin --tty {pod name} -- /bin/bash
+  /app/script/run_seed_job {seed type} {file name without extension}
+  ```
+  Where `seed type` is a value from the `SeedFileType` enum in the OpenAPI spec.  e.g.
+  ```
+  kubectl exec --stdin --tty {pod name} -- /bin/bash
+  /app/script/run_seed_job approved_premises ap_seed_file
+  ```
+- Check the logs via `kubectl logs {pod name}` to see how processing is progressing.

--- a/script/run_seed_job
+++ b/script/run_seed_job
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# script/run_seed_job: Run a seed job for given type and name of CSV file in seed directory.  e.g.
+#                      script/run_seed_job approved_premises ap_upload
+#                      Would start a seed job for the ap_upload.csv file
+
+set -e
+
+curl --location --request POST 'http://127.0.0.1:8080/seed' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "seedType": "'$1'",
+    "fileName": "'$2'"
+}'
+
+echo "Requested job - check the application logs for processing status"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/AsyncConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -43,6 +43,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/domain-events-api.yml", permitAll)
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
+        authorize(HttpMethod.POST, "/seed", permitAll)
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.SeedApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.UnauthenticatedProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
+
+@Service
+class SeedController(private val seedService: SeedService) : SeedApiDelegate {
+  override fun seedPost(seedRequest: SeedRequest): ResponseEntity<Unit> {
+    throwIfNotLoopbackRequest()
+
+    seedService.seedData(seedRequest.seedType, seedRequest.fileName)
+
+    return ResponseEntity(HttpStatus.ACCEPTED)
+  }
+
+  private fun throwIfNotLoopbackRequest() {
+    val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+    val remoteAddress = request.remoteAddr
+
+    if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
+      throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
@@ -15,7 +15,7 @@ class SeedController(private val seedService: SeedService) : SeedApiDelegate {
   override fun seedPost(seedRequest: SeedRequest): ResponseEntity<Unit> {
     throwIfNotLoopbackRequest()
 
-    seedService.seedData(seedRequest.seedType, seedRequest.fileName)
+    seedService.seedDataAsync(seedRequest.seedType, seedRequest.fileName)
 
     return ResponseEntity(HttpStatus.ACCEPTED)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
@@ -4,7 +4,7 @@ import org.zalando.problem.AbstractThrowableProblem
 import org.zalando.problem.Exceptional
 import org.zalando.problem.Status
 
-class UnauthenticatedProblem() : AbstractThrowableProblem(null, "Unauthenticated", Status.UNAUTHORIZED, "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") {
+class UnauthenticatedProblem(detail: String = "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") : AbstractThrowableProblem(null, "Unauthenticated", Status.UNAUTHORIZED, detail) {
   override fun getCause(): Exceptional? {
     return null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import java.util.UUID
+
+class ApprovedPremisesSeedJob(
+  fileName: String,
+  private val premisesRepository: PremisesRepository
+) : SeedJob<ApprovedPremisesSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredColumns = 12
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = ApprovedPremisesSeedCsvRow(
+    id = UUID.fromString(columns["id"]!!),
+    name = columns["name"]!!,
+    addressLine1 = columns["addressLine1"]!!,
+    postcode = columns["postcode"]!!,
+    totalBeds = Integer.parseInt(columns["totalBeds"]!!),
+    notes = columns["notes"]!!,
+    probationRegionId = UUID.fromString(columns["probationRegionId"]!!),
+    localAuthorityAreaId = UUID.fromString(columns["localAuthorityAreaId"]),
+    characteristicIds = columns["characteristicIds"]!!.split(",").map { UUID.fromString(it.trim()) },
+    status = PropertyStatus.valueOf(columns["status"]!!),
+    apCode = columns["apCode"]!!,
+    qCode = columns["qCode"]!!
+  )
+
+  override fun processRow(row: ApprovedPremisesSeedCsvRow) = log.info("TODO: Process AP Premises row: $row")
+}
+
+data class ApprovedPremisesSeedCsvRow(
+  val id: UUID,
+  val name: String,
+  val addressLine1: String,
+  val postcode: String,
+  val totalBeds: Int,
+  val notes: String,
+  val probationRegionId: UUID,
+  val localAuthorityAreaId: UUID,
+  val characteristicIds: List<UUID>,
+  val status: PropertyStatus,
+  val apCode: String,
+  val qCode: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import java.util.UUID
+
+abstract class SeedJob <RowType> (
+  val id: UUID = UUID.randomUUID(),
+  val fileName: String,
+  val requiredColumns: Int
+) {
+  init {
+    if (fileName.contains("/") || fileName.contains("\\") || fileName.contains(".")) {
+      throw RuntimeException("Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied")
+    }
+  }
+
+  abstract fun deserializeRow(columns: Map<String, String>): RowType
+  abstract fun processRow(row: RowType)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedLogger.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedLogger.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class SeedLogger {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun info(message: String) = log.info(message)
+  fun error(message: String) = log.error(message)
+  fun error(message: String, throwable: Throwable) = log.error(message, throwable)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -1,16 +1,98 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
-import org.slf4j.LoggerFactory
+import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationContext
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 
 @Service
-class SeedService {
-  private val log = LoggerFactory.getLogger(this::class.java)
-
+class SeedService(
+  @Value("\${seed.file-prefix}") private val seedFilePrefix: String,
+  private val applicationContext: ApplicationContext,
+  private val transactionTemplate: TransactionTemplate,
+  private val seedLogger: SeedLogger
+) {
   @Async
+  fun seedDataAsync(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename)
+
   fun seedData(seedFileType: SeedFileType, filename: String) {
-    log.info("Starting seed request: $seedFileType - $filename")
+    seedLogger.info("Starting seed request: $seedFileType - $filename")
+
+    try {
+      val job = when (seedFileType) {
+        SeedFileType.approvedPremises -> ApprovedPremisesSeedJob(
+          filename,
+          applicationContext.getBean(PremisesRepository::class.java)
+        )
+      }
+
+      transactionTemplate.executeWithoutResult { processJob(job) }
+    } catch (exception: Exception) {
+      seedLogger.error("Unable to complete Seed Job", exception)
+    }
+  }
+
+  private inline fun <reified T> processJob(job: SeedJob<T>) {
+    // During processing, the CSV file is processed one row at a time to avoid OOM issues.
+    // It is preferable to fail fast rather than processing half of a file before stopping,
+    // so we first do a full pass but only deserializing each row
+    ensureCsvCanBeDeserialized(job)
+    processCsv(job)
+  }
+
+  private fun <T> processCsv(job: SeedJob<T>) {
+    var rowNumber = 0
+
+    try {
+      csvReader().open("$seedFilePrefix/${job.fileName}.csv") {
+        readAllWithHeaderAsSequence().forEach { row ->
+
+          if (rowNumber != 0) {
+            val deserializedRow = job.deserializeRow(row)
+
+            job.processRow(deserializedRow)
+          }
+
+          rowNumber += 1
+        }
+      }
+    } catch (exception: Exception) {
+      throw RuntimeException("Unable to process CSV at row $rowNumber", exception)
+    }
+  }
+
+  private fun <T> ensureCsvCanBeDeserialized(job: SeedJob<T>) {
+    seedLogger.info("Validating that CSV can be fully read")
+    var rowNumber = 0
+    val errors = mutableListOf<String>()
+
+    try {
+      csvReader().open("$seedFilePrefix/${job.fileName}.csv") {
+        readAllWithHeaderAsSequence().forEach { row ->
+          try {
+            if (rowNumber != 0) {
+              job.deserializeRow(row)
+            }
+          } catch (exception: Exception) {
+            errors += "Unable to deserialize CSV at row: $rowNumber: ${exception.printStackTrace()}"
+          }
+
+          rowNumber += 1
+        }
+      }
+    } catch (exception: Exception) {
+      throw RuntimeException("There was an issue opening the CSV file", exception)
+    }
+
+    if (errors.any()) {
+      throw RuntimeException("There were issues deserializing the CSV:\n${errors.joinToString(", \n")}")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+
+@Service
+class SeedService {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @Async
+  fun seedData(seedFileType: SeedFileType, filename: String) {
+    log.info("Starting seed request: $seedFileType - $filename")
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -155,3 +155,6 @@ caches:
     expiry-seconds: 1200
   inmateDetails:
     expiry-seconds: 1200
+
+seed:
+  file-prefix: "/seed"

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1931,6 +1931,24 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /seed:
+    post:
+      summary: Starts the data seeding process, can only be called from a local connection
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SeedRequest'
+        required: true
+      responses:
+        202:
+          description: successfully requested task
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
 components:
   responses:
     401Response:
@@ -3563,3 +3581,17 @@ components:
         - createdAt
         - typeCode
         - typeDescription
+    SeedRequest:
+      type: object
+      properties:
+        seedType:
+          $ref: '#/components/schemas/SeedFileType'
+        fileName:
+          type: string
+      required:
+        - seedType
+        - fileName
+    SeedFileType:
+      type: string
+      enum:
+        - approved_premises

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTest.kt
@@ -1,10 +1,46 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.Path
 
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class SeedTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var seedService: SeedService
+
+  @Value("\${seed.file-prefix}")
+  lateinit var seedFilePrefix: String
+
+  @MockkBean
+  lateinit var mockSeedLogger: SeedLogger
+  private val logEntries = mutableListOf<LogEntry>()
+
+  @BeforeEach
+  fun setUp() {
+    every { mockSeedLogger.info(any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "info", null)
+    }
+    every { mockSeedLogger.error(any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "error", null)
+    }
+    every { mockSeedLogger.error(any(), any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "error", it.invocation.args[1] as Throwable)
+    }
+  }
+
   @Test
   fun `Requesting a Seed operation returns 202`() {
     webTestClient.post()
@@ -19,4 +55,94 @@ class SeedTest : IntegrationTestBase() {
       .expectStatus()
       .isAccepted
   }
+
+  @Test
+  fun `Attempting to process a file containing dots logs an error`() {
+    seedService.seedData(SeedFileType.approvedPremises, "afile.csv")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message!!.contains(
+          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"
+        )
+    }
+  }
+
+  @Test
+  fun `Attempting to process a file containing forward slashes logs an error`() {
+    seedService.seedData(SeedFileType.approvedPremises, "/afile")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message!!.contains(
+          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"
+        )
+    }
+  }
+
+  @Test
+  fun `Attempting to process a file containing backward slashes logs an error`() {
+    seedService.seedData(SeedFileType.approvedPremises, "\\afile")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message!!.contains(
+          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"
+        )
+    }
+  }
+
+  @Test
+  fun `Attempting to process a non-existent file logs an error`() {
+    seedService.seedData(SeedFileType.approvedPremises, "non-existent")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message!!.contains(
+          "There was an issue opening the CSV file"
+        )
+    }
+  }
+
+  @Test
+  fun `Attempting to process a malformed file logs an error`() {
+    withCsv(
+      "malformed",
+      """
+id,name,addressLine1,postcode,totalBeds,notes,probationRegionId,localAuthorityAreaId,characteristicIds,status,apCode,qCode
+f5fb56ad-54ed-46e9-8c0e-c1e8581cfd5d,An AP,Address 1,PC1PC2,12,Notes,384b8abb-f335-499e-b41d-dc3d852f0761,cdd12e06-8cc7-4ae5-bcdc-23271f2492db,,status,APCODE,QCODE
+,,,
+      """.trimIndent()
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "malformed")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause!!.message == "Fields num seems to be 12 on each row, but on 2th csv row, fields num is 4."
+    }
+  }
+
+  private fun withCsv(csvName: String, contents: String) {
+    if (! Files.isDirectory(Path(seedFilePrefix))) {
+      Files.createDirectory(Path(seedFilePrefix))
+    }
+    Files.writeString(Path("$seedFilePrefix/$csvName.csv"), contents, StandardOpenOption.CREATE)
+  }
 }
+
+data class LogEntry(
+  val message: String,
+  val level: String,
+  val throwable: Throwable?
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
+
+class SeedTest : IntegrationTestBase() {
+  @Test
+  fun `Requesting a Seed operation returns 202`() {
+    webTestClient.post()
+      .uri("/seed")
+      .bodyValue(
+        SeedRequest(
+          seedType = SeedFileType.approvedPremises,
+          fileName = "file.csv"
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isAccepted
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -82,3 +82,6 @@ caches:
     expiry-seconds: 1200
   inmateDetails:
     expiry-seconds: 1200
+
+seed:
+  file-prefix: "./test-seed-csvs"


### PR DESCRIPTION
This lays the foundations for the seeding work.

- Adds an endpoint POST /seed which accepts the type of seeding and a filename
- This endpoint returns 202 Accepted then starts the processing in a background thread
- We check that the entire file can be parsed and deserialized first (if not, collecting errors where possible)
- Then row by row, process each file

This doesn't actually do any processing with the Approved Premises CSV yet as this is more focussed around the reusable parts.