### PR TITLE
Enable log-client-credentials-jwt-info on preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,7 +18,7 @@ generic-service:
     SERVICES_CASE-NOTES_BASE-URL: https://preprod.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-preprod.hmpps.service.justice.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all
-    LOG-CLIENT-CREDENTIALS-JWT-INFO: false
+    LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
 


### PR DESCRIPTION
This setting causes the app to log the client_id, authorities, scopes and expiry when it retrieves a client_credentials JWT for service->service call authentication.  Turning this on in pre-prod to debug an issue with calling Offender Case Notes Service (we need to ensure we have the correct authorities.)  This does not log the JWT signature so is safe to enable.