### PR TITLE
Cope with missing email property from Community API StaffMember

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -42,7 +42,7 @@ data class UserEntity(
   var name: String,
   val deliusUsername: String,
   val deliusStaffIdentifier: Long,
-  var email: String,
+  var email: String?,
   var telephoneNumber: String?,
   @OneToMany(mappedBy = "createdByUser")
   val applications: MutableList<ApplicationEntity>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class StaffUserDetails(
   val username: String,
-  val email: String,
+  val email: String?,
   val telephoneNumber: String?,
   val staffCode: String,
   val staffIdentifier: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -42,7 +42,7 @@ class UserService(
 
     if (userHasChanged(user, deliusUser)) {
       user.name = deliusUser.staff.fullName
-      user.email = deliusUser.email
+      user.email = deliusUser.email.toString()
       user.telephoneNumber = deliusUser.telephoneNumber
 
       user = userRepository.save(user)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3393,7 +3393,6 @@ components:
       required:
         - name
         - deliusUsername
-        - email
         - roles
         - qualifications
     UserRole:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 
 class StaffUserDetailsFactory : Factory<StaffUserDetails> {
   private var username: Yielded<String> = { randomStringUpperCase(10) }
-  private var email: Yielded<String> = { randomStringUpperCase(8) }
+  private var email: Yielded<String?> = { randomStringUpperCase(8) }
   private var telephoneNumber: Yielded<String> = { randomStringUpperCase(8) }
   private var staffCode: Yielded<String> = { randomStringUpperCase(8) }
   private var staffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
@@ -24,6 +24,10 @@ class StaffUserDetailsFactory : Factory<StaffUserDetails> {
 
   fun withEmail(email: String) = apply {
     this.email = { email }
+  }
+
+  fun withoutEmail() = apply {
+    this.email = { null }
   }
 
   fun withTelephoneNumber(telephoneNumber: String) = apply {


### PR DESCRIPTION
When seeding users and roles we discovered that many of our Managers, Assessors and Workflow Managers do not have an email in their Delius `StaffMember` entity as represented via the `api/secure/staff/username/` endpoint.

This commit makes the email property optional.

We need to liaise with the F/E team to ensure that this doesn't introduce a breaking change where that `email` attribute is displayed to an Assessor who wishes to ask the Applicant a clarification question. See:

https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/500