### PR TITLE
Add repeatable migrations for dev

### DIFF
--- a/doc/architecture/decisions/0010-use-repeatable-migrations-for-dev-and-test.md
+++ b/doc/architecture/decisions/0010-use-repeatable-migrations-for-dev-and-test.md
@@ -1,0 +1,88 @@
+# 10. use_repeatable_migrations_for_dev_and_test
+
+Date: 2023-01-17
+
+## Status
+
+Accepted
+
+## Context
+
+We need to ensure that our development and test environments have
+predictable data, so we can log in, run tests and carry out usability
+testing sessions with users. As we run automated tests on dev, it's also
+important that the environment doesn't get clogged with automatically
+created data.
+
+## Decision
+
+We will use [repeatable Flyway migrations](https://flywaydb.org/blog/flyway-timestampsandrepeatables)
+to tear down and set up the data to a known state.
+
+These migrations will be in the format:
+
+```text
+R__$NUM_$NAME_OF_MIGRATION.sql
+```
+
+Where `$NUM` is the order we want the migration to be run in, and
+`$NAME_OF_MIGRATION` is a description of the migration to be run.
+
+Each migration will also have a comment at the top like so:
+
+```sql
+-- ${flyway:timestamp}
+```
+
+This changes the checksum for the repeatable migrations, meaning they
+get executed each time we migrate.
+
+In dev, we will have SQL migrations manually written to drop the
+tables and insert the data previously written in the previous data
+migrations. We will also drop the bookings table to remove any
+bookings created in the e2e tests.
+
+For test, we have a [Wiremock repo](https://github.com/ministryofjustice/hmpps-community-accommodation-wiremock),
+which mocks away external services.
+This repo also has a helper script, which uses mock data to generate /
+re-generate migrations based on any changes made to the mocks.
+
+When data changes in the mocks, we will the following command in
+the Wiremock project:
+
+```bash
+script/generate_migrations /path/to/api/directory
+```
+
+to generate new migrations. We will then open a PR in the API to
+project to commit the new migrations to the repo.
+
+To ensure these migrations are run on deploy, we add the paths to the
+`SPRING_FLYWAY_LOCATIONS` environment variable in the appropriate
+directories, i.e:
+
+```yaml
+SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev
+```
+
+```yaml
+SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev,classpath:db/migration/test
+```
+
+## Consequences
+
+This will ensure that all data in both dev and test environments
+are cleaned up on every deploy. This means that we should consider
+data in both of those environments to be ephemeral, unless it is
+specifially added to a repeatable migration.
+
+As these migrations are destructive, it is important that these
+migrations are not run in prod or pre-prod. We see the fact that
+the running of these migrations is controlled by a environment
+variable change, which will be approved by another developer, to
+be an appropriate safeguard against this.
+
+We will also need to be aware that in some rare cases, a
+deployment may run at the same time as e2e tests running, which
+may break the tests. If this happens, we'll have to rerun the
+tests.

--- a/src/main/resources/db/migration/local+dev/R__1_create_users.sql
+++ b/src/main/resources/db/migration/local+dev/R__1_create_users.sql
@@ -1,0 +1,8 @@
+-- ${flyway:timestamp}
+TRUNCATE TABLE users CASCADE;
+--These are randomly generated names
+
+INSERT INTO "users" (id, name, delius_username, delius_staff_identifier) VALUES
+    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547),
+    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096),
+    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544);

--- a/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
+++ b/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
@@ -1,0 +1,12 @@
+-- ${flyway:timestamp}
+TRUNCATE TABLE premises CASCADE;
+
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 1', 'd33006b7-55d9-4a8e-b722-5e18093dbcdf', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'Something House', NULL, 'LA9 1DS', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 30);
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 2', 'ada106c7-e1fb-409a-a38e-0002ea8e7e45', '89faa462-7ea6-45ba-b169-93d947d20cae', 'Something Court', NULL, 'EC1 3XZ', '6b4a1308-17af-4c1a-a330-6005bec9e27b', 'temporary-accommodation', 'active', 10);
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 3', '36c7b1f2-5a4b-467b-838c-2970c9c253cf', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'Something Place', NULL, 'SA1 1AF', 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'temporary-accommodation', 'active', 25);
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('1 Somewhere', '459eeaba-55ac-4a1f-bae2-bad810d4016b', '5283aca7-21bd-4ded-96ec-09cc6f76468e', 'Beckenham Road', 'Notes', 'GL56 0QQ', 'd73ae6b5-041e-4d44-b859-b8c77567d893', 'approved-premises', 'active', 20);
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('2 Somewhere', 'e03c82e9-f335-414a-87a0-866060397d4a', '7de4177b-9177-4c28-9bb6-5f5292619546', 'Bedford AP', 'Notes', 'GL56 0QQ', '0544d95a-f6bb-43f8-9be7-aae66e3bf244', 'approved-premises', 'active', 30);
+
+INSERT INTO approved_premises (premises_id, q_code, ap_code) VALUES
+    ('459eeaba-55ac-4a1f-bae2-bad810d4016b', 'Q022', 'BCKNHAM'),
+    ('e03c82e9-f335-414a-87a0-866060397d4a', 'Q005', 'BDFORD');

--- a/src/main/resources/db/migration/local+dev/R__3_create_characteristics.sql
+++ b/src/main/resources/db/migration/local+dev/R__3_create_characteristics.sql
@@ -1,0 +1,21 @@
+-- ${flyway:timestamp}
+TRUNCATE TABLE characteristics CASCADE;
+
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('199334d3-fabb-432f-84c3-0e92eaf13f24', '*', 'Pub nearby', 'approved-premises');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('94021062-f692-4877-b6e8-f36c7ff87a18', '*', 'Not suitable for registered sex offenders (RSO)', 'approved-premises');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('7846fbf2-b423-4ccc-b23b-d8b866f86bde', '*', 'Men only', 'approved-premises');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('a862be08-a96a-4337-9f46-26286db8015f', '*', 'Wheelchair accessible', 'approved-premises');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('fffb3004-5f0a-4e88-8350-fb89a0168296', 'premises', 'Park nearby', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('684f919a-4c4a-4e80-9b3a-1dcd35873b3f', 'premises', 'Pub nearby', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('78c5d99b-9702-4bf2-a23d-c2a0cf3a017d', 'premises', 'School nearby', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('2fff6ede-7035-4e8d-81ad-5fcd894b99cf', 'premises', 'Men only', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('8221f1ad-3aaf-406a-b918-dbdef956ea17', 'premises', 'Women only', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('12e2e689-b3fb-469d-baec-2fb68e15e85b', 'room', 'Single bed', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('08b756e2-0b82-4f49-a124-35ea4ebb1634', 'room', 'Double bed', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('7dd3bac5-3d1c-4acb-b110-b1614b2c95d8', 'room', 'Shared kitchen', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('e730bdea-6157-4910-b1b0-450b29bf0c9f', 'room', 'Shared bathroom', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('2183d873-8270-4e93-8518-3a668a053689', 'room', 'Lift access', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('a2dd4661-c7fe-4294-b3fd-3fc877e62aa5', '*', 'Not suitable for registered sex offenders (RSO)', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('62c4d8cf-b612-4110-9e27-5c29982f9fcf', '*', 'Not suitable for arson offenders', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('99bb0f33-ff92-4606-9d1c-43bcf0c42ef4', '*', 'Floor level access', 'temporary-accommodation');
+insert into "characteristics" ("id", "model_scope", "name", "service_scope") values ('d2f7796a-88e5-4e53-ab6d-dabb145b6a60', '*', 'Wheelchair accessible', 'temporary-accommodation');

--- a/src/main/resources/db/migration/local+dev/R__4_clear_bookings.sql
+++ b/src/main/resources/db/migration/local+dev/R__4_clear_bookings.sql
@@ -1,0 +1,2 @@
+-- ${flyway:timestamp}
+TRUNCATE TABLE bookings CASCADE;


### PR DESCRIPTION
This ensures we return to a predictable state on each deploy. I’ve kept the old migrations so we don’t get any errors about missing migrations.

I’ve also added an ADR to document this decision, as well as the previous decision to use repeatable migrations in test.