### PR TITLE
(873) Add an endpoint to get user details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.UsersApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import java.util.UUID
+
+@Service
+class UsersController(
+  private val userService: UserService,
+  private val userTransformer: UserTransformer
+) : UsersApiDelegate {
+
+  override fun usersIdGet(id: UUID): ResponseEntity<User> {
+    val userEntity = when (val result = userService.getUserForId(id)) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> result.entity
+    }
+
+    return ResponseEntity(userTransformer.transformJpaToApi(userEntity), HttpStatus.OK)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -42,6 +42,8 @@ data class UserEntity(
   val name: String,
   val deliusUsername: String,
   val deliusStaffIdentifier: Long,
+  val email: String,
+  val telephoneNumber: String?,
   @OneToMany(mappedBy = "createdByUser")
   val applications: MutableList<ApplicationEntity>,
   @OneToMany(mappedBy = "user")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -42,8 +42,8 @@ data class UserEntity(
   val name: String,
   val deliusUsername: String,
   val deliusStaffIdentifier: Long,
-  val email: String,
-  val telephoneNumber: String?,
+  var email: String,
+  var telephoneNumber: String?,
   @OneToMany(mappedBy = "createdByUser")
   val applications: MutableList<ApplicationEntity>,
   @OneToMany(mappedBy = "user")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -45,6 +45,8 @@ class UserService(
         name = "${staffUserDetails.staff.forenames} ${staffUserDetails.staff.surname}",
         deliusUsername = username,
         deliusStaffIdentifier = staffUserDetails.staffIdentifier,
+        email = staffUserDetails.email,
+        telephoneNumber = staffUserDetails.telephoneNumber,
         applications = mutableListOf(),
         roles = mutableListOf(),
         qualifications = mutableListOf()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -15,6 +15,8 @@ class UserTransformer {
   fun transformJpaToApi(jpa: UserEntity) = User(
     deliusUsername = jpa.deliusUsername,
     roles = jpa.roles.map(::transformRoleToApi),
+    email = jpa.email,
+    telephoneNumber = jpa.telephoneNumber,
     qualifications = jpa.qualifications.map(::transformQualificationToApi)
   )
 

--- a/src/main/resources/db/migration/all/20230110115806__add_contact_details_to_user.sql
+++ b/src/main/resources/db/migration/all/20230110115806__add_contact_details_to_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN email text NOT NULL DEFAULT 'unknown@digital.justice.gov.uk';
+ALTER TABLE users ADD COLUMN telephone_number text;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3319,6 +3319,10 @@ components:
       properties:
         deliusUsername:
           type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
         roles:
           type: array
           items:
@@ -3329,6 +3333,7 @@ components:
             $ref: '#/components/schemas/UserQualification'
       required:
         - deliusUsername
+        - email
         - roles
         - qualifications
     UserRole:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1989,6 +1989,30 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /users/{id}:
+    get:
+      summary: Get information about a specific user
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the user
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successfully retrieved information on user
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/User'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /seed:
     post:
       summary: Starts the data seeding process, can only be called from a local connection

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -6,13 +6,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class UserEntityFactory : Factory<UserEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringUpperCase(12) }
+  private var email: Yielded<String> = { randomEmailAddress() }
+  private var telephoneNumber: Yielded<String> = { randomNumberChars(12) }
   private var deliusUsername: Yielded<String> = { randomStringUpperCase(12) }
   private var deliusStaffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
   private var applications: Yielded<MutableList<ApplicationEntity>> = { mutableListOf() }
@@ -55,9 +59,19 @@ class UserEntityFactory : Factory<UserEntity> {
     this.qualifications = { qualifications }
   }
 
+  fun withEmail(email: String) = apply {
+    this.email = { email }
+  }
+
+  fun withTelephoneNumber(telephoneNumber: String) = apply {
+    this.telephoneNumber = { telephoneNumber }
+  }
+
   override fun produce(): UserEntity = UserEntity(
     id = this.id(),
     name = this.name(),
+    email = this.email(),
+    telephoneNumber = this.telephoneNumber(),
     deliusUsername = this.deliusUsername(),
     deliusStaffIdentifier = this.deliusStaffIdentifier(),
     applications = this.applications(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -35,6 +35,8 @@ class ProfileTest : IntegrationTestBase() {
   @Test
   fun `Getting own profile returns OK with correct body`() {
     val deliusUsername = "JimJimmerson"
+    val email = "foo@bar.com"
+    val telephoneNumber = "123445677"
 
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = deliusUsername,
@@ -44,6 +46,8 @@ class ProfileTest : IntegrationTestBase() {
 
     val userEntity = userEntityFactory.produceAndPersist {
       withDeliusUsername(deliusUsername)
+      withEmail(email)
+      withTelephoneNumber(telephoneNumber)
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -67,6 +71,8 @@ class ProfileTest : IntegrationTestBase() {
         objectMapper.writeValueAsString(
           User(
             deliusUsername = deliusUsername,
+            email = email,
+            telephoneNumber = telephoneNumber,
             roles = listOf(ApiUserRole.assessor),
             qualifications = listOf(ApiUserQualification.pipe)
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import java.util.UUID
+
+class UsersTest : IntegrationTestBase() {
+  val id: UUID = UUID.fromString("aff9a4dc-e208-4e4b-abe6-99aff7f6af8a")
+
+  @Test
+  fun `Getting a user without a JWT returns 401`() {
+    webTestClient.get()
+      .uri("/users/$id")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting a user with a non-Delius JWT returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "nomis"
+    )
+
+    webTestClient.get()
+      .uri("/users/$id")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting a user returns OK with correct body`() {
+    val deliusUsername = "JimJimmerson"
+    val email = "foo@bar.com"
+    val telephoneNumber = "123445677"
+
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = deliusUsername,
+      authSource = "delius",
+      roles = listOf("ROLE_PROBATION")
+    )
+
+    userEntityFactory.produceAndPersist {
+      withId(id)
+      withDeliusUsername(deliusUsername)
+      withEmail(email)
+      withTelephoneNumber(telephoneNumber)
+    }
+
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername(deliusUsername)
+        .withEmail(email)
+        .withTelephoneNumber(telephoneNumber)
+        .produce()
+    )
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+    webTestClient.get()
+      .uri("/users/$id")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        objectMapper.writeValueAsString(
+          User(
+            deliusUsername = deliusUsername,
+            email = email,
+            telephoneNumber = telephoneNumber,
+            roles = emptyList(),
+            qualifications = emptyList(),
+          )
+        )
+      )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -4,7 +4,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
@@ -15,8 +18,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
 
 class UserServiceTest {
   private val mockHttpAuthService = mockk<HttpAuthService>()
@@ -78,5 +83,118 @@ class UserServiceTest {
 
     verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
     verify(exactly = 1) { mockUserRepository.save(any()) }
+  }
+
+  @Nested
+  class GetUserForId {
+    private val mockHttpAuthService = mockk<HttpAuthService>()
+    private val mockCommunityApiClient = mockk<CommunityApiClient>()
+    private val mockUserRepository = mockk<UserRepository>()
+    private val mockUserRoleAssignmentRepository = mockk<UserRoleAssignmentRepository>()
+    private val mockUserQualificationAssignmentRepository = mockk<UserQualificationAssignmentRepository>()
+
+    private val userService = UserService(
+      mockHttpAuthService,
+      mockCommunityApiClient,
+      mockUserRepository,
+      mockUserRoleAssignmentRepository,
+      mockUserQualificationAssignmentRepository
+    )
+
+    private val id = UUID.fromString("21b61d19-3a96-4b88-8df9-a5e89bc6fe73")
+    private val username = "SOMEPERSON"
+    private val forename = "Jim"
+    private val surname = "Jimmerson"
+    private val staffIdentifier = 5678
+
+    private val userFactory = UserEntityFactory()
+      .withDeliusUsername(username)
+      .withName("$forename $surname")
+      .withDeliusStaffIdentifier(staffIdentifier.toLong())
+
+    private val staffUserDetailsFactory = StaffUserDetailsFactory()
+      .withUsername(username)
+      .withForenames(forename)
+      .withSurname(surname)
+      .withStaffIdentifier(staffIdentifier.toLong())
+
+    @BeforeEach
+    fun setup() {
+      every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as UserEntity }
+    }
+
+    @Test
+    fun `it returns the user's details from the Community API and saves the email address`() {
+      val user = userFactory.produce()
+      val deliusUser = staffUserDetailsFactory
+        .withEmail("foo@example.com")
+        .withTelephoneNumber("0123456789")
+        .produce()
+
+      every { mockUserRepository.findByIdOrNull(id) } returns user
+      every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
+        HttpStatus.OK,
+        deliusUser
+      )
+
+      val result = userService.getUserForId(id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+
+      var entity = result.entity
+
+      assertThat(entity.id).isEqualTo(user.id)
+      assertThat(entity.name).isEqualTo(user.name)
+      assertThat(entity.deliusUsername).isEqualTo(user.deliusUsername)
+      assertThat(entity.email).isEqualTo(deliusUser.email)
+      assertThat(entity.telephoneNumber).isEqualTo(deliusUser.telephoneNumber)
+
+      verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
+      verify(exactly = 1) { mockUserRepository.save(any()) }
+    }
+
+    @Test
+    fun `it does not save the object if the email and telephone number are the same as Delius`() {
+      val email = "foo@example.com"
+      val telephoneNumber = "0123456789"
+
+      val user = userFactory
+        .withEmail(email)
+        .withTelephoneNumber(telephoneNumber)
+        .produce()
+
+      val deliusUser = staffUserDetailsFactory
+        .withEmail(email)
+        .withTelephoneNumber(telephoneNumber)
+        .produce()
+
+      every { mockUserRepository.findByIdOrNull(id) } returns user
+      every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
+        HttpStatus.OK,
+        deliusUser
+      )
+
+      val result = userService.getUserForId(id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+
+      var entity = result.entity
+
+      assertThat(entity.id).isEqualTo(user.id)
+      assertThat(entity.name).isEqualTo(user.name)
+
+      verify(exactly = 0) { mockUserRepository.save(any()) }
+    }
+
+    @Test
+    fun `it returns not found when there is no user for that ID`() {
+      every { mockUserRepository.findByIdOrNull(id) } returns null
+
+      val result = userService.getUserForId(id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -9,6 +9,7 @@ import kotlin.random.Random
 
 private val charPoolMultiCaseNumbers = ('a'..'z') + ('A'..'Z') + ('0'..'9')
 private val charPoolUpperCase = ('A'..'Z').toList()
+private val charPoolLowerCase = ('a'..'z').toList()
 private val charPoolNumbers = ('0'..'9').toList()
 
 private fun randomWithCharPool(charPool: List<Char>, length: Int) = (1..length)
@@ -19,6 +20,8 @@ private fun randomWithCharPool(charPool: List<Char>, length: Int) = (1..length)
 fun randomStringMultiCaseWithNumbers(length: Int) = randomWithCharPool(charPoolMultiCaseNumbers, length)
 
 fun randomStringUpperCase(length: Int) = randomWithCharPool(charPoolUpperCase, length)
+
+fun randomEmailAddress() = randomWithCharPool(charPoolLowerCase, 5) + "." + randomWithCharPool(charPoolLowerCase, 8) + "@" + randomWithCharPool(charPoolLowerCase, 6) + ".com"
 
 fun randomNumberChars(length: Int) = randomWithCharPool(charPoolNumbers, length)
 


### PR DESCRIPTION
This adds an endpoint to get the user details for a user with a specific ID. If ther details in Delius are different, we update the database to match these details and return the updated object.