### PR TITLE
Allow local authority area to be optional for Temporary Accommodation Premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -47,7 +47,7 @@ abstract class PremisesEntity(
   var probationRegion: ProbationRegionEntity,
   @ManyToOne
   @JoinColumn(name = "local_authority_area_id")
-  var localAuthorityArea: LocalAuthorityAreaEntity,
+  var localAuthorityArea: LocalAuthorityAreaEntity?,
   @OneToMany(mappedBy = "premises")
   val bookings: MutableList<BookingEntity>,
   @OneToMany(mappedBy = "premises")
@@ -113,7 +113,7 @@ class TemporaryAccommodationPremisesEntity(
   totalBeds: Int,
   notes: String,
   probationRegion: ProbationRegionEntity,
-  localAuthorityArea: LocalAuthorityAreaEntity,
+  localAuthorityArea: LocalAuthorityAreaEntity?,
   bookings: MutableList<BookingEntity>,
   lostBeds: MutableList<LostBedsEntity>,
   rooms: MutableList<RoomEntity>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -29,7 +29,7 @@ class PremisesTransformer(
       availableBedsForToday = availableBedsForToday,
       probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
-      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
+      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea!!),
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
       status = jpa.status,
     )
@@ -44,7 +44,7 @@ class PremisesTransformer(
       availableBedsForToday = availableBedsForToday,
       probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
-      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea),
+      localAuthorityArea = jpa.localAuthorityArea?.let { localAuthorityAreaTransformer.transformJpaToApi(it) },
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
       status = jpa.status,
       pdu = jpa.pdu,

--- a/src/main/resources/db/migration/all/20230113145929__make_local_authority_area_id_nullable_in_premises.sql
+++ b/src/main/resources/db/migration/all/20230113145929__make_local_authority_area_id_nullable_in_premises.sql
@@ -1,0 +1,1 @@
+ALTER TABLE premises ALTER COLUMN local_authority_area_id DROP NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2132,7 +2132,6 @@ components:
         - availableBedsForToday
         - probationRegion
         - apArea
-        - localAuthorityArea
         - status
     ApprovedPremises:
       allOf:
@@ -2144,6 +2143,7 @@ components:
               example: NEHOPE1
       required:
         - apCode
+        - localAuthorityArea
     TemporaryAccommodationPremises:
       allOf:
         - $ref: '#/components/schemas/Premises'
@@ -2184,7 +2184,6 @@ components:
         - name
         - addressLine1
         - postcode
-        - localAuthorityAreaId
         - probationRegionId
         - characteristicIds
         - status
@@ -3269,7 +3268,6 @@ components:
       required:
         - addressLine1
         - postcode
-        - localAuthorityAreaId
         - probationRegionId
         - characteristicIds
         - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
@@ -213,7 +213,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     assertThat(persistedApprovedPremises.totalBeds).isEqualTo(csvRow.totalBeds)
     assertThat(persistedApprovedPremises.notes).isEqualTo(csvRow.notes)
     assertThat(persistedApprovedPremises.probationRegion.name).isEqualTo(csvRow.probationRegion)
-    assertThat(persistedApprovedPremises.localAuthorityArea.name).isEqualTo(csvRow.localAuthorityArea)
+    assertThat(persistedApprovedPremises.localAuthorityArea!!.name).isEqualTo(csvRow.localAuthorityArea)
     assertThat(persistedApprovedPremises.characteristics.map { it.name }).isEqualTo(csvRow.characteristics)
     assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
   }
@@ -267,7 +267,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     assertThat(persistedApprovedPremises.totalBeds).isEqualTo(csvRow.totalBeds)
     assertThat(persistedApprovedPremises.notes).isEqualTo(csvRow.notes)
     assertThat(persistedApprovedPremises.probationRegion.name).isEqualTo(csvRow.probationRegion)
-    assertThat(persistedApprovedPremises.localAuthorityArea.name).isEqualTo(csvRow.localAuthorityArea)
+    assertThat(persistedApprovedPremises.localAuthorityArea!!.name).isEqualTo(csvRow.localAuthorityArea)
     assertThat(persistedApprovedPremises.characteristics.map { it.name }).isEqualTo(csvRow.characteristics)
     assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
   }


### PR DESCRIPTION
> See [ticket #654 on the CAS3 Trello board](https://trello.com/c/Yc06LzHr/654-local-authority-is-optional-when-creating-editing-a-property).

This PR modifies Temporary Accommodation Premises to allow the local authority area to be optional. This enables users to create or modify a premises even if they don't know which local authority is the correct one (such as if they are not familiar with the area and there is no obvious choice). The existing requirement that the local authority area is provided has been preserved for Approved Premises to avoid a breaking change.