### PR TITLE
Expose users and roles to ROLE_ADMIN only

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -82,7 +82,7 @@ enum class UserRole {
   MANAGER,
   WORKFLOW_MANAGER,
   APPLICANT,
-  ADMIN
+  ROLE_ADMIN
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -37,6 +38,10 @@ class UserService(
     val username = deliusPrincipal.name
 
     return getUserForUsername(username)
+  }
+
+  fun getAllUsers(): List<UserEntity> {
+    return userRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))
   }
 
   fun getUserForId(id: java.util.UUID): AuthorisableActionResult<UserEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -37,7 +37,7 @@ class UserTransformer(
   }
 
   private fun transformRoleToApi(userRole: UserRoleAssignmentEntity): ApiUserRole = when (userRole.role) {
-    UserRole.ADMIN -> ApiUserRole.admin
+    UserRole.ROLE_ADMIN -> ApiUserRole.roleAdmin
     UserRole.ASSESSOR -> ApiUserRole.assessor
     UserRole.MATCHER -> ApiUserRole.matcher
     UserRole.MANAGER -> ApiUserRole.manager

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3450,7 +3450,7 @@ components:
         - manager
         - workflow_manager
         - applicant
-        - admin
+        - role_admin
     UserQualification:
       type: string
       enum:


### PR DESCRIPTION
The list is sorted by name.

Our plan is that first phase of the Role Admin area will comprise a list
of users and their role. Adjustments to the role assignment will be managed
through the existing user seeding mechanism. See [`UsersSeedJob`](https://github.com/ministryofjustice/approved-premises-api/blob/expose-users-and-roles-to-role-admin/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt)

The facility to add and remove roles through the UI will follow.

In due course we'll need to paginate this list. For the initial release
we expect about 250 user with roles to be managed.

Perhaps we'll want some filtering, e.g.

- only show users with internally managed roles
- show users with a particular role