### PR TITLE
Log row level errors when seeding, and continue

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
@@ -33,9 +33,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
+        it.message == "Error on row 1:" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Probation Region Not Real Region does not exist"
+        it.throwable.message == "Probation Region Not Real Region does not exist"
     }
   }
 
@@ -61,9 +61,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
+        it.message == "Error on row 1:" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Local Authority Area Not Real Authority does not exist"
+        it.throwable.message == "Local Authority Area Not Real Authority does not exist"
     }
   }
 
@@ -92,9 +92,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
+        it.message == "Error on row 1:" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Characteristic Not Real Characteristic does not exist"
+        it.throwable.message == "Characteristic Not Real Characteristic does not exist"
     }
   }
 
@@ -128,9 +128,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
+        it.message == "Error on row 1:" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Service scope does not match for Characteristic ${characteristic.id}"
+        it.throwable.message == "Service scope does not match for Characteristic ${characteristic.id}"
     }
   }
 
@@ -165,9 +165,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
+        it.message == "Error on row 1:" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Model scope does not match for Characteristic ${characteristic.id}"
+        it.throwable.message == "Model scope does not match for Characteristic ${characteristic.id}"
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
@@ -35,10 +35,11 @@ class SeedUserRoleAssignmentsTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
+        it.message.contains("Error on row 1:") &&
         it.throwable != null &&
         it.throwable.cause != null &&
-        it.throwable.cause!!.message == "Could not get user INVALID-USER"
+        it.throwable.message!!.contains("Could not get user INVALID-USER") &&
+        it.throwable.cause!!.message!!.contains("Unable to complete GET request to /secure/staff/username/INVALID-USER")
     }
   }
 


### PR DESCRIPTION
If there's an error during the `ensureCsvCanBeDeserialized()` test we continue to abort the entire seeding.

However, if there's an error processing an individual row (`job.processRow()`) we now catch the error and:

- log the full exception
- accumulate the exception message in a list which we log at the end of the seeding job

In this way we can attempt to seed 100 users, have 95 successful seedings and see a list of 5 problem rows to take away and remediate, e.g.

```
  The following row-level errors were raised:
  Error on row 1: Could not get user FREDBLOGGS
  Error on row 21: Could not get user JOENINETY
  Error on row 32: Could not get user CINDYSHERMAN
  Error on row 76: Could not get user ANDYPANDY
  Error on row 95: Could not get user OLIVEOIL

```