### PR TITLE
Additional seed data for Temporary Accommodation rooms/bookings in the test env

### DIFF
--- a/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
+++ b/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
@@ -6,6 +6,7 @@ insert into "premises" ("address_line1", "id", "local_authority_area_id", "name"
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 3', '36c7b1f2-5a4b-467b-838c-2970c9c253cf', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'Something Place', NULL, 'SA1 1AF', 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'temporary-accommodation', 'active', 25);
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('1 Somewhere', '459eeaba-55ac-4a1f-bae2-bad810d4016b', '5283aca7-21bd-4ded-96ec-09cc6f76468e', 'Beckenham Road', 'Notes', 'GL56 0QQ', 'd73ae6b5-041e-4d44-b859-b8c77567d893', 'approved-premises', 'active', 20);
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('2 Somewhere', 'e03c82e9-f335-414a-87a0-866060397d4a', '7de4177b-9177-4c28-9bb6-5f5292619546', 'Bedford AP', 'Notes', 'GL56 0QQ', '0544d95a-f6bb-43f8-9be7-aae66e3bf244', 'approved-premises', 'active', 30);
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 4', 'b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'f66f8c8d-e811-471a-9f4d-45d4046c6f79', 'Fourth Avenue', NULL, 'FY1 7VG', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 0);
 
 INSERT INTO approved_premises (premises_id, q_code, ap_code) VALUES
     ('459eeaba-55ac-4a1f-bae2-bad810d4016b', 'Q022', 'BCKNHAM'),
@@ -14,4 +15,5 @@ INSERT INTO approved_premises (premises_id, q_code, ap_code) VALUES
 INSERT INTO temporary_accommodation_premises (premises_id, pdu) VALUES
     ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Cumbria'),
     ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Camden and Islington'),
-    ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Swansea, Neath Port Talbot');
+    ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Swansea, Neath Port Talbot'),
+    ('b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'North West Lancashire (Blackpool and lower tier LAs in Lancashire - Fylde, Wyre and Lancaster)');

--- a/src/main/resources/db/migration/local+dev/R__4_clear_bookings.sql
+++ b/src/main/resources/db/migration/local+dev/R__4_clear_bookings.sql
@@ -1,2 +1,2 @@
 -- ${flyway:timestamp}
-TRUNCATE TABLE bookings CASCADE;
+-- This file intentionally left blank for historical reasons.

--- a/src/main/resources/db/migration/test/R__1_create_users.sql
+++ b/src/main/resources/db/migration/test/R__1_create_users.sql
@@ -11,7 +11,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '50107',
+      '67695',
       'AP_USER_TEST_1',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'AP Test User 1'
@@ -27,7 +27,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '9399',
+      '24550',
       'AP_USER_TEST_2',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       'AP Test User 2'
@@ -43,7 +43,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '59189',
+      '97968',
       'AP_USER_TEST_3',
       '68715a03-06af-49ee-bae5-039c824ab9af',
       'AP Test User 3'
@@ -59,7 +59,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '1184',
+      '86058',
       'AP_USER_TEST_4',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       'AP Test User 4'
@@ -75,7 +75,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '45480',
+      '97507',
       'AP_USER_TEST_5',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'AP Test User 5'
@@ -91,7 +91,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '53952',
+      '64762',
       'CAS_NCC_TEST1',
       '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       'NCC User 1'
@@ -107,7 +107,7 @@ TRUNCATE TABLE users CASCADE;
     )
   values
     (
-      '0',
+      '66464',
       'CAS_NCC_TEST2',
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       'NCC User 2'

--- a/src/main/resources/db/migration/test/R__2_create_rooms.sql
+++ b/src/main/resources/db/migration/test/R__2_create_rooms.sql
@@ -103,3 +103,103 @@ TRUNCATE TABLE beds CASCADE;
       );
     
 
+  insert into
+    rooms ("id", "name", "notes", "premises_id")
+  values
+    (
+      'a82a64f0-a9b6-4854-a5c6-eecb16d8724a',
+      'ROOM6',
+      NULL,
+      'b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d'
+    );
+  
+    insert into
+        beds ("id", "name", "room_id")
+    values
+      (
+        'bdf9f9f6-6d53-4577-bffe-fc5f0ab3de0f',
+        'default-bed',
+        'a82a64f0-a9b6-4854-a5c6-eecb16d8724a'
+      );
+    
+
+  insert into
+    rooms ("id", "name", "notes", "premises_id")
+  values
+    (
+      '1363dca9-baac-46d4-b045-1da39b7aa46d',
+      'ROOM7',
+      NULL,
+      'ada106c7-e1fb-409a-a38e-0002ea8e7e45'
+    );
+  
+    insert into
+        beds ("id", "name", "room_id")
+    values
+      (
+        '055f1f4a-4f86-4ed1-80dc-b793f96c3003',
+        'default-bed',
+        '1363dca9-baac-46d4-b045-1da39b7aa46d'
+      );
+    
+
+  insert into
+    rooms ("id", "name", "notes", "premises_id")
+  values
+    (
+      '53ab0bb3-1553-46e8-877b-6ce6a7ee5d3c',
+      'ROOM8',
+      NULL,
+      'ada106c7-e1fb-409a-a38e-0002ea8e7e45'
+    );
+  
+    insert into
+        beds ("id", "name", "room_id")
+    values
+      (
+        '5f307ee5-e53a-47b3-85b1-a85f0436d9bb',
+        'default-bed',
+        '53ab0bb3-1553-46e8-877b-6ce6a7ee5d3c'
+      );
+    
+
+  insert into
+    rooms ("id", "name", "notes", "premises_id")
+  values
+    (
+      '6f8f50e9-0467-46fa-964b-20d901078631',
+      'ROOM9',
+      NULL,
+      '36c7b1f2-5a4b-467b-838c-2970c9c253cf'
+    );
+  
+    insert into
+        beds ("id", "name", "room_id")
+    values
+      (
+        'a9c6a648-bb73-4d03-b670-a01e3d67dc7a',
+        'default-bed',
+        '6f8f50e9-0467-46fa-964b-20d901078631'
+      );
+    
+
+  insert into
+    rooms ("id", "name", "notes", "premises_id")
+  values
+    (
+      '390883bb-9689-4e17-bfd6-2a762ae182a2',
+      'ROOM10',
+      NULL,
+      '36c7b1f2-5a4b-467b-838c-2970c9c253cf'
+    );
+  
+    insert into
+        beds ("id", "name", "room_id")
+    values
+      (
+        '8eb3fa96-48fe-4e24-8015-16bf009ad5ca',
+        'default-bed',
+        '390883bb-9689-4e17-bfd6-2a762ae182a2'
+      );
+    
+

--- a/src/main/resources/db/migration/test/R__3_create_bookings.sql
+++ b/src/main/resources/db/migration/test/R__3_create_bookings.sql
@@ -1,7 +1,5 @@
 
 -- ${flyway:timestamp}
-TRUNCATE TABLE arrivals CASCADE;
-TRUNCATE TABLE bookings CASCADE;
 --- Add some Bookings arriving today ---
 
 INSERT INTO
@@ -19,7 +17,7 @@ INSERT INTO
   )
 VALUES
   (
-    'afcabcb9-7abe-495c-a67e-381380fbcc2d',
+    '85c8eb35-5c48-436b-9c1d-7791ba3abb1c',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '315VWWC',
@@ -29,7 +27,8 @@ VALUES
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -47,7 +46,7 @@ INSERT INTO
   )
 VALUES
   (
-    '21b99116-6e7e-4c90-afa0-a1be915fb36c',
+    '0a3555d0-2aa2-4825-8e56-b759540ae0ce',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '4Y29R9P',
@@ -57,7 +56,8 @@ VALUES
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -75,7 +75,7 @@ INSERT INTO
   )
 VALUES
   (
-    '480a0b60-e486-4333-aad0-4e33432a7081',
+    'fa21630f-4b7f-452e-9a78-dbadd748bc17',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '4ZUIHFX',
@@ -85,7 +85,8 @@ VALUES
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 --- Add some Temporary accommodation bookings ---
 
@@ -104,17 +105,18 @@ INSERT INTO
   )
 VALUES
   (
-    '29fe043d-2a15-42f7-9a1e-fdeca535e893',
+    '8067f115-d87e-4ed4-9242-53eacd749042',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'QA93YYK',
+    'N6OUTAY',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     'fe86a602-6873-49d3-ac3a-3dfef743ae03',
     'temporary-accommodation',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -132,18 +134,38 @@ INSERT INTO
   )
 VALUES
   (
-    '963d2738-2420-4595-83d5-0b11aa2e4a06',
+    '3bab931b-b694-4651-99fc-83f50b030ad1',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    '315VWWC',
+    '5EC66UT',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     'e8887df9-b31b-4e9c-931a-e063d778ab0d',
     'temporary-accommodation',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
+
+INSERT INTO
+  confirmations (
+    "id",
+    "booking_id",
+    "date_time",
+    "notes",
+    "created_at"
+  )
+VALUES
+  (
+    '96e87ea3-4116-4fcd-aff4-4c6bb3aaecf6',
+    '3bab931b-b694-4651-99fc-83f50b030ad1',
+    CURRENT_DATE,
+    NULL,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
 
 INSERT INTO
   bookings (
@@ -160,18 +182,59 @@ INSERT INTO
   )
 VALUES
   (
-    '7e56bed8-8675-4359-8b74-96dd76af599c',
+    '20f6e044-78d9-4e0b-8098-ccb4926d51bd',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    '52W7TQG',
+    'HTVI42B',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     '135812b4-e6c0-4ccf-9502-4bfea66f3bd3',
     'temporary-accommodation',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE,
+    '20f6e044-78d9-4e0b-8098-ccb4926d51bd',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    'f6b4d21e-f7cc-4417-8f08-33cae23a8252',
+    NULL
+  )
+ON CONFLICT(id) DO NOTHING;
+  
+
+INSERT INTO
+  confirmations (
+    "id",
+    "booking_id",
+    "date_time",
+    "notes",
+    "created_at"
+  )
+VALUES
+  (
+    'f956f4cd-208c-41ae-b186-50afb1b9d857',
+    '20f6e044-78d9-4e0b-8098-ccb4926d51bd',
+    CURRENT_DATE,
+    NULL,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
 
 INSERT INTO
   bookings (
@@ -188,7 +251,7 @@ INSERT INTO
   )
 VALUES
   (
-    'fcbec43a-8186-43d0-bfb2-f607e6126ffc',
+    '12e35bda-00f7-4d12-bbc3-733ed9b4fda6',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '5EC66UT',
@@ -198,8 +261,74 @@ VALUES
     'd97bdcb9-f7b3-477b-a073-71939fac297a',
     'temporary-accommodation',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
+
+INSERT INTO
+  departures (
+    "id",
+    "date_time",
+    "departure_reason_id",
+    "move_on_category_id",
+    "destination_provider_id",
+    "notes",
+    "booking_id",
+    "created_at"
+  )
+VALUES
+  (
+    '8a30d8cb-3404-4db5-ae8f-54e3efdeb46b',
+    CURRENT_DATE + 84,
+    'f4d00e1c-8bfd-40e9-8241-a7d0f744e737',
+    '587dc0dc-9073-4992-9d58-5576753050e9',
+    NULL,
+    NULL,
+    '12e35bda-00f7-4d12-bbc3-733ed9b4fda6',
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
+
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    CURRENT_DATE,
+    '12e35bda-00f7-4d12-bbc3-733ed9b4fda6',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    '11176e1c-48e2-4beb-a81e-4a8eb54a68d1',
+    NULL
+  )
+ON CONFLICT(id) DO NOTHING;
+  
+
+INSERT INTO
+  confirmations (
+    "id",
+    "booking_id",
+    "date_time",
+    "notes",
+    "created_at"
+  )
+VALUES
+  (
+    'bec85422-4590-4d6e-b5df-7205298790d5',
+    '12e35bda-00f7-4d12-bbc3-733ed9b4fda6',
+    CURRENT_DATE,
+    NULL,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
 
 INSERT INTO
   bookings (
@@ -216,18 +345,109 @@ INSERT INTO
   )
 VALUES
   (
-    '3c2e85f6-6fde-4417-91ec-c343d66d0287',
+    'bfd363fc-b1be-480d-bc1f-4a928c99ab50',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'Z33A1BU',
+    'YRPARSH',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     '8be1ed0e-dae7-42d2-97e0-95c95fdb4c50',
     'temporary-accommodation',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
+
+INSERT INTO
+  cancellations (
+    "id",
+    "date",
+    "notes",
+    "booking_id",
+    "cancellation_reason_id",
+    "created_at"
+  )
+VALUES
+  (
+    'b1a73c9a-20ad-4fcc-88a7-e255f8e43903',
+    CURRENT_DATE - 14,
+    NULL,
+    'bfd363fc-b1be-480d-bc1f-4a928c99ab50',
+    'd2a0d037-53db-4bb2-b9f7-afa07948a3f5',
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "bed_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '241cfcac-c6c2-429f-9317-690fb6bfe4a5',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    'JCRH9V5',
+    CURRENT_DATE,
+    CURRENT_DATE + 84,
+    'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
+    'bdf9f9f6-6d53-4577-bffe-fc5f0ab3de0f',
+    'temporary-accommodation',
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+
+
+INSERT INTO
+  non_arrivals (
+    "id",
+    "date",
+    "notes",
+    "booking_id",
+    "non_arrival_reason_id",
+    "created_at"
+  )
+VALUES
+  (
+    '0caefa7e-3618-4708-9307-cb6266538212',
+    CURRENT_DATE + 2,
+    NULL,
+    '241cfcac-c6c2-429f-9317-690fb6bfe4a5',
+    'e9184f2e-f409-461e-b149-492a02cb1655',
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
+
+INSERT INTO
+  confirmations (
+    "id",
+    "booking_id",
+    "date_time",
+    "notes",
+    "created_at"
+  )
+VALUES
+  (
+    '102c2e18-19d2-4fa7-bbf8-ea5d0628e62e',
+    '241cfcac-c6c2-429f-9317-690fb6bfe4a5',
+    CURRENT_DATE,
+    NULL,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+  
 --- Add some Bookings arriving soon ---
 
 INSERT INTO
@@ -245,17 +465,18 @@ INSERT INTO
   )
 VALUES
   (
-    'a5f250a6-bdf1-4cdd-b0e7-ceeb888c934d',
-    CURRENT_DATE + 4,
+    'cf3003db-b146-4b1f-b5a8-5a7f9d6223c8',
+    CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     '52W7TQG',
-    CURRENT_DATE + 4,
+    CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -273,17 +494,47 @@ INSERT INTO
   )
 VALUES
   (
-    'b1e57e3a-254c-452a-846e-681911718789',
-    CURRENT_DATE + 3,
+    '6e5dcbed-7d52-496f-8958-6503f156fbff',
+    CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     '5EC66UT',
+    CURRENT_DATE + 4,
+    CURRENT_DATE + 84,
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    NULL,
+    'approved-premises',
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+
+
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "bed_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '164d7a18-7a56-4628-a95d-a8bff55a1f1f',
+    CURRENT_DATE + 3,
+    CURRENT_DATE + 84,
+    'BWEFOI7',
     CURRENT_DATE + 3,
     CURRENT_DATE + 84,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -301,45 +552,18 @@ INSERT INTO
   )
 VALUES
   (
-    '13e80c7e-05f4-4582-9737-afee19f286ef',
+    'fc943a82-2966-4a8c-92f7-94cc7f29c899',
     CURRENT_DATE + 2,
-    CURRENT_DATE + 84,
-    'BWEFOI7',
-    CURRENT_DATE + 2,
-    CURRENT_DATE + 84,
-    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
-    NULL,
-    'approved-premises',
-    CURRENT_DATE
-  );
-
-
-INSERT INTO
-  bookings (
-    "id",
-    "arrival_date",
-    "departure_date",
-    "crn",
-    "original_arrival_date",
-    "original_departure_date",
-    "premises_id",
-    "bed_id",
-    "service",
-    "created_at"
-  )
-VALUES
-  (
-    '8431d276-a7a8-4836-96d6-9d7cf2625ae4',
-    CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     'GSR1T2F',
-    CURRENT_DATE + 4,
+    CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 --- Add some Bookings departing today ---
 
@@ -358,7 +582,7 @@ INSERT INTO
   )
 VALUES
   (
-    '16e7f3fb-5353-42fe-b3c1-e6874733d899',
+    '65304b6a-61de-4930-a54f-5e1e3eb4b21d',
     CURRENT_DATE - 84,
     CURRENT_DATE,
     'HRV83TE',
@@ -368,7 +592,8 @@ VALUES
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -383,12 +608,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '16e7f3fb-5353-42fe-b3c1-e6874733d899',
+    '65304b6a-61de-4930-a54f-5e1e3eb4b21d',
     CURRENT_DATE,
     CURRENT_DATE,
-    'e9543cc9-a253-422a-8a61-0b14de8d1bcc',
+    'b2af3908-5f3f-40ef-84cd-0df5683c0f05',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 
 INSERT INTO
@@ -406,7 +632,7 @@ INSERT INTO
   )
 VALUES
   (
-    'aad04043-9702-474c-a617-bcdf18729d3e',
+    '08b7c9ed-6900-4fa4-bd8f-7e431cfce5fd',
     CURRENT_DATE - 84,
     CURRENT_DATE,
     'HTVI42B',
@@ -416,7 +642,8 @@ VALUES
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -431,12 +658,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    'aad04043-9702-474c-a617-bcdf18729d3e',
+    '08b7c9ed-6900-4fa4-bd8f-7e431cfce5fd',
     CURRENT_DATE,
     CURRENT_DATE,
-    '2d6e14c7-1c04-4f8e-aec6-e5910a68f33d',
+    'e20e1cd8-5581-41e9-9060-1c30bfc78d98',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 --- Add some Bookings departing soon ---
 
@@ -455,17 +683,18 @@ INSERT INTO
   )
 VALUES
   (
-    '26844b1a-d847-4c5b-b8cc-1e3e50c04438',
+    'ed29449d-fd5c-42bb-a685-676c9f8f8dec',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 4,
+    CURRENT_DATE + 1,
     'HRV83TE',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 4,
+    CURRENT_DATE + 1,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -480,12 +709,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '26844b1a-d847-4c5b-b8cc-1e3e50c04438',
+    'ed29449d-fd5c-42bb-a685-676c9f8f8dec',
     CURRENT_DATE,
-    CURRENT_DATE + 4,
-    'db3ef90d-7c78-46bc-a3b4-e80b3b326b48',
+    CURRENT_DATE + 1,
+    'd8f0efab-07b4-48cf-a1f1-ad2b73eac279',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 
 INSERT INTO
@@ -503,17 +733,18 @@ INSERT INTO
   )
 VALUES
   (
-    'c060600b-0e5b-475f-acfd-74a79a7bbd7e',
+    'd19a5b81-2b76-4d5a-893e-52cdc1a601b8',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 4,
+    CURRENT_DATE + 2,
     'HTVI42B',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 4,
+    CURRENT_DATE + 2,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -528,12 +759,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    'c060600b-0e5b-475f-acfd-74a79a7bbd7e',
+    'd19a5b81-2b76-4d5a-893e-52cdc1a601b8',
     CURRENT_DATE,
-    CURRENT_DATE + 4,
-    'dc43f4e0-5e09-44af-a7a3-a5482122a6cb',
+    CURRENT_DATE + 2,
+    '06534dfa-0108-4dbf-9ebc-6f8141bfd31e',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 --- Add some arrived Bookings ---
 
@@ -552,17 +784,18 @@ INSERT INTO
   )
 VALUES
   (
-    '78ca5657-1797-46bd-9fc3-3cec04fd8263',
+    'c64f0e8e-c8a7-41ac-9bf3-d58b28d527b7',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 48,
+    CURRENT_DATE + 13,
     'HUN3BN0',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 48,
+    CURRENT_DATE + 13,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -577,12 +810,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '78ca5657-1797-46bd-9fc3-3cec04fd8263',
+    'c64f0e8e-c8a7-41ac-9bf3-d58b28d527b7',
     CURRENT_DATE,
-    CURRENT_DATE + 48,
-    'f15cb65e-79f1-408e-8764-fbe71e9e709f',
+    CURRENT_DATE + 13,
+    'ee52f4ef-22b7-49d3-9931-112c98ce9457',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 
 INSERT INTO
@@ -600,17 +834,18 @@ INSERT INTO
   )
 VALUES
   (
-    '76b32d8e-1913-4c05-9433-a22f0357a3a4',
+    '04206c50-9a15-4fa8-b5d5-26811102258f',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 25,
+    CURRENT_DATE + 11,
     'IHGHXYM',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 25,
+    CURRENT_DATE + 11,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -625,12 +860,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '76b32d8e-1913-4c05-9433-a22f0357a3a4',
+    '04206c50-9a15-4fa8-b5d5-26811102258f',
     CURRENT_DATE,
-    CURRENT_DATE + 25,
-    '819ebbf3-6f88-4b67-a7e9-8ecfe2b8a136',
+    CURRENT_DATE + 11,
+    'cc3add97-2b68-4cb6-9142-6cb6842223ee',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 
 INSERT INTO
@@ -648,17 +884,18 @@ INSERT INTO
   )
 VALUES
   (
-    'f1b73388-93ec-4bcf-9d27-601099015621',
+    'bfdf867a-4f0e-4462-b388-b05af315c140',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 8,
+    CURRENT_DATE + 20,
     'JCRH9V5',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 8,
+    CURRENT_DATE + 20,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -673,12 +910,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    'f1b73388-93ec-4bcf-9d27-601099015621',
+    'bfdf867a-4f0e-4462-b388-b05af315c140',
     CURRENT_DATE,
-    CURRENT_DATE + 8,
-    '75507b9f-d95c-4ed6-baee-1368546a98e5',
+    CURRENT_DATE + 20,
+    '1575ea9d-7824-4a24-a3bb-dba83a978094',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 
 INSERT INTO
@@ -696,17 +934,18 @@ INSERT INTO
   )
 VALUES
   (
-    '42305942-8b3d-4e98-af0f-4ce0edd40693',
+    '9f904a9b-ca17-4648-a9d8-4c934a6689d9',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 60,
+    CURRENT_DATE + 39,
     'N6OUTAY',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 60,
+    CURRENT_DATE + 39,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -721,12 +960,13 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '42305942-8b3d-4e98-af0f-4ce0edd40693',
+    '9f904a9b-ca17-4648-a9d8-4c934a6689d9',
     CURRENT_DATE,
-    CURRENT_DATE + 60,
-    '4f48352d-d671-4ddf-baef-dc7693dc4d42',
+    CURRENT_DATE + 39,
+    'ffe2c15a-90de-44ab-b8fb-4843e2ac109f',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
 
 INSERT INTO
@@ -744,17 +984,18 @@ INSERT INTO
   )
 VALUES
   (
-    '55aa555a-84a9-4aeb-a81d-bdc7a6888c74',
+    '4e77927b-7ccf-4e80-8b38-335b3e4f501c',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 52,
+    CURRENT_DATE + 35,
     'PR5E5Y2',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 52,
+    CURRENT_DATE + 35,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
     CURRENT_DATE
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
 
 
 INSERT INTO
@@ -769,11 +1010,12 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '55aa555a-84a9-4aeb-a81d-bdc7a6888c74',
+    '4e77927b-7ccf-4e80-8b38-335b3e4f501c',
     CURRENT_DATE,
-    CURRENT_DATE + 52,
-    '06f64391-0f46-4759-862c-d97b4cdeface',
+    CURRENT_DATE + 35,
+    '0d59544b-b839-4619-b698-662eba439cfc',
     NULL
-  );
+  )
+ON CONFLICT(id) DO NOTHING;
   
   

--- a/src/main/resources/db/migration/test/R__4_create_applications.sql
+++ b/src/main/resources/db/migration/test/R__4_create_applications.sql
@@ -24,9 +24,9 @@ BEGIN
   )
   values
     (
-      '1f796970-df6c-4518-b133-3baa6008a74d',
-      CURRENT_DATE + 25,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'a3ae72b1-0284-439b-9fd9-e1237fa57a19',
+      CURRENT_DATE + 7,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       '315VWWC',
       applicationData,
       applicationDocument,
@@ -40,7 +40,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 29
+      CURRENT_DATE + 16
     );
   
 
@@ -57,7 +57,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      '1f796970-df6c-4518-b133-3baa6008a74d',
+      'a3ae72b1-0284-439b-9fd9-e1237fa57a19',
       false,
       false,
       'M2500295343',
@@ -76,9 +76,9 @@ BEGIN
   )
   VALUES
     (
-      'a226c8bf-83b3-4a02-925b-42535539ba88',
-      '1f796970-df6c-4518-b133-3baa6008a74d',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'e7668161-e933-4aae-bd4b-116c1e92b37d',
+      'a3ae72b1-0284-439b-9fd9-e1237fa57a19',
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -106,9 +106,9 @@ BEGIN
   )
   values
     (
-      'e505e336-53b2-46fa-a2f2-379e19cb1b3d',
-      CURRENT_DATE + 12,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'caa8ef6d-8b2c-4cd5-b626-375196da9a4d',
+      CURRENT_DATE + 29,
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       '4Y29R9P',
       applicationData,
       applicationDocument,
@@ -122,7 +122,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 15
+      CURRENT_DATE + 12
     );
   
 
@@ -139,7 +139,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      'e505e336-53b2-46fa-a2f2-379e19cb1b3d',
+      'caa8ef6d-8b2c-4cd5-b626-375196da9a4d',
       false,
       false,
       'M2500295343',
@@ -158,254 +158,8 @@ BEGIN
   )
   VALUES
     (
-      '5897d64a-3a15-493c-b57a-d06eabadd9c5',
-      'e505e336-53b2-46fa-a2f2-379e19cb1b3d',
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '0832b3b1-77a1-489a-a79c-8cfae49eeb06',
-      CURRENT_DATE + 24,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      '4ZUIHFX',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 27
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '0832b3b1-77a1-489a-a79c-8cfae49eeb06',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'b034d785-70fd-480b-b505-74eee5edd2ef',
-      '0832b3b1-77a1-489a-a79c-8cfae49eeb06',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '744abd7e-2cba-4e90-99f7-74869909cac4',
-      CURRENT_DATE + 25,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      '52W7TQG',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 6
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '744abd7e-2cba-4e90-99f7-74869909cac4',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'cf68dd7f-14c6-4a99-8e7c-af90f4300deb',
-      '744abd7e-2cba-4e90-99f7-74869909cac4',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '17d805d7-d66d-412b-992d-1f6ecf18bf27',
-      CURRENT_DATE + 5,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      '5EC66UT',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 15
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '17d805d7-d66d-412b-992d-1f6ecf18bf27',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'aadf002a-ecb8-42f3-aaa0-88d2d12ef212',
-      '17d805d7-d66d-412b-992d-1f6ecf18bf27',
+      '4c935bda-0745-4c1c-9ab7-6e7e302d5433',
+      'caa8ef6d-8b2c-4cd5-b626-375196da9a4d',
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -434,10 +188,174 @@ BEGIN
   )
   values
     (
-      '3bbc30ba-0c8c-4cd3-a000-5f72466e3592',
-      CURRENT_DATE + 29,
+      '320f3046-11b4-482c-83e8-d2ebad559ff2',
+      CURRENT_DATE + 1,
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      '4ZUIHFX',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 2
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '320f3046-11b4-482c-83e8-d2ebad559ff2',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '087df236-7661-4471-ae4d-b743683087af',
+      '320f3046-11b4-482c-83e8-d2ebad559ff2',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '62bbd92f-617e-400a-9116-f1e8143c3cb5',
+      CURRENT_DATE + 24,
       '68715a03-06af-49ee-bae5-039c824ab9af',
-      '8LO3HSH',
+      '52W7TQG',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 20
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '62bbd92f-617e-400a-9116-f1e8143c3cb5',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '6049f5ca-e256-4225-876e-31ac1d428cdb',
+      '62bbd92f-617e-400a-9116-f1e8143c3cb5',
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '134ad1c6-6039-4f06-8ada-8956f7af75b5',
+      CURRENT_DATE + 13,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '5EC66UT',
       applicationData,
       applicationDocument,
       (
@@ -467,7 +385,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      '3bbc30ba-0c8c-4cd3-a000-5f72466e3592',
+      '134ad1c6-6039-4f06-8ada-8956f7af75b5',
       false,
       false,
       'M2500295343',
@@ -486,8 +404,8 @@ BEGIN
   )
   VALUES
     (
-      '06da7600-70e3-4d17-89d3-4472d1d29bea',
-      '3bbc30ba-0c8c-4cd3-a000-5f72466e3592',
+      '73bc2eb1-0568-4a0d-965f-21a56e53f4cb',
+      '134ad1c6-6039-4f06-8ada-8956f7af75b5',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -516,9 +434,91 @@ BEGIN
   )
   values
     (
-      'b3ff9a95-2137-47c3-ac84-eec1322bf4fc',
-      CURRENT_DATE + 19,
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      '2899785d-50e9-45f7-9f9c-589eb4e720f9',
+      CURRENT_DATE + 16,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '8LO3HSH',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 2
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '2899785d-50e9-45f7-9f9c-589eb4e720f9',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '25d425c5-c9a6-4129-b16f-25274956dd2f',
+      '2899785d-50e9-45f7-9f9c-589eb4e720f9',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '715c185a-6e84-41ec-8cf3-e0833842e040',
+      CURRENT_DATE + 2,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'BWEFOI7',
       applicationData,
       applicationDocument,
@@ -549,7 +549,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      'b3ff9a95-2137-47c3-ac84-eec1322bf4fc',
+      '715c185a-6e84-41ec-8cf3-e0833842e040',
       false,
       false,
       'M2500295343',
@@ -568,9 +568,9 @@ BEGIN
   )
   VALUES
     (
-      '360636cf-bded-4d17-b1cd-5f21f2763c5d',
-      'b3ff9a95-2137-47c3-ac84-eec1322bf4fc',
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      'b2a51fbb-8a2f-4603-9678-9d7b01a46111',
+      '715c185a-6e84-41ec-8cf3-e0833842e040',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -598,9 +598,9 @@ BEGIN
   )
   values
     (
-      '0fb40446-68be-44af-936e-b0d11f414bdf',
-      CURRENT_DATE + 25,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '89e1d2c2-e847-45dd-b0b4-a9faf99324b6',
+      CURRENT_DATE + 15,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       'GSR1T2F',
       applicationData,
       applicationDocument,
@@ -614,7 +614,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 25
+      CURRENT_DATE + 28
     );
   
 
@@ -631,7 +631,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      '0fb40446-68be-44af-936e-b0d11f414bdf',
+      '89e1d2c2-e847-45dd-b0b4-a9faf99324b6',
       false,
       false,
       'M2500295343',
@@ -650,9 +650,9 @@ BEGIN
   )
   VALUES
     (
-      '0edefb75-d06b-4c93-9a52-602d0f0be30f',
-      '0fb40446-68be-44af-936e-b0d11f414bdf',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'fb8b4775-d87f-4eb9-94c0-dfbab1aa107b',
+      '89e1d2c2-e847-45dd-b0b4-a9faf99324b6',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -680,9 +680,9 @@ BEGIN
   )
   values
     (
-      'c253c552-97d0-48d6-8680-6d94b0d7db52',
-      CURRENT_DATE + 28,
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      '5fefb142-adc7-415c-8c31-752f27d79d0b',
+      CURRENT_DATE + 2,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       'HRV83TE',
       applicationData,
       applicationDocument,
@@ -696,7 +696,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 17
+      CURRENT_DATE + 26
     );
   
 
@@ -713,7 +713,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      'c253c552-97d0-48d6-8680-6d94b0d7db52',
+      '5fefb142-adc7-415c-8c31-752f27d79d0b',
       false,
       false,
       'M2500295343',
@@ -732,9 +732,9 @@ BEGIN
   )
   VALUES
     (
-      'f1fd7acd-7567-4712-9eb1-e53fd7d86e6f',
-      'c253c552-97d0-48d6-8680-6d94b0d7db52',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '694895df-9805-4960-abc3-064b675bdcca',
+      '5fefb142-adc7-415c-8c31-752f27d79d0b',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -762,830 +762,10 @@ BEGIN
   )
   values
     (
-      'ecb8d067-b67f-4b11-9bdc-ee20a4aa6f81',
-      CURRENT_DATE + 28,
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      'ce9d741d-8a63-4e83-b309-7b61b727117c',
+      CURRENT_DATE + 15,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'HTVI42B',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 7
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'ecb8d067-b67f-4b11-9bdc-ee20a4aa6f81',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '9daf08a0-5378-4214-8045-ce2bc731db1e',
-      'ecb8d067-b67f-4b11-9bdc-ee20a4aa6f81',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '8fe60294-c821-4284-bab8-b4743d648760',
-      CURRENT_DATE + 9,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'HUN3BN0',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 13
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '8fe60294-c821-4284-bab8-b4743d648760',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '6520bd28-7d01-490c-b0aa-8e0ed9d80b72',
-      '8fe60294-c821-4284-bab8-b4743d648760',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '546251a5-bf83-4d9f-ab40-efb3f6749a10',
-      CURRENT_DATE + 12,
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      'IHGHXYM',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 27
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '546251a5-bf83-4d9f-ab40-efb3f6749a10',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '9b84af3d-d9ae-47f1-9141-ca16c1d443d3',
-      '546251a5-bf83-4d9f-ab40-efb3f6749a10',
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '13da62e2-e3f8-4a3b-b57f-93a52467ca87',
-      CURRENT_DATE + 5,
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      'JCRH9V5',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 12
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '13da62e2-e3f8-4a3b-b57f-93a52467ca87',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '3e3b1d38-ad95-4888-acf8-bbe102234170',
-      '13da62e2-e3f8-4a3b-b57f-93a52467ca87',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'f4a853d4-e7a0-4a9d-aa2a-1c62f2bf22d5',
-      CURRENT_DATE + 13,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'N6OUTAY',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 0
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'f4a853d4-e7a0-4a9d-aa2a-1c62f2bf22d5',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '8bb7b046-77b1-4ae9-b514-151b63a79923',
-      'f4a853d4-e7a0-4a9d-aa2a-1c62f2bf22d5',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'cbdb326b-df81-45c3-b61e-51827f4a5c17',
-      CURRENT_DATE + 10,
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
-      'PI251LM',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 2
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'cbdb326b-df81-45c3-b61e-51827f4a5c17',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'c4c58257-296c-4490-949b-83295a18b717',
-      'cbdb326b-df81-45c3-b61e-51827f4a5c17',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'af8236b1-2ad6-4ee4-96fd-f967be61f874',
-      CURRENT_DATE + 21,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      'PR5E5Y2',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 3
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'af8236b1-2ad6-4ee4-96fd-f967be61f874',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '698d2847-4428-4dd8-8fe3-a2d704f255a2',
-      'af8236b1-2ad6-4ee4-96fd-f967be61f874',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      'a74a3263-2fa7-48c0-9e2d-a2b47cb4eca4',
-      CURRENT_DATE + 29,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'QA93YYK',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 22
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'a74a3263-2fa7-48c0-9e2d-a2b47cb4eca4',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '06f7d42c-63ef-46ee-a791-2d589e3de82d',
-      'a74a3263-2fa7-48c0-9e2d-a2b47cb4eca4',
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '9742015b-a0ba-4131-b25f-e3cf10934f04',
-      CURRENT_DATE + 6,
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      'XCMSG3I',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 1
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '9742015b-a0ba-4131-b25f-e3cf10934f04',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'b44c6740-bdb9-4ec1-9b9a-f9ea748e826c',
-      '9742015b-a0ba-4131-b25f-e3cf10934f04',
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '717a2153-b973-4cb3-8b9f-0e94d07e846d',
-      CURRENT_DATE + 13,
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      'YRPARSH',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 17
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '717a2153-b973-4cb3-8b9f-0e94d07e846d',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '17f8d37a-fa73-4124-8491-afd8446851d1',
-      '717a2153-b973-4cb3-8b9f-0e94d07e846d',
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at"
-  )
-  values
-    (
-      '74199fd8-3d2d-483f-b2aa-92830498bb72',
-      CURRENT_DATE + 4,
-      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
-      'Z33A1BU',
       applicationData,
       applicationDocument,
       (
@@ -1615,7 +795,7 @@ BEGIN
     (
       '2500295345',
       '2',
-      '74199fd8-3d2d-483f-b2aa-92830498bb72',
+      'ce9d741d-8a63-4e83-b309-7b61b727117c',
       false,
       false,
       'M2500295343',
@@ -1634,8 +814,828 @@ BEGIN
   )
   VALUES
     (
-      '5d602ac4-c055-403f-976d-2aa3db93032d',
-      '74199fd8-3d2d-483f-b2aa-92830498bb72',
+      'f5dae5cb-6425-4737-951a-32278082ed41',
+      'ce9d741d-8a63-4e83-b309-7b61b727117c',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'a376537c-1d6e-447d-82dd-e7677ce5a282',
+      CURRENT_DATE + 29,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'HUN3BN0',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 28
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'a376537c-1d6e-447d-82dd-e7677ce5a282',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '76e08ed2-2686-4d40-9b1b-661691f9a948',
+      'a376537c-1d6e-447d-82dd-e7677ce5a282',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '7518d90a-1206-46f9-bc06-cb945921f9f2',
+      CURRENT_DATE + 6,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      'IHGHXYM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 5
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '7518d90a-1206-46f9-bc06-cb945921f9f2',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '9537cdcf-651c-483f-8330-0591c8259902',
+      '7518d90a-1206-46f9-bc06-cb945921f9f2',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '77bfbba7-5d9a-4bac-be06-6965dc44fff0',
+      CURRENT_DATE + 19,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      'JCRH9V5',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 19
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '77bfbba7-5d9a-4bac-be06-6965dc44fff0',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '0ea89112-a441-4786-9c60-9b346a90c749',
+      '77bfbba7-5d9a-4bac-be06-6965dc44fff0',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '5e438fdd-b772-4607-b210-76dfe4bf87d0',
+      CURRENT_DATE + 22,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      'N6OUTAY',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 29
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '5e438fdd-b772-4607-b210-76dfe4bf87d0',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '78b69fbf-483c-48c9-a059-e7136c77feb2',
+      '5e438fdd-b772-4607-b210-76dfe4bf87d0',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '6a81cac4-8935-47fc-a3fa-278feb849dc2',
+      CURRENT_DATE + 10,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'PI251LM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 22
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '6a81cac4-8935-47fc-a3fa-278feb849dc2',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'b9bf3434-8c2e-41f5-b39e-c1c45ff1590b',
+      '6a81cac4-8935-47fc-a3fa-278feb849dc2',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '2ed1b0d6-b35e-444f-ad8a-4af15ed6a7f7',
+      CURRENT_DATE + 14,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'PR5E5Y2',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 0
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '2ed1b0d6-b35e-444f-ad8a-4af15ed6a7f7',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '1386c4f0-b2c5-44d7-8922-ba26271002f5',
+      '2ed1b0d6-b35e-444f-ad8a-4af15ed6a7f7',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '0f09f888-457f-436d-a266-81fe366c8ac9',
+      CURRENT_DATE + 27,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      'QA93YYK',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 2
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '0f09f888-457f-436d-a266-81fe366c8ac9',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '86d7d331-2bfb-4737-b173-51517793b46b',
+      '0f09f888-457f-436d-a266-81fe366c8ac9',
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '2ed2606b-7515-4063-a6f9-164c7e10ce07',
+      CURRENT_DATE + 17,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'XCMSG3I',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 19
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '2ed2606b-7515-4063-a6f9-164c7e10ce07',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '1e3f76fc-c603-4f9e-be81-d68b7cc34871',
+      '2ed2606b-7515-4063-a6f9-164c7e10ce07',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '5904b06c-09bf-4e84-b949-5af15ce2119f',
+      CURRENT_DATE + 11,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      'YRPARSH',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 7
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '5904b06c-09bf-4e84-b949-5af15ce2119f',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '0b5c1b1a-3c1c-4c4e-81df-4cd200188591',
+      '5904b06c-09bf-4e84-b949-5af15ce2119f',
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      'fbe84d6a-5ce2-439d-914f-593f7c7a9539',
+      CURRENT_DATE + 21,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'Z33A1BU',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 1
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'fbe84d6a-5ce2-439d-914f-593f7c7a9539',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'd34fa634-74be-4bc8-821a-6c38e6c844e8',
+      'fbe84d6a-5ce2-439d-914f-593f7c7a9539',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       CURRENT_DATE,
       CURRENT_DATE,


### PR DESCRIPTION
This is a rework of #366.

This PR achieves the same result, but empties out the `R__0_clear_bookings.sql` instead of renaming it (avoiding breaking the migrations) and uses `ON CONFLICT(id) DO NOTHING` for the booking seeding.