### PR TITLE
Add /users/me endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -27,4 +27,8 @@ class UsersController(
 
     return ResponseEntity(userTransformer.transformJpaToApi(userEntity), HttpStatus.OK)
   }
+
+  override fun usersMeGet(): ResponseEntity<User> {
+    return ResponseEntity(userTransformer.transformJpaToApi(userService.getUserForRequest()), HttpStatus.OK)
+  }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1995,6 +1995,22 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /users/me:
+    get:
+      summary: Get information about the current logged in user
+      responses:
+        200:
+          description: successfully retrieved information on user
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/User'
+        401:
+          $ref: '#/components/schemas/401Response'
+        403:
+          $ref: '#/components/schemas/403Response'
+        500:
+          $ref: '#/components/schemas/500Response'
   /seed:
     post:
       summary: Starts the data seeding process, can only be called from a local connection


### PR DESCRIPTION
This PR provides an endpoint to get information about the current logged in user without knowing their ID.

This will enable upcoming work such as [allowing the Temporary Accommodation frontend to know which probation region a user is assigned to](https://trello.com/c/p0UPjpJn/714-api-can-retrieve-regional-information-about-a-member-of-staff).