### PR TITLE
Temporary logging around retrieving allocated Assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -28,6 +29,8 @@ class AssessmentService(
   private val assessmentClarificationNoteRepository: AssessmentClarificationNoteRepository,
   private val jsonSchemaService: JsonSchemaService
 ) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
   fun getVisibleAssessmentsForUser(user: UserEntity): List<AssessmentEntity> {
     // TODO: Potentially needs LAO enforcing too: https://trello.com/c/alNxpm9e/856-investigate-whether-assessors-will-have-access-to-limited-access-offenders
 
@@ -36,11 +39,15 @@ class AssessmentService(
     val assessments = if (user.hasRole(UserRole.WORKFLOW_MANAGER)) {
       assessmentRepository.findAll()
     } else {
+      log.info("Finding assessments allocated to user id: ${user.id}")
       assessmentRepository.findAllByAllocatedToUser_Id(user.id)
     }
 
+    log.info("Found ${assessments.count()} assessments for user")
+
     assessments.forEach {
       it.schemaUpToDate = it.schemaVersion.id == latestSchema.id
+      log.info("Assessment ${it.id} schema up to date?: ${it.schemaUpToDate}")
     }
 
     return assessments


### PR DESCRIPTION
Due to an issue in the test environment we have a need to see, temporarily, at which point assessments are being lost.