### PR TITLE
Add unique constraint over delius username

### DIFF
--- a/src/main/resources/db/migration/all/20230302151100__unique_constraint_for_delius_username.sql
+++ b/src/main/resources/db/migration/all/20230302151100__unique_constraint_for_delius_username.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD CONSTRAINT unique_delius_username UNIQUE (delius_username);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -54,7 +54,7 @@ class ProfileTest : IntegrationTestBase() {
   @Test
   fun `Getting own Approved Premises profile returns OK with correct body`() {
     val id = UUID.randomUUID()
-    val deliusUsername = "JimJimmerson"
+    val deliusUsername = "JIMJIMMERSON"
     val email = "foo@bar.com"
     val telephoneNumber = "123445677"
 
@@ -102,7 +102,7 @@ class ProfileTest : IntegrationTestBase() {
   @Test
   fun `Getting own Temporary Accommodation profile returns OK with correct body`() {
     val id = UUID.randomUUID()
-    val deliusUsername = "JimJimmerson"
+    val deliusUsername = "JIMJIMMERSON"
     val email = "foo@bar.com"
     val telephoneNumber = "123445677"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class UserCaseSensitivityTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var userService: UserService
+
+  @Test
+  fun `Fetching a user with lowercase username returns the user with normalised uppercase username`() {
+    `Given a User` { userEntity, _ ->
+      val returnedUser = userService.getUserForUsername(userEntity.deliusUsername.lowercase())
+
+      assertThat(returnedUser.id).isEqualTo(userEntity.id)
+    }
+  }
+}


### PR DESCRIPTION
There should always be a 1:1 relationship between an entry in the "users" table and a Delius user.