### PR TITLE
Add 'keyWorker' to 'person.departed' domain event

### DIFF
--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -707,6 +707,8 @@ components:
           $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
+        keyWorker:
+          $ref: '#/components/schemas/StaffMember'
         premises:
           $ref: '#/components/schemas/Premises'
         departedAt:


### PR DESCRIPTION
The Delius team would like the consuming integration to use the name of the practitioner who recorded the departure, on the Contact in Delius (Officer field).

This assumes that the key worker is the person recording the departure.