### PR TITLE
(Fix) Set 'current nights stayed' column in bookings reports to blank for a booking with a departure

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
@@ -19,7 +19,11 @@ class BookingsReportGenerator : ReportGenerator<BookingEntity, BookingsReportRow
     BookingsReportRow::endDate from { it.arrival?.expectedDepartureDate }
     BookingsReportRow::actualEndDate from { it.departure?.dateTime?.toLocalDate() }
     BookingsReportRow::currentNightsStayed from { entity ->
-      entity.arrival?.arrivalDate?.let { ChronoUnit.DAYS.between(it, LocalDate.now()).toInt() }
+      if (entity.departure != null) {
+        null
+      } else {
+        entity.arrival?.arrivalDate?.let { ChronoUnit.DAYS.between(it, LocalDate.now()).toInt() }
+      }
     }
     BookingsReportRow::actualNightsStayed from { entity ->
       val arrivalDate = entity.arrival?.arrivalDate ?: return@from null


### PR DESCRIPTION
When generating a bookings report, if a booking has a departure recorded, the `currentNightsStayed` column will still display the number of days between the arrival and the current date, leading to potential confusion.

# Observed behaviour

Given a booking with an arrival date of 1/1/2022 and a departure date of 1/4/2022, a report generated on 12/1/2023 would produce a row with the following columns of interest:

| `currentNightsStayed` | `actualNightsStayed` |
| --: | --: |
| `376` | `90` |

# Expected behaviour

The above booking should be represented in a report generated on 12/1/2023 as follows for the columns of interest:

| `currentNightsStayed` | `actualNightsStayed` |
| --: | --: |
| *(blank)* | `90` |

# Solution

The `BookingsReportGenerator.convert` method has been updated to set `currentNightsStayed` to `null` if a departure exists on the booking.