### PR TITLE
Provide calculated bedspace count for Temporary Accommodation premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -38,7 +38,7 @@ class PremisesTransformer(
       name = jpa.name,
       addressLine1 = jpa.addressLine1,
       postcode = jpa.postcode,
-      bedCount = jpa.totalBeds,
+      bedCount = jpa.rooms.flatMap { it.beds }.size,
       service = ServiceName.temporaryAccommodation.value,
       notes = jpa.notes,
       availableBedsForToday = availableBedsForToday,


### PR DESCRIPTION
> See [ticket #651 on the CAS3 Trello board](https://trello.com/c/4Mv34gQd/651-reflect-bedspace-count-in-list-of-properties).

This PR updates the JPA-to-API mapping for a Temporary Accommodation premises to use the total number of bedspaces in all rooms in the premises to set `bedCount` rather than the `totalBeds` property on the JPA entity. This provides an always-accurate value for the premises as it exists in the database, rather than relying on a separately stored value which may diverge from the true number.