### PR TITLE
993 - Application view changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -23,6 +23,9 @@ import javax.persistence.Table
 interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")
   fun <T : ApplicationEntity> findAllByCreatedByUser_Id(id: UUID, type: Class<T>): List<ApplicationEntity>
+
+  @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn IN (:crns)")
+  fun <T : ApplicationEntity> findByCrnIn(crns: List<String>, type: Class<T>): List<ApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -52,6 +52,7 @@ data class UserEntity(
   val qualifications: MutableList<UserQualificationAssignmentEntity>
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
+  fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)
   fun hasQualification(userQualification: UserQualification) = qualifications.any { it.qualification === userQualification }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -36,8 +37,24 @@ class ApplicationService(
       TemporaryAccommodationApplicationEntity::class.java
     }
 
-    return applicationRepository.findAllByCreatedByUser_Id(userEntity.id, entityType)
+    val applications = if (userEntity.hasAnyRole(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER)) {
+      applicationRepository.findAll()
+    } else {
+      val teamCaseload = when (val teamCaseloadResult = offenderService.getTeamCaseLoad(userDistinguishedName)) {
+        is AuthorisableActionResult.Success -> teamCaseloadResult.entity
+        else -> throw RuntimeException("Unable to get caseload CRNs")
+      }
+
+      val teamCaseloadCrns = teamCaseload.map { it.offenderCrn }
+
+      applicationRepository.findByCrnIn(teamCaseloadCrns, entityType)
+    }
+
+    return applications
       .map(jsonSchemaService::checkSchemaOutdated)
+      .filter {
+        offenderService.canAccessOffender(userDistinguishedName, it.crn)
+      }
   }
 
   fun getApplicationForUsername(applicationId: UUID, userDistinguishedName: String): AuthorisableActionResult<ApplicationEntity> {


### PR DESCRIPTION
Change authorisation policy fo the list applications and get specific application endpoints.

This is now based on team caseload - if the CRN is managed by someone in the requesting user's team(s) then they are allowed to view the application.

Additionally: `WORKFLOW_MANAGER`, `ASSESSOR`, `MATCHER`, `MANAGER` holding users can see all applications except those prohibited to them via LAO.