### PR TITLE
903 user role seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,5 @@ sonar-project.properties
 
 nomis-db/
 
-test-seed-csvs/
-seed/
+test-seed-csvs/**
+seed/**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -50,6 +50,7 @@ data class UserEntity(
   val qualifications: MutableList<UserQualificationAssignmentEntity>
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
+  fun hasQualification(userQualification: UserQualification) = qualifications.any { it.qualification === userQualification }
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
+
+class UsersSeedJob(
+  fileName: String,
+  private val userService: UserService
+) : SeedJob<UsersSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredColumns = 2
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = UsersSeedCsvRow(
+    deliusUsername = columns["deliusUsername"]!!,
+    roles = parseAllRolesOrThrow(columns["roles"]!!.split(",").filter(String::isNotBlank)),
+    qualifications = parseAllQualificationsOrThrow(columns["qualifications"]!!.split(",").filter(String::isNotBlank))
+  )
+
+  private fun parseAllRolesOrThrow(roleNames: List<String>): List<UserRole> {
+    val unknownRoles = mutableListOf<String>()
+
+    val roles = roleNames.mapNotNull {
+      try {
+        UserRole.valueOf(it)
+      } catch (_: Exception) {
+        unknownRoles += it
+        null
+      }
+    }
+
+    if (unknownRoles.any()) {
+      throw RuntimeException("Unrecognised User Role(s): $unknownRoles")
+    }
+
+    return roles
+  }
+
+  private fun parseAllQualificationsOrThrow(qualificationNames: List<String>): List<UserQualification> {
+    val unknownQualifications = mutableListOf<String>()
+
+    val roles = qualificationNames.mapNotNull {
+      try {
+        UserQualification.valueOf(it)
+      } catch (_: Exception) {
+        unknownQualifications += it
+        null
+      }
+    }
+
+    if (unknownQualifications.any()) {
+      throw RuntimeException("Unrecognised User Qualifications(s): $unknownQualifications")
+    }
+
+    return roles
+  }
+
+  override fun processRow(row: UsersSeedCsvRow) {
+    log.info("Setting roles for ${row.deliusUsername} to exactly ${row.roles.joinToString(",")}, qualifications to exactly: ${row.qualifications.joinToString(",")}")
+
+    val user = try {
+      userService.getUserForUsername(row.deliusUsername)
+    } catch (exception: Exception) {
+      throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
+    }
+
+    userService.clearRoles(user)
+    userService.clearQualifications(user)
+    row.roles.forEach {
+      userService.addRoleToUser(user, it)
+    }
+    row.qualifications.forEach {
+      userService.addQualificationToUser(user, it)
+    }
+  }
+}
+
+data class UsersSeedCsvRow(
+  val deliusUsername: String,
+  val roles: List<UserRole>,
+  val qualifications: List<UserQualification>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -4,19 +4,31 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentRepository
 import java.util.UUID
 
 @Service
 class UserService(
   private val httpAuthService: HttpAuthService,
   private val communityApiClient: CommunityApiClient,
-  private val userRepository: UserRepository
+  private val userRepository: UserRepository,
+  private val userRoleAssignmentRepository: UserRoleAssignmentRepository,
+  private val userQualificationAssignmentRepository: UserQualificationAssignmentRepository
 ) {
   fun getUserForRequest(): UserEntity {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
 
+    return getUserForUsername(username)
+  }
+
+  fun getUserForUsername(username: String): UserEntity {
     val existingUser = userRepository.findByDeliusUsername(username)
     if (existingUser != null) return existingUser
 
@@ -38,5 +50,41 @@ class UserService(
         qualifications = mutableListOf()
       )
     )
+  }
+
+  fun addRoleToUser(user: UserEntity, role: UserRole) {
+    if (user.hasRole(role)) return
+
+    user.roles.add(
+      userRoleAssignmentRepository.save(
+        UserRoleAssignmentEntity(
+          id = UUID.randomUUID(),
+          user = user,
+          role = role
+        )
+      )
+    )
+  }
+
+  fun addQualificationToUser(user: UserEntity, qualification: UserQualification) {
+    if (user.hasQualification(qualification)) return
+
+    user.qualifications.add(
+      userQualificationAssignmentRepository.save(
+        UserQualificationAssignmentEntity(
+          id = UUID.randomUUID(),
+          user = user,
+          qualification = qualification
+        )
+      )
+    )
+  }
+
+  fun clearRoles(user: UserEntity) {
+    userRoleAssignmentRepository.deleteAllById(user.roles.map(UserRoleAssignmentEntity::id))
+  }
+
+  fun clearQualifications(user: UserEntity) {
+    userQualificationAssignmentRepository.deleteAllById(user.qualifications.map(UserQualificationAssignmentEntity::id))
   }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3595,3 +3595,4 @@ components:
       type: string
       enum:
         - approved_premises
+        - user

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -395,4 +395,13 @@ abstract class IntegrationTestBase {
           )
       )
   )
+
+  fun mockStaffUserInfoCommunityApiCallNotFound(username: String) = wiremockServer.stubFor(
+    WireMock.get(urlEqualTo("/secure/staff/username/$username"))
+      .willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(404)
+      )
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
@@ -1,0 +1,232 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedUserRoleAssignmentsTest : SeedTestBase() {
+  @Test
+  fun `Attempting to seed a non existent user logs an error`() {
+    mockStaffUserInfoCommunityApiCallNotFound("invalid-user")
+
+    withCsv(
+      "invalid-user",
+      userRoleAssignmentSeedCsvRowsToCsv(
+        listOf(
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername("invalid-user")
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.user, "invalid-user")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.cause != null &&
+        it.throwable.cause!!.message == "Could not get user invalid-user"
+    }
+  }
+
+  @Test
+  fun `Attempting to seed a real but currently unknown user succeeds`() {
+    mockClientCredentialsJwtRequest()
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername("unknown-user")
+        .withStaffIdentifier(6789)
+        .produce()
+    )
+
+    withCsv(
+      "unknown-user",
+      userRoleAssignmentSeedCsvRowsToCsv(
+        listOf(
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername("unknown-user")
+            .withTypedRoles(listOf(UserRole.ASSESSOR, UserRole.WORKFLOW_MANAGER))
+            .withTypedQualifications(listOf(UserQualification.PIPE))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.user, "unknown-user")
+
+    val persistedUser = userRepository.findByDeliusUsername("unknown-user")
+
+    assertThat(persistedUser).isNotNull
+    assertThat(persistedUser!!.deliusStaffIdentifier).isEqualTo(6789)
+    assertThat(persistedUser.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
+      UserRole.ASSESSOR,
+      UserRole.WORKFLOW_MANAGER
+    )
+    assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification)).containsExactlyInAnyOrder(
+      UserQualification.PIPE
+    )
+  }
+
+  @Test
+  fun `Attempting to assign roles to a currently known user succeeds`() {
+    userEntityFactory.produceAndPersist {
+      withDeliusUsername("known-user")
+    }
+
+    withCsv(
+      "known-user",
+      userRoleAssignmentSeedCsvRowsToCsv(
+        listOf(
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername("known-user")
+            .withTypedRoles(listOf(UserRole.ASSESSOR, UserRole.WORKFLOW_MANAGER))
+            .withTypedQualifications(listOf(UserQualification.PIPE))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.user, "known-user")
+
+    val persistedUser = userRepository.findByDeliusUsername("known-user")
+
+    assertThat(persistedUser).isNotNull
+    assertThat(persistedUser!!.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
+      UserRole.ASSESSOR,
+      UserRole.WORKFLOW_MANAGER
+    )
+    assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification)).containsExactlyInAnyOrder(
+      UserQualification.PIPE
+    )
+  }
+
+  @Test
+  fun `Attempting to assign a non-existent role logs an error`() {
+    userEntityFactory.produceAndPersist {
+      withDeliusUsername("known-user")
+    }
+
+    withCsv(
+      "unknown-role",
+      userRoleAssignmentSeedCsvRowsToCsv(
+        listOf(
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername("known-user")
+            .withUntypedRoles(listOf("WORKFLOW_MANAGEF"))
+            .withTypedQualifications(listOf(UserQualification.PIPE))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.user, "unknown-role")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Unrecognised User Role(s): [WORKFLOW_MANAGEF]")
+    }
+  }
+
+  @Test
+  fun `Attempting to assign a non-existent qualification logs an error`() {
+    userEntityFactory.produceAndPersist {
+      withDeliusUsername("known-user")
+    }
+
+    withCsv(
+      "unknown-qualification",
+      userRoleAssignmentSeedCsvRowsToCsv(
+        listOf(
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername("known-user")
+            .withUntypedQualifications(listOf("PIPEE"))
+            .produce()
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.user, "unknown-qualification")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Unrecognised User Qualifications(s): [PIPEE]")
+    }
+  }
+
+  private fun userRoleAssignmentSeedCsvRowsToCsv(rows: List<UsersSeedUntypedEnumsCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "deliusUsername",
+        "roles",
+        "qualifications"
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.deliusUsername)
+        .withQuotedField(it.roles.joinToString(","))
+        .withQuotedField(it.qualifications.joinToString(","))
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}
+
+class UserRoleAssignmentsSeedCsvRowFactory : Factory<UsersSeedUntypedEnumsCsvRow> {
+  private var deliusUsername: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var roles: Yielded<List<String>> = { listOf(UserRole.ASSESSOR.name) }
+  private var qualifications: Yielded<List<String>> = { listOf(UserQualification.PIPE.name) }
+
+  fun withDeliusUsername(deliusUsername: String) = apply {
+    this.deliusUsername = { deliusUsername }
+  }
+
+  fun withTypedRoles(roles: List<UserRole>) = apply {
+    this.roles = { roles.map { it.name } }
+  }
+
+  fun withUntypedRoles(roles: List<String>) = apply {
+    this.roles = { roles }
+  }
+
+  fun withTypedQualifications(qualifications: List<UserQualification>) = apply {
+    this.qualifications = { qualifications.map { it.name } }
+  }
+
+  fun withUntypedQualifications(qualifications: List<String>) = apply {
+    this.qualifications = { qualifications }
+  }
+
+  override fun produce() = UsersSeedUntypedEnumsCsvRow(
+    deliusUsername = this.deliusUsername(),
+    roles = this.roles(),
+    qualifications = this.qualifications()
+  )
+}
+
+data class UsersSeedUntypedEnumsCsvRow(
+  val deliusUsername: String,
+  val roles: List<String>,
+  val qualifications: List<String>
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/UserTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/UserTestRepository.kt
@@ -8,7 +8,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssig
 import java.util.UUID
 
 @Repository
-interface UserTestRepository : JpaRepository<UserEntity, UUID>
+interface UserTestRepository : JpaRepository<UserEntity, UUID> {
+  fun findByDeliusUsername(deliusUsername: String): UserEntity?
+}
 
 @Repository
 interface UserRoleAssignmentTestRepository : JpaRepository<UserRoleAssignmentEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -12,7 +12,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
@@ -20,8 +22,16 @@ class UserServiceTest {
   private val mockHttpAuthService = mockk<HttpAuthService>()
   private val mockCommunityApiClient = mockk<CommunityApiClient>()
   private val mockUserRepository = mockk<UserRepository>()
+  private val mockUserRoleAssignmentRepository = mockk<UserRoleAssignmentRepository>()
+  private val mockUserQualificationAssignmentRepository = mockk<UserQualificationAssignmentRepository>()
 
-  private val userService = UserService(mockHttpAuthService, mockCommunityApiClient, mockUserRepository)
+  private val userService = UserService(
+    mockHttpAuthService,
+    mockCommunityApiClient,
+    mockUserRepository,
+    mockUserRoleAssignmentRepository,
+    mockUserQualificationAssignmentRepository
+  )
 
   @Test
   fun `getUserForRequest returns existing User when exists, does not call Community API or save`() {


### PR DESCRIPTION
This can be triggered by placing a CSV file in the /seed directory (in dev etc.) or ./seed when running locally with the following format:
```
deliusUsername,roles,qualifications
SomeOne,"ASSESSOR,WORKFLOW_MANAGER","WOMENS,PIPE"
...
```

The job is then started by sending a POST to /seed from within the container (or just from postman if running locally) with the following body (where our CSV file is named user-upload.csv):
```
{
    "seedType": "user",
    "fileName": "user-upload"
}
```
This will return a 202 Accepted to indicate the job has been started. You can then monitor the progress of the job from the API logs.

An initial pass is made to ensure each row can be deserialized. If any rows fails this stage then no processing will happen and an error will be logged explaining the issue that needs to be remediated.

For each user, if they exist in Delius but not yet in our users table, then they are fetchedd from Delius.  If we already have them in our table then just the roles are set.  Roles are set to exactly what is provided in the CSV so any existing role assignments are removed.

