### PR TITLE
Simple implementation of PDU for Temporary Accommodation premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -97,7 +97,8 @@ class PremisesController(
         body.probationRegionId,
         body.characteristicIds,
         body.notes,
-        body.status
+        body.status,
+        body.pdu,
       )
 
     val validationResult = when (updatePremisesResult) {
@@ -149,7 +150,8 @@ class PremisesController(
         name = body.name,
         notes = body.notes,
         characteristicIds = body.characteristicIds,
-        status = body.status
+        status = body.status,
+        pdu = body.pdu,
       )
     )
     return ResponseEntity(premisesTransformer.transformJpaToApi(premises, premises.totalBeds), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -118,7 +118,8 @@ class TemporaryAccommodationPremisesEntity(
   lostBeds: MutableList<LostBedsEntity>,
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
-  status: PropertyStatus
+  status: PropertyStatus,
+  var pdu: String,
 ) : PremisesEntity(
   id,
   name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -47,6 +47,7 @@ class PremisesTransformer(
       localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
       status = jpa.status,
+      pdu = jpa.pdu,
     )
     else -> throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/resources/db/migration/all/20230104163132__add_pdu_column_to_premises.sql
+++ b/src/main/resources/db/migration/all/20230104163132__add_pdu_column_to_premises.sql
@@ -1,0 +1,17 @@
+ALTER TABLE temporary_accommodation_premises ADD COLUMN pdu TEXT;
+
+-- Some TA premises may have existing rows on the table.
+UPDATE temporary_accommodation_premises
+SET pdu = 'Not specified';
+
+ALTER TABLE temporary_accommodation_premises ALTER COLUMN pdu SET NOT NULL;
+
+-- Some TA premises do not have existing rows on the table, and will need them.
+INSERT INTO temporary_accommodation_premises(premises_id, pdu)
+SELECT id, 'Not specified'
+FROM premises
+WHERE premises.service = 'temporary-accommodation'
+AND premises.id NOT IN (
+    SELECT premises_id
+    FROM temporary_accommodation_premises
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2147,6 +2147,12 @@ components:
     TemporaryAccommodationPremises:
       allOf:
         - $ref: '#/components/schemas/Premises'
+        - type: object
+          properties:
+            pdu:
+              type: string
+      required:
+        - pdu
     NewPremises:
       type: object
       properties:
@@ -2172,6 +2178,8 @@ components:
             format: uuid
         status:
           $ref: '#/components/schemas/PropertyStatus'
+        pdu:
+          type: string
       required:
         - name
         - addressLine1
@@ -3256,6 +3264,8 @@ components:
             format: uuid
         status:
           $ref: '#/components/schemas/PropertyStatus'
+        pdu:
+          type: string
       required:
         - addressLine1
         - postcode

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -25,6 +25,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
   private var service: Yielded<String> = { ServiceName.temporaryAccommodation.value }
   private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.values().asList()) }
+  private var pdu: Yielded<String> = { randomStringUpperCase(15) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -73,6 +74,11 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   fun withStatus(status: PropertyStatus) = apply {
     this.status = { status }
   }
+
+  fun withPdu(pdu: String) = apply {
+    this.pdu = { pdu }
+  }
+
   override fun produce(): TemporaryAccommodationPremisesEntity = TemporaryAccommodationPremisesEntity(
     id = this.id(),
     name = this.name(),
@@ -86,6 +92,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     notes = this.notes(),
     rooms = mutableListOf(),
     characteristics = mutableListOf(),
-    status = this.status()
+    status = this.status(),
+    pdu = this.pdu(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -105,7 +105,8 @@ class BookingTransformerTest {
     notes = "",
     rooms = mutableListOf(),
     characteristics = mutableListOf(),
-    status = PropertyStatus.active
+    status = PropertyStatus.active,
+    pdu = ""
   )
 
   private val baseBookingEntity = BookingEntity(


### PR DESCRIPTION
> See [ticket #570 on the CAS3 Trello board](https://trello.com/c/TON49LwD/570-users-can-assign-a-property-to-a-region-and-pdu).

This PR introduces PDUs to Temporary Accommodation premises. This has been done in a minimal and unopinionated way as a temporary measure to avoid conflicting with CAS1's planned changes to how geographic entities are modelled in the database, and will be revisited once those changes have been made.

This minimal PDU support is implemented by:
- Adding a `pdu` column to the `temporary_accommodation_premises` table. This column is just stored as text - while a more robust implementation would involve another table and a foreign key relationship, introducing such a table might complicate the previously mentioned model changes.
- Updating the `TemporaryAccommodationPremises` API schema with a required `pdu` property, and the `NewPremises` and `UpdatePremises` schemas with an optional `pdu` property. Validation logic in the service layer enforces that the PDU is provided when creating or updating a Temporary Accommodation premises. The `pdu` property has no effect on an Approved Premises.

Other things to note:
- No reference data endpoint for PDUs has been implemented. To avoid unnecessary breaking changes, the existence of this endpoint relies on the changes to the geographic model being largely in place. As a consequence, the Temporary Accommodation UI must maintain its own internal set of valid PDUs.
- There is no canonical list of PDUs within the API itself. This is closely related to the above point, but as a consequence means that the API currently must accept it as an arbitrary string from the client. The risk from this is that a value that does not correspond to a real PDU is sent to the API, complicating future migrations that change how PDUs are stored without a catch-all mapping. However, the Temporary Accommodation UI will present its internally-stored set of PDUs as a dropdown list without free text entry, and the PDU is not stored for an Approved Premises, so the probability is acceptably low.