### PR TITLE
Seed test environment with data

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -18,7 +18,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://api-dev.prison.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://dev.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
-    SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev
+    SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev,classpath:db/migration/test
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,10 +19,11 @@ spring:
         - "stdout"
 
   flyway:
+    repeatable-sql-migration-prefix: "R"
     sql-migration-prefix: ""
     outOfOrder: true
     locations: classpath:db/migration/all
-    placeholderReplacement: false
+    placeholderReplacement: true
 
   jpa:
     hibernate:

--- a/src/main/resources/db/migration/test/R__1_create_users.sql
+++ b/src/main/resources/db/migration/test/R__1_create_users.sql
@@ -1,0 +1,84 @@
+
+-- ${flyway:timestamp}
+TRUNCATE TABLE users CASCADE;
+
+  insert into
+    users (
+      "delius_staff_identifier",
+      "delius_username",
+      "id",
+      "name"
+    )
+  values
+    (
+      '43440',
+      'AP_TEST_USER_1',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'AP Test User 1'
+    );
+
+
+  insert into
+    users (
+      "delius_staff_identifier",
+      "delius_username",
+      "id",
+      "name"
+    )
+  values
+    (
+      '24065',
+      'AP_TEST_USER_2',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'AP Test User 2'
+    );
+
+
+  insert into
+    users (
+      "delius_staff_identifier",
+      "delius_username",
+      "id",
+      "name"
+    )
+  values
+    (
+      '95593',
+      'AP_TEST_USER_3',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'AP Test User 3'
+    );
+
+
+  insert into
+    users (
+      "delius_staff_identifier",
+      "delius_username",
+      "id",
+      "name"
+    )
+  values
+    (
+      '97381',
+      'AP_TEST_USER_4',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'AP Test User 4'
+    );
+
+
+  insert into
+    users (
+      "delius_staff_identifier",
+      "delius_username",
+      "id",
+      "name"
+    )
+  values
+    (
+      '60364',
+      'AP_TEST_USER_5',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'AP Test User 5'
+    );
+
+

--- a/src/main/resources/db/migration/test/R__1_create_users.sql
+++ b/src/main/resources/db/migration/test/R__1_create_users.sql
@@ -11,7 +11,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '43440',
+      '33763',
       'AP_TEST_USER_1',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'AP Test User 1'
@@ -27,7 +27,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '24065',
+      '14441',
       'AP_TEST_USER_2',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       'AP Test User 2'
@@ -43,7 +43,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '95593',
+      '96979',
       'AP_TEST_USER_3',
       '68715a03-06af-49ee-bae5-039c824ab9af',
       'AP Test User 3'
@@ -59,7 +59,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '97381',
+      '62704',
       'AP_TEST_USER_4',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       'AP Test User 4'
@@ -75,7 +75,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '60364',
+      '30751',
       'AP_TEST_USER_5',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'AP Test User 5'

--- a/src/main/resources/db/migration/test/R__2_create_bookings.sql
+++ b/src/main/resources/db/migration/test/R__2_create_bookings.sql
@@ -18,7 +18,7 @@ INSERT INTO
   )
 VALUES
   (
-    '02c669de-5cd4-4599-906f-9dd846a6977e',
+    '073ceefb-6bfb-4425-9b36-96bcb0330af3',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '315VWWC',
@@ -44,7 +44,7 @@ INSERT INTO
   )
 VALUES
   (
-    '47f7d7b7-09dd-4214-90a7-74b16c276566',
+    'cf38f87c-4d64-43d5-ad31-d0f0c03e65f7',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '4Y29R9P',
@@ -70,7 +70,7 @@ INSERT INTO
   )
 VALUES
   (
-    '170ed76c-97aa-46eb-a8c6-56465203ce03',
+    '58b8b2e1-0948-4374-82e4-27b1c848808e',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '4ZUIHFX',
@@ -97,7 +97,7 @@ INSERT INTO
   )
 VALUES
   (
-    'f453cd2f-258b-406b-9d59-3f91efc26a94',
+    '38be7810-55a5-448a-9b74-67d0ea2c6bea',
     CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     '52W7TQG',
@@ -123,7 +123,7 @@ INSERT INTO
   )
 VALUES
   (
-    '6035000f-c2e6-4474-b5cc-640cf9a60660',
+    '9ae6fefb-873b-44b8-bab0-ae4f58fef451',
     CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     '5EC66UT',
@@ -149,11 +149,11 @@ INSERT INTO
   )
 VALUES
   (
-    '7e64450c-c0ef-400d-a4f3-156d663f60ef',
-    CURRENT_DATE + 1,
+    '58888937-c0a6-4e4e-9d59-103ade3cdab3',
+    CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     'BWEFOI7',
-    CURRENT_DATE + 1,
+    CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
@@ -175,7 +175,7 @@ INSERT INTO
   )
 VALUES
   (
-    'e091ccf8-b61e-4587-9899-cc7673f38f1c',
+    'd5469aca-ada9-469e-b364-7a13972d537f',
     CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     'GSR1T2F',
@@ -202,7 +202,7 @@ INSERT INTO
   )
 VALUES
   (
-    'c6c17927-589b-4eb6-aca8-64fcd52fc620',
+    '08c1f449-114f-43bc-beb3-8f18fdb8b82e',
     CURRENT_DATE - 84,
     CURRENT_DATE,
     'HRV83TE',
@@ -226,10 +226,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    'c6c17927-589b-4eb6-aca8-64fcd52fc620',
+    '08c1f449-114f-43bc-beb3-8f18fdb8b82e',
     CURRENT_DATE,
     CURRENT_DATE,
-    '666aa21e-0e5b-460b-9f12-cba787bb2e21',
+    '31d49adc-e7b6-462d-9203-0f6d9a5d107e',
     NULL
   );
   
@@ -248,7 +248,7 @@ INSERT INTO
   )
 VALUES
   (
-    '4aabf4ac-43c9-40fa-9784-67463f489bb4',
+    '5471d52d-e622-45c1-ad4a-5c743a2238df',
     CURRENT_DATE - 84,
     CURRENT_DATE,
     'HTVI42B',
@@ -272,10 +272,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '4aabf4ac-43c9-40fa-9784-67463f489bb4',
+    '5471d52d-e622-45c1-ad4a-5c743a2238df',
     CURRENT_DATE,
     CURRENT_DATE,
-    'fcc5c100-a3c6-4ffb-8f62-838e76e19799',
+    '4f3bdce0-0403-4fbd-a033-76355e090b9b',
     NULL
   );
   
@@ -295,12 +295,12 @@ INSERT INTO
   )
 VALUES
   (
-    '7b1fd735-5634-464a-8fe2-3cda0ec029b5',
+    '5bc77984-a1bf-4441-831a-d0b02db8ede7',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 1,
+    CURRENT_DATE + 3,
     'HRV83TE',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 1,
+    CURRENT_DATE + 3,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
     CURRENT_DATE
@@ -319,10 +319,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '7b1fd735-5634-464a-8fe2-3cda0ec029b5',
+    '5bc77984-a1bf-4441-831a-d0b02db8ede7',
     CURRENT_DATE,
-    CURRENT_DATE + 1,
-    'd2b5426b-2647-4d3d-9c51-448bae3c3e82',
+    CURRENT_DATE + 3,
+    '640255ea-b8ec-4680-a942-8725cc713393',
     NULL
   );
   
@@ -341,7 +341,7 @@ INSERT INTO
   )
 VALUES
   (
-    '0a6cb591-84f1-468b-8a96-23fde59b8e8b',
+    '6124de81-31f6-40ef-8059-86f433f385e2',
     CURRENT_DATE - 84,
     CURRENT_DATE + 2,
     'HTVI42B',
@@ -365,10 +365,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '0a6cb591-84f1-468b-8a96-23fde59b8e8b',
+    '6124de81-31f6-40ef-8059-86f433f385e2',
     CURRENT_DATE,
     CURRENT_DATE + 2,
-    '82dca5e9-452b-4d77-a568-7691bd869190',
+    '0cd204c3-ea79-4595-9b8f-9f27a0bf57dd',
     NULL
   );
   
@@ -388,12 +388,12 @@ INSERT INTO
   )
 VALUES
   (
-    '2c684d44-0b32-4538-a23a-03b88d3e31c8',
+    'ad46c28a-883b-47ea-a746-eebd1feda4fa',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 44,
+    CURRENT_DATE + 7,
     'HUN3BN0',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 44,
+    CURRENT_DATE + 7,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
     CURRENT_DATE
@@ -412,10 +412,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '2c684d44-0b32-4538-a23a-03b88d3e31c8',
+    'ad46c28a-883b-47ea-a746-eebd1feda4fa',
     CURRENT_DATE,
-    CURRENT_DATE + 44,
-    'c9c8ac4c-274a-4dae-82e1-6a2f8fcbf41b',
+    CURRENT_DATE + 7,
+    '57d00f36-f13c-4d90-bcb9-c7fe1218d810',
     NULL
   );
   
@@ -434,12 +434,12 @@ INSERT INTO
   )
 VALUES
   (
-    'e9e076c3-4470-4bc6-ad63-579edbc67348',
+    '1c177eaf-30cf-4c1a-9f3f-21ec009328e7',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 60,
+    CURRENT_DATE + 31,
     'IHGHXYM',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 60,
+    CURRENT_DATE + 31,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
     CURRENT_DATE
@@ -458,10 +458,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    'e9e076c3-4470-4bc6-ad63-579edbc67348',
+    '1c177eaf-30cf-4c1a-9f3f-21ec009328e7',
     CURRENT_DATE,
-    CURRENT_DATE + 60,
-    'eb26a525-dca3-42b4-bfd7-dc2113b6b861',
+    CURRENT_DATE + 31,
+    '4041b12c-0ec0-40a3-b678-660ad7705180',
     NULL
   );
   
@@ -480,12 +480,12 @@ INSERT INTO
   )
 VALUES
   (
-    '7ea914c2-d404-4ecc-96ef-30f9fbb964be',
+    '18744e00-94f3-460f-9f83-87397549442f',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 54,
+    CURRENT_DATE + 59,
     'JCRH9V5',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 54,
+    CURRENT_DATE + 59,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
     CURRENT_DATE
@@ -504,10 +504,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '7ea914c2-d404-4ecc-96ef-30f9fbb964be',
+    '18744e00-94f3-460f-9f83-87397549442f',
     CURRENT_DATE,
-    CURRENT_DATE + 54,
-    'fb10aa74-f7ab-42b3-be7c-e3830147c98e',
+    CURRENT_DATE + 59,
+    'c2a45301-3486-44a1-bb14-39f643468838',
     NULL
   );
   
@@ -526,12 +526,12 @@ INSERT INTO
   )
 VALUES
   (
-    '1802fb60-252a-4cce-974b-81d37a55ae28',
+    '4a155f3f-5672-4d71-ae42-e9e32b6cf12c',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 56,
+    CURRENT_DATE + 15,
     'N6OUTAY',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 56,
+    CURRENT_DATE + 15,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
     CURRENT_DATE
@@ -550,10 +550,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '1802fb60-252a-4cce-974b-81d37a55ae28',
+    '4a155f3f-5672-4d71-ae42-e9e32b6cf12c',
     CURRENT_DATE,
-    CURRENT_DATE + 56,
-    '0a669c71-5dde-49d2-9752-a8e01739d43b',
+    CURRENT_DATE + 15,
+    'c3f3adb2-fe21-4703-b6ba-8cabfb31a66e',
     NULL
   );
   
@@ -572,12 +572,12 @@ INSERT INTO
   )
 VALUES
   (
-    '81cd1404-549e-4aff-9e2e-212bc71b79d3',
+    '21bab63c-03f1-48ff-85b1-cad092aca9ee',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 21,
+    CURRENT_DATE + 31,
     'PR5E5Y2',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 21,
+    CURRENT_DATE + 31,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     'approved-premises',
     CURRENT_DATE
@@ -596,10 +596,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '81cd1404-549e-4aff-9e2e-212bc71b79d3',
+    '21bab63c-03f1-48ff-85b1-cad092aca9ee',
     CURRENT_DATE,
-    CURRENT_DATE + 21,
-    'd2d5ebdb-e877-4c0e-8a84-ac4bcf21dd26',
+    CURRENT_DATE + 31,
+    'b145fc80-9fab-46df-b224-941f4526fa18',
     NULL
   );
   

--- a/src/main/resources/db/migration/test/R__2_create_bookings.sql
+++ b/src/main/resources/db/migration/test/R__2_create_bookings.sql
@@ -1,0 +1,606 @@
+
+-- ${flyway:timestamp}
+TRUNCATE TABLE arrivals CASCADE;
+TRUNCATE TABLE bookings CASCADE;
+--- Add some Bookings arriving today ---
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '02c669de-5cd4-4599-906f-9dd846a6977e',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '315VWWC',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '47f7d7b7-09dd-4214-90a7-74b16c276566',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '4Y29R9P',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '170ed76c-97aa-46eb-a8c6-56465203ce03',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '4ZUIHFX',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+--- Add some Bookings arriving soon ---
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    'f453cd2f-258b-406b-9d59-3f91efc26a94',
+    CURRENT_DATE + 2,
+    CURRENT_DATE + 84,
+    '52W7TQG',
+    CURRENT_DATE + 2,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '6035000f-c2e6-4474-b5cc-640cf9a60660',
+    CURRENT_DATE + 4,
+    CURRENT_DATE + 84,
+    '5EC66UT',
+    CURRENT_DATE + 4,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '7e64450c-c0ef-400d-a4f3-156d663f60ef',
+    CURRENT_DATE + 1,
+    CURRENT_DATE + 84,
+    'BWEFOI7',
+    CURRENT_DATE + 1,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    'e091ccf8-b61e-4587-9899-cc7673f38f1c',
+    CURRENT_DATE + 2,
+    CURRENT_DATE + 84,
+    'GSR1T2F',
+    CURRENT_DATE + 2,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+--- Add some Bookings departing today ---
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    'c6c17927-589b-4eb6-aca8-64fcd52fc620',
+    CURRENT_DATE - 84,
+    CURRENT_DATE,
+    'HRV83TE',
+    CURRENT_DATE - 84,
+    CURRENT_DATE,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 84,
+    'c6c17927-589b-4eb6-aca8-64fcd52fc620',
+    CURRENT_DATE,
+    CURRENT_DATE,
+    '666aa21e-0e5b-460b-9f12-cba787bb2e21',
+    NULL
+  );
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '4aabf4ac-43c9-40fa-9784-67463f489bb4',
+    CURRENT_DATE - 84,
+    CURRENT_DATE,
+    'HTVI42B',
+    CURRENT_DATE - 84,
+    CURRENT_DATE,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 84,
+    '4aabf4ac-43c9-40fa-9784-67463f489bb4',
+    CURRENT_DATE,
+    CURRENT_DATE,
+    'fcc5c100-a3c6-4ffb-8f62-838e76e19799',
+    NULL
+  );
+  
+--- Add some Bookings departing soon ---
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '7b1fd735-5634-464a-8fe2-3cda0ec029b5',
+    CURRENT_DATE - 84,
+    CURRENT_DATE + 1,
+    'HRV83TE',
+    CURRENT_DATE - 84,
+    CURRENT_DATE + 1,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 84,
+    '7b1fd735-5634-464a-8fe2-3cda0ec029b5',
+    CURRENT_DATE,
+    CURRENT_DATE + 1,
+    'd2b5426b-2647-4d3d-9c51-448bae3c3e82',
+    NULL
+  );
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '0a6cb591-84f1-468b-8a96-23fde59b8e8b',
+    CURRENT_DATE - 84,
+    CURRENT_DATE + 2,
+    'HTVI42B',
+    CURRENT_DATE - 84,
+    CURRENT_DATE + 2,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 84,
+    '0a6cb591-84f1-468b-8a96-23fde59b8e8b',
+    CURRENT_DATE,
+    CURRENT_DATE + 2,
+    '82dca5e9-452b-4d77-a568-7691bd869190',
+    NULL
+  );
+  
+--- Add some arrived Bookings ---
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '2c684d44-0b32-4538-a23a-03b88d3e31c8',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 44,
+    'HUN3BN0',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 44,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 7,
+    '2c684d44-0b32-4538-a23a-03b88d3e31c8',
+    CURRENT_DATE,
+    CURRENT_DATE + 44,
+    'c9c8ac4c-274a-4dae-82e1-6a2f8fcbf41b',
+    NULL
+  );
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    'e9e076c3-4470-4bc6-ad63-579edbc67348',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 60,
+    'IHGHXYM',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 60,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 7,
+    'e9e076c3-4470-4bc6-ad63-579edbc67348',
+    CURRENT_DATE,
+    CURRENT_DATE + 60,
+    'eb26a525-dca3-42b4-bfd7-dc2113b6b861',
+    NULL
+  );
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '7ea914c2-d404-4ecc-96ef-30f9fbb964be',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 54,
+    'JCRH9V5',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 54,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 7,
+    '7ea914c2-d404-4ecc-96ef-30f9fbb964be',
+    CURRENT_DATE,
+    CURRENT_DATE + 54,
+    'fb10aa74-f7ab-42b3-be7c-e3830147c98e',
+    NULL
+  );
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '1802fb60-252a-4cce-974b-81d37a55ae28',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 56,
+    'N6OUTAY',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 56,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 7,
+    '1802fb60-252a-4cce-974b-81d37a55ae28',
+    CURRENT_DATE,
+    CURRENT_DATE + 56,
+    '0a669c71-5dde-49d2-9752-a8e01739d43b',
+    NULL
+  );
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '81cd1404-549e-4aff-9e2e-212bc71b79d3',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 21,
+    'PR5E5Y2',
+    CURRENT_DATE - 7,
+    CURRENT_DATE + 21,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE - 7,
+    '81cd1404-549e-4aff-9e2e-212bc71b79d3',
+    CURRENT_DATE,
+    CURRENT_DATE + 21,
+    'd2d5ebdb-e877-4c0e-8a84-ac4bcf21dd26',
+    NULL
+  );
+  
+  

--- a/src/main/resources/db/migration/test/R__3_create_applications.sql
+++ b/src/main/resources/db/migration/test/R__3_create_applications.sql
@@ -7,7 +7,7 @@ TRUNCATE TABLE assessments CASCADE;
 DO $$
 DECLARE
    applicationData json := '{"basic-information":{"sentence-type":{"sentenceType":"bailPlacement"},"situation":{"situation":"bailSentence"},"release-date":{"releaseDate-year":"2022","releaseDate-month":"11","releaseDate-day":"14","releaseDate":"2022-11-14","knowReleaseDate":"yes"},"placement-date":{"startDateSameAsReleaseDate":"yes"},"placement-purpose":{"placementPurposes":["drugAlcoholMonitoring","otherReason"],"otherReason":"Reason"}},"type-of-ap":{"ap-type":{"type":"standard"}},"oasys-import":{"optional-oasys-sections":{"needsLinkedToReoffending":[{"section":1,"name":"accommodation","linkedToHarm":false,"linkedToReOffending":true},{"section":2,"name":"relationships","linkedToHarm":false,"linkedToReOffending":true}],"otherNeeds":[{"section":3,"name":"emotional","linkedToHarm":false,"linkedToReOffending":false},{"section":4,"name":"thinking","linkedToHarm":false,"linkedToReOffending":false}]},"rosh-summary":{"roshAnswers":["Some answer for the first RoSH question. With an extra comment 1","Some answer for the second RoSH question. With an extra comment 2","Some answer for the third RoSH question. With an extra comment 3"],"roshSummaries":[{"questionNumber":"1","label":"The first RoSH question","answer":"Some answer for the first RoSH question"},{"questionNumber":"2","label":"The second RoSH question","answer":"Some answer for the second RoSH question"},{"questionNumber":"3","label":"The third RoSH question","answer":"Some answer for the third RoSH question"}]},"offence-details":{"offenceDetailsAnswers":["Some answer for the first offence details question. With an extra comment 1","Some answer for the second offence details question. With an extra comment 2","Some answer for the third offence details question. With an extra comment 3"],"offenceDetailsSummaries":[{"questionNumber":"1","label":"The first offence details question","answer":"Some answer for the first offence details question"},{"questionNumber":"2","label":"The second offence details question","answer":"Some answer for the second offence details question"},{"questionNumber":"3","label":"The third offence details question","answer":"Some answer for the third offence details question"}]},"supporting-information":{"supportingInformationAnswers":["Some answer for the first supporting information question. With an extra comment 1","Some answer for the second supporting information question. With an extra comment 2","Some answer for the third supporting information question. With an extra comment 3"],"supportingInformationSummaries":[{"questionNumber":"1","label":"The first supporting information question","answer":"Some answer for the first supporting information question"},{"questionNumber":"2","label":"The second supporting information question","answer":"Some answer for the second supporting information question"},{"questionNumber":"3","label":"The third supporting information question","answer":"Some answer for the third supporting information question"}]},"risk-management-plan":{"riskManagementAnswers":["Some answer for the first risk management question. With an extra comment 1","Some answer for the second risk management question. With an extra comment 2","Some answer for the third risk management question. With an extra comment 3"],"riskManagementSummaries":[{"questionNumber":"1","label":"The first risk management question","answer":"Some answer for the first risk management question"},{"questionNumber":"2","label":"The second risk management question","answer":"Some answer for the second risk management question"},{"questionNumber":"3","label":"The third risk management question","answer":"Some answer for the third risk management question"}]},"risk-to-self":{"riskToSelfAnswers":["Some answer for the first risk to self question. With an extra comment 1","Some answer for the second risk to self question. With an extra comment 2","Some answer for the third risk to self question. With an extra comment 3"],"riskToSelfSummaries":[{"questionNumber":"1","label":"The first risk to self question","answer":"Some answer for the first risk to self question"},{"questionNumber":"2","label":"The second risk to self question","answer":"Some answer for the second risk to self question"},{"questionNumber":"3","label":"The third risk to self question","answer":"Some answer for the third risk to self question"}]}},"risk-management-features":{"risk-management-features":{"manageRiskDetails":"est vero nesciunt","additionalFeaturesDetails":"deleniti enim necessitatibus"},"convicted-offences":{"response":"yes"},"type-of-convicted-offence":{"offenceConvictions":["arson","sexualOffence","hateCrimes","childNonSexualOffence"]},"date-of-offence":{"arsonOffence":["current"],"hateCrime":["previous"],"inPersonSexualOffence":["current","previous"]},"rehabilitative-interventions":{"rehabilitativeInterventions":["accommodation","drugsAndAlcohol","childrenAndFamilies","health","educationTrainingAndEmployment","financeBenefitsAndDebt","attitudesAndBehaviour","abuse","other"],"otherIntervention":"Another"}},"prison-information":{"case-notes":{"caseNoteIds":["a30173ca-061f-42c9-a1a2-28c70b282d3f","4a477187-b77f-4fcc-a919-43a6633ee868"],"selectedCaseNotes":[{"authorName":"Denise Collins","id":"a30173ca-061f-42c9-a1a2-28c70b282d3f","createdAt":"2022-11-10","occurredAt":"2022-10-19","sensitive":false,"subType":"Ressettlement","type":"Social Care","note":"Note 1"},{"authorName":"Leticia Mann","id":"4a477187-b77f-4fcc-a919-43a6633ee868","createdAt":"2022-07-24","occurredAt":"2022-09-22","sensitive":true,"subType":"Quality Work","type":"General","note":"Note 2"}],"moreDetail":"some details","adjudications":[{"id":69927,"reportedAt":"2022-10-09","establishment":"Hawthorne","offenceDescription":"Nam vel nisi fugiat veniam possimus omnis.","hearingHeld":false,"finding":"NOT_PROVED"},{"id":39963,"reportedAt":"2022-07-10","establishment":"Oklahoma City","offenceDescription":"Illum maxime enim explicabo soluta sequi voluptas.","hearingHeld":true,"finding":"PROVED"},{"id":77431,"reportedAt":"2022-05-30","establishment":"Jurupa Valley","offenceDescription":"Quis porro nemo voluptates doloribus atque quis provident iure.","hearingHeld":false,"finding":"PROVED"}]}},"location-factors":{"describe-location-factors":{"postcodeArea":"SW1","positiveFactors":"Some positive factors","restrictions":"yes","restrictionDetail":"Restrictions go here","alternativeRadiusAccepted":"yes","alternativeRadius":"70","differentPDU":"no"},"pdu-transfer":{"transferStatus":"yes","probationPractitioner":"Probation Practicioner"}},"access-and-healthcare":{"access-needs":{"additionalNeeds":["mobility","learningDisability","neurodivergentConditions"],"religiousOrCulturalNeeds":"yes","religiousOrCulturalNeedsDetails":"sunt at minus","needsInterpreter":"yes","interpreterLanguage":"beatae eligendi explicabo","careActAssessmentCompleted":"yes"},"access-needs-mobility":{"needsWheelchair":"yes","mobilityNeeds":"laboriosam","visualImpairment":"exercitationem"},"covid":{"fullyVaccinated":"yes","highRisk":"yes","additionalCovidInfo":"additional info"}},"further-considerations":{"room-sharing":{"riskToStaff":"no","riskToStaffDetail":"","riskToOthers":"no","riskToOthersDetail":"","sharingConcerns":"yes","sharingConcernsDetail":"Some details here","traumaConcerns":"no","traumaConcernsDetail":"","sharingBenefits":"no","sharingBenefitsDetail":""},"vulnerability":{"exploitable":"no","exploitableDetail":"","exploitOthers":"yes","exploitOthersDetail":"Some details here"},"previous-placements":{"previousPlacement":"yes","previousPlacementDetail":"Some details here"},"complex-case-board":{"complexCaseBoard":"yes","complexCaseBoardDetail":"Some details here"},"catering":{"catering":"yes","cateringDetail":"Some details here"},"arson":{"arson":"yes","arsonDetail":"Some details here"}},"move-on":{"placement-duration":{"duration":"10","durationDetail":"Some more information"},"relocation-region":{"postcodeArea":"XX1"},"plans-in-place":{"arePlansInPlace":"yes"},"type-of-accommodation":{"accommodationType":"foreignNational","otherAccommodationType":""},"foreign-national":{"response":"yes","date-year":"2015","date-month":"1","date-day":"1","date":"2015-01-01"}},"attach-required-documents":{"attach-documents":{"selectedDocuments":[{"id":"aeb43e06-a4a1-460f-9acf-e2495de84604","level":"Offender","fileName":"Random offender document1.pdf","createdAt":"2019-09-10T00:00:00Z","typeCode":"OFFENDER_DOCUMENT","typeDescription":"Offender related","description":"Some Description 1"},{"id":"5f8a2288-0a17-4e45-afd5-5e57794a7b53","level":"Conviction","fileName":"national.asm","createdAt":"2022-09-13","typeCode":"serenade","typeDescription":"porter","description":"Some Description 2"}]}},"check-your-answers":{"review":{"reviewed":"1"}}}';
-   applicationDocument json := '{"basic-information":[{"Which of the following best describes the sentence type?":"Standard determinate custody"},{"What type of release will the application support?":"Release on Temporary License (ROTL)"},{"Do you know Justyn Flatley’s release date?":"Yes","Release Date":"Saturday 1 April 2023"},{"Is Saturday 1 April 2023 the date you want the placement to start?":"Yes"},{"What is the purpose of the AP placement?":"Prevent contact, Help individual readjust to life outside custody"}],"type-of-ap":[{"Which type of AP does Justyn Flatley require?":"Standard"}],"oasys-import":[{"Needs linked to reoffending":"9. Alcohol","Needs not linked to risk of serious harm or reoffending":"5. Finance, 11. Thinking and behavioural"},{"R10.1":"[R10.1] IN CUSTODY\r\n \r\n KNOWN ADULTS:\r\n Such as Ms Elaine Underhill and any of the victims of the index offence if they are placed close to Mr Smith cell.\r\n \r\n CHILDREN:\r\n Simon Smith, Roger Smith, Lindy Smith","R10.2":"[R10.2] IN CUSTODY:\r\n \r\n KNOWN ADULTS:\r\n Intimidation, threats of violence, use of weapons or boiling water, physical education and violent assault, long term psychological impact as a result of Mr Smith violent behaviour. This harm may be cause in the course of physical altercation due to seeking revenge or holding grudges...","R10.3":"[R10.3] STATIC RISK FACTORS:\r\n \r\n Mr Smith gender - At the time of the offence, Mr Smith was 35 years old and considered to be in the higher risk group.\r\n \r\n STABLE DYNAMIC RISK FACTORS:\r\n Thinking and behaviour - limited ability to manage mood or emotions poor impulse control. Mr Smith demonstrated cognitive deficit in committing the index offences and this still remains a concern...","R10.4":"[R10.4] CIRCUMSTANCES:\r\n A lack of stable accommodation\r\n unemployment\r\n non constructive use of time\r\n breakdown of family support\r\n being unable to access benefits\r\n \r\n UNDERLYING FACTORS:\r\n pro criminal attitudes supporting commission of crime...","R10.5":"[R10.5] Engage with Mental Health Services in prison and in the community.\r\n Maintain emotional stability.\r\n Abstain from alcohol.\r\n Abstain from illegal drugs.\r\n Regular testing for alcohol and drug use, in prison and on Licence.\r\n Maintain stable accommodation..."},{"2.1":"","2.4.1":"","2.4.2":"","2.12":"","2.5":"","2.8.3":"","2.98":""},{"3.9":"[3.9] Mr Smith told me that he was renting a room in a shared house, prior to his current remand...","4.9":"[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his...","5.9":"[5.9] Mr Smith was in receipt of Job Seekers Allowance prior to his current remand in custody...","9.9":"[9.9] Mr Smith told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years...","11.9":"[11.9] The circumstances of the current offence suggest that Mr Smith acted ..."},{"RM28":"[RM28] Mr Smith is currently on remand awaiting sentence","RM35":"[RM35] Placeholder content for additional comments","RM34":"[RM34] Discuss any concerns with line manager/SPO Increase frequency of reporting Bring forward MAPPA/Consider Level 2 MAPPA professionals meetings  considered if MAPPA not applicable. Consider referral to Approved Premises Consider motivational interviewing/engagement officer.  Joint interview with police OM or other relevant agencies? To raise concerns Referral to substance misues worker for additional support. Warning letters to be employed Recall/Breach if risk not manageable.","RM33":"[RM33] Undertake sentence planning with OS within 8 or 16 weeks of sentence carats - continue to work with Mr Smith and refer for relevant programmes during any prison sentence imposed. DIP supervise DRR is imposed or provide support post release if conditions/requirements to manage the specific risks.","RM32":"[RM32] Requires referral to community drug DIP upon  release. To link in with employment/training resources such as College and ETEO. Completion of victim empathy module via 1-1 supervision to build upon awareness of impact of offending.   Level setting to be undertaken by Senior Probation Officer and OMU. Multi Agency Public Protection Panel to be convened if level 2 either at start of supervision or 6 months prior to release","RM31":"[RM31] State they will have secure accommodation for Mr Smith  and partner on release, although she too is subject to a DRR at present. Supportive wider family.  Has completed previously Short Duration programme and attended one of the support sessions .  Engaged with CARATS in custody.  Complied with voluntary drug tests in custody. Some motivation to desist from alcohol/drug use in the future, this needs to be encouraged with use of community resources. Completed drug and heroin awareness programmes in custody.","RM30":"[RM30] Probation Officer, Education training and employment Officer, Prison Offender Supervisor","RM28.1":"[RM28.1] Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."},{"R8.1.1":"Review 06.10.21:\r\n \r\n         There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021...","R8.2.1":"Has told prison staff that he swallowed batteries on one occasion due to wanting..","R8.3.1":"Review 06.10.21:\r\n \r\n         A previous assessor opined that Mr Smith was displaying all the characteristics of someone..."}],"risk-management-features":[{"Describe why an AP placement is needed to manage the risk of Justyn Flatley":"Some words","Provide details of any additional measures that will be necessary for the management of risk":"Some words"},{"Has Justyn Flatley ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?":"No"},{"Which rehabilitative interventions will support the person''s Approved Premises (AP) placement?":"Drugs and alcohol, Children and families"}],"prison-information":[{"Selected prison case notes that support this application":["Array"],"Adjudications":["Array"]}],"location-factors":[{"What is the preferred location for the AP placement?":"WS1","Give details of any positive factors for the person in this location.":"Some words","Are there any restrictions linked to placement location?":"No","If an AP Placement is not available in the persons preferred area, would a placement further away be considered?":"No","Is the person moving to a different area where they''ll be managed by a different probation delivery unit (PDU)?":"No"},{"Have you agreed Justyn Flatley''s transfer/supervision with the receiving PDU?":"No, I still need to make arrangements"}],"access-and-healthcare":[{"Does Justyn Flatley have any of the following needs?":"Learning disability, hearing impairment","Does Justyn Flatley have any religious or cultural needs?":"No","Details of religious or cultural needs":"","Does Justyn Flatley need an interpreter?":"No","Has a care act assessment been completed?":"No"},{"Has Justyn Flatley been fully vaccinated for COVID-19?":"No","Is Justyn Flatley at a higher risk from COVID-19?":"No"}],"further-considerations":[{"Is there any evidence that the person may pose a risk to AP staff?":"No","Is there any evidence that the person may pose a risk to other AP residents?":"No","Do you have any concerns about the person sharing a bedroom?":"No","Is there any evidence of previous trauma or significant event in the persons history which would indicate that room share may not be suitable?":"No","Is there potential for the person to benefit from a room share?":"No"},{"Are you aware that Justyn Flatley is vulnerable to exploitation from others?":"No","Is there any evidence or expectation that Justyn Flatley may groom, radicalise or exploit others?":"No"},{"Has Justyn Flatley stayed or been offered a placement in an AP before?":"No"},{"Does Justyn Flatley''s gender identity require a complex case board to review their application?":"No"},{"Do you have any concerns about Justyn Flatley catering for themselves?":"No"},{"Does Justyn Flatley need a specialist arson room?":"No"}],"move-on":[{"What duration of placement do you recommend?":"11 weeks","Provide any additional information":"Some words"},{"Where is Justyn Flatley most likely to live when they move on from the AP?":"WS13"},{"Are move on arrangements already in place for when the person leaves the AP?":"No"},{"What type of accommodation will Justyn Flatley have when they leave the AP?":"Supported housing"}],"attach-required-documents":[{"PRE-CONS.pdf":"Previous convictions as of 01/09/2019","Personal circumstances.pdf.pdf":"Personal circumstance of AP - Medication in Posession  - Assessment started on 11/09/2019","NSIOffender.pdf":"Non Statutory Intervention for OPD Community Pathway on 16/10/2019","paroleParom1Report_04092019_122116_OMIC_A_X320741.pdf":"Parole Assessment Report at Berwyn (HMP) requested on 05/09/2019"}],"check-your-answers":[{}]}';
+   applicationDocument json := '{"basic-information":[{"Which of the following best describes the sentence type?":"Standard determinate custody"},{"What type of release will the application support?":"Release on Temporary License (ROTL)"},{"Do you know Mr Smith’s release date?":"Yes","Release Date":"Saturday 1 April 2023"},{"Is Saturday 1 April 2023 the date you want the placement to start?":"Yes"},{"What is the purpose of the AP placement?":"Prevent contact, Help individual readjust to life outside custody"}],"type-of-ap":[{"Which type of AP does Mr Smith require?":"Standard"}],"oasys-import":[{"Needs linked to reoffending":"9. Alcohol","Needs not linked to risk of serious harm or reoffending":"5. Finance, 11. Thinking and behavioural"},{"R10.1":"[R10.1] IN CUSTODY\r\n \r\n KNOWN ADULTS:\r\n Such as Ms Elaine Underhill and any of the victims of the index offence if they are placed close to Mr Smith cell.\r\n \r\n CHILDREN:\r\n Simon Smith, Roger Smith, Lindy Smith","R10.2":"[R10.2] IN CUSTODY:\r\n \r\n KNOWN ADULTS:\r\n Intimidation, threats of violence, use of weapons or boiling water, physical education and violent assault, long term psychological impact as a result of Mr Smith violent behaviour. This harm may be cause in the course of physical altercation due to seeking revenge or holding grudges...","R10.3":"[R10.3] STATIC RISK FACTORS:\r\n \r\n Mr Smith gender - At the time of the offence, Mr Smith was 35 years old and considered to be in the higher risk group.\r\n \r\n STABLE DYNAMIC RISK FACTORS:\r\n Thinking and behaviour - limited ability to manage mood or emotions poor impulse control. Mr Smith demonstrated cognitive deficit in committing the index offences and this still remains a concern...","R10.4":"[R10.4] CIRCUMSTANCES:\r\n A lack of stable accommodation\r\n unemployment\r\n non constructive use of time\r\n breakdown of family support\r\n being unable to access benefits\r\n \r\n UNDERLYING FACTORS:\r\n pro criminal attitudes supporting commission of crime...","R10.5":"[R10.5] Engage with Mental Health Services in prison and in the community.\r\n Maintain emotional stability.\r\n Abstain from alcohol.\r\n Abstain from illegal drugs.\r\n Regular testing for alcohol and drug use, in prison and on Licence.\r\n Maintain stable accommodation..."},{"2.1":"","2.4.1":"","2.4.2":"","2.12":"","2.5":"","2.8.3":"","2.98":""},{"3.9":"[3.9] Mr Smith told me that he was renting a room in a shared house, prior to his current remand...","4.9":"[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his...","5.9":"[5.9] Mr Smith was in receipt of Job Seekers Allowance prior to his current remand in custody...","9.9":"[9.9] Mr Smith told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years...","11.9":"[11.9] The circumstances of the current offence suggest that Mr Smith acted ..."},{"RM28":"[RM28] Mr Smith is currently on remand awaiting sentence","RM35":"[RM35] Placeholder content for additional comments","RM34":"[RM34] Discuss any concerns with line manager/SPO Increase frequency of reporting Bring forward MAPPA/Consider Level 2 MAPPA professionals meetings  considered if MAPPA not applicable. Consider referral to Approved Premises Consider motivational interviewing/engagement officer.  Joint interview with police OM or other relevant agencies? To raise concerns Referral to substance misues worker for additional support. Warning letters to be employed Recall/Breach if risk not manageable.","RM33":"[RM33] Undertake sentence planning with OS within 8 or 16 weeks of sentence carats - continue to work with Mr Smith and refer for relevant programmes during any prison sentence imposed. DIP supervise DRR is imposed or provide support post release if conditions/requirements to manage the specific risks.","RM32":"[RM32] Requires referral to community drug DIP upon  release. To link in with employment/training resources such as College and ETEO. Completion of victim empathy module via 1-1 supervision to build upon awareness of impact of offending.   Level setting to be undertaken by Senior Probation Officer and OMU. Multi Agency Public Protection Panel to be convened if level 2 either at start of supervision or 6 months prior to release","RM31":"[RM31] State they will have secure accommodation for Mr Smith  and partner on release, although she too is subject to a DRR at present. Supportive wider family.  Has completed previously Short Duration programme and attended one of the support sessions .  Engaged with CARATS in custody.  Complied with voluntary drug tests in custody. Some motivation to desist from alcohol/drug use in the future, this needs to be encouraged with use of community resources. Completed drug and heroin awareness programmes in custody.","RM30":"[RM30] Probation Officer, Education training and employment Officer, Prison Offender Supervisor","RM28.1":"[RM28.1] Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."},{"R8.1.1":"Review 06.10.21:\r\n \r\n         There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021...","R8.2.1":"Has told prison staff that he swallowed batteries on one occasion due to wanting..","R8.3.1":"Review 06.10.21:\r\n \r\n         A previous assessor opined that Mr Smith was displaying all the characteristics of someone..."}],"risk-management-features":[{"Describe why an AP placement is needed to manage the risk of Mr Smith":"Some words","Provide details of any additional measures that will be necessary for the management of risk":"Some words"},{"Has Mr Smith ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?":"No"},{"Which rehabilitative interventions will support the person''s Approved Premises (AP) placement?":"Drugs and alcohol, Children and families"}],"prison-information":[{"Selected prison case notes that support this application":["Array"],"Adjudications":["Array"]}],"location-factors":[{"What is the preferred location for the AP placement?":"WS1","Give details of any positive factors for the person in this location.":"Some words","Are there any restrictions linked to placement location?":"No","If an AP Placement is not available in the persons preferred area, would a placement further away be considered?":"No","Is the person moving to a different area where they''ll be managed by a different probation delivery unit (PDU)?":"No"},{"Have you agreed Mr Smith''s transfer/supervision with the receiving PDU?":"No, I still need to make arrangements"}],"access-and-healthcare":[{"Does Mr Smith have any of the following needs?":"Learning disability, hearing impairment","Does Mr Smith have any religious or cultural needs?":"No","Details of religious or cultural needs":"","Does Mr Smith need an interpreter?":"No","Has a care act assessment been completed?":"No"},{"Has Mr Smith been fully vaccinated for COVID-19?":"No","Is Mr Smith at a higher risk from COVID-19?":"No"}],"further-considerations":[{"Is there any evidence that the person may pose a risk to AP staff?":"No","Is there any evidence that the person may pose a risk to other AP residents?":"No","Do you have any concerns about the person sharing a bedroom?":"No","Is there any evidence of previous trauma or significant event in the persons history which would indicate that room share may not be suitable?":"No","Is there potential for the person to benefit from a room share?":"No"},{"Are you aware that Mr Smith is vulnerable to exploitation from others?":"No","Is there any evidence or expectation that Mr Smith may groom, radicalise or exploit others?":"No"},{"Has Mr Smith stayed or been offered a placement in an AP before?":"No"},{"Does Mr Smith''s gender identity require a complex case board to review their application?":"No"},{"Do you have any concerns about Mr Smith catering for themselves?":"No"},{"Does Mr Smith need a specialist arson room?":"No"}],"move-on":[{"What duration of placement do you recommend?":"11 weeks","Provide any additional information":"Some words"},{"Where is Mr Smith most likely to live when they move on from the AP?":"WS13"},{"Are move on arrangements already in place for when the person leaves the AP?":"No"},{"What type of accommodation will Mr Smith have when they leave the AP?":"Supported housing"}],"attach-required-documents":[{"PRE-CONS.pdf":"Previous convictions as of 01/09/2019","Personal circumstances.pdf.pdf":"Personal circumstance of AP - Medication in Posession  - Assessment started on 11/09/2019","NSIOffender.pdf":"Non Statutory Intervention for OPD Community Pathway on 16/10/2019","paroleParom1Report_04092019_122116_OMIC_A_X320741.pdf":"Parole Assessment Report at Berwyn (HMP) requested on 05/09/2019"}],"check-your-answers":[{}]}';
 BEGIN
 
 
@@ -24,9 +24,9 @@ BEGIN
   )
   values
     (
-      '35e63614-e68c-4d7d-8996-8dd72c7b8ea5',
-      CURRENT_DATE + 25,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      '2f2f0795-30c3-4bbc-af00-12f3373c16b8',
+      CURRENT_DATE + 20,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
       '315VWWC',
       applicationData,
       applicationDocument,
@@ -40,7 +40,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 3
+      CURRENT_DATE + 0
     );
   
 
@@ -57,7 +57,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      '35e63614-e68c-4d7d-8996-8dd72c7b8ea5',
+      '2f2f0795-30c3-4bbc-af00-12f3373c16b8',
       false,
       false,
       'M2500295343',
@@ -76,8 +76,8 @@ BEGIN
   )
   VALUES
     (
-      '9afe9b99-71be-42d3-bd8d-bdef38065d71',
-      '35e63614-e68c-4d7d-8996-8dd72c7b8ea5',
+      '11c2c5ed-32d6-4239-ba25-6dd8a0d8a13e',
+      '2f2f0795-30c3-4bbc-af00-12f3373c16b8',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -106,1404 +106,10 @@ BEGIN
   )
   values
     (
-      '0ffdf858-a3e4-4fda-a1d8-1a87b4d6f71e',
-      CURRENT_DATE + 10,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      '70139e7f-5454-4fcd-9682-eff43bec498f',
+      CURRENT_DATE + 22,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       '4Y29R9P',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 0
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '0ffdf858-a3e4-4fda-a1d8-1a87b4d6f71e',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'de01f811-e10e-4845-ae33-d05521491436',
-      '0ffdf858-a3e4-4fda-a1d8-1a87b4d6f71e',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'e422232a-9459-45d4-b48d-f8443f1774f0',
-      CURRENT_DATE + 9,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      '4ZUIHFX',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 0
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'e422232a-9459-45d4-b48d-f8443f1774f0',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '9a63ecfc-7155-4e37-a51e-04964457b4e8',
-      'e422232a-9459-45d4-b48d-f8443f1774f0',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '1f7fd593-1b4e-4843-8575-20e1e63555da',
-      CURRENT_DATE + 27,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      '52W7TQG',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 15
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '1f7fd593-1b4e-4843-8575-20e1e63555da',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '49da0ae4-3ba7-4778-a817-7e5b5cc8c2fd',
-      '1f7fd593-1b4e-4843-8575-20e1e63555da',
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'c9187c64-f8a7-4ec7-9351-7f6e414b2681',
-      CURRENT_DATE + 2,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      '5EC66UT',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 10
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'c9187c64-f8a7-4ec7-9351-7f6e414b2681',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'e7393185-6c71-4e14-bd38-bc67c7270fb3',
-      'c9187c64-f8a7-4ec7-9351-7f6e414b2681',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '1ba0d70b-36f9-4b3c-bfcd-ecf474e5ec6a',
-      CURRENT_DATE + 6,
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      '8LO3HSH',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 5
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '1ba0d70b-36f9-4b3c-bfcd-ecf474e5ec6a',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '281dcf30-756a-4ae6-bbbd-730380e3bc63',
-      '1ba0d70b-36f9-4b3c-bfcd-ecf474e5ec6a',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '0ecff4e1-6851-4893-a779-5ef695caabdf',
-      CURRENT_DATE + 12,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      'BWEFOI7',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 18
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '0ecff4e1-6851-4893-a779-5ef695caabdf',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'c26644e7-337e-43af-a57c-bc40a25823e3',
-      '0ecff4e1-6851-4893-a779-5ef695caabdf',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '18387705-a22a-4dc7-ae39-9a0bd95e5735',
-      CURRENT_DATE + 5,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'GSR1T2F',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 11
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '18387705-a22a-4dc7-ae39-9a0bd95e5735',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'ae60a9dd-e542-4777-8764-0874d8610b48',
-      '18387705-a22a-4dc7-ae39-9a0bd95e5735',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '4cedfea8-52a7-4846-81b6-e4f768923733',
-      CURRENT_DATE + 28,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'HRV83TE',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 20
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '4cedfea8-52a7-4846-81b6-e4f768923733',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '60195bb3-ca9f-4647-a6ae-c6b44c76ca84',
-      '4cedfea8-52a7-4846-81b6-e4f768923733',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'cd31a8a9-6f7d-4f41-9b5d-a2306db59133',
-      CURRENT_DATE + 8,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'HTVI42B',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 12
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'cd31a8a9-6f7d-4f41-9b5d-a2306db59133',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'f4a55720-1a9b-4acb-832e-7cec48eaad9f',
-      'cd31a8a9-6f7d-4f41-9b5d-a2306db59133',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '3041e294-e3c7-4cec-9449-82a301d2af6e',
-      CURRENT_DATE + 13,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      'HUN3BN0',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 24
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '3041e294-e3c7-4cec-9449-82a301d2af6e',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '0711a132-93f1-49b9-bc1e-79b92566c3f2',
-      '3041e294-e3c7-4cec-9449-82a301d2af6e',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'e3ef8fd7-9e41-4983-b467-622ace779558',
-      CURRENT_DATE + 26,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      'IHGHXYM',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 29
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'e3ef8fd7-9e41-4983-b467-622ace779558',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '57082020-4311-4b73-b302-141240ac5100',
-      'e3ef8fd7-9e41-4983-b467-622ace779558',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '637b7b24-e086-45ec-be3f-d689c7c8b32b',
-      CURRENT_DATE + 17,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      'JCRH9V5',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 5
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '637b7b24-e086-45ec-be3f-d689c7c8b32b',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'f8c4572c-2987-42bc-9f16-cb26354c5ad3',
-      '637b7b24-e086-45ec-be3f-d689c7c8b32b',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '6e38628a-6ac3-447b-b733-c88677f67f57',
-      CURRENT_DATE + 24,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      'N6OUTAY',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 25
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '6e38628a-6ac3-447b-b733-c88677f67f57',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'beb05e58-35da-4671-a744-38662b2a87b8',
-      '6e38628a-6ac3-447b-b733-c88677f67f57',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '930a0717-ea15-4c4b-8cab-02625ca4e319',
-      CURRENT_DATE + 7,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'PI251LM',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 28
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '930a0717-ea15-4c4b-8cab-02625ca4e319',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '3d6f4507-698c-4a5e-8bad-662b687680b2',
-      '930a0717-ea15-4c4b-8cab-02625ca4e319',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '2ff19c8b-22ca-4156-ad87-a5c29c68b4d4',
-      CURRENT_DATE + 17,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      'PR5E5Y2',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 5
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '2ff19c8b-22ca-4156-ad87-a5c29c68b4d4',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '2497d891-cb35-45df-a596-1a1bbcfa0a37',
-      '2ff19c8b-22ca-4156-ad87-a5c29c68b4d4',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'e168a312-1f6f-4b2f-9b84-01f299a698a7',
-      CURRENT_DATE + 5,
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      'QA93YYK',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 25
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'e168a312-1f6f-4b2f-9b84-01f299a698a7',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '8304c24e-4fc4-43ea-ad80-977fa877eba0',
-      'e168a312-1f6f-4b2f-9b84-01f299a698a7',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '8eddfe1e-9800-44d2-b977-f93d8bc88072',
-      CURRENT_DATE + 0,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'XCMSG3I',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 22
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '8eddfe1e-9800-44d2-b977-f93d8bc88072',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '6e8b8700-cedc-4b8b-a876-1d837796e2a0',
-      '8eddfe1e-9800-44d2-b977-f93d8bc88072',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'ffb38b0c-4a89-4b45-a023-51560d65b7fb',
-      CURRENT_DATE + 25,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      'YRPARSH',
       applicationData,
       applicationDocument,
       (
@@ -1533,7 +139,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      'ffb38b0c-4a89-4b45-a023-51560d65b7fb',
+      '70139e7f-5454-4fcd-9682-eff43bec498f',
       false,
       false,
       'M2500295343',
@@ -1552,8 +158,582 @@ BEGIN
   )
   VALUES
     (
-      '371321af-c5fe-475a-9865-0d06e8a8933a',
-      'ffb38b0c-4a89-4b45-a023-51560d65b7fb',
+      '84f503a6-7576-41f1-86fa-44892310fbf3',
+      '70139e7f-5454-4fcd-9682-eff43bec498f',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '21821ee4-1100-45e4-b657-f3d96699d89d',
+      CURRENT_DATE + 7,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '4ZUIHFX',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 26
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '21821ee4-1100-45e4-b657-f3d96699d89d',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '66d1189a-1380-4ae7-8384-d5cc218176a0',
+      '21821ee4-1100-45e4-b657-f3d96699d89d',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'be56caed-b69e-4b34-ab09-a7c9b0c70f4a',
+      CURRENT_DATE + 1,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      '52W7TQG',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 20
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'be56caed-b69e-4b34-ab09-a7c9b0c70f4a',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '6290316a-6d1c-481b-9c1e-40d96be3dcc5',
+      'be56caed-b69e-4b34-ab09-a7c9b0c70f4a',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '6afced9a-a0ae-4013-84de-503f25334473',
+      CURRENT_DATE + 25,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '5EC66UT',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 19
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '6afced9a-a0ae-4013-84de-503f25334473',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '2ca1cb88-8628-4f9c-82c9-a58accb6c8e5',
+      '6afced9a-a0ae-4013-84de-503f25334473',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'f988e450-0017-40f9-9e4d-e27484bc7b66',
+      CURRENT_DATE + 21,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '8LO3HSH',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 15
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'f988e450-0017-40f9-9e4d-e27484bc7b66',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '4343e319-206c-4d5f-9610-26688b80f811',
+      'f988e450-0017-40f9-9e4d-e27484bc7b66',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '2d6af1be-cc15-43ed-a940-feb8826953e4',
+      CURRENT_DATE + 16,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'BWEFOI7',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 6
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '2d6af1be-cc15-43ed-a940-feb8826953e4',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '8c90cb5b-7ca6-41bb-931c-b4fe48a728bf',
+      '2d6af1be-cc15-43ed-a940-feb8826953e4',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'b8af221f-61da-4338-88ab-e502e10a3256',
+      CURRENT_DATE + 24,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'GSR1T2F',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 20
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'b8af221f-61da-4338-88ab-e502e10a3256',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '7ef4b33d-11ff-424e-afb1-bb7fffe98240',
+      'b8af221f-61da-4338-88ab-e502e10a3256',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '1c64ab71-b389-4fc2-9f55-05523e93f503',
+      CURRENT_DATE + 7,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'HRV83TE',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 25
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '1c64ab71-b389-4fc2-9f55-05523e93f503',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'a1d3934a-ec76-4555-b652-d8e5f684c8b0',
+      '1c64ab71-b389-4fc2-9f55-05523e93f503',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -1582,10 +762,666 @@ BEGIN
   )
   values
     (
-      'ccb80ad8-f07e-4e18-a0b5-f401d5745cdf',
-      CURRENT_DATE + 6,
+      'b155aeef-ce00-4a8c-b700-7cd475d40a2b',
+      CURRENT_DATE + 0,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'HTVI42B',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 2
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'b155aeef-ce00-4a8c-b700-7cd475d40a2b',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'f4f8c779-84d9-40c1-840b-3bd8a848183d',
+      'b155aeef-ce00-4a8c-b700-7cd475d40a2b',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      'Z33A1BU',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'be86194d-e9dc-4c2c-9149-9f8a8baf08d4',
+      CURRENT_DATE + 8,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'HUN3BN0',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 0
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'be86194d-e9dc-4c2c-9149-9f8a8baf08d4',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'a3aeed66-ac61-47bf-b5bf-8be33e9b0277',
+      'be86194d-e9dc-4c2c-9149-9f8a8baf08d4',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'f1dcf109-1d37-4f07-a8cf-0afafea652ac',
+      CURRENT_DATE + 17,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'IHGHXYM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 18
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'f1dcf109-1d37-4f07-a8cf-0afafea652ac',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '7cfc0ea7-c0fe-4ad3-bc44-cda2f26ded2f',
+      'f1dcf109-1d37-4f07-a8cf-0afafea652ac',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '94b6b6ce-0792-4340-a810-b9c6dec0d1c2',
+      CURRENT_DATE + 16,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'JCRH9V5',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 15
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '94b6b6ce-0792-4340-a810-b9c6dec0d1c2',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'd42744e0-b19b-450a-9934-d7b03844dfab',
+      '94b6b6ce-0792-4340-a810-b9c6dec0d1c2',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '53cb87e2-804f-4b69-a50f-923dc753567a',
+      CURRENT_DATE + 11,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'N6OUTAY',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 22
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '53cb87e2-804f-4b69-a50f-923dc753567a',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '4a72af67-fa2f-4e84-914b-53c02373161a',
+      '53cb87e2-804f-4b69-a50f-923dc753567a',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '8f788870-e88c-449c-a5e8-194bd63b01d9',
+      CURRENT_DATE + 26,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'PI251LM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 22
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '8f788870-e88c-449c-a5e8-194bd63b01d9',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '130ab04e-b0ab-4414-bbef-4141374d6635',
+      '8f788870-e88c-449c-a5e8-194bd63b01d9',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '7d7c6eb8-89c8-4723-a255-8220b43fcdc4',
+      CURRENT_DATE + 16,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'PR5E5Y2',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 11
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '7d7c6eb8-89c8-4723-a255-8220b43fcdc4',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '04cad38f-f151-48a2-9c45-f54679b30c88',
+      '7d7c6eb8-89c8-4723-a255-8220b43fcdc4',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'f6d7032c-8fdb-4706-8c69-0dc2a4074a26',
+      CURRENT_DATE + 1,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'QA93YYK',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 20
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'f6d7032c-8fdb-4706-8c69-0dc2a4074a26',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '5ede72f0-4637-4ef5-a9c5-a3d2bb19f843',
+      'f6d7032c-8fdb-4706-8c69-0dc2a4074a26',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'e2e1841f-a625-42ea-a030-07c120229689',
+      CURRENT_DATE + 4,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'XCMSG3I',
       applicationData,
       applicationDocument,
       (
@@ -1615,7 +1451,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      'ccb80ad8-f07e-4e18-a0b5-f401d5745cdf',
+      'e2e1841f-a625-42ea-a030-07c120229689',
       false,
       false,
       'M2500295343',
@@ -1634,9 +1470,173 @@ BEGIN
   )
   VALUES
     (
-      '84cd417b-7a49-470e-8f6c-03748cabbe35',
-      'ccb80ad8-f07e-4e18-a0b5-f401d5745cdf',
+      'a681cafa-a79b-4ce2-812d-7722691734de',
+      'e2e1841f-a625-42ea-a030-07c120229689',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'dfc9e61e-a043-4d7a-9bed-7fe462517f37',
+      CURRENT_DATE + 24,
       '68715a03-06af-49ee-bae5-039c824ab9af',
+      'YRPARSH',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 9
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'dfc9e61e-a043-4d7a-9bed-7fe462517f37',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '32c394d5-9afb-495b-8348-3936a096a341',
+      'dfc9e61e-a043-4d7a-9bed-7fe462517f37',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '0ba231be-be19-4dcc-9d76-7a5a9c91dfe4',
+      CURRENT_DATE + 6,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'Z33A1BU',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 21
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '0ba231be-be19-4dcc-9d76-7a5a9c91dfe4',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '4e3785eb-2c3a-4c00-a7f8-4b0fb0e9c7be',
+      '0ba231be-be19-4dcc-9d76-7a5a9c91dfe4',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       CURRENT_DATE,
       CURRENT_DATE,
       (

--- a/src/main/resources/db/migration/test/R__3_create_applications.sql
+++ b/src/main/resources/db/migration/test/R__3_create_applications.sql
@@ -1,0 +1,1653 @@
+
+-- ${flyway:timestamp}
+TRUNCATE TABLE applications CASCADE;
+TRUNCATE TABLE assessments CASCADE;
+
+
+DO $$
+DECLARE
+   applicationData json := '{"basic-information":{"sentence-type":{"sentenceType":"bailPlacement"},"situation":{"situation":"bailSentence"},"release-date":{"releaseDate-year":"2022","releaseDate-month":"11","releaseDate-day":"14","releaseDate":"2022-11-14","knowReleaseDate":"yes"},"placement-date":{"startDateSameAsReleaseDate":"yes"},"placement-purpose":{"placementPurposes":["drugAlcoholMonitoring","otherReason"],"otherReason":"Reason"}},"type-of-ap":{"ap-type":{"type":"standard"}},"oasys-import":{"optional-oasys-sections":{"needsLinkedToReoffending":[{"section":1,"name":"accommodation","linkedToHarm":false,"linkedToReOffending":true},{"section":2,"name":"relationships","linkedToHarm":false,"linkedToReOffending":true}],"otherNeeds":[{"section":3,"name":"emotional","linkedToHarm":false,"linkedToReOffending":false},{"section":4,"name":"thinking","linkedToHarm":false,"linkedToReOffending":false}]},"rosh-summary":{"roshAnswers":["Some answer for the first RoSH question. With an extra comment 1","Some answer for the second RoSH question. With an extra comment 2","Some answer for the third RoSH question. With an extra comment 3"],"roshSummaries":[{"questionNumber":"1","label":"The first RoSH question","answer":"Some answer for the first RoSH question"},{"questionNumber":"2","label":"The second RoSH question","answer":"Some answer for the second RoSH question"},{"questionNumber":"3","label":"The third RoSH question","answer":"Some answer for the third RoSH question"}]},"offence-details":{"offenceDetailsAnswers":["Some answer for the first offence details question. With an extra comment 1","Some answer for the second offence details question. With an extra comment 2","Some answer for the third offence details question. With an extra comment 3"],"offenceDetailsSummaries":[{"questionNumber":"1","label":"The first offence details question","answer":"Some answer for the first offence details question"},{"questionNumber":"2","label":"The second offence details question","answer":"Some answer for the second offence details question"},{"questionNumber":"3","label":"The third offence details question","answer":"Some answer for the third offence details question"}]},"supporting-information":{"supportingInformationAnswers":["Some answer for the first supporting information question. With an extra comment 1","Some answer for the second supporting information question. With an extra comment 2","Some answer for the third supporting information question. With an extra comment 3"],"supportingInformationSummaries":[{"questionNumber":"1","label":"The first supporting information question","answer":"Some answer for the first supporting information question"},{"questionNumber":"2","label":"The second supporting information question","answer":"Some answer for the second supporting information question"},{"questionNumber":"3","label":"The third supporting information question","answer":"Some answer for the third supporting information question"}]},"risk-management-plan":{"riskManagementAnswers":["Some answer for the first risk management question. With an extra comment 1","Some answer for the second risk management question. With an extra comment 2","Some answer for the third risk management question. With an extra comment 3"],"riskManagementSummaries":[{"questionNumber":"1","label":"The first risk management question","answer":"Some answer for the first risk management question"},{"questionNumber":"2","label":"The second risk management question","answer":"Some answer for the second risk management question"},{"questionNumber":"3","label":"The third risk management question","answer":"Some answer for the third risk management question"}]},"risk-to-self":{"riskToSelfAnswers":["Some answer for the first risk to self question. With an extra comment 1","Some answer for the second risk to self question. With an extra comment 2","Some answer for the third risk to self question. With an extra comment 3"],"riskToSelfSummaries":[{"questionNumber":"1","label":"The first risk to self question","answer":"Some answer for the first risk to self question"},{"questionNumber":"2","label":"The second risk to self question","answer":"Some answer for the second risk to self question"},{"questionNumber":"3","label":"The third risk to self question","answer":"Some answer for the third risk to self question"}]}},"risk-management-features":{"risk-management-features":{"manageRiskDetails":"est vero nesciunt","additionalFeaturesDetails":"deleniti enim necessitatibus"},"convicted-offences":{"response":"yes"},"type-of-convicted-offence":{"offenceConvictions":["arson","sexualOffence","hateCrimes","childNonSexualOffence"]},"date-of-offence":{"arsonOffence":["current"],"hateCrime":["previous"],"inPersonSexualOffence":["current","previous"]},"rehabilitative-interventions":{"rehabilitativeInterventions":["accommodation","drugsAndAlcohol","childrenAndFamilies","health","educationTrainingAndEmployment","financeBenefitsAndDebt","attitudesAndBehaviour","abuse","other"],"otherIntervention":"Another"}},"prison-information":{"case-notes":{"caseNoteIds":["a30173ca-061f-42c9-a1a2-28c70b282d3f","4a477187-b77f-4fcc-a919-43a6633ee868"],"selectedCaseNotes":[{"authorName":"Denise Collins","id":"a30173ca-061f-42c9-a1a2-28c70b282d3f","createdAt":"2022-11-10","occurredAt":"2022-10-19","sensitive":false,"subType":"Ressettlement","type":"Social Care","note":"Note 1"},{"authorName":"Leticia Mann","id":"4a477187-b77f-4fcc-a919-43a6633ee868","createdAt":"2022-07-24","occurredAt":"2022-09-22","sensitive":true,"subType":"Quality Work","type":"General","note":"Note 2"}],"moreDetail":"some details","adjudications":[{"id":69927,"reportedAt":"2022-10-09","establishment":"Hawthorne","offenceDescription":"Nam vel nisi fugiat veniam possimus omnis.","hearingHeld":false,"finding":"NOT_PROVED"},{"id":39963,"reportedAt":"2022-07-10","establishment":"Oklahoma City","offenceDescription":"Illum maxime enim explicabo soluta sequi voluptas.","hearingHeld":true,"finding":"PROVED"},{"id":77431,"reportedAt":"2022-05-30","establishment":"Jurupa Valley","offenceDescription":"Quis porro nemo voluptates doloribus atque quis provident iure.","hearingHeld":false,"finding":"PROVED"}]}},"location-factors":{"describe-location-factors":{"postcodeArea":"SW1","positiveFactors":"Some positive factors","restrictions":"yes","restrictionDetail":"Restrictions go here","alternativeRadiusAccepted":"yes","alternativeRadius":"70","differentPDU":"no"},"pdu-transfer":{"transferStatus":"yes","probationPractitioner":"Probation Practicioner"}},"access-and-healthcare":{"access-needs":{"additionalNeeds":["mobility","learningDisability","neurodivergentConditions"],"religiousOrCulturalNeeds":"yes","religiousOrCulturalNeedsDetails":"sunt at minus","needsInterpreter":"yes","interpreterLanguage":"beatae eligendi explicabo","careActAssessmentCompleted":"yes"},"access-needs-mobility":{"needsWheelchair":"yes","mobilityNeeds":"laboriosam","visualImpairment":"exercitationem"},"covid":{"fullyVaccinated":"yes","highRisk":"yes","additionalCovidInfo":"additional info"}},"further-considerations":{"room-sharing":{"riskToStaff":"no","riskToStaffDetail":"","riskToOthers":"no","riskToOthersDetail":"","sharingConcerns":"yes","sharingConcernsDetail":"Some details here","traumaConcerns":"no","traumaConcernsDetail":"","sharingBenefits":"no","sharingBenefitsDetail":""},"vulnerability":{"exploitable":"no","exploitableDetail":"","exploitOthers":"yes","exploitOthersDetail":"Some details here"},"previous-placements":{"previousPlacement":"yes","previousPlacementDetail":"Some details here"},"complex-case-board":{"complexCaseBoard":"yes","complexCaseBoardDetail":"Some details here"},"catering":{"catering":"yes","cateringDetail":"Some details here"},"arson":{"arson":"yes","arsonDetail":"Some details here"}},"move-on":{"placement-duration":{"duration":"10","durationDetail":"Some more information"},"relocation-region":{"postcodeArea":"XX1"},"plans-in-place":{"arePlansInPlace":"yes"},"type-of-accommodation":{"accommodationType":"foreignNational","otherAccommodationType":""},"foreign-national":{"response":"yes","date-year":"2015","date-month":"1","date-day":"1","date":"2015-01-01"}},"attach-required-documents":{"attach-documents":{"selectedDocuments":[{"id":"aeb43e06-a4a1-460f-9acf-e2495de84604","level":"Offender","fileName":"Random offender document1.pdf","createdAt":"2019-09-10T00:00:00Z","typeCode":"OFFENDER_DOCUMENT","typeDescription":"Offender related","description":"Some Description 1"},{"id":"5f8a2288-0a17-4e45-afd5-5e57794a7b53","level":"Conviction","fileName":"national.asm","createdAt":"2022-09-13","typeCode":"serenade","typeDescription":"porter","description":"Some Description 2"}]}},"check-your-answers":{"review":{"reviewed":"1"}}}';
+   applicationDocument json := '{"basic-information":[{"Which of the following best describes the sentence type?":"Standard determinate custody"},{"What type of release will the application support?":"Release on Temporary License (ROTL)"},{"Do you know Justyn Flatley’s release date?":"Yes","Release Date":"Saturday 1 April 2023"},{"Is Saturday 1 April 2023 the date you want the placement to start?":"Yes"},{"What is the purpose of the AP placement?":"Prevent contact, Help individual readjust to life outside custody"}],"type-of-ap":[{"Which type of AP does Justyn Flatley require?":"Standard"}],"oasys-import":[{"Needs linked to reoffending":"9. Alcohol","Needs not linked to risk of serious harm or reoffending":"5. Finance, 11. Thinking and behavioural"},{"R10.1":"[R10.1] IN CUSTODY\r\n \r\n KNOWN ADULTS:\r\n Such as Ms Elaine Underhill and any of the victims of the index offence if they are placed close to Mr Smith cell.\r\n \r\n CHILDREN:\r\n Simon Smith, Roger Smith, Lindy Smith","R10.2":"[R10.2] IN CUSTODY:\r\n \r\n KNOWN ADULTS:\r\n Intimidation, threats of violence, use of weapons or boiling water, physical education and violent assault, long term psychological impact as a result of Mr Smith violent behaviour. This harm may be cause in the course of physical altercation due to seeking revenge or holding grudges...","R10.3":"[R10.3] STATIC RISK FACTORS:\r\n \r\n Mr Smith gender - At the time of the offence, Mr Smith was 35 years old and considered to be in the higher risk group.\r\n \r\n STABLE DYNAMIC RISK FACTORS:\r\n Thinking and behaviour - limited ability to manage mood or emotions poor impulse control. Mr Smith demonstrated cognitive deficit in committing the index offences and this still remains a concern...","R10.4":"[R10.4] CIRCUMSTANCES:\r\n A lack of stable accommodation\r\n unemployment\r\n non constructive use of time\r\n breakdown of family support\r\n being unable to access benefits\r\n \r\n UNDERLYING FACTORS:\r\n pro criminal attitudes supporting commission of crime...","R10.5":"[R10.5] Engage with Mental Health Services in prison and in the community.\r\n Maintain emotional stability.\r\n Abstain from alcohol.\r\n Abstain from illegal drugs.\r\n Regular testing for alcohol and drug use, in prison and on Licence.\r\n Maintain stable accommodation..."},{"2.1":"","2.4.1":"","2.4.2":"","2.12":"","2.5":"","2.8.3":"","2.98":""},{"3.9":"[3.9] Mr Smith told me that he was renting a room in a shared house, prior to his current remand...","4.9":"[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his...","5.9":"[5.9] Mr Smith was in receipt of Job Seekers Allowance prior to his current remand in custody...","9.9":"[9.9] Mr Smith told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years...","11.9":"[11.9] The circumstances of the current offence suggest that Mr Smith acted ..."},{"RM28":"[RM28] Mr Smith is currently on remand awaiting sentence","RM35":"[RM35] Placeholder content for additional comments","RM34":"[RM34] Discuss any concerns with line manager/SPO Increase frequency of reporting Bring forward MAPPA/Consider Level 2 MAPPA professionals meetings  considered if MAPPA not applicable. Consider referral to Approved Premises Consider motivational interviewing/engagement officer.  Joint interview with police OM or other relevant agencies? To raise concerns Referral to substance misues worker for additional support. Warning letters to be employed Recall/Breach if risk not manageable.","RM33":"[RM33] Undertake sentence planning with OS within 8 or 16 weeks of sentence carats - continue to work with Mr Smith and refer for relevant programmes during any prison sentence imposed. DIP supervise DRR is imposed or provide support post release if conditions/requirements to manage the specific risks.","RM32":"[RM32] Requires referral to community drug DIP upon  release. To link in with employment/training resources such as College and ETEO. Completion of victim empathy module via 1-1 supervision to build upon awareness of impact of offending.   Level setting to be undertaken by Senior Probation Officer and OMU. Multi Agency Public Protection Panel to be convened if level 2 either at start of supervision or 6 months prior to release","RM31":"[RM31] State they will have secure accommodation for Mr Smith  and partner on release, although she too is subject to a DRR at present. Supportive wider family.  Has completed previously Short Duration programme and attended one of the support sessions .  Engaged with CARATS in custody.  Complied with voluntary drug tests in custody. Some motivation to desist from alcohol/drug use in the future, this needs to be encouraged with use of community resources. Completed drug and heroin awareness programmes in custody.","RM30":"[RM30] Probation Officer, Education training and employment Officer, Prison Offender Supervisor","RM28.1":"[RM28.1] Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."},{"R8.1.1":"Review 06.10.21:\r\n \r\n         There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021...","R8.2.1":"Has told prison staff that he swallowed batteries on one occasion due to wanting..","R8.3.1":"Review 06.10.21:\r\n \r\n         A previous assessor opined that Mr Smith was displaying all the characteristics of someone..."}],"risk-management-features":[{"Describe why an AP placement is needed to manage the risk of Justyn Flatley":"Some words","Provide details of any additional measures that will be necessary for the management of risk":"Some words"},{"Has Justyn Flatley ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?":"No"},{"Which rehabilitative interventions will support the person''s Approved Premises (AP) placement?":"Drugs and alcohol, Children and families"}],"prison-information":[{"Selected prison case notes that support this application":["Array"],"Adjudications":["Array"]}],"location-factors":[{"What is the preferred location for the AP placement?":"WS1","Give details of any positive factors for the person in this location.":"Some words","Are there any restrictions linked to placement location?":"No","If an AP Placement is not available in the persons preferred area, would a placement further away be considered?":"No","Is the person moving to a different area where they''ll be managed by a different probation delivery unit (PDU)?":"No"},{"Have you agreed Justyn Flatley''s transfer/supervision with the receiving PDU?":"No, I still need to make arrangements"}],"access-and-healthcare":[{"Does Justyn Flatley have any of the following needs?":"Learning disability, hearing impairment","Does Justyn Flatley have any religious or cultural needs?":"No","Details of religious or cultural needs":"","Does Justyn Flatley need an interpreter?":"No","Has a care act assessment been completed?":"No"},{"Has Justyn Flatley been fully vaccinated for COVID-19?":"No","Is Justyn Flatley at a higher risk from COVID-19?":"No"}],"further-considerations":[{"Is there any evidence that the person may pose a risk to AP staff?":"No","Is there any evidence that the person may pose a risk to other AP residents?":"No","Do you have any concerns about the person sharing a bedroom?":"No","Is there any evidence of previous trauma or significant event in the persons history which would indicate that room share may not be suitable?":"No","Is there potential for the person to benefit from a room share?":"No"},{"Are you aware that Justyn Flatley is vulnerable to exploitation from others?":"No","Is there any evidence or expectation that Justyn Flatley may groom, radicalise or exploit others?":"No"},{"Has Justyn Flatley stayed or been offered a placement in an AP before?":"No"},{"Does Justyn Flatley''s gender identity require a complex case board to review their application?":"No"},{"Do you have any concerns about Justyn Flatley catering for themselves?":"No"},{"Does Justyn Flatley need a specialist arson room?":"No"}],"move-on":[{"What duration of placement do you recommend?":"11 weeks","Provide any additional information":"Some words"},{"Where is Justyn Flatley most likely to live when they move on from the AP?":"WS13"},{"Are move on arrangements already in place for when the person leaves the AP?":"No"},{"What type of accommodation will Justyn Flatley have when they leave the AP?":"Supported housing"}],"attach-required-documents":[{"PRE-CONS.pdf":"Previous convictions as of 01/09/2019","Personal circumstances.pdf.pdf":"Personal circumstance of AP - Medication in Posession  - Assessment started on 11/09/2019","NSIOffender.pdf":"Non Statutory Intervention for OPD Community Pathway on 16/10/2019","paroleParom1Report_04092019_122116_OMIC_A_X320741.pdf":"Parole Assessment Report at Berwyn (HMP) requested on 05/09/2019"}],"check-your-answers":[{}]}';
+BEGIN
+
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '35e63614-e68c-4d7d-8996-8dd72c7b8ea5',
+      CURRENT_DATE + 25,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      '315VWWC',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 3
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '35e63614-e68c-4d7d-8996-8dd72c7b8ea5',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '9afe9b99-71be-42d3-bd8d-bdef38065d71',
+      '35e63614-e68c-4d7d-8996-8dd72c7b8ea5',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '0ffdf858-a3e4-4fda-a1d8-1a87b4d6f71e',
+      CURRENT_DATE + 10,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      '4Y29R9P',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 0
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '0ffdf858-a3e4-4fda-a1d8-1a87b4d6f71e',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'de01f811-e10e-4845-ae33-d05521491436',
+      '0ffdf858-a3e4-4fda-a1d8-1a87b4d6f71e',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'e422232a-9459-45d4-b48d-f8443f1774f0',
+      CURRENT_DATE + 9,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      '4ZUIHFX',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 0
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'e422232a-9459-45d4-b48d-f8443f1774f0',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '9a63ecfc-7155-4e37-a51e-04964457b4e8',
+      'e422232a-9459-45d4-b48d-f8443f1774f0',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '1f7fd593-1b4e-4843-8575-20e1e63555da',
+      CURRENT_DATE + 27,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '52W7TQG',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 15
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '1f7fd593-1b4e-4843-8575-20e1e63555da',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '49da0ae4-3ba7-4778-a817-7e5b5cc8c2fd',
+      '1f7fd593-1b4e-4843-8575-20e1e63555da',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'c9187c64-f8a7-4ec7-9351-7f6e414b2681',
+      CURRENT_DATE + 2,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '5EC66UT',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 10
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'c9187c64-f8a7-4ec7-9351-7f6e414b2681',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'e7393185-6c71-4e14-bd38-bc67c7270fb3',
+      'c9187c64-f8a7-4ec7-9351-7f6e414b2681',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '1ba0d70b-36f9-4b3c-bfcd-ecf474e5ec6a',
+      CURRENT_DATE + 6,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '8LO3HSH',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 5
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '1ba0d70b-36f9-4b3c-bfcd-ecf474e5ec6a',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '281dcf30-756a-4ae6-bbbd-730380e3bc63',
+      '1ba0d70b-36f9-4b3c-bfcd-ecf474e5ec6a',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '0ecff4e1-6851-4893-a779-5ef695caabdf',
+      CURRENT_DATE + 12,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'BWEFOI7',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 18
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '0ecff4e1-6851-4893-a779-5ef695caabdf',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'c26644e7-337e-43af-a57c-bc40a25823e3',
+      '0ecff4e1-6851-4893-a779-5ef695caabdf',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '18387705-a22a-4dc7-ae39-9a0bd95e5735',
+      CURRENT_DATE + 5,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'GSR1T2F',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 11
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '18387705-a22a-4dc7-ae39-9a0bd95e5735',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'ae60a9dd-e542-4777-8764-0874d8610b48',
+      '18387705-a22a-4dc7-ae39-9a0bd95e5735',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '4cedfea8-52a7-4846-81b6-e4f768923733',
+      CURRENT_DATE + 28,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'HRV83TE',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 20
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '4cedfea8-52a7-4846-81b6-e4f768923733',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '60195bb3-ca9f-4647-a6ae-c6b44c76ca84',
+      '4cedfea8-52a7-4846-81b6-e4f768923733',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'cd31a8a9-6f7d-4f41-9b5d-a2306db59133',
+      CURRENT_DATE + 8,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'HTVI42B',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 12
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'cd31a8a9-6f7d-4f41-9b5d-a2306db59133',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'f4a55720-1a9b-4acb-832e-7cec48eaad9f',
+      'cd31a8a9-6f7d-4f41-9b5d-a2306db59133',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '3041e294-e3c7-4cec-9449-82a301d2af6e',
+      CURRENT_DATE + 13,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'HUN3BN0',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 24
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '3041e294-e3c7-4cec-9449-82a301d2af6e',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '0711a132-93f1-49b9-bc1e-79b92566c3f2',
+      '3041e294-e3c7-4cec-9449-82a301d2af6e',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'e3ef8fd7-9e41-4983-b467-622ace779558',
+      CURRENT_DATE + 26,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'IHGHXYM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 29
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'e3ef8fd7-9e41-4983-b467-622ace779558',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '57082020-4311-4b73-b302-141240ac5100',
+      'e3ef8fd7-9e41-4983-b467-622ace779558',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '637b7b24-e086-45ec-be3f-d689c7c8b32b',
+      CURRENT_DATE + 17,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'JCRH9V5',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 5
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '637b7b24-e086-45ec-be3f-d689c7c8b32b',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'f8c4572c-2987-42bc-9f16-cb26354c5ad3',
+      '637b7b24-e086-45ec-be3f-d689c7c8b32b',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '6e38628a-6ac3-447b-b733-c88677f67f57',
+      CURRENT_DATE + 24,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'N6OUTAY',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 25
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '6e38628a-6ac3-447b-b733-c88677f67f57',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'beb05e58-35da-4671-a744-38662b2a87b8',
+      '6e38628a-6ac3-447b-b733-c88677f67f57',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '930a0717-ea15-4c4b-8cab-02625ca4e319',
+      CURRENT_DATE + 7,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'PI251LM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 28
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '930a0717-ea15-4c4b-8cab-02625ca4e319',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '3d6f4507-698c-4a5e-8bad-662b687680b2',
+      '930a0717-ea15-4c4b-8cab-02625ca4e319',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '2ff19c8b-22ca-4156-ad87-a5c29c68b4d4',
+      CURRENT_DATE + 17,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'PR5E5Y2',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 5
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '2ff19c8b-22ca-4156-ad87-a5c29c68b4d4',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '2497d891-cb35-45df-a596-1a1bbcfa0a37',
+      '2ff19c8b-22ca-4156-ad87-a5c29c68b4d4',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'e168a312-1f6f-4b2f-9b84-01f299a698a7',
+      CURRENT_DATE + 5,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'QA93YYK',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 25
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'e168a312-1f6f-4b2f-9b84-01f299a698a7',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '8304c24e-4fc4-43ea-ad80-977fa877eba0',
+      'e168a312-1f6f-4b2f-9b84-01f299a698a7',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '8eddfe1e-9800-44d2-b977-f93d8bc88072',
+      CURRENT_DATE + 0,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'XCMSG3I',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 22
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '8eddfe1e-9800-44d2-b977-f93d8bc88072',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '6e8b8700-cedc-4b8b-a876-1d837796e2a0',
+      '8eddfe1e-9800-44d2-b977-f93d8bc88072',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'ffb38b0c-4a89-4b45-a023-51560d65b7fb',
+      CURRENT_DATE + 25,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'YRPARSH',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 21
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'ffb38b0c-4a89-4b45-a023-51560d65b7fb',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '371321af-c5fe-475a-9865-0d06e8a8933a',
+      'ffb38b0c-4a89-4b45-a023-51560d65b7fb',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'ccb80ad8-f07e-4e18-a0b5-f401d5745cdf',
+      CURRENT_DATE + 6,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'Z33A1BU',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 8
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'ccb80ad8-f07e-4e18-a0b5-f401d5745cdf',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '84cd417b-7a49-470e-8f6c-03748cabbe35',
+      'ccb80ad8-f07e-4e18-a0b5-f401d5745cdf',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+END $$;


### PR DESCRIPTION
This allows us to run [repeatable migrations](https://flywaydb.org/documentation/tutorials/repeatable) in the test environment, so we can be sure there's predictable data for user testing etc, and the environment doesn't get clogged up with test data. 

There's also a PR in the Wiremock repo https://github.com/ministryofjustice/hmpps-community-accommodation-wiremock/pull/7 that will allow us to generate these migrations in a predictable and consistent way.