### PR TITLE
Add performance data to domain events

### DIFF
--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -557,6 +557,10 @@ components:
           type: string
           example: 'Release on Temporary Licence (ROTL)'
           readOnly: true
+        age:
+          type: integer
+          example: 43
+          readOnly: true
         targetLocation:
           type: string
           example: LS2

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -629,11 +629,14 @@ components:
           format: date-time
           readOnly: true
         assessedBy:
-          $ref: '#/components/schemas/StaffMember'
-        assessmentArea:
-          $ref: '#/components/schemas/ProbationArea'
-        assessmentCru:
-          $ref: '#/components/schemas/Cru'
+          type: object
+          properties:
+            staffMember:
+              $ref: '#/components/schemas/StaffMember'
+            probationArea:
+              $ref: '#/components/schemas/ProbationArea'
+            cru:
+              $ref: '#/components/schemas/Cru'
         decision:
           type: string
           example: Rejected

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -549,6 +549,10 @@ components:
           type: integer
           example: 57
           readOnly: true
+        offenceDescription:
+          type: string
+          example: 'Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801'
+          readOnly: true
         targetLocation:
           type: string
           example: LS2

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -663,9 +663,12 @@ components:
           format: date-time
           readOnly: true
         bookedBy:
-          $ref: '#/components/schemas/StaffMember'
-        bookingCru:
-          $ref: '#/components/schemas/Cru'
+          type: object
+          properties:
+            staffMember:
+              $ref: '#/components/schemas/StaffMember'
+            cru:
+              $ref: '#/components/schemas/Cru'
         premises:
           $ref: '#/components/schemas/Premises'
         arrivalOn:
@@ -698,9 +701,12 @@ components:
           format: date-time
           readOnly: true
         attemptedBy:
-          $ref: '#/components/schemas/StaffMember'
-        matchingCru:
-          $ref: '#/components/schemas/Cru'
+          type: object
+          properties:
+            staffMember:
+              $ref: '#/components/schemas/StaffMember'
+            cru:
+              $ref: '#/components/schemas/Cru'
         failureDescription:
           type: string
           example: No availability

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -510,7 +510,7 @@ components:
           $ref: '#/components/schemas/DeliusEventNumber'
         targetLocation:
           type: string
-          example: Gateshead
+          example: LS2
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
         applicationCru:

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -541,6 +541,10 @@ components:
           $ref: '#/components/schemas/PersonReference'
         deliusEventNumber:
           $ref: '#/components/schemas/DeliusEventNumber'
+        mappaCategories:
+          type: string
+          example: 'M2'
+          readOnly: true
         targetLocation:
           type: string
           example: LS2

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -553,6 +553,10 @@ components:
           type: string
           example: 'Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801'
           readOnly: true
+        releaseType:
+          type: string
+          example: 'Release on Temporary Licence (ROTL)'
+          readOnly: true
         targetLocation:
           type: string
           example: LS2

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -544,23 +544,26 @@ components:
         targetLocation:
           type: string
           example: LS2
-        probationArea:
-          $ref: '#/components/schemas/ProbationArea'
-        applicationCru:
-          $ref: '#/components/schemas/Cru'
-        applicationTeam:
-          $ref: '#/components/schemas/Team'
-        applicationLdu:
-          $ref: '#/components/schemas/Ldu'
-        applicationRegion:
-          $ref: '#/components/schemas/Region'
         submittedAt:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
           readOnly: true
         submittedBy:
-          $ref: '#/components/schemas/StaffMember'
+          type: object
+          properties:
+            staffMember:
+              $ref: '#/components/schemas/StaffMember'
+            probationArea:
+              $ref: '#/components/schemas/ProbationArea'
+            cru:
+              $ref: '#/components/schemas/Cru'
+            team:
+              $ref: '#/components/schemas/Team'
+            ldu:
+              $ref: '#/components/schemas/Ldu'
+            region:
+              $ref: '#/components/schemas/Region'
 
     ApplicationWithdrawn:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -464,16 +464,27 @@ components:
         username:
           type: string
           example: JohnSmithNPS
+    Cru:
+      type: object
+      properties:
+        code:
+          type: string
+          example: N02
+          readOnly: true
+        name:
+          type: string
+          example: NPS North East
+          readOnly: true
     ProbationArea:
       type: object
       properties:
         code:
           type: string
-          example: N54
+          example: N02
           readOnly: true
         name:
           type: string
-          example: North East Region
+          example: NPS North East
           readOnly: true
     PersonReference:
       type: object
@@ -502,6 +513,8 @@ components:
           example: Gateshead
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
+        applicationCru:
+          $ref: '#/components/schemas/Cru'
         submittedAt:
           type: string
           example: '2022-11-30T14:51:30'
@@ -551,6 +564,8 @@ components:
           $ref: '#/components/schemas/StaffMember'
         assessmentArea:
           $ref: '#/components/schemas/ProbationArea'
+        assessmentCru:
+          $ref: '#/components/schemas/Cru'
         decision:
           type: string
           example: Rejected
@@ -578,6 +593,8 @@ components:
           readOnly: true
         bookedBy:
           $ref: '#/components/schemas/StaffMember'
+        bookingCru:
+          $ref: '#/components/schemas/Cru'
         premises:
           $ref: '#/components/schemas/Premises'
         arrivalOn:
@@ -611,6 +628,8 @@ components:
           readOnly: true
         attemptedBy:
           $ref: '#/components/schemas/StaffMember'
+        matchingCru:
+          $ref: '#/components/schemas/Cru'
         failureDescription:
           type: string
           example: No availability

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -475,6 +475,39 @@ components:
           type: string
           example: NPS North East
           readOnly: true
+    Ldu:
+      type: object
+      properties:
+        code:
+          type: string
+          example: N54PPU
+          readOnly: true
+        name:
+          type: string
+          example: Public Protection NE
+          readOnly: true
+    Region:
+      type: object
+      properties:
+        code:
+          type: string
+          example: NE
+          readOnly: true
+        name:
+          type: string
+          example: North East
+          readOnly: true
+    Team:
+      type: object
+      properties:
+        code:
+          type: string
+          example: N54NGH
+          readOnly: true
+        name:
+          type: string
+          example: Gateshead 1
+          readOnly: true
     ProbationArea:
       type: object
       properties:
@@ -515,6 +548,12 @@ components:
           $ref: '#/components/schemas/ProbationArea'
         applicationCru:
           $ref: '#/components/schemas/Cru'
+        applicationTeam:
+          $ref: '#/components/schemas/Team'
+        applicationLdu:
+          $ref: '#/components/schemas/Ldu'
+        applicationRegion:
+          $ref: '#/components/schemas/Region'
         submittedAt:
           type: string
           example: '2022-11-30T14:51:30'

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -545,6 +545,10 @@ components:
           type: string
           example: 'M2'
           readOnly: true
+        sentenceLengthInMonths:
+          type: integer
+          example: 57
+          readOnly: true
         targetLocation:
           type: string
           example: LS2

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -561,6 +561,12 @@ components:
           type: integer
           example: 43
           readOnly: true
+        gender:
+          type: string
+          readOnly: true
+          enum:
+            - Male
+            - Female
         targetLocation:
           type: string
           example: LS2


### PR DESCRIPTION
This PR comprises a number of changes to domain events to record information needed when processing to generate metrics for the performance hub. See notes from [meeting of Dec 14th 2022](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4258365759/Performance+Metrics+Meeting+on+Weds+Dec+14th+2022).

**NB**: This PR causes breaking changes to the integrations which have been written to consume these events and update Delius. An accompanying PR is required to adjust [those integrations](https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/main/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/ApprovedPremisesService.kt).

## Changes

### application.submitted

Adds:

```
    "mappaCategories": "M2",
    "sentenceLengthInMonths": 57,
    "offenceDescription": "Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801",
    "releaseType": "Release on Temporary Licence (ROTL)",
    "age": 43,
    "gender": "Male",
    "targetLocation": "LS2", // postcode district rather than placename
```


Reworks `submittedBy` key to include geographic information as well as staff info:
```
    "submittedBy": {
      "staffMember": {
        "staffCode": "N54A999",
        "staffIdentifier": 1501234567,
        "forenames": "John",
        "surname": "Smith",
        "username": "JohnSmithNPS"
      },
      "probationArea": {
        "code": "N02",
        "name": "NPS North East"
      },
      "cru": {
        "code": "N02",
        "name": "NPS North East"
      },
      "team": {
        "code": "N54NGH",
        "name": "Gateshead 1"
      },
      "ldu": {
        "code": "N54PPU",
        "name": "Public Protection NE"
      },
      "region": {
        "code": "NE",
        "name": "North East"
      }
    }
```

### application.assessed

Reworks `assessedBy` key to include CRU information as well as staff info:

```
"assessedBy": {
      "staffMember": {
        "staffCode": "N54A999",
        "staffIdentifier": 1501234567,
        "forenames": "John",
        "surname": "Smith",
        "username": "JohnSmithNPS"
      },
      "probationArea": {
        "code": "N02",
        "name": "NPS North East"
      },
      "cru": {
        "code": "N02",
        "name": "NPS North East"
      }
    },
```

### booking.made

Reworks `bookedBy` key to include CRU information as well as staff info:

```
    "bookedBy": {
      "staffMember": {
        "staffCode": "N54A999",
        "staffIdentifier": 1501234567,
        "forenames": "John",
        "surname": "Smith",
        "username": "JohnSmithNPS"
      },
      "cru": {
        "code": "N02",
        "name": "NPS North East"
      }
    },
```

### booking.not-made

Reworks `attemptedBy` key to include CRU information as well as staff info:

```
  "attemptedBy": {
      "staffMember": {
        "staffCode": "N54A999",
        "staffIdentifier": 1501234567,
        "forenames": "John",
        "surname": "Smith",
        "username": "JohnSmithNPS"
      },
      "cru": {
        "code": "N02",
        "name": "NPS North East"
      }
    },
```