### PR TITLE
Automatically associate bookings with an Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -25,8 +25,8 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")
   fun <T : ApplicationEntity> findAllByCreatedByUser_Id(id: UUID, type: Class<T>): List<ApplicationEntity>
 
-  @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn IN (:crns)")
-  fun <T : ApplicationEntity> findByCrnIn(crns: List<String>, type: Class<T>): List<ApplicationEntity>
+  @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn = :crn")
+  fun <T : ApplicationEntity> findByCrn(crn: String, type: Class<T>): List<ApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -11,6 +11,7 @@ import javax.persistence.Table
 @Repository
 interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID> {
   fun findAllByService(name: String): List<OfflineApplicationEntity>
+  fun findAllByServiceAndCrn(name: String, crn: String): List<OfflineApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -378,4 +378,17 @@ class ApplicationService(
       )
     )
   }
+
+  fun getApplicationsForCrn(crn: String, serviceName: ServiceName): List<ApplicationEntity> {
+    val entityType = if (serviceName == ServiceName.approvedPremises) {
+      ApprovedPremisesApplicationEntity::class.java
+    } else {
+      TemporaryAccommodationApplicationEntity::class.java
+    }
+
+    return applicationRepository.findByCrn(crn, entityType)
+  }
+
+  fun getOfflineApplicationsForCrn(crn: String, serviceName: ServiceName) =
+    offlineApplicationRepository.findAllByServiceAndCrn(crn, serviceName.value)
 }


### PR DESCRIPTION
When creating a Booking, where possible associate it with the latest submitted Application or Offline Application.

For AP Bookings, failure to do this will return a 400.  TA Bookings are still creatable without an Application.