### PR TITLE
Fixes for running seeding remotely

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
 
 COPY --from=builder --chown=appuser:appgroup /app/script/run_seed_job /app
-RUN mkdir /seed
+RUN mkdir /tmp/seed
 
 USER 2000
 

--- a/doc/how-to/run_seed_job_remotely.md
+++ b/doc/how-to/run_seed_job_remotely.md
@@ -5,9 +5,9 @@ To process a seed CSV against a non-local environment:
 - Ensure nobody is deploying a change (or is going to deploy a change shortly.)
 - Run `kubectl get pod` against the namespace for the environment you wish to run the seed job in.
 - Copy the name of one of the running `hmpps-approved-premises-api` pods.
-- Transfer the CSV to the `/seed` directory in the container via kubectl, e.g.
+- Transfer the CSV to the `/tmp/seed` directory in the container via kubectl, e.g.
   ```
-  kubectl cp /local/path/ap_seed_file.csv {pod name}:/seed/ap_seed_file.csv
+  kubectl cp /local/path/ap_seed_file.csv {pod name}:/tmp/seed/ap_seed_file.csv
   ```
 - Run the helper script from within the container to trigger the seed job:
   ```

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -162,4 +162,4 @@ caches:
     expiry-seconds: 1200
 
 seed:
-  file-prefix: "/seed"
+  file-prefix: "/tmp/seed"


### PR DESCRIPTION
Cannot mkdir on / since this would need to be a volume - so make a directory in /tmp instead.