### PR TITLE
(873) Update clarification notes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -220,15 +220,22 @@ class AssessmentController(
     updatedClarificationNote: UpdatedClarificationNote
   ): ResponseEntity<ClarificationNote> {
     val user = userService.getUserForRequest()
+    val clarificiationNoteResult = assessmentService.updateAssessmentClarificationNote(
+      user,
+      assessmentId,
+      noteId,
+      updatedClarificationNote.response,
+      updatedClarificationNote.responseReceivedOn
+    )
 
-    val clarificiationNoteResult = when (val clarificiationNoteResult = assessmentService.updateAssessmentClarificationNote(user, assessmentId, noteId, updatedClarificationNote.response)) {
+    val clarificiationNoteEntityResult = when (clarificiationNoteResult) {
       is AuthorisableActionResult.Success -> clarificiationNoteResult.entity
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
     }
 
-    val updatedClarificationNote = when (clarificiationNoteResult) {
-      is ValidatableActionResult.Success -> clarificiationNoteResult.entity
+    val updatedClarificationNote = when (clarificiationNoteEntityResult) {
+      is ValidatableActionResult.Success -> clarificiationNoteEntityResult.entity
       else -> throw InternalServerErrorProblem("You must provide a response")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -201,7 +201,7 @@ class AssessmentController(
   ): ResponseEntity<ClarificationNote> {
     val user = userService.getUserForRequest()
 
-    val clarificiationNoteResult = assessmentService.addAssessmentClarificationNote(user, assessmentId, newClarificationNote.text)
+    val clarificiationNoteResult = assessmentService.addAssessmentClarificationNote(user, assessmentId, newClarificationNote.query)
     val clarificiationNote = when (clarificiationNoteResult) {
       is AuthorisableActionResult.Success -> clarificiationNoteResult.entity
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentReje
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
@@ -210,6 +211,29 @@ class AssessmentController(
 
     return ResponseEntity.ok(
       assessmentClarificationNoteTransformer.transformJpaToApi(clarificiationNote)
+    )
+  }
+
+  override fun assessmentsAssessmentIdNotesNoteIdPut(
+    assessmentId: UUID,
+    noteId: UUID,
+    updatedClarificationNote: UpdatedClarificationNote
+  ): ResponseEntity<ClarificationNote> {
+    val user = userService.getUserForRequest()
+
+    val clarificiationNoteResult = when (val clarificiationNoteResult = assessmentService.updateAssessmentClarificationNote(user, assessmentId, noteId, updatedClarificationNote.response)) {
+      is AuthorisableActionResult.Success -> clarificiationNoteResult.entity
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    }
+
+    val updatedClarificationNote = when (clarificiationNoteResult) {
+      is ValidatableActionResult.Success -> clarificiationNoteResult.entity
+      else -> throw InternalServerErrorProblem("You must provide a response")
+    }
+
+    return ResponseEntity.ok(
+      assessmentClarificationNoteTransformer.transformJpaToApi(updatedClarificationNote)
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -83,5 +83,7 @@ data class AssessmentClarificationNoteEntity(
   val createdByUser: UserEntity,
   val createdAt: OffsetDateTime,
 
-  val text: String
+  val query: String,
+
+  val response: String?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -54,7 +54,7 @@ data class AssessmentEntity(
   var rejectionRationale: String?,
 
   @OneToMany(mappedBy = "assessment")
-  val clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
+  var clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
 
   @Transient
   var schemaUpToDate: Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
@@ -87,5 +88,7 @@ data class AssessmentClarificationNoteEntity(
 
   val query: String,
 
-  var response: String?
+  var response: String?,
+
+  var responseReceivedOn: LocalDate?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -66,7 +66,9 @@ enum class AssessmentDecision {
 }
 
 @Repository
-interface AssessmentClarificationNoteRepository : JpaRepository<AssessmentClarificationNoteEntity, UUID>
+interface AssessmentClarificationNoteRepository : JpaRepository<AssessmentClarificationNoteEntity, UUID> {
+  fun findByAssessmentIdAndId(assessmentId: UUID, id: UUID): AssessmentClarificationNoteEntity?
+}
 
 @Entity
 @Table(name = "assessment_clarification_notes")
@@ -85,5 +87,5 @@ data class AssessmentClarificationNoteEntity(
 
   val query: String,
 
-  val response: String?
+  var response: String?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -227,7 +227,8 @@ class AssessmentService(
         assessment = assessment,
         createdByUser = user,
         createdAt = OffsetDateTime.now(),
-        text = text
+        query = text,
+        response = null
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -254,6 +254,12 @@ class AssessmentService(
       return AuthorisableActionResult.Unauthorised()
     }
 
+    if (clarificationNoteEntity.response !== null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("A response has already been added to this note")
+      )
+    }
+
     clarificationNoteEntity.response = response
     clarificationNoteEntity.responseReceivedOn = responseReceivedOn
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -228,7 +228,8 @@ class AssessmentService(
         createdByUser = user,
         createdAt = OffsetDateTime.now(),
         query = text,
-        response = null
+        response = null,
+        responseReceivedOn = null,
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -236,7 +237,7 @@ class AssessmentService(
     return AuthorisableActionResult.Success(clarificationNoteEntity)
   }
 
-  fun updateAssessmentClarificationNote(user: UserEntity, assessmentId: UUID, id: UUID, response: String): AuthorisableActionResult<ValidatableActionResult<AssessmentClarificationNoteEntity>> {
+  fun updateAssessmentClarificationNote(user: UserEntity, assessmentId: UUID, id: UUID, response: String, responseReceivedOn: LocalDate): AuthorisableActionResult<ValidatableActionResult<AssessmentClarificationNoteEntity>> {
     val assessment = when (val assessmentResult = getAssessmentForUser(user, assessmentId)) {
       is AuthorisableActionResult.Success -> assessmentResult.entity
       is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised()
@@ -254,6 +255,7 @@ class AssessmentService(
     }
 
     clarificationNoteEntity.response = response
+    clarificationNoteEntity.responseReceivedOn = responseReceivedOn
 
     val savedNote = assessmentClarificationNoteRepository.save(clarificationNoteEntity)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
@@ -12,5 +12,6 @@ class AssessmentClarificationNoteTransformer {
     createdByStaffMemberId = jpa.createdByUser.id,
     query = jpa.query,
     response = jpa.response,
+    responseReceivedOn = jpa.responseReceivedOn,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
@@ -10,6 +10,7 @@ class AssessmentClarificationNoteTransformer {
     id = jpa.id,
     createdAt = jpa.createdAt,
     createdByStaffMemberId = jpa.createdByUser.id,
-    text = jpa.text
+    query = jpa.query,
+    response = jpa.response,
   )
 }

--- a/src/main/resources/db/migration/all/20230106113836__clarification_notes_now_have_a_query_and_a_response.sql
+++ b/src/main/resources/db/migration/all/20230106113836__clarification_notes_now_have_a_query_and_a_response.sql
@@ -1,0 +1,4 @@
+ALTER TABLE assessment_clarification_notes
+    RENAME COLUMN text TO query;
+
+ALTER TABLE assessment_clarification_notes ADD COLUMN response text;

--- a/src/main/resources/db/migration/all/20230109090123__add_response_received_on_to_clarification_note.sql
+++ b/src/main/resources/db/migration/all/20230109090123__add_response_received_on_to_clarification_note.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessment_clarification_notes ADD COLUMN response_received_on DATE;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3166,6 +3166,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClarificationNote'
+        status:
+          $ref: '#/components/schemas/AssessmentStatus'
       discriminator:
         propertyName: service
         mapping:
@@ -3179,6 +3181,12 @@ components:
         - createdAt
         - allocatedAt
         - clarificationNotes
+    AssessmentStatus:
+      type: string
+      enum:
+        - pending
+        - active
+        - completed
     ApprovedPremisesAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3294,8 +3294,13 @@ components:
       properties:
         response:
           type: string
+        responseReceivedOn:
+          type: string
+          format: date
+          example: 2022-07-28
       required:
         - response
+        - responseReceivedOn
     NewClarificationNote:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3229,20 +3229,22 @@ components:
         createdByStaffMemberId:
           type: string
           format: uuid
-        text:
+        query:
+          type: string
+        response:
           type: string
       required:
         - id
         - createdAt
         - createdByStaffMemberId
-        - text
+        - query
     NewClarificationNote:
       type: object
       properties:
-        text:
+        query:
           type: string
       required:
-        - text
+        - query
     Reallocation:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3274,6 +3274,9 @@ components:
         createdAt:
           type: string
           format: date-time
+        responseReceivedOn:
+          type: string
+          format: date
         createdByStaffMemberId:
           type: string
           format: uuid

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1836,6 +1836,46 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /assessments/{assessmentId}/notes/{noteId}:
+    put:
+      tags:
+        - Assessment data
+      summary: Updates an assessment's clarification note
+      parameters:
+        - in: path
+          name: assessmentId
+          required: true
+          description: Id of the assessment
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: noteId
+          required: true
+          description: Id of the clarification note
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Clarification note
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdatedClarificationNote'
+        required: true
+      responses:
+        201:
+          description: successfully updated a clarification note
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ClarificationNote'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}/acceptance:
     post:
       tags:
@@ -3238,6 +3278,13 @@ components:
         - createdAt
         - createdByStaffMemberId
         - query
+    UpdatedClarificationNote:
+      type: object
+      properties:
+        response:
+          type: string
+      required:
+        - response
     NewClarificationNote:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -17,6 +18,7 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
   private var createdBy: Yielded<UserEntity>? = null
   private var query: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var response: Yielded<String?> = { null }
+  private var responseReceivedOn: Yielded<LocalDate?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -42,12 +44,17 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     this.response = { response }
   }
 
+  fun withResponseReceivedOn(responseReceivedOn: LocalDate) = apply {
+    this.responseReceivedOn = { responseReceivedOn }
+  }
+
   override fun produce(): AssessmentClarificationNoteEntity = AssessmentClarificationNoteEntity(
     id = this.id(),
     assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
     createdAt = this.createdAt(),
     createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
     query = this.query(),
-    response = this.response()
+    response = this.response(),
+    responseReceivedOn = this.responseReceivedOn()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -15,7 +15,8 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
   private var assessment: Yielded<AssessmentEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var createdBy: Yielded<UserEntity>? = null
-  private var text: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var query: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var response: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -33,8 +34,12 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     this.createdBy = { createdBy }
   }
 
-  fun withText(text: String) = apply {
-    this.text = { text }
+  fun withQuery(query: String) = apply {
+    this.query = { query }
+  }
+
+  fun withResponse(response: String) = apply {
+    this.response = { response }
   }
 
   override fun produce(): AssessmentClarificationNoteEntity = AssessmentClarificationNoteEntity(
@@ -42,6 +47,7 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
     createdAt = this.createdAt(),
     createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
-    text = this.text()
+    query = this.query(),
+    response = this.response()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -16,7 +16,7 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var createdBy: Yielded<UserEntity>? = null
   private var query: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
-  private var response: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var response: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
@@ -28,7 +28,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var allocatedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
-  private var decision: Yielded<AssessmentDecision> = { AssessmentDecision.ACCEPTED }
+  private var decision: Yielded<AssessmentDecision?> = { AssessmentDecision.ACCEPTED }
   private var allocatedToUser: Yielded<UserEntity>? = null
   private var rejectionRationale: Yielded<String?> = { null }
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
@@ -65,7 +65,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     this.submittedAt = { submittedAt }
   }
 
-  fun withDecision(decision: AssessmentDecision) = apply {
+  fun withDecision(decision: AssessmentDecision?) = apply {
     this.decision = { decision }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class AssessmentTest : IntegrationTestBase() {
@@ -417,7 +418,8 @@ class AssessmentTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         UpdatedClarificationNote(
-          response = "some text"
+          response = "some text",
+          responseReceivedOn = LocalDate.parse("2022-03-04")
         )
       )
       .exchange()
@@ -425,5 +427,6 @@ class AssessmentTest : IntegrationTestBase() {
       .isOk
       .expectBody()
       .jsonPath("$.response").isEqualTo("some text")
+      .jsonPath("$.responseReceivedOn").isEqualTo("2022-03-04")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -355,13 +355,13 @@ class AssessmentTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewClarificationNote(
-          text = "some text"
+          query = "some text"
         )
       )
       .exchange()
       .expectStatus()
       .isOk
       .expectBody()
-      .jsonPath("$.text").isEqualTo("some text")
+      .jsonPath("$.query").isEqualTo("some text")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -832,7 +833,8 @@ class AssessmentServiceTest {
         user,
         assessment.id,
         assessmentClarificationNoteEntity.id,
-        "Some response"
+        "Some response",
+        LocalDate.parse("2022-03-03")
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -858,7 +860,8 @@ class AssessmentServiceTest {
         user,
         assessment.id,
         assessmentClarificationNoteEntity.id,
-        "Some response"
+        "Some response",
+        LocalDate.parse("2022-03-03")
       )
 
       assertThat(result is AuthorisableActionResult.NotFound).isTrue
@@ -881,7 +884,8 @@ class AssessmentServiceTest {
         user,
         assessment.id,
         assessmentClarificationNoteEntity.id,
-        "Some response"
+        "Some response",
+        LocalDate.parse("2022-03-03")
       )
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -4,12 +4,16 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
@@ -27,29 +31,34 @@ class AssessmentTransformerTest {
     mockAssessmentClarificationNoteTransformer
   )
 
+  private val allocatedToUser = UserEntityFactory().produce()
+
+  private val assessmentFactory = AssessmentEntityFactory()
+    .withApplication(mockk<ApprovedPremisesApplicationEntity>())
+    .withId(UUID.fromString("7d0d3b38-5bc3-45c7-95eb-4d714cbd0db1"))
+    .withAssessmentSchema(
+      ApprovedPremisesAssessmentJsonSchemaEntity(
+        id = UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"),
+        addedAt = OffsetDateTime.now(),
+        schema = "{}"
+      )
+    )
+    .withDecision(JpaAssessmentDecision.REJECTED)
+    .withRejectionRationale("reasoning")
+    .withData("{\"data\": \"something\"}")
+    .withCreatedAt(OffsetDateTime.parse("2022-12-14T12:05:00Z"))
+    .withSubmittedAt(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
+    .withAllocatedToUser(allocatedToUser)
+
+  @BeforeEach
+  fun setup() {
+    every { mockApplicationsTransformer.transformJpaToApi(any(), any(), any()) } returns mockk<ApprovedPremisesApplication>()
+    every { mockAssessmentClarificationNoteTransformer.transformJpaToApi(any()) } returns mockk()
+  }
+
   @Test
   fun `transformJpaToApi transforms correctly`() {
-    val allocatedToUser = UserEntityFactory().produce()
-
-    val assessment = AssessmentEntityFactory()
-      .withApplication(mockk<ApprovedPremisesApplicationEntity>())
-      .withId(UUID.fromString("7d0d3b38-5bc3-45c7-95eb-4d714cbd0db1"))
-      .withAssessmentSchema(
-        ApprovedPremisesAssessmentJsonSchemaEntity(
-          id = UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"),
-          addedAt = OffsetDateTime.now(),
-          schema = "{}"
-        )
-      )
-      .withDecision(JpaAssessmentDecision.REJECTED)
-      .withRejectionRationale("reasoning")
-      .withData("{\"data\": \"something\"}")
-      .withCreatedAt(OffsetDateTime.parse("2022-12-14T12:05:00Z"))
-      .withSubmittedAt(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
-      .withAllocatedToUser(allocatedToUser)
-      .produce()
-
-    every { mockApplicationsTransformer.transformJpaToApi(any(), any(), any()) } returns mockk<ApprovedPremisesApplication>()
+    val assessment = assessmentFactory.produce()
 
     val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
 
@@ -60,5 +69,49 @@ class AssessmentTransformerTest {
     assertThat(result.createdAt).isEqualTo(OffsetDateTime.parse("2022-12-14T12:05:00Z"))
     assertThat(result.submittedAt).isEqualTo(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
     assertThat(result.allocatedToStaffMemberId).isEqualTo(allocatedToUser.id)
+  }
+
+  @Test
+  fun `transformJpaToApi sets a pending status when there is a clarification note with no response`() {
+    val assessment = assessmentFactory.withDecision(null).produce()
+
+    val clarificationNotes = mutableListOf(
+      AssessmentClarificationNoteEntityFactory()
+        .withAssessment(assessment)
+        .withResponse("Some text")
+        .withCreatedBy(UserEntityFactory().produce())
+        .produce(),
+      AssessmentClarificationNoteEntityFactory()
+        .withAssessment(assessment)
+        .withCreatedBy(UserEntityFactory().produce())
+        .produce()
+    )
+
+    assessment.clarificationNotes = clarificationNotes
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+
+    assertThat(result.status).isEqualTo(AssessmentStatus.pending)
+  }
+
+  @Test
+  fun `transformJpaToApi sets a completed status when there is a decision`() {
+    val assessment = assessmentFactory
+      .withDecision(AssessmentDecision.ACCEPTED)
+      .produce()
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+
+    assertThat(result.status).isEqualTo(AssessmentStatus.completed)
+  }
+
+  @Test
+  fun `transformJpaToApi sets an active status when there is no decision`() {
+    val assessment = assessmentFactory
+      .produce()
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+
+    assertThat(result.status).isEqualTo(AssessmentStatus.completed)
   }
 }


### PR DESCRIPTION
This adds some new columns to the Clarification Notes object, as well as allowing users to update a note with both a response, and when the response was received.