### PR TITLE
Allow risks to be skipped with a flag set

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -79,7 +79,7 @@ class ApplicationsController(
   }
 
   @Transactional
-  override fun applicationsPost(body: NewApplication, xServiceName: ServiceName?): ResponseEntity<Application> {
+  override fun applicationsPost(body: NewApplication, xServiceName: ServiceName?, createWithRisks: Boolean?): ResponseEntity<Application> {
     val serviceName = xServiceName?.value ?: ServiceName.approvedPremises.value
 
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
@@ -87,7 +87,7 @@ class ApplicationsController(
 
     val (offender, inmate) = getPersonDetail(body.crn)
 
-    val application = when (val applicationResult = applicationService.createApplication(body.crn, username, deliusPrincipal.token.tokenValue, serviceName, body.convictionId, body.deliusEventNumber, body.offenceId)) {
+    val application = when (val applicationResult = applicationService.createApplication(body.crn, username, deliusPrincipal.token.tokenValue, serviceName, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = applicationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = applicationResult.validationMessages)
       is ValidatableActionResult.Success -> applicationResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -79,7 +79,7 @@ class ApprovedPremisesApplicationEntity(
   val offenceId: String,
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   @Convert(disableConversion = true)
-  val riskRatings: PersonRisks
+  val riskRatings: PersonRisks?
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -32,7 +32,7 @@ class ApplicationsTransformer(
       isPipeApplication = jpa.isPipeApplication,
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
-      risks = risksTransformer.transformDomainToApi(jpa.riskRatings, jpa.crn)
+      risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null
     )
     is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
       id = jpa.id,

--- a/src/main/resources/db/migration/all/20230125094732__allow_risks_to_be_null.sql
+++ b/src/main/resources/db/migration/all/20230125094732__allow_risks_to_be_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ALTER COLUMN risk_ratings DROP NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1192,6 +1192,12 @@ paths:
           description: Which service the application will belong to, defaults to approved-premises
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: createWithRisks
+          in: query
+          required: false
+          description: Instructs the API to create and return risk information from the OASys API (defaults to true)
+          schema:
+            type: boolean
       requestBody:
         description: Information to create a blank application with
         content:
@@ -3061,7 +3067,6 @@ components:
             document:
               $ref: '#/components/schemas/AnyValue'
           required:
-            - risks
             - createdByUserId
             - schemaVersion
             - outdatedSchema


### PR DESCRIPTION
This allows us to set a flag to skip the creation of risks when creating an application. This will allow us to go live without the reliance on the OASys integration, which may not be ready for beta. If we do use this, we’ll need to backfill any applications without risks added, which may be a manual process.