### PR TITLE
993 - Support reallocating Assessments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,10 @@ tasks.register("bootRunLocal") {
   finalizedBy("bootRun")
 }
 
+tasks.test {
+  jvmArgs("--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED")
+}
+
 openApiGenerate {
   generatorName.set("kotlin-spring")
   inputSpec.set("$rootDir/src/main/resources/static/api.yml")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -46,6 +46,7 @@ data class AssessmentEntity(
   val allocatedToUser: UserEntity,
 
   val allocatedAt: OffsetDateTime,
+  var reallocatedAt: OffsetDateTime?,
 
   val createdAt: OffsetDateTime,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -19,6 +19,7 @@ import javax.persistence.Table
 @Repository
 interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   fun findAllByAllocatedToUser_Id(userId: UUID): List<AssessmentEntity>
+  fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -54,6 +54,9 @@ data class UserEntity(
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)
   fun hasQualification(userQualification: UserQualification) = qualifications.any { it.qualification === userQualification }
+  fun hasAllQualifications(requiredQualifications: List<UserQualification>) = requiredQualifications.all(::hasQualification)
+
+  override fun toString() = "User $id"
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -148,6 +148,12 @@ class AssessmentService(
       )
     }
 
+    if (assessment.reallocatedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")
+      )
+    }
+
     val validationErrors = ValidationErrors()
     val assessmentData = assessment.data
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -200,6 +200,12 @@ class AssessmentService(
       )
     }
 
+    if (assessment.reallocatedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")
+      )
+    }
+
     val validationErrors = ValidationErrors()
     val assessmentData = assessment.data
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -113,6 +113,12 @@ class AssessmentService(
       )
     }
 
+    if (assessment.reallocatedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")
+      )
+    }
+
     assessment.data = data
 
     val savedAssessment = assessmentRepository.save(assessment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -82,6 +82,7 @@ class AssessmentService(
         data = null, document = null, schemaVersion = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java),
         allocatedToUser = allocatedUser,
         allocatedAt = dateTimeNow,
+        reallocatedAt = null,
         createdAt = dateTimeNow,
         submittedAt = null,
         decision = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -64,6 +64,7 @@ class AssessmentTransformer(
   private fun getStatus(entity: AssessmentEntity) = when {
     entity.decision !== null -> AssessmentStatus.completed
     entity.clarificationNotes.any { it.response == null } -> AssessmentStatus.pending
+    entity.reallocatedAt != null -> AssessmentStatus.reallocated
     else -> AssessmentStatus.active
   }
 }

--- a/src/main/resources/db/migration/all/20230116143807__add_deallocated_at_to_assessments.sql
+++ b/src/main/resources/db/migration/all/20230116143807__add_deallocated_at_to_assessments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessments ADD COLUMN reallocated_at TIMESTAMP WITH TIME ZONE;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3228,6 +3228,7 @@ components:
         - pending
         - active
         - completed
+        - reallocated
     ApprovedPremisesAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3361,6 +3361,8 @@ components:
         userId:
           type: string
           format: uuid
+      required:
+        - userId
     User:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
@@ -27,6 +27,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
   }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var allocatedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var decision: Yielded<AssessmentDecision?> = { AssessmentDecision.ACCEPTED }
   private var allocatedToUser: Yielded<UserEntity>? = null
@@ -61,6 +62,10 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     this.allocatedAt = { allocatedAt }
   }
 
+  fun withReallocatedAt(reallocatedAt: OffsetDateTime?) = apply {
+    this.reallocatedAt = { reallocatedAt }
+  }
+
   fun withSubmittedAt(submittedAt: OffsetDateTime?) = apply {
     this.submittedAt = { submittedAt }
   }
@@ -93,6 +98,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
     allocatedToUser = this.allocatedToUser?.invoke() ?: throw RuntimeException("Must provide an allocatedToUser"),
     allocatedAt = this.allocatedAt(),
+    reallocatedAt = this.reallocatedAt(),
     rejectionRationale = this.rejectionRationale(),
     clarificationNotes = this.clarificationNotes()
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -1,0 +1,199 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.every
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import java.time.OffsetDateTime
+
+class ReallocationAtomicTest : IntegrationTestBase() {
+  @SpykBean
+  lateinit var realAssessmentRepository: AssessmentRepository
+
+  private val offenderDetails = OffenderDetailsSummaryFactory()
+    .withCrn("CRN123")
+    .withNomsNumber("NOMS321")
+    .produce()
+
+  private val otherOffenderDetails = OffenderDetailsSummaryFactory()
+    .withCrn("OTHERCRN")
+    .withNomsNumber("OTHERNOMS")
+    .produce()
+
+  @BeforeEach
+  fun setup() {
+    approvedPremisesApplicationJsonSchemaRepository.deleteAll()
+
+    val inmateDetail = InmateDetailFactory()
+      .withOffenderNo("NOMS321")
+      .produce()
+
+    val otherInmateDetail = InmateDetailFactory()
+      .withOffenderNo("OTHERNOMS")
+      .produce()
+
+    mockOffenderDetailsCommunityApiCall(offenderDetails)
+    mockInmateDetailPrisonsApiCall(inmateDetail)
+
+    mockOffenderDetailsCommunityApiCall(otherOffenderDetails)
+    mockInmateDetailPrisonsApiCall(otherInmateDetail)
+
+    mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+  }
+
+  @Test
+  fun `Database exception after setting reallocated on original Assessment results in that change being rolled back`() {
+    val requestUsername = "PROBATIONPERSON"
+    val otherUsername = "OTHERUSER"
+    val assigneeUsername = "ASSIGNEEUSER"
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt(requestUsername)
+
+    val requestUser = userEntityFactory.produceAndPersist {
+      withDeliusUsername(requestUsername)
+    }
+    userRoleAssignmentEntityFactory.produceAndPersist {
+      withUser(requestUser)
+      withRole(UserRole.WORKFLOW_MANAGER)
+    }
+
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername(requestUsername)
+        .produce()
+    )
+
+    val otherUser = userEntityFactory.produceAndPersist {
+      withDeliusUsername(otherUsername)
+    }
+
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername(otherUsername)
+        .produce()
+    )
+
+    val assigneeUser = userEntityFactory.produceAndPersist {
+      withDeliusUsername(assigneeUsername)
+    }
+
+    mockStaffUserInfoCommunityApiCall(
+      StaffUserDetailsFactory()
+        .withUsername(assigneeUsername)
+        .produce()
+    )
+
+    userRoleAssignmentEntityFactory.produceAndPersist {
+      withUser(assigneeUser)
+      withRole(UserRole.ASSESSOR)
+    }
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+    val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist()
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCreatedByUser(otherUser)
+      withApplicationSchema(applicationSchema)
+    }
+
+    val existingAssessment = assessmentEntityFactory.produceAndPersist {
+      withApplication(application)
+      withAllocatedToUser(otherUser)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    every { realAssessmentRepository.save(match { it.id != existingAssessment.id }) } throws RuntimeException("I am a database error")
+
+    webTestClient.post()
+      .uri("/applications/${application.id}/allocations")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        Reallocation(
+          userId = assigneeUser.id
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .is5xxServerError
+
+    val assessments = assessmentRepository.findAll()
+
+    Assertions.assertThat(assessments.first { it.id == existingAssessment.id }.reallocatedAt).isNull()
+  }
+
+  private fun serializableToJsonNode(serializable: Any?): JsonNode {
+    if (serializable == null) return NullNode.instance
+    if (serializable is String) return objectMapper.readTree(serializable)
+
+    return objectMapper.readTree(objectMapper.writeValueAsString(serializable))
+  }
+
+  private fun mockOffenderDetailsCommunityApiCall404(crn: String) = wiremockServer.stubFor(
+    WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/$crn"))
+      .willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(404)
+      )
+  )
+
+  private fun mockInmateDetailPrisonsApiCall404(offenderNo: String) = wiremockServer.stubFor(
+    WireMock.get(WireMock.urlEqualTo("/api/offenders/$offenderNo"))
+      .willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(404)
+      )
+  )
+
+  private fun produceAndPersistBasicApplication(crn: String): ApplicationEntity {
+    val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+      withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": {
+            "thingId": {
+              "description": "The unique identifier for a thing",
+              "type": "integer"
+            }
+          },
+          "required": [ "thingId" ]
+        }
+        """
+      )
+    }
+
+    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(jsonSchema)
+      withCrn(crn)
+      withCreatedByUser(userEntity)
+      withData(
+        """
+          {
+             "thingId": 123
+          }
+          """
+      )
+    }
+
+    return application
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -383,6 +383,44 @@ class AssessmentServiceTest {
   }
 
   @Test
+  fun `updateAssessment returns general validation error for Assessment where assessment has been deallocated`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}"
+    )
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withSubmittedAt(null)
+      .withDecision(null)
+      .withAllocatedToUser(user)
+      .withAssessmentSchema(schema)
+      .withreallocatedAt(OffsetDateTime.now())
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema
+
+    val result = assessmentService.updateAssessment(user, assessmentId, "{}")
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+    assertThat(validationResult is ValidatableActionResult.GeneralValidationError)
+    val generalValidationError = validationResult as ValidatableActionResult.GeneralValidationError
+    assertThat(generalValidationError.message).isEqualTo("The application has been reallocated, this assessment is read only")
+  }
+
+  @Test
   fun `updateAssessment returns updated assessment`() {
     val assessmentId = UUID.randomUUID()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -762,6 +762,44 @@ class AssessmentServiceTest {
   }
 
   @Test
+  fun `rejectAssessment returns general validation error for Assessment where assessment has been deallocated`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .produce()
+
+    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}"
+    )
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
+      .withId(assessmentId)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(UserEntityFactory().produce())
+          .produce()
+      )
+      .withSubmittedAt(null)
+      .withDecision(null)
+      .withAllocatedToUser(user)
+      .withAssessmentSchema(schema)
+      .withReallocatedAt(OffsetDateTime.now())
+      .produce()
+
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema
+
+    val result = assessmentService.rejectAssessment(user, assessmentId, "{}", "reasoning")
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+    assertThat(validationResult is ValidatableActionResult.GeneralValidationError)
+    val generalValidationError = validationResult as ValidatableActionResult.GeneralValidationError
+    assertThat(generalValidationError.message).isEqualTo("The application has been reallocated, this assessment is read only")
+  }
+
+  @Test
   fun `rejectAssessment returns field validation error when JSON schema not satisfied by data`() {
     val assessmentId = UUID.randomUUID()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -106,12 +106,25 @@ class AssessmentTransformerTest {
   }
 
   @Test
-  fun `transformJpaToApi sets an active status when there is no decision`() {
+  fun `transformJpaToApi sets a deallocated status when there is a deallocated timestamp`() {
     val assessment = assessmentFactory
+      .withDecision(null)
+      .withReallocatedAt(OffsetDateTime.now())
       .produce()
 
     val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
 
-    assertThat(result.status).isEqualTo(AssessmentStatus.completed)
+    assertThat(result.status).isEqualTo(AssessmentStatus.reallocated)
+  }
+
+  @Test
+  fun `transformJpaToApi sets an active status when there is no decision`() {
+    val assessment = assessmentFactory
+      .withDecision(null)
+      .produce()
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+
+    assertThat(result.status).isEqualTo(AssessmentStatus.active)
   }
 }


### PR DESCRIPTION
This PR implements the POST `/applications/{id}/allocations` endpoint spec.  This allows users with `WORKFLOW_MANAGER` to reallocate an assessment provided the user they are assigning to has the `ASSESSOR` role and where applicable the relevant qualifications.