### PR TITLE
Staff Details Teams can be nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
@@ -9,7 +9,7 @@ data class StaffUserDetails(
   val staffCode: String,
   val staffIdentifier: Long,
   val staff: StaffNames,
-  val teams: List<StaffUserTeamMembership>
+  val teams: List<StaffUserTeamMembership>?
 )
 
 data class StaffNames(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -355,7 +355,7 @@ class OffenderService(
       is ClientResult.Failure.Other -> staffDetailsResult.throwException()
     }
 
-    val uniqueManagedOffenders = staffDetails.teams.flatMap {
+    val uniqueManagedOffenders = staffDetails.teams?.flatMap {
       val caseloadResult = communityApiClient.getCaseloadForTeam(it.code)
 
       val caseload = when (caseloadResult) {
@@ -370,9 +370,9 @@ class OffenderService(
       }
 
       caseload.managedOffenders
-    }.distinctBy {
+    }?.distinctBy {
       it.offenderCrn
-    }
+    } ?: emptyList()
 
     return AuthorisableActionResult.Success(
       uniqueManagedOffenders


### PR DESCRIPTION
Community API omits the teams key when staff member is not in any teams (rather than returning an empty array).  This deserializes to null so teams needs to be nullable.