### PR TITLE
Provide user reports of all bookings/bookings for a region

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
 
   implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.7.0")
 
+  implementation("org.jetbrains.kotlinx:dataframe:0.8.1")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.3")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.Resource
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReportsApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ReportService
+import java.io.ByteArrayOutputStream
+import java.util.UUID
+
+@Service
+class ReportsController(
+  private val reportService: ReportService,
+) : ReportsApiDelegate {
+  override fun reportsBookingsGet(xServiceName: ServiceName, probationRegionId: UUID?): ResponseEntity<Resource> {
+    val properties = BookingsReportProperties(xServiceName, probationRegionId)
+    val outputStream = ByteArrayOutputStream()
+
+    reportService.createBookingsReport(properties, outputStream)
+
+    return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
+
+import org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+class BookingsReportGenerator : ReportGenerator<BookingEntity, BookingsReportRow, BookingsReportProperties>() {
+
+  override val convert: CreateDataFrameDsl<BookingEntity>.() -> Unit = {
+    BookingsReportRow::probationRegion from { it.premises.probationRegion.name }
+    BookingsReportRow::crn from { it.crn }
+    BookingsReportRow::offerAccepted from { it.confirmation != null }
+    BookingsReportRow::isCancelled from { it.cancellation != null }
+    BookingsReportRow::cancellationReason from { it.cancellation?.reason?.name }
+    BookingsReportRow::startDate from { it.arrival?.arrivalDate }
+    BookingsReportRow::endDate from { it.arrival?.expectedDepartureDate }
+    BookingsReportRow::actualEndDate from { it.departure?.dateTime?.toLocalDate() }
+    BookingsReportRow::currentNightsStayed from { entity ->
+      entity.arrival?.arrivalDate?.let { ChronoUnit.DAYS.between(it, LocalDate.now()).toInt() }
+    }
+    BookingsReportRow::actualNightsStayed from { entity ->
+      val arrivalDate = entity.arrival?.arrivalDate ?: return@from null
+      entity.departure?.dateTime?.let { ChronoUnit.DAYS.between(arrivalDate, it.toLocalDate()).toInt() }
+    }
+    BookingsReportRow::accommodationOutcome from { it.departure?.moveOnCategory?.name }
+  }
+
+  override fun filter(properties: BookingsReportProperties): (BookingEntity) -> Boolean = {
+    it.service == properties.serviceName.value &&
+      (properties.probationRegionId == null || it.premises.probationRegion.id == properties.probationRegionId)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ReportGenerator.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
+
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+
+abstract class ReportGenerator<Input, Output, Properties> {
+  protected abstract fun filter(properties: Properties): (Input) -> Boolean
+  protected abstract val convert: CreateDataFrameDsl<Input>.() -> Unit
+
+  fun createReport(data: List<Input>, properties: Properties): DataFrame<Output> {
+    val filter = filter(properties)
+    val convert = convertUnchecked()
+
+    // Small amount of jiggery-pokery here to coerce the DataFrame into the desired type.
+    // The extension method `Iterable<T>.toDataFrame()` requires its type parameters to be
+    // reifiable, which they aren't here.
+    // This seems overly cautious as DataFrame allows reshaping of the columns pretty much at will,
+    // but casting the input items as Any will allow it to work, as long as the converter DSL
+    // closure is also cast to accept an Any.
+    // From there we can call `DataFrame.cast()` to get it to be the desired `DataFrame<Output>`
+    // type.
+    return data.filter(filter)
+      .map { it as Any }
+      .toDataFrame(convert)
+      .cast()
+  }
+
+  // This cast of the `convert` closure to use Any as the type parameter is safe as in practice
+  // it will only ever have items of the type specified by the type parameter `Input`.
+  @Suppress("UNCHECKED_CAST")
+  private fun convertUnchecked(): CreateDataFrameDsl<Any>.() -> Unit = convert as CreateDataFrameDsl<Any>.() -> Unit
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import java.time.LocalDate
+
+data class BookingsReportRow(
+  val probationRegion: String,
+  val crn: String,
+  val offerAccepted: Boolean,
+  val isCancelled: Boolean,
+  val cancellationReason: String?,
+  val startDate: LocalDate?,
+  val endDate: LocalDate?,
+  val actualEndDate: LocalDate?,
+  val currentNightsStayed: Int?,
+  val actualNightsStayed: Int?,
+  val accommodationOutcome: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BookingsReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BookingsReportProperties.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import java.util.UUID
+
+data class BookingsReportProperties(
+  val serviceName: ServiceName,
+  val probationRegionId: UUID?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.apache.poi.ss.usermodel.WorkbookFactory
+import org.jetbrains.kotlinx.dataframe.io.writeExcel
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import java.io.OutputStream
+
+@Service
+class ReportService(
+  private val bookingRepository: BookingRepository
+) {
+  fun createBookingsReport(properties: BookingsReportProperties, outputStream: OutputStream) {
+    BookingsReportGenerator()
+      .createReport(bookingRepository.findAll(), properties)
+      .writeExcel(outputStream) {
+        WorkbookFactory.create(true)
+      }
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1949,6 +1949,33 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reports/bookings:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet of all bookings for the specified service and (optional) region.
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Only bookings for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+        - name: probationRegionId
+          in: query
+          required: false
+          description: If provided, only bookings for this region will be returned
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: Successfully retrieved the report
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
 components:
   responses:
     401Response:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.io.readExcel
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+
+class ReportsTest : IntegrationTestBase() {
+  @Test
+  fun `Get bookings report returns OK with correct body`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    val keyWorker = ContextStaffMemberFactory().produce()
+    mockStaffMembersContextApiCall(keyWorker, premises.qCode)
+
+    val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
+      withPremises(premises)
+      withServiceName(ServiceName.approvedPremises)
+      withStaffKeyWorkerCode(keyWorker.code)
+      withCrn("CRN123")
+    }
+
+    bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+    bookings[2].let {
+      it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+      it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
+      it.departure = departureEntityFactory.produceAndPersist {
+        withBooking(it)
+        withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
+        withYieldedReason { departureReasonEntityFactory.produceAndPersist() }
+        withYieldedMoveOnCategory { moveOnCategoryEntityFactory.produceAndPersist() }
+      }
+    }
+    bookings[3].let {
+      it.cancellation = cancellationEntityFactory.produceAndPersist {
+        withBooking(it)
+        withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+      }
+    }
+    bookings[4].let {
+      it.nonArrival = nonArrivalEntityFactory.produceAndPersist {
+        withBooking(it)
+        withYieldedReason { nonArrivalReasonEntityFactory.produceAndPersist() }
+      }
+    }
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn("CRN123")
+      .withNomsNumber("NOMS321")
+      .produce()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+    val expectedDataFrame = BookingsReportGenerator()
+      .createReport(bookings, BookingsReportProperties(ServiceName.approvedPremises, null))
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reports/bookings")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.approvedPremises.value)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .consumeWith {
+        val actual = DataFrame
+          .readExcel(it.responseBody!!.inputStream())
+          .convertTo<BookingsReportRow>(ExcessiveColumns.Remove)
+        assertThat(actual).isEqualTo(expectedDataFrame)
+      }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -1,0 +1,578 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.generator
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class BookingsReportGeneratorTest {
+  private val reportGenerator = BookingsReportGenerator()
+
+  @Test
+  fun `Only bookings from the specified service are returned in the report`() {
+    val approvedPremisesBookings = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produceMany()
+      .take(5)
+      .toList()
+
+    val temporaryAccommodationBookings = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produceMany()
+      .take(4)
+      .toList()
+
+    val allBookings = approvedPremisesBookings + temporaryAccommodationBookings
+
+    val actual1 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual1.count()).isEqualTo(5)
+
+    val actual2 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual2.count()).isEqualTo(4)
+  }
+
+  @Test
+  fun `Only bookings from the specified probation region are returned in the report`() {
+    val probationRegionId = UUID.randomUUID()
+
+    val expectedBookings = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withId(probationRegionId)
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produceMany()
+      .take(5)
+      .toList()
+
+    val unexpectedBookings = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produceMany()
+      .take(4)
+      .toList()
+
+    val allBookings = expectedBookings + unexpectedBookings
+
+    val actual = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, probationRegionId))
+    assertThat(actual.count()).isEqualTo(5)
+  }
+
+  @Test
+  fun `Bookings from all probation regions are returned in the report if no probation region ID is provided`() {
+    val expectedBookings = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produceMany()
+      .take(5)
+      .toList()
+
+    val actual = reportGenerator.createReport(expectedBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(5)
+  }
+
+  @Test
+  fun `The probation region name is returned in the report`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withName("East of England")
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::probationRegion]).isEqualTo("East of England")
+  }
+
+  @Test
+  fun `The CRN is returned in the report`() {
+    val booking = BookingEntityFactory()
+      .withCrn("X123456")
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::crn]).isEqualTo("X123456")
+  }
+
+  @Test
+  fun `The 'offer accepted' column is true in the report if the booking was confirmed`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.confirmation = ConfirmationEntityFactory()
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::offerAccepted]).isTrue
+  }
+
+  @Test
+  fun `The 'offer accepted' column is false in the report if the booking was not confirmed`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::offerAccepted]).isFalse
+  }
+
+  @Test
+  fun `The 'is cancelled' column is true and the cancellation reason is returned in the report if the booking was cancelled`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.cancellation = CancellationEntityFactory()
+      .withYieldedReason {
+        CancellationReasonEntityFactory()
+          .withName("House exploded")
+          .produce()
+      }
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::isCancelled]).isTrue
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::cancellationReason]).isEqualTo("House exploded")
+  }
+
+  @Test
+  fun `The 'is cancelled' column is false and no cancellation reason is returned in the report if the booking was not cancelled`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::isCancelled]).isFalse
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::cancellationReason]).isNull()
+  }
+
+  @Test
+  fun `The start and end dates are returned from the arrival in the report if it exists`() {
+    val today = LocalDate.now()
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.arrival = ArrivalEntityFactory()
+      .withArrivalDate(today)
+      .withExpectedDepartureDate(today.plusDays(84L))
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::startDate]).isEqualTo(today)
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::endDate]).isEqualTo(today.plusDays(84L))
+  }
+
+  @Test
+  fun `The start and end dates are not returned in the report if the booking has no arrival`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::startDate]).isNull()
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::endDate]).isNull()
+  }
+
+  @Test
+  fun `The actual end date is returned in the report if the booking has a departure`() {
+    val now = OffsetDateTime.now()
+    val today = now.toLocalDate()
+
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.departure = DepartureEntityFactory()
+      .withDateTime(now)
+      .withYieldedReason {
+        DepartureReasonEntityFactory()
+          .produce()
+      }
+      .withYieldedMoveOnCategory {
+        MoveOnCategoryEntityFactory()
+          .produce()
+      }
+      .withYieldedDestinationProvider {
+        DestinationProviderEntityFactory()
+          .produce()
+      }
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::actualEndDate]).isEqualTo(today)
+  }
+
+  @Test
+  fun `The actual end date is not returned in the report if the booking has no departure`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::actualEndDate]).isNull()
+  }
+
+  @Test
+  fun `The number of nights stayed so far is returned from the arrival in the report if it exists`() {
+    val today = LocalDate.now()
+    val arrivalDate = today.minusDays(37L)
+
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.arrival = ArrivalEntityFactory()
+      .withArrivalDate(arrivalDate)
+      .withExpectedDepartureDate(arrivalDate.plusDays(84L))
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isEqualTo(37)
+  }
+
+  @Test
+  fun `The number of nights stayed so far is not returned in the report if the booking has no arrival`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isNull()
+  }
+
+  @Test
+  fun `The actual number of nights stayed is returned in the report if the booking has a departure`() {
+    val now = OffsetDateTime.now()
+    val today = now.toLocalDate()
+    val expectedDepartureDate = today.minusDays(3L)
+    val arrivalDate = expectedDepartureDate.minusDays(84L)
+
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.arrival = ArrivalEntityFactory()
+      .withArrivalDate(arrivalDate)
+      .withExpectedDepartureDate(expectedDepartureDate)
+      .withBooking(booking)
+      .produce()
+
+    booking.departure = DepartureEntityFactory()
+      .withDateTime(now)
+      .withYieldedReason {
+        DepartureReasonEntityFactory()
+          .produce()
+      }
+      .withYieldedMoveOnCategory {
+        MoveOnCategoryEntityFactory()
+          .produce()
+      }
+      .withYieldedDestinationProvider {
+        DestinationProviderEntityFactory()
+          .produce()
+      }
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isEqualTo(87L)
+  }
+
+  @Test
+  fun `The actual number of nights stayed is returned in the report if the booking has no departure`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.approvedPremises)
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isNull()
+  }
+
+  @Test
+  fun `The accommodation outcome is returned from the departure in the report if it exists`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    booking.departure = DepartureEntityFactory()
+      .withYieldedReason {
+        DepartureReasonEntityFactory()
+          .produce()
+      }
+      .withYieldedMoveOnCategory {
+        MoveOnCategoryEntityFactory()
+          .withName("Joined the Space Force")
+          .produce()
+      }
+      .withYieldedDestinationProvider {
+        DestinationProviderEntityFactory()
+          .produce()
+      }
+      .withBooking(booking)
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::accommodationOutcome]).isEqualTo("Joined the Space Force")
+  }
+
+  @Test
+  fun `The accommodation outcome is not returned in the report if the booking has no departure`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::accommodationOutcome]).isNull()
+  }
+}


### PR DESCRIPTION
> See [ticket #639 on the CAS3 Trello board](https://trello.com/c/z61TtnJY/639-reporting-for-bookings).

This PR enables users to create reports by providing data about bookings in a spreadsheet format.

Changes in this PR:
- The `GET /reports/bookings` endpoint has been introduced. This endpoint has an optional `probationRegionId` query parameter which can be used for filtering bookings by probation region, or all bookings can be returned if this parameter is omitted. A successful request returns a response with `Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (i.e. an XLSX file) and the generated spreadsheet in the body.
- The concept of a report generator has been created. The `ReportGenerator` base class can be inherited to provide specific report functionality, such as the `BookingsReportGenerator`. A `ReportGenerator` implementation must specify its input, output, and configuration types. The report generators use the [Kotlin DataFrame](https://kotlin.github.io/dataframe/overview.html) library to provide the transformation and Excel serialization functionality.
- The `ReportService` class has been added to provide functionality to the API endpoint. `ReportService` methods are intended to use `ReportGenerator` instances to filter and transform the data, and are responsible for serializing the generated report to an `OutputStream`. 