### PR TITLE
903 - Approved Premises seeding job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ sonar-project.properties
 nomis-db/
 
 test-seed-csvs/
+seed/

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -11,6 +11,8 @@ interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
 
   @Query("SELECT c FROM CharacteristicEntity c WHERE c.serviceScope = :serviceName")
   fun findAllByServiceScope(serviceName: String): List<CharacteristicEntity>
+
+  fun findByName(name: String): CharacteristicEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -8,7 +8,9 @@ import javax.persistence.Id
 import javax.persistence.OneToMany
 import javax.persistence.Table
 @Repository
-interface LocalAuthorityAreaRepository : JpaRepository<LocalAuthorityAreaEntity, UUID>
+interface LocalAuthorityAreaRepository : JpaRepository<LocalAuthorityAreaEntity, UUID> {
+  fun findByName(name: String): LocalAuthorityAreaEntity?
+}
 
 @Entity
 @Table(name = "local_authority_areas")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -80,8 +80,8 @@ class ApprovedPremisesEntity(
   localAuthorityArea: LocalAuthorityAreaEntity,
   bookings: MutableList<BookingEntity>,
   lostBeds: MutableList<LostBedsEntity>,
-  val apCode: String,
-  val qCode: String,
+  var apCode: String,
+  var qCode: String,
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
   status: PropertyStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -11,7 +11,9 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
-interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID>
+interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID> {
+  fun findByName(name: String): ProbationRegionEntity?
+}
 
 @Entity
 @Table(name = "probation_regions")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
@@ -33,9 +33,9 @@ class ApprovedPremisesSeedJob(
     postcode = columns["postcode"]!!,
     totalBeds = Integer.parseInt(columns["totalBeds"]!!),
     notes = columns["notes"]!!,
-    probationRegionId = UUID.fromString(columns["probationRegionId"]!!),
-    localAuthorityAreaId = UUID.fromString(columns["localAuthorityAreaId"]),
-    characteristicIds = columns["characteristicIds"]!!.split(",").filter { it.isNotBlank() }.map { UUID.fromString(it.trim()) },
+    probationRegion = columns["probationRegionId"]!!,
+    localAuthorityArea = columns["localAuthorityAreaId"]!!,
+    characteristics = columns["characteristicIds"]!!.split(",").filter { it.isNotBlank() }.map { it.trim() },
     status = PropertyStatus.valueOf(columns["status"]!!),
     apCode = columns["apCode"]!!,
     qCode = columns["qCode"]!!
@@ -48,13 +48,13 @@ class ApprovedPremisesSeedJob(
       throw RuntimeException("Premises ${row.id} is of type ${existingPremises::class.qualifiedName}, cannot be updated with Approved Premises Seed Job")
     }
 
-    val probationRegion = probationRegionRepository.findByIdOrNull(row.probationRegionId)
-      ?: throw RuntimeException("Probation Region ${row.probationRegionId} does not exist")
+    val probationRegion = probationRegionRepository.findByName(row.probationRegion)
+      ?: throw RuntimeException("Probation Region ${row.probationRegion} does not exist")
 
-    val localAuthorityArea = localAuthorityAreaRepository.findByIdOrNull(row.localAuthorityAreaId)
-      ?: throw RuntimeException("Local Authority Area ${row.localAuthorityAreaId} does not exist")
+    val localAuthorityArea = localAuthorityAreaRepository.findByName(row.localAuthorityArea)
+      ?: throw RuntimeException("Local Authority Area ${row.localAuthorityArea} does not exist")
 
-    val characteristics = row.characteristicIds.map {
+    val characteristics = row.characteristics.map {
       characteristicService.getCharacteristic(it)
         ?: throw RuntimeException("Characteristic $it does not exist")
     }
@@ -156,9 +156,9 @@ data class ApprovedPremisesSeedCsvRow(
   val postcode: String,
   val totalBeds: Int,
   val notes: String,
-  val probationRegionId: UUID,
-  val localAuthorityAreaId: UUID,
-  val characteristicIds: List<UUID>,
+  val probationRegion: String,
+  val localAuthorityArea: String,
+  val characteristics: List<String>,
   val status: PropertyStatus,
   val apCode: String,
   val qCode: String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/CsvBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/CsvBuilder.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+class CsvBuilder {
+  private var csv = StringBuilder()
+
+  fun withUnquotedField(field: Any) = apply {
+    csv.append("$field,")
+  }
+
+  fun withHeader(vararg fields: Any) = withUnquotedFields(fields)
+  fun withUnquotedFields(vararg fields: Any) = apply {
+    fields.forEach {
+      csv.append("$it,")
+    }
+  }
+
+  fun withQuotedField(field: Any) = apply {
+    csv.append("\"$field\",")
+  }
+
+  fun withQuotedFields(vararg fields: Any) = apply {
+    fields.forEach {
+      csv.append("\"$it\",")
+    }
+  }
+
+  fun newRow() = apply {
+    csv.deleteCharAt(csv.length - 1)
+    csv.append("\n")
+  }
+
+  fun build() = csv.toString()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
@@ -18,6 +18,9 @@ class CharacteristicService(
   fun getCharacteristic(characteristicId: UUID): CharacteristicEntity? =
     characteristicRepository.findByIdOrNull(characteristicId)
 
+  fun getCharacteristic(characteristicName: String): CharacteristicEntity? =
+    characteristicRepository.findByName(characteristicName)
+
   fun serviceScopeMatches(characteristic: CharacteristicEntity, target: Any): Boolean {
     val targetService = getServiceForTarget(target) ?: return false
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,3 +14,6 @@ spring:
     password: ""
 
 log-client-credentials-jwt-info: true
+
+seed:
+  file-prefix: "./seed"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CharacteristicEntityFactory.kt
@@ -13,6 +13,10 @@ class CharacteristicEntityFactory : Factory<CharacteristicEntity> {
   private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
   private var modelScope: Yielded<String> = { randomStringUpperCase(4) }
 
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
   fun withServiceScope(serviceScope: String) = apply {
     this.serviceScope = { serviceScope }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
@@ -1,0 +1,390 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedApprovedPremisesTest : SeedTestBase() {
+  @Test
+  fun `Attempting to create an Approved Premises with an invalid Probation Region Id logs an error`() {
+    withCsv(
+      "invalid-probation",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          ApprovedPremisesSeedCsvRowFactory()
+            .withProbationRegionId(UUID.fromString("012ec12b-a915-40d4-800a-8c89cc801486"))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-probation")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause!!.message == "Probation Region 012ec12b-a915-40d4-800a-8c89cc801486 does not exist"
+    }
+  }
+
+  @Test
+  fun `Attempting to create an Approved Premises with an invalid Local Authority Area Id logs an error`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    withCsv(
+      "invalid-local-authority",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          ApprovedPremisesSeedCsvRowFactory()
+            .withProbationRegionId(probationRegion.id)
+            .withLocalAuthorityAreaId(UUID.fromString("79aa2e39-3c88-4957-be74-a2047694195d"))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-local-authority")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause!!.message == "Local Authority Area 79aa2e39-3c88-4957-be74-a2047694195d does not exist"
+    }
+  }
+
+  @Test
+  fun `Attempting to create an Approved Premises with an invalid characteristic logs an error`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    withCsv(
+      "invalid-probation",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          ApprovedPremisesSeedCsvRowFactory()
+            .withProbationRegionId(probationRegion.id)
+            .withLocalAuthorityAreaId(localAuthorityArea.id)
+            .withCharacteristicIds(listOf(UUID.fromString("8e04628f-2cdd-4d9a-8ae7-27689d7daa73")))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-probation")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause!!.message == "Characteristic 8e04628f-2cdd-4d9a-8ae7-27689d7daa73 does not exist"
+    }
+  }
+
+  @Test
+  fun `Attempting to create an Approved Premises with an incorrectly service-scoped characteristic logs an error`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    val characteristic = characteristicEntityFactory.produceAndPersist {
+      withId(UUID.fromString("8e04628f-2cdd-4d9a-8ae7-27689d7daa73"))
+      withServiceScope("temporary-accommodation")
+    }
+
+    withCsv(
+      "invalid-service-scope",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          ApprovedPremisesSeedCsvRowFactory()
+            .withProbationRegionId(probationRegion.id)
+            .withLocalAuthorityAreaId(localAuthorityArea.id)
+            .withCharacteristicIds(listOf(characteristic.id))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-service-scope")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause!!.message == "Service scope does not match for Characteristic ${characteristic.id}"
+    }
+  }
+
+  @Test
+  fun `Attempting to create an Approved Premises with an incorrectly model-scoped characteristic logs an error`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    val characteristic = characteristicEntityFactory.produceAndPersist {
+      withId(UUID.fromString("8e04628f-2cdd-4d9a-8ae7-27689d7daa73"))
+      withServiceScope("approved-premises")
+      withModelScope("booking")
+    }
+
+    withCsv(
+      "invalid-model-scope",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          ApprovedPremisesSeedCsvRowFactory()
+            .withProbationRegionId(probationRegion.id)
+            .withLocalAuthorityAreaId(localAuthorityArea.id)
+            .withCharacteristicIds(listOf(characteristic.id))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-model-scope")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause!!.message == "Model scope does not match for Characteristic ${characteristic.id}"
+    }
+  }
+
+  @Test
+  fun `Creating a new Approved Premises persists correctly`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    val characteristic = characteristicEntityFactory.produceAndPersist {
+      withId(UUID.fromString("8e04628f-2cdd-4d9a-8ae7-27689d7daa73"))
+      withServiceScope("approved-premises")
+      withModelScope("premises")
+    }
+
+    val csvRow = ApprovedPremisesSeedCsvRowFactory()
+      .withId(UUID.randomUUID())
+      .withProbationRegionId(probationRegion.id)
+      .withLocalAuthorityAreaId(localAuthorityArea.id)
+      .withCharacteristicIds(listOf(characteristic.id))
+      .produce()
+
+    withCsv(
+      "new-ap",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          csvRow
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "new-ap")
+
+    val persistedApprovedPremises = approvedPremisesRepository.findByIdOrNull(csvRow.id)
+    assertThat(persistedApprovedPremises).isNotNull
+    assertThat(persistedApprovedPremises!!.id).isEqualTo(csvRow.id)
+    assertThat(persistedApprovedPremises.apCode).isEqualTo(csvRow.apCode)
+    assertThat(persistedApprovedPremises.name).isEqualTo(csvRow.name)
+    assertThat(persistedApprovedPremises.addressLine1).isEqualTo(csvRow.addressLine1)
+    assertThat(persistedApprovedPremises.postcode).isEqualTo(csvRow.postcode)
+    assertThat(persistedApprovedPremises.totalBeds).isEqualTo(csvRow.totalBeds)
+    assertThat(persistedApprovedPremises.notes).isEqualTo(csvRow.notes)
+    assertThat(persistedApprovedPremises.probationRegion.id).isEqualTo(csvRow.probationRegionId)
+    assertThat(persistedApprovedPremises.localAuthorityArea.id).isEqualTo(csvRow.localAuthorityAreaId)
+    assertThat(persistedApprovedPremises.characteristics.map { it.id }).isEqualTo(csvRow.characteristicIds)
+    assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
+  }
+
+  @Test
+  fun `Updating an existing Approved Premises persists correctly`() {
+    val originalProbationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val updatedProbationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val originalLocalAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    val updatedLocalAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    val existingApprovedPremises = approvedPremisesEntityFactory.produceAndPersist {
+      withId(UUID.randomUUID())
+      withProbationRegion(originalProbationRegion)
+      withLocalAuthorityArea(originalLocalAuthorityArea)
+      withQCode("OLD Q-CODE")
+    }
+
+    val csvRow = ApprovedPremisesSeedCsvRowFactory()
+      .withId(existingApprovedPremises.id)
+      .withProbationRegionId(updatedProbationRegion.id)
+      .withLocalAuthorityAreaId(updatedLocalAuthorityArea.id)
+      .withCharacteristicIds(emptyList())
+      .produce()
+
+    withCsv(
+      "update-ap",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          csvRow
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremises, "update-ap")
+
+    val persistedApprovedPremises = approvedPremisesRepository.findByIdOrNull(csvRow.id)
+    assertThat(persistedApprovedPremises).isNotNull
+    assertThat(persistedApprovedPremises!!.id).isEqualTo(csvRow.id)
+    assertThat(persistedApprovedPremises.apCode).isEqualTo(csvRow.apCode)
+    assertThat(persistedApprovedPremises.name).isEqualTo(csvRow.name)
+    assertThat(persistedApprovedPremises.addressLine1).isEqualTo(csvRow.addressLine1)
+    assertThat(persistedApprovedPremises.postcode).isEqualTo(csvRow.postcode)
+    assertThat(persistedApprovedPremises.totalBeds).isEqualTo(csvRow.totalBeds)
+    assertThat(persistedApprovedPremises.notes).isEqualTo(csvRow.notes)
+    assertThat(persistedApprovedPremises.probationRegion.id).isEqualTo(csvRow.probationRegionId)
+    assertThat(persistedApprovedPremises.localAuthorityArea.id).isEqualTo(csvRow.localAuthorityAreaId)
+    assertThat(persistedApprovedPremises.characteristics.map { it.id }).isEqualTo(csvRow.characteristicIds)
+    assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
+  }
+
+  private fun approvedPremisesSeedCsvRowsToCsv(rows: List<ApprovedPremisesSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "id",
+        "name",
+        "addressLine1",
+        "postcode",
+        "totalBeds",
+        "notes",
+        "probationRegionId",
+        "localAuthorityAreaId",
+        "characteristicIds",
+        "status",
+        "apCode",
+        "qCode"
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.id)
+        .withQuotedField(it.name)
+        .withQuotedField(it.addressLine1)
+        .withQuotedField(it.postcode)
+        .withUnquotedField(it.totalBeds)
+        .withQuotedFields(it.notes)
+        .withQuotedField(it.probationRegionId)
+        .withQuotedField(it.localAuthorityAreaId)
+        .withQuotedField(it.characteristicIds.joinToString(","))
+        .withQuotedField(it.status.value)
+        .withQuotedField(it.apCode)
+        .withQuotedField(it.qCode)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}
+
+class ApprovedPremisesSeedCsvRowFactory : Factory<ApprovedPremisesSeedCsvRow> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var addressLine1: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var postcode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var totalBeds: Yielded<Int> = { randomInt(5, 50) }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var probationRegionId: Yielded<UUID> = { UUID.randomUUID() }
+  private var localAuthorityAreaId: Yielded<UUID> = { UUID.randomUUID() }
+  private var characteristicIds: Yielded<List<UUID>> = { listOf() }
+  private var status: Yielded<PropertyStatus> = { PropertyStatus.active }
+  private var apCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var qCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withAddressLine1(addressLine1: String) = apply {
+    this.addressLine1 = { addressLine1 }
+  }
+
+  fun withPostcode(postcode: String) = apply {
+    this.postcode = { postcode }
+  }
+
+  fun withTotalBeds(totalBeds: Int) = apply {
+    this.totalBeds = { totalBeds }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withProbationRegionId(probationRegionId: UUID) = apply {
+    this.probationRegionId = { probationRegionId }
+  }
+
+  fun withLocalAuthorityAreaId(localAuthorityAreaId: UUID) = apply {
+    this.localAuthorityAreaId = { localAuthorityAreaId }
+  }
+
+  fun withCharacteristicIds(characteristicIds: List<UUID>) = apply {
+    this.characteristicIds = { characteristicIds }
+  }
+
+  fun withStatus(status: PropertyStatus) = apply {
+    this.status = { status }
+  }
+
+  fun withApCode(apCode: String) = apply {
+    this.apCode = { apCode }
+  }
+
+  fun withQCode(qCode: String) = apply {
+    this.qCode = { qCode }
+  }
+
+  override fun produce() = ApprovedPremisesSeedCsvRow(
+    id = this.id(),
+    name = this.name(),
+    addressLine1 = this.addressLine1(),
+    postcode = this.postcode(),
+    totalBeds = this.totalBeds(),
+    notes = this.notes(),
+    probationRegionId = this.probationRegionId(),
+    localAuthorityAreaId = this.localAuthorityAreaId(),
+    characteristicIds = this.characteristicIds(),
+    status = this.status(),
+    apCode = this.apCode(),
+    qCode = this.qCode()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
@@ -17,13 +17,13 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class SeedApprovedPremisesTest : SeedTestBase() {
   @Test
-  fun `Attempting to create an Approved Premises with an invalid Probation Region Id logs an error`() {
+  fun `Attempting to create an Approved Premises with an invalid Probation Region logs an error`() {
     withCsv(
       "invalid-probation",
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
-            .withProbationRegionId(UUID.fromString("012ec12b-a915-40d4-800a-8c89cc801486"))
+            .withProbationRegion("Not Real Region")
             .produce()
         )
       )
@@ -35,7 +35,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       it.level == "error" &&
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Probation Region 012ec12b-a915-40d4-800a-8c89cc801486 does not exist"
+        it.throwable.cause!!.message == "Probation Region Not Real Region does not exist"
     }
   }
 
@@ -50,8 +50,8 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
-            .withProbationRegionId(probationRegion.id)
-            .withLocalAuthorityAreaId(UUID.fromString("79aa2e39-3c88-4957-be74-a2047694195d"))
+            .withProbationRegion(probationRegion.name)
+            .withLocalAuthorityArea("Not Real Authority")
             .produce()
         )
       )
@@ -63,7 +63,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       it.level == "error" &&
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Local Authority Area 79aa2e39-3c88-4957-be74-a2047694195d does not exist"
+        it.throwable.cause!!.message == "Local Authority Area Not Real Authority does not exist"
     }
   }
 
@@ -76,25 +76,25 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
     withCsv(
-      "invalid-probation",
+      "invalid-characteristic",
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
-            .withProbationRegionId(probationRegion.id)
-            .withLocalAuthorityAreaId(localAuthorityArea.id)
-            .withCharacteristicIds(listOf(UUID.fromString("8e04628f-2cdd-4d9a-8ae7-27689d7daa73")))
+            .withProbationRegion(probationRegion.name)
+            .withLocalAuthorityArea(localAuthorityArea.name)
+            .withCharacteristics(listOf("Not Real Characteristic"))
             .produce()
         )
       )
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-probation")
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-characteristic")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Characteristic 8e04628f-2cdd-4d9a-8ae7-27689d7daa73 does not exist"
+        it.throwable.cause!!.message == "Characteristic Not Real Characteristic does not exist"
     }
   }
 
@@ -116,9 +116,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
-            .withProbationRegionId(probationRegion.id)
-            .withLocalAuthorityAreaId(localAuthorityArea.id)
-            .withCharacteristicIds(listOf(characteristic.id))
+            .withProbationRegion(probationRegion.name)
+            .withLocalAuthorityArea(localAuthorityArea.name)
+            .withCharacteristics(listOf(characteristic.name))
             .produce()
         )
       )
@@ -153,9 +153,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
-            .withProbationRegionId(probationRegion.id)
-            .withLocalAuthorityAreaId(localAuthorityArea.id)
-            .withCharacteristicIds(listOf(characteristic.id))
+            .withProbationRegion(probationRegion.name)
+            .withLocalAuthorityArea(localAuthorityArea.name)
+            .withCharacteristics(listOf(characteristic.name))
             .produce()
         )
       )
@@ -187,9 +187,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     val csvRow = ApprovedPremisesSeedCsvRowFactory()
       .withId(UUID.randomUUID())
-      .withProbationRegionId(probationRegion.id)
-      .withLocalAuthorityAreaId(localAuthorityArea.id)
-      .withCharacteristicIds(listOf(characteristic.id))
+      .withProbationRegion(probationRegion.name)
+      .withLocalAuthorityArea(localAuthorityArea.name)
+      .withCharacteristics(listOf(characteristic.name))
       .produce()
 
     withCsv(
@@ -212,9 +212,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     assertThat(persistedApprovedPremises.postcode).isEqualTo(csvRow.postcode)
     assertThat(persistedApprovedPremises.totalBeds).isEqualTo(csvRow.totalBeds)
     assertThat(persistedApprovedPremises.notes).isEqualTo(csvRow.notes)
-    assertThat(persistedApprovedPremises.probationRegion.id).isEqualTo(csvRow.probationRegionId)
-    assertThat(persistedApprovedPremises.localAuthorityArea.id).isEqualTo(csvRow.localAuthorityAreaId)
-    assertThat(persistedApprovedPremises.characteristics.map { it.id }).isEqualTo(csvRow.characteristicIds)
+    assertThat(persistedApprovedPremises.probationRegion.name).isEqualTo(csvRow.probationRegion)
+    assertThat(persistedApprovedPremises.localAuthorityArea.name).isEqualTo(csvRow.localAuthorityArea)
+    assertThat(persistedApprovedPremises.characteristics.map { it.name }).isEqualTo(csvRow.characteristics)
     assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
   }
 
@@ -241,9 +241,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     val csvRow = ApprovedPremisesSeedCsvRowFactory()
       .withId(existingApprovedPremises.id)
-      .withProbationRegionId(updatedProbationRegion.id)
-      .withLocalAuthorityAreaId(updatedLocalAuthorityArea.id)
-      .withCharacteristicIds(emptyList())
+      .withProbationRegion(updatedProbationRegion.name)
+      .withLocalAuthorityArea(updatedLocalAuthorityArea.name)
+      .withCharacteristics(emptyList())
       .produce()
 
     withCsv(
@@ -266,9 +266,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     assertThat(persistedApprovedPremises.postcode).isEqualTo(csvRow.postcode)
     assertThat(persistedApprovedPremises.totalBeds).isEqualTo(csvRow.totalBeds)
     assertThat(persistedApprovedPremises.notes).isEqualTo(csvRow.notes)
-    assertThat(persistedApprovedPremises.probationRegion.id).isEqualTo(csvRow.probationRegionId)
-    assertThat(persistedApprovedPremises.localAuthorityArea.id).isEqualTo(csvRow.localAuthorityAreaId)
-    assertThat(persistedApprovedPremises.characteristics.map { it.id }).isEqualTo(csvRow.characteristicIds)
+    assertThat(persistedApprovedPremises.probationRegion.name).isEqualTo(csvRow.probationRegion)
+    assertThat(persistedApprovedPremises.localAuthorityArea.name).isEqualTo(csvRow.localAuthorityArea)
+    assertThat(persistedApprovedPremises.characteristics.map { it.name }).isEqualTo(csvRow.characteristics)
     assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
   }
 
@@ -298,9 +298,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
         .withQuotedField(it.postcode)
         .withUnquotedField(it.totalBeds)
         .withQuotedFields(it.notes)
-        .withQuotedField(it.probationRegionId)
-        .withQuotedField(it.localAuthorityAreaId)
-        .withQuotedField(it.characteristicIds.joinToString(","))
+        .withQuotedField(it.probationRegion)
+        .withQuotedField(it.localAuthorityArea)
+        .withQuotedField(it.characteristics.joinToString(","))
         .withQuotedField(it.status.value)
         .withQuotedField(it.apCode)
         .withQuotedField(it.qCode)
@@ -318,9 +318,9 @@ class ApprovedPremisesSeedCsvRowFactory : Factory<ApprovedPremisesSeedCsvRow> {
   private var postcode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var totalBeds: Yielded<Int> = { randomInt(5, 50) }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
-  private var probationRegionId: Yielded<UUID> = { UUID.randomUUID() }
-  private var localAuthorityAreaId: Yielded<UUID> = { UUID.randomUUID() }
-  private var characteristicIds: Yielded<List<UUID>> = { listOf() }
+  private var probationRegion: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
+  private var localAuthorityArea: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
+  private var characteristics: Yielded<List<String>> = { listOf() }
   private var status: Yielded<PropertyStatus> = { PropertyStatus.active }
   private var apCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var qCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
@@ -349,16 +349,16 @@ class ApprovedPremisesSeedCsvRowFactory : Factory<ApprovedPremisesSeedCsvRow> {
     this.notes = { notes }
   }
 
-  fun withProbationRegionId(probationRegionId: UUID) = apply {
-    this.probationRegionId = { probationRegionId }
+  fun withProbationRegion(probationRegion: String) = apply {
+    this.probationRegion = { probationRegion }
   }
 
-  fun withLocalAuthorityAreaId(localAuthorityAreaId: UUID) = apply {
-    this.localAuthorityAreaId = { localAuthorityAreaId }
+  fun withLocalAuthorityArea(localAuthorityArea: String) = apply {
+    this.localAuthorityArea = { localAuthorityArea }
   }
 
-  fun withCharacteristicIds(characteristicIds: List<UUID>) = apply {
-    this.characteristicIds = { characteristicIds }
+  fun withCharacteristics(characteristics: List<String>) = apply {
+    this.characteristics = { characteristics }
   }
 
   fun withStatus(status: PropertyStatus) = apply {
@@ -380,9 +380,9 @@ class ApprovedPremisesSeedCsvRowFactory : Factory<ApprovedPremisesSeedCsvRow> {
     postcode = this.postcode(),
     totalBeds = this.totalBeds(),
     notes = this.notes(),
-    probationRegionId = this.probationRegionId(),
-    localAuthorityAreaId = this.localAuthorityAreaId(),
-    characteristicIds = this.characteristicIds(),
+    probationRegion = this.probationRegion(),
+    localAuthorityArea = this.localAuthorityArea(),
+    characteristics = this.characteristics(),
     status = this.status(),
     apCode = this.apCode(),
     qCode = this.qCode()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedScaffoldingTest.kt
@@ -1,46 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
-import com.ninjasquad.springmockk.MockkBean
-import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
-import java.nio.file.Files
-import java.nio.file.StandardOpenOption
-import kotlin.io.path.Path
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
-class SeedTest : IntegrationTestBase() {
-  @Autowired
-  lateinit var seedService: SeedService
-
-  @Value("\${seed.file-prefix}")
-  lateinit var seedFilePrefix: String
-
-  @MockkBean
-  lateinit var mockSeedLogger: SeedLogger
-  private val logEntries = mutableListOf<LogEntry>()
-
-  @BeforeEach
-  fun setUp() {
-    every { mockSeedLogger.info(any()) } answers {
-      logEntries += LogEntry(it.invocation.args[0] as String, "info", null)
-    }
-    every { mockSeedLogger.error(any()) } answers {
-      logEntries += LogEntry(it.invocation.args[0] as String, "error", null)
-    }
-    every { mockSeedLogger.error(any(), any()) } answers {
-      logEntries += LogEntry(it.invocation.args[0] as String, "error", it.invocation.args[1] as Throwable)
-    }
-  }
-
+class SeedScaffoldingTest : SeedTestBase() {
   @Test
   fun `Requesting a Seed operation returns 202`() {
     webTestClient.post()
@@ -132,17 +99,4 @@ f5fb56ad-54ed-46e9-8c0e-c1e8581cfd5d,An AP,Address 1,PC1PC2,12,Notes,384b8abb-f3
         it.throwable.cause!!.message == "Fields num seems to be 12 on each row, but on 2th csv row, fields num is 4."
     }
   }
-
-  private fun withCsv(csvName: String, contents: String) {
-    if (! Files.isDirectory(Path(seedFilePrefix))) {
-      Files.createDirectory(Path(seedFilePrefix))
-    }
-    Files.writeString(Path("$seedFilePrefix/$csvName.csv"), contents, StandardOpenOption.CREATE)
-  }
 }
-
-data class LogEntry(
-  val message: String,
-  val level: String,
-  val throwable: Throwable?
-)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTestBase.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.Path
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+abstract class SeedTestBase : IntegrationTestBase() {
+  @Autowired
+  lateinit var seedService: SeedService
+
+  @Value("\${seed.file-prefix}")
+  lateinit var seedFilePrefix: String
+
+  @MockkBean
+  lateinit var mockSeedLogger: SeedLogger
+  protected val logEntries = mutableListOf<LogEntry>()
+
+  @BeforeEach
+  fun setUp() {
+    every { mockSeedLogger.info(any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "info", null)
+    }
+    every { mockSeedLogger.error(any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "error", null)
+    }
+    every { mockSeedLogger.error(any(), any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "error", it.invocation.args[1] as Throwable)
+    }
+  }
+
+  protected fun withCsv(csvName: String, contents: String) {
+    if (!Files.isDirectory(Path(seedFilePrefix))) {
+      Files.createDirectory(Path(seedFilePrefix))
+    }
+    Files.writeString(
+      Path("$seedFilePrefix/$csvName.csv"), contents,
+      StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
+    )
+  }
+}
+
+data class LogEntry(
+  val message: String,
+  val level: String,
+  val throwable: Throwable?
+)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,9 @@ spring:
     locations: classpath:db/migration/all
   jpa:
     database: postgresql
+    properties:
+      hibernate:
+        enable_lazy_load_no_trans: true
   redis:
     host: localhost
     port: 6377


### PR DESCRIPTION
This can be triggered by placing a CSV file in the `/seed` directory (in dev etc.) or `./seed` when running locally with the following format:

```
id,name,addressLine1,postcode,totalBeds,notes,probationRegionId,localAuthorityAreaId,characteristicIds,status,apCode,qCode
...
```

The job is then started by sending a POST to `/seed` from within the container (or just from postman if running locally) with the following body (where our CSV file is named `ap-upload.csv`):

```
{
    "seedType": "approved_premises",
    "fileName": "ap-upload"
}
```

This will return a 202 Accepted to indicate the job has been started.  You can then monitor the progress of the job from the API logs.

An initial pass is made to ensure each row can be deserialized (e.g. are UUIDs well formed, do we have integers where we need them etc.)  If any rows fails this stage then no processing will happen and an error will be logged explaining the issue that needs to be remediated.

The processing then begins.  For each row, IDs are checked first to ensure they actually correspond to real entities (e.g. for Local Authority Areas and Characteristics) then the Premises is either created or updated if it already exists.

Processing happens synchronously, if any row fails the job will stop.