### PR TITLE
(Fix) Add PDUs to Temporary Accommodation premises in repeatable Flyway migration for dev

### DIFF
--- a/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
+++ b/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
@@ -10,3 +10,8 @@ insert into "premises" ("address_line1", "id", "local_authority_area_id", "name"
 INSERT INTO approved_premises (premises_id, q_code, ap_code) VALUES
     ('459eeaba-55ac-4a1f-bae2-bad810d4016b', 'Q022', 'BCKNHAM'),
     ('e03c82e9-f335-414a-87a0-866060397d4a', 'Q005', 'BDFORD');
+
+INSERT INTO temporary_accommodation_premises (premises_id, pdu) VALUES
+    ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Cumbria'),
+    ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Camden and Islington'),
+    ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Swansea, Neath Port Talbot');


### PR DESCRIPTION
# Observed behaviour

A request to `GET /premises/` returns an HTTP 500 response locally and on the dev server. This response is caused by an exception with the following message:

```
Parameter specified as non-null is null: method uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationPremises.<init>, parameter pdu
```

# Expected behaviour

A request to `GET /premises` should successfully return a list of all premises.

# Solution

Currently the repeatable migrations for dev environments introduced in #353 do not provide PDUs for Temporary Accommodation premises. This PR adds appropriate PDUs to the Temporary Accommodation premises created in the `R__2_create_premises.sql` migration to resolve the issue.