### PR TITLE
Chore/deploy to prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,21 +58,20 @@ workflows:
             - hmpps-approved-premises-api-preprod
           requires:
             - request-preprod-approval
-
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - approved-premises-api-prod
-#          requires:
-#            - request-prod-approval
+      - request-prod-approval:
+          type: approval
+          requires:
+            - deploy_preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          slack_notification: true
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          context:
+            - hmpps-common-vars
+            - approved-premises-api-prod
+          requires:
+            - request-prod-approval
 
   security:
     triggers:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,11 +4,21 @@
 generic-service:
   ingress:
     host: approved-premises-api.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-approved-premises-api-prod-cert
 
   env:
+    SPRING_PROFILES_ACTIVE: prod
+    APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+    SERVICES_COMMUNITY-API_BASE-URL: https://community-api-secure.probation.service.justice.gov.uk
+    SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.delius.probation.hmpps.dsd.io
+    SERVICES_ASSESS-RISKS-AND-NEEDS-API_BASE-URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk
+    SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier.hmpps.service.justice.gov.uk
+    SERVICES_PRISONS-API_BASE-URL: https://api.prison.service.justice.gov.uk
+    SERVICES_CASE-NOTES_BASE-URL: https://offender-case-notes.service.justice.gov.uk
+    SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys.hmpps.service.justice.gov.uk
+    SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all
+    LOG-CLIENT-CREDENTIALS-JWT-INFO: false
+    SENTRY_ENVIRONMENT: prod
+    CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
     SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.hmpps.service.justice.gov.uk
-
-# CloudPlatform AlertManager receiver to route prometheus alerts to slack
-# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
-generic-prometheus-alerts:
-  alertSeverity: digital-prison-service


### PR DESCRIPTION
https://trello.com/c/EnjCxzGs/12-set-up-production

Add the Helm deploy charts to configure the deployed app and CircleCI to allow us to deploy.

This should not be merged until we're happy to deploy the app to production. This is currently pending the CAS1 side of the pentest.

We need to confirm the urls for at least 2 of the production services that have comments. From what I've heard the integrations service might not be in production so I wonder what the impact is if that app isn't available, are we blocked?