### PR TITLE
Fix failing 'create non-arrival' test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1749,7 +1749,7 @@ class BookingTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewNonarrival(
-          date = LocalDate.parse("2023-01-18"),
+          date = booking.arrivalDate,
           reason = nonArrivalReason.id,
           notes = "Notes"
         )
@@ -1759,7 +1759,7 @@ class BookingTest : IntegrationTestBase() {
       .isOk
       .expectBody()
       .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
-      .jsonPath("$.date").isEqualTo("2023-01-18")
+      .jsonPath("$.date").isEqualTo(booking.arrivalDate.toString())
       .jsonPath("$.reason.id").isEqualTo(nonArrivalReason.id.toString())
       .jsonPath("$.notes").isEqualTo("Notes")
   }


### PR DESCRIPTION
As dates are randomly chosen, occasionally the booking would be given a date before the non-arrival date used in the test, which would cause a 400 Bad Request response with the error message 'afterBookingArrivalDate'.

This test has been changed to use the arrival date of the booking as the date for the non-arrival.