### PR TITLE
1038 - Associate booking with Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -342,6 +342,8 @@ class PremisesController(
         originalArrivalDate = body.arrivalDate,
         originalDepartureDate = body.departureDate,
         createdAt = OffsetDateTime.now(),
+        application = null,
+        offlineApplication = null
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -43,6 +43,12 @@ data class BookingEntity(
   var cancellation: CancellationEntity?,
   @OneToOne(mappedBy = "booking")
   var confirmation: ConfirmationEntity?,
+  @OneToOne
+  @JoinColumn(name = "application_id")
+  var application: ApplicationEntity?,
+  @OneToOne
+  @JoinColumn(name = "offline_application_id")
+  var offlineApplication: OfflineApplicationEntity?,
   @OneToMany(mappedBy = "booking")
   var extensions: MutableList<ExtensionEntity>,
   @ManyToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID>
+
+@Entity
+@Table(name = "offline_applications")
+data class OfflineApplicationEntity(
+  @Id
+  val id: UUID,
+  val crn: String,
+  val service: String,
+  val submittedAt: OffsetDateTime,
+  val createdAt: OffsetDateTime
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.Table
 
 @Repository
 interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID> {
-  fun findAllWhereService(name: String): List<OfflineApplicationEntity>
+  fun findAllByService(name: String): List<OfflineApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -9,7 +9,9 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID>
+interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID> {
+  fun findAllWhereService(name: String): List<OfflineApplicationEntity>
+}
 
 @Entity
 @Table(name = "offline_applications")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -58,7 +58,7 @@ class ApplicationService(
       ?: return emptyList()
 
     val applications = if (userEntity.hasAnyRole(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER)) {
-      offlineApplicationRepository.findAllWhereService(serviceName.value)
+      offlineApplicationRepository.findAllByService(serviceName.value)
     } else {
       emptyList()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
@@ -45,4 +47,11 @@ class ApplicationsTransformer(
     )
     else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
   }
+
+  fun transformJpaToApi(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplication(
+    id = jpa.id,
+    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+    createdAt = jpa.createdAt,
+    submittedAt = jpa.submittedAt
+  )
 }

--- a/src/main/resources/db/migration/all/20230123135851__offline_applications.sql
+++ b/src/main/resources/db/migration/all/20230123135851__offline_applications.sql
@@ -1,0 +1,8 @@
+CREATE TABLE offline_applications (
+    id UUID NOT NULL,
+    crn TEXT NOT NULL,
+    service TEXT NOT NULL,
+    submitted_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/main/resources/db/migration/all/20230123135852__link_booking_applications.sql
+++ b/src/main/resources/db/migration/all/20230123135852__link_booking_applications.sql
@@ -1,0 +1,4 @@
+ALTER TABLE bookings ADD COLUMN application_id UUID;
+ALTER TABLE bookings ADD CONSTRAINT application_id_fk FOREIGN KEY (application_id) REFERENCES applications(id);
+ALTER TABLE bookings ADD COLUMN offline_application_id UUID;
+ALTER TABLE bookings ADD CONSTRAINT offline_application_id_fk FOREIGN KEY (offline_application_id) REFERENCES offline_applications(id);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3015,38 +3015,28 @@ components:
           format: uuid
         person:
           $ref: '#/components/schemas/Person'
-        createdByUserId:
-          type: string
-          format: uuid
-        schemaVersion:
-          type: string
-          format: uuid
-        outdatedSchema:
-          type: boolean
         createdAt:
           type: string
           format: date-time
         submittedAt:
           type: string
           format: date-time
-        data:
-          $ref: '#/components/schemas/AnyValue'
-        document:
-          $ref: '#/components/schemas/AnyValue'
       discriminator:
-        propertyName: service
+        propertyName: type
         mapping:
+          Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - id
-        - crn
-        - createdByUserId
-        - schemaVersion
-        - outdatedSchema
-        - createdAt
         - person
-        - service
+        - createdAt
+        - type
+    OfflineApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties: { }
     ApprovedPremisesApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -3058,13 +3048,44 @@ components:
               type: boolean
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
           required:
             - risks
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
         - type: object
-          properties: {}
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+          required:
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
     NewApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
-import kotlin.RuntimeException
 
 class BookingEntityFactory : Factory<BookingEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
@@ -155,5 +154,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
     originalArrivalDate = this.originalArrivalDate?.invoke() ?: this.arrivalDate(),
     originalDepartureDate = this.originalDepartureDate?.invoke() ?: this.departureDate(),
     createdAt = this.createdAt(),
+    application = null,
+    offlineApplication = null
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var service: Yielded<String> = { "approved-premises" }
+  private var submittedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withService(service: String) = apply {
+    this.service = { service }
+  }
+
+  fun withSubmittedAt(submittedAt: OffsetDateTime) = apply {
+    this.submittedAt = { submittedAt }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  override fun produce() = OfflineApplicationEntity(
+    id = this.id(),
+    crn = this.crn(),
+    service = this.service(),
+    submittedAt = this.submittedAt(),
+    createdAt = this.createdAt()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApplication
@@ -174,7 +175,7 @@ class ApplicationTest : IntegrationTestBase() {
       .responseBody
       .blockFirst()
 
-    val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<Application>>() {})
+    val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplication>>() {})
 
     assertThat(responseBody).anyMatch {
       outdatedApplicationEntityCreatedByUser.id == it.id &&
@@ -308,7 +309,7 @@ class ApplicationTest : IntegrationTestBase() {
       .responseBody
       .blockFirst()
 
-    val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<Application>>() {})
+    val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplication>>() {})
 
     assertThat(responseBody).anyMatch {
       outdatedApplicationEntityCreatedByUser.id == it.id &&
@@ -537,7 +538,7 @@ class ApplicationTest : IntegrationTestBase() {
       .responseBody
       .blockFirst()
 
-    val responseBody = objectMapper.readValue(rawResponseBody, Application::class.java)
+    val responseBody = objectMapper.readValue(rawResponseBody, ApprovedPremisesApplication::class.java)
 
     assertThat(responseBody).matches {
       applicationEntity.id == it.id &&
@@ -749,7 +750,7 @@ class ApplicationTest : IntegrationTestBase() {
       .responseBody
       .blockFirst()
 
-    val responseBody = objectMapper.readValue(rawResponseBody, Application::class.java)
+    val responseBody = objectMapper.readValue(rawResponseBody, ApprovedPremisesApplication::class.java)
 
     assertThat(responseBody).matches {
       nonUpgradableApplicationEntity.id == it.id &&
@@ -921,7 +922,7 @@ class ApplicationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isCreated
-      .returnResult(Application::class.java)
+      .returnResult(ApprovedPremisesApplication::class.java)
 
     assertThat(result.responseHeaders["Location"]).anyMatch {
       it.matches(Regex("/applications/.+"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
@@ -71,6 +72,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
@@ -107,6 +109,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.MoveOnCategoryTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.OfflineApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
@@ -199,6 +202,9 @@ abstract class IntegrationTestBase {
   lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationPremisesTestRepository
 
   @Autowired
+  lateinit var offlineApplicationRepository: OfflineApplicationTestRepository
+
+  @Autowired
   lateinit var approvedPremisesApplicationJsonSchemaRepository: ApprovedPremisesApplicationJsonSchemaTestRepository
 
   @Autowired
@@ -248,6 +254,7 @@ abstract class IntegrationTestBase {
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
   lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
   lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
+  lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
   lateinit var approvedPremisesAssessmentJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesAssessmentJsonSchemaEntity, UUID, ApprovedPremisesAssessmentJsonSchemaEntityFactory>
   lateinit var userEntityFactory: PersistedFactory<UserEntity, UUID, UserEntityFactory>
@@ -304,6 +311,7 @@ abstract class IntegrationTestBase {
     extensionEntityFactory = PersistedFactory(ExtensionEntityFactory(), extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory(NonArrivalReasonEntityFactory(), nonArrivalReasonRepository)
     approvedPremisesApplicationEntityFactory = PersistedFactory(ApprovedPremisesApplicationEntityFactory(), approvedPremisesApplicationRepository)
+    offlineApplicationEntityFactory = PersistedFactory(OfflineApplicationEntityFactory(), offlineApplicationRepository)
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory(ApprovedPremisesApplicationJsonSchemaEntityFactory(), approvedPremisesApplicationJsonSchemaRepository)
     approvedPremisesAssessmentJsonSchemaEntityFactory = PersistedFactory(ApprovedPremisesAssessmentJsonSchemaEntityFactory(), approvedPremisesAssessmentJsonSchemaRepository)
     userEntityFactory = PersistedFactory(UserEntityFactory(), userRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/OfflineApplicationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/OfflineApplicationTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import java.util.UUID
+
+@Repository
+interface OfflineApplicationTestRepository : JpaRepository<OfflineApplicationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -5,12 +5,15 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
@@ -18,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
@@ -43,6 +47,7 @@ class ApplicationServiceTest {
   private val mockUserService = mockk<UserService>()
   private val mockAssessmentService = mockk<AssessmentService>()
   private val mockJsonLogicService = mockk<JsonLogicService>()
+  private val mockOfflineApplicationRepository = mockk<OfflineApplicationRepository>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
@@ -51,7 +56,8 @@ class ApplicationServiceTest {
     mockOffenderService,
     mockUserService,
     mockAssessmentService,
-    mockJsonLogicService
+    mockJsonLogicService,
+    mockOfflineApplicationRepository
   )
 
   @Test
@@ -588,5 +594,77 @@ class ApplicationServiceTest {
 
     verify { mockApplicationRepository.save(any()) }
     verify(exactly = 1) { mockAssessmentService.createAssessment(application) }
+  }
+
+  @Test
+  fun `Get all offline applications where Probation Officer with provided distinguished name does not exist returns empty list`() {
+    val distinguishedName = "SOMEPERSON"
+
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns null
+
+    assertThat(applicationService.getAllOfflineApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).isEmpty()
+  }
+
+  @Test
+  fun `Get all offline applications where Probation Officer exists returns empty list for user without any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER`() {
+    val userId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
+    val distinguishedName = "SOMEPERSON"
+    val userEntity = UserEntityFactory()
+      .withId(userId)
+      .withDeliusUsername(distinguishedName)
+      .produce()
+    val offlineApplicationEntities = listOf(
+      OfflineApplicationEntityFactory()
+        .produce(),
+      OfflineApplicationEntityFactory()
+        .produce(),
+      OfflineApplicationEntityFactory()
+        .produce()
+    )
+
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
+    every { mockOfflineApplicationRepository.findAllWhereService("approved-premises") } returns offlineApplicationEntities
+    every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+
+    offlineApplicationEntities.forEach {
+      every { mockOffenderService.canAccessOffender(distinguishedName, it.crn) } returns true
+    }
+
+    assertThat(applicationService.getAllOfflineApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).isEmpty()
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "WORKFLOW_MANAGER", "ASSESSOR", "MATCHER", "MANAGER" ])
+  fun `Get all offline applications where Probation Officer exists returns repository results for user with any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER`(role: UserRole) {
+    val userId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
+    val distinguishedName = "SOMEPERSON"
+    val userEntity = UserEntityFactory()
+      .withId(userId)
+      .withDeliusUsername(distinguishedName)
+      .produce()
+      .apply {
+        roles += UserRoleAssignmentEntityFactory()
+          .withUser(this)
+          .withRole(role)
+          .produce()
+      }
+    val offlineApplicationEntities = listOf(
+      OfflineApplicationEntityFactory()
+        .produce(),
+      OfflineApplicationEntityFactory()
+        .produce(),
+      OfflineApplicationEntityFactory()
+        .produce()
+    )
+
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
+    every { mockOfflineApplicationRepository.findAllWhereService("approved-premises") } returns offlineApplicationEntities
+    every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+
+    offlineApplicationEntities.forEach {
+      every { mockOffenderService.canAccessOffender(distinguishedName, it.crn) } returns true
+    }
+
+    assertThat(applicationService.getAllOfflineApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).containsAll(offlineApplicationEntities)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -623,7 +623,7 @@ class ApplicationServiceTest {
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
-    every { mockOfflineApplicationRepository.findAllWhereService("approved-premises") } returns offlineApplicationEntities
+    every { mockOfflineApplicationRepository.findAllByService("approved-premises") } returns offlineApplicationEntities
 
     offlineApplicationEntities.forEach {
       every { mockOffenderService.canAccessOffender(distinguishedName, it.crn) } returns true
@@ -657,7 +657,7 @@ class ApplicationServiceTest {
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
-    every { mockOfflineApplicationRepository.findAllWhereService("approved-premises") } returns offlineApplicationEntities
+    every { mockOfflineApplicationRepository.findAllByService("approved-premises") } returns offlineApplicationEntities
 
     offlineApplicationEntities.forEach {
       every { mockOffenderService.canAccessOffender(distinguishedName, it.crn) } returns true
@@ -671,7 +671,7 @@ class ApplicationServiceTest {
     val distinguishedName = "SOMEPERSON"
     val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
-    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns null
+    every { mockOfflineApplicationRepository.findByIdOrNull(applicationId) } returns null
 
     assertThat(applicationService.getOfflineApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.NotFound).isTrue
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -52,7 +53,7 @@ class AssessmentTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockApplicationsTransformer.transformJpaToApi(any(), any(), any()) } returns mockk<ApprovedPremisesApplication>()
+    every { mockApplicationsTransformer.transformJpaToApi(any<ApplicationEntity>(), any(), any()) } returns mockk<ApprovedPremisesApplication>()
     every { mockAssessmentClarificationNoteTransformer.transformJpaToApi(any()) } returns mockk()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -129,6 +129,8 @@ class BookingTransformerTest {
     originalArrivalDate = LocalDate.parse("2022-08-10"),
     originalDepartureDate = LocalDate.parse("2022-08-30"),
     createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
+    application = null,
+    offlineApplication = null
   )
 
   private val staffMember = StaffMember(


### PR DESCRIPTION
**Introduce the concept of an Offline Application**

A new table `offline_applications` stores info on offline/pre-digital service applications.  There is currently no way of inserting data into this table, this will be a seeding task in a subsequent PR.

**Add a reference to Application or Offline Application from Booking**

Allow a Booking to link to an Application or Offline Application.  The reference is not currently populated but will be in a subsequent PR.