### PR TITLE
Retain premises and users in dev and test environments

### DIFF
--- a/src/main/resources/db/migration/local+dev/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev/R__1_create_dev_users.sql
@@ -1,8 +1,9 @@
 -- ${flyway:timestamp}
-TRUNCATE TABLE users CASCADE;
+
 --These are randomly generated names
 
 INSERT INTO "users" (id, name, delius_username, delius_staff_identifier) VALUES
     ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547),
     ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096),
-    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544);
+    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544)
+ON CONFLICT (id) DO NOTHING;

--- a/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
+++ b/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
@@ -1,19 +1,21 @@
 -- ${flyway:timestamp}
-TRUNCATE TABLE premises CASCADE;
 
-insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 1', 'd33006b7-55d9-4a8e-b722-5e18093dbcdf', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'Something House', NULL, 'LA9 1DS', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 30);
-insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 2', 'ada106c7-e1fb-409a-a38e-0002ea8e7e45', '89faa462-7ea6-45ba-b169-93d947d20cae', 'Something Court', NULL, 'EC1 3XZ', '6b4a1308-17af-4c1a-a330-6005bec9e27b', 'temporary-accommodation', 'active', 10);
-insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 3', '36c7b1f2-5a4b-467b-838c-2970c9c253cf', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'Something Place', NULL, 'SA1 1AF', 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'temporary-accommodation', 'active', 25);
-insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('1 Somewhere', '459eeaba-55ac-4a1f-bae2-bad810d4016b', '5283aca7-21bd-4ded-96ec-09cc6f76468e', 'Beckenham Road', 'Notes', 'GL56 0QQ', 'd73ae6b5-041e-4d44-b859-b8c77567d893', 'approved-premises', 'active', 20);
-insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('2 Somewhere', 'e03c82e9-f335-414a-87a0-866060397d4a', '7de4177b-9177-4c28-9bb6-5f5292619546', 'Bedford AP', 'Notes', 'GL56 0QQ', '0544d95a-f6bb-43f8-9be7-aae66e3bf244', 'approved-premises', 'active', 30);
-insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 4', 'b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'f66f8c8d-e811-471a-9f4d-45d4046c6f79', 'Fourth Avenue', NULL, 'FY1 7VG', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 0);
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 1', 'd33006b7-55d9-4a8e-b722-5e18093dbcdf', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'Something House', NULL, 'LA9 1DS', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 30) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 2', 'ada106c7-e1fb-409a-a38e-0002ea8e7e45', '89faa462-7ea6-45ba-b169-93d947d20cae', 'Something Court', NULL, 'EC1 3XZ', '6b4a1308-17af-4c1a-a330-6005bec9e27b', 'temporary-accommodation', 'active', 10) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 3', '36c7b1f2-5a4b-467b-838c-2970c9c253cf', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'Something Place', NULL, 'SA1 1AF', 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'temporary-accommodation', 'active', 25) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('1 Somewhere', '459eeaba-55ac-4a1f-bae2-bad810d4016b', '5283aca7-21bd-4ded-96ec-09cc6f76468e', 'Beckenham Road', 'Notes', 'GL56 0QQ', 'd73ae6b5-041e-4d44-b859-b8c77567d893', 'approved-premises', 'active', 20) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('2 Somewhere', 'e03c82e9-f335-414a-87a0-866060397d4a', '7de4177b-9177-4c28-9bb6-5f5292619546', 'Bedford AP', 'Notes', 'GL56 0QQ', '0544d95a-f6bb-43f8-9be7-aae66e3bf244', 'approved-premises', 'active', 30) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 4', 'b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'f66f8c8d-e811-471a-9f4d-45d4046c6f79', 'Fourth Avenue', NULL, 'FY1 7VG', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO approved_premises (premises_id, q_code, ap_code) VALUES
     ('459eeaba-55ac-4a1f-bae2-bad810d4016b', 'Q022', 'BCKNHAM'),
-    ('e03c82e9-f335-414a-87a0-866060397d4a', 'Q005', 'BDFORD');
+    ('e03c82e9-f335-414a-87a0-866060397d4a', 'Q005', 'BDFORD')
+ON CONFLICT (premises_id) DO NOTHING;
+
 
 INSERT INTO temporary_accommodation_premises (premises_id, pdu) VALUES
     ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Cumbria'),
     ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Camden and Islington'),
     ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Swansea, Neath Port Talbot'),
-    ('b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'North West Lancashire (Blackpool and lower tier LAs in Lancashire - Fylde, Wyre and Lancaster)');
+    ('b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'North West Lancashire (Blackpool and lower tier LAs in Lancashire - Fylde, Wyre and Lancaster)')
+ON CONFLICT (premises_id) DO NOTHING;

--- a/src/main/resources/db/migration/test/R__1_create_users.sql
+++ b/src/main/resources/db/migration/test/R__1_create_users.sql
@@ -1,6 +1,5 @@
 
 -- ${flyway:timestamp}
-TRUNCATE TABLE users CASCADE;
 
   insert into
     users (
@@ -15,7 +14,8 @@ TRUNCATE TABLE users CASCADE;
       'AP_USER_TEST_1',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'AP Test User 1'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 
   insert into
@@ -31,7 +31,8 @@ TRUNCATE TABLE users CASCADE;
       'AP_USER_TEST_2',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       'AP Test User 2'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 
   insert into
@@ -47,7 +48,8 @@ TRUNCATE TABLE users CASCADE;
       'AP_USER_TEST_3',
       '68715a03-06af-49ee-bae5-039c824ab9af',
       'AP Test User 3'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 
   insert into
@@ -63,7 +65,8 @@ TRUNCATE TABLE users CASCADE;
       'AP_USER_TEST_4',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       'AP Test User 4'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 
   insert into
@@ -79,7 +82,8 @@ TRUNCATE TABLE users CASCADE;
       'AP_USER_TEST_5',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'AP Test User 5'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 
   insert into
@@ -95,7 +99,8 @@ TRUNCATE TABLE users CASCADE;
       'CAS_NCC_TEST1',
       '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       'NCC User 1'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 
   insert into
@@ -111,6 +116,7 @@ TRUNCATE TABLE users CASCADE;
       'CAS_NCC_TEST2',
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       'NCC User 2'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 
 


### PR DESCRIPTION
We are now seeding users (and roles/qualifications) and premises using the: [SeedJob](https://github.com/ministryofjustice/approved-premises-api/blob/main/doc/how-to/run_seed_job_remotely.md) process.

So that seeding isn't lost on dev and test at every deploy we now stop truncating the `users` and `premises` tables on every migration run (every deployment).