### PR TITLE
Add probation region to users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ProfileApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
@@ -13,9 +14,9 @@ class ProfileController(
   private val userService: UserService,
   private val userTransformer: UserTransformer
 ) : ProfileApiDelegate {
-  override fun profileGet(): ResponseEntity<User> {
+  override fun profileGet(xServiceName: ServiceName): ResponseEntity<User> {
     val userEntity = userService.getUserForRequest()
 
-    return ResponseEntity(userTransformer.transformJpaToApi(userEntity), HttpStatus.OK)
+    return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.UsersApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -18,13 +19,13 @@ class UsersController(
   private val userTransformer: UserTransformer
 ) : UsersApiDelegate {
 
-  override fun usersIdGet(id: UUID): ResponseEntity<User> {
+  override fun usersIdGet(id: UUID, xServiceName: ServiceName): ResponseEntity<User> {
     val userEntity = when (val result = userService.getUserForId(id)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> result.entity
     }
 
-    return ResponseEntity(userTransformer.transformJpaToApi(userEntity), HttpStatus.OK)
+    return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -13,6 +13,7 @@ import javax.persistence.Table
 @Repository
 interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID> {
   fun findByName(name: String): ProbationRegionEntity?
+  fun findByDeliusCode(deliusCode: String): ProbationRegionEntity?
 }
 
 @Entity
@@ -25,5 +26,6 @@ data class ProbationRegionEntity(
   @JoinColumn(name = "ap_area_id")
   val apArea: ApAreaEntity,
   @OneToMany(mappedBy = "probationRegion")
-  val premises: MutableList<PremisesEntity>
+  val premises: MutableList<PremisesEntity>,
+  val deliusCode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -49,7 +49,9 @@ data class UserEntity(
   @OneToMany(mappedBy = "user")
   val roles: MutableList<UserRoleAssignmentEntity>,
   @OneToMany(mappedBy = "user")
-  val qualifications: MutableList<UserQualificationAssignmentEntity>
+  val qualifications: MutableList<UserQualificationAssignmentEntity>,
+  @ManyToOne
+  val probationRegion: ProbationRegionEntity,
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
@@ -9,7 +9,8 @@ data class StaffUserDetails(
   val staffCode: String,
   val staffIdentifier: Long,
   val staff: StaffNames,
-  val teams: List<StaffUserTeamMembership>?
+  val teams: List<StaffUserTeamMembership>?,
+  val probationArea: StaffProbationArea,
 )
 
 data class StaffNames(
@@ -34,4 +35,8 @@ data class StaffUserTeamMembership(
 data class KeyValue(
   val code: String,
   val description: String
+)
+
+data class StaffProbationArea(
+  val code: String,
 )

--- a/src/main/resources/db/migration/all/20230123152127__add_delius_region_code_to_probation_regions.sql
+++ b/src/main/resources/db/migration/all/20230123152127__add_delius_region_code_to_probation_regions.sql
@@ -1,0 +1,52 @@
+ALTER TABLE probation_regions ADD COLUMN delius_code TEXT;
+ALTER TABLE probation_regions ADD CONSTRAINT delius_code_unique UNIQUE (delius_code);
+
+UPDATE probation_regions
+SET delius_code = 'N53'
+WHERE "name" = 'East Midlands';
+
+UPDATE probation_regions
+SET delius_code = 'N56'
+WHERE "name" = 'East of England';
+
+UPDATE probation_regions
+SET delius_code = 'MCG'
+WHERE "name" = 'Greater Manchester';
+
+UPDATE probation_regions
+SET delius_code = 'N57'
+WHERE "name" = 'Kent, Surrey & Sussex';
+
+UPDATE probation_regions
+SET delius_code = 'N07'
+WHERE "name" = 'London';
+
+UPDATE probation_regions
+SET delius_code = 'N54'
+WHERE "name" = 'North East';
+
+UPDATE probation_regions
+SET delius_code = 'N51'
+WHERE "name" = 'North West';
+
+UPDATE probation_regions
+SET delius_code = 'N59'
+WHERE "name" = 'South Central';
+
+UPDATE probation_regions
+SET delius_code = 'N58'
+WHERE "name" = 'South West';
+
+UPDATE probation_regions
+SET delius_code = 'N03'
+WHERE "name" = 'Wales';
+
+UPDATE probation_regions
+SET delius_code = 'N52'
+WHERE "name" = 'West Midlands';
+
+UPDATE probation_regions
+SET delius_code = 'N55'
+WHERE "name" = 'Yorkshire & The Humber';
+
+ALTER TABLE probation_regions ALTER COLUMN delius_code SET NOT NULL;

--- a/src/main/resources/db/migration/all/20230123154608__add_probation_region_to_users.sql
+++ b/src/main/resources/db/migration/all/20230123154608__add_probation_region_to_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN probation_region_id UUID NOT NULL;
+ALTER TABLE "users" ADD FOREIGN KEY (probation_region_id) REFERENCES probation_regions(id);

--- a/src/main/resources/db/migration/local+dev/20230123154607__clear_existing_users.sql
+++ b/src/main/resources/db/migration/local+dev/20230123154607__clear_existing_users.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE "users" CASCADE;

--- a/src/main/resources/db/migration/local+dev/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev/R__1_create_dev_users.sql
@@ -2,8 +2,8 @@
 
 --These are randomly generated names
 
-INSERT INTO "users" (id, name, delius_username, delius_staff_identifier) VALUES
-    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547),
-    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096),
-    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544)
+INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id) VALUES
+    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891'), -- North East
+    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad'), -- East of England
+    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c') -- Wales
 ON CONFLICT (id) DO NOTHING;

--- a/src/main/resources/db/migration/test/R__1_create_users.sql
+++ b/src/main/resources/db/migration/test/R__1_create_users.sql
@@ -1,19 +1,22 @@
 
 -- ${flyway:timestamp}
 
+
   insert into
     users (
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '67695',
+      '54281',
       'AP_USER_TEST_1',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      'AP Test User 1'
+      'AP Test User 1',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 
@@ -23,14 +26,16 @@
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '24550',
+      '34260',
       'AP_USER_TEST_2',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
-      'AP Test User 2'
+      'AP Test User 2',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 
@@ -40,14 +45,16 @@
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '97968',
+      '8522',
       'AP_USER_TEST_3',
       '68715a03-06af-49ee-bae5-039c824ab9af',
-      'AP Test User 3'
+      'AP Test User 3',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 
@@ -57,14 +64,16 @@
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '86058',
+      '3210',
       'AP_USER_TEST_4',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'AP Test User 4'
+      'AP Test User 4',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 
@@ -74,14 +83,16 @@
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '97507',
+      '57009',
       'AP_USER_TEST_5',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      'AP Test User 5'
+      'AP Test User 5',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 
@@ -91,14 +102,16 @@
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '64762',
+      '10088',
       'CAS_NCC_TEST1',
       '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      'NCC User 1'
+      'NCC User 1',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 
@@ -108,14 +121,16 @@
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
-      '66464',
+      '27207',
       'CAS_NCC_TEST2',
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
-      'NCC User 2'
+      'NCC User 2',
+      '43606be0-9836-441d-9bc1-5586de9ac931'
     )
   ON CONFLICT (id) DO NOTHING;
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1927,6 +1927,13 @@ paths:
       tags:
         - Auth
       summary: Returns information on the logged in user
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successfully retrieved information on user
@@ -1962,6 +1969,12 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/UserQualification'
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successfully retrieved users
@@ -1988,6 +2001,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successfully retrieved information on user
@@ -3374,27 +3393,55 @@ components:
     User:
       type: object
       properties:
-        name:
+        id:
           type: string
-        deliusUsername:
-          type: string
-        email:
-          type: string
-        telephoneNumber:
-          type: string
+          format: uuid
+        region:
+          $ref: '#/components/schemas/ProbationRegion'
         roles:
           type: array
           items:
             $ref: '#/components/schemas/UserRole'
-        qualifications:
-          type: array
-          items:
-            $ref: '#/components/schemas/UserQualification'
+        service:
+          type: string
+          example: CAS1
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesUser'
+          CAS3: '#/components/schemas/TemporaryAccommodationUser'
       required:
-        - name
-        - deliusUsername
+        - id
+        - region
         - roles
-        - qualifications
+        - service
+    ApprovedPremisesUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            name:
+              type: string
+            deliusUsername:
+              type: string
+            email:
+              type: string
+            telephoneNumber:
+              type: string
+            qualifications:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserQualification'
+          required:
+            - name
+            - deliusUsername
+            - qualifications
+    TemporaryAccommodationUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties: {}
+          required: []
     UserRole:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
@@ -11,6 +11,7 @@ class ProbationRegionEntityFactory : Factory<ProbationRegionEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var apArea: Yielded<ApAreaEntity>? = null
+  private var deliusCode: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -28,10 +29,15 @@ class ProbationRegionEntityFactory : Factory<ProbationRegionEntity> {
     this.apArea = { apArea }
   }
 
+  fun withDeliusCode(deliusCode: String) = apply {
+    this.deliusCode = { deliusCode }
+  }
+
   override fun produce(): ProbationRegionEntity = ProbationRegionEntity(
     id = this.id(),
     name = this.name(),
     premises = mutableListOf(),
-    apArea = this.apArea?.invoke() ?: throw RuntimeException("Must provide an ApArea")
+    apArea = this.apArea?.invoke() ?: throw RuntimeException("Must provide an ApArea"),
+    deliusCode = this.deliusCode(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
@@ -3,9 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffNames
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffProbationArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserTeamMembership
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 
 class StaffUserDetailsFactory : Factory<StaffUserDetails> {
@@ -17,6 +19,7 @@ class StaffUserDetailsFactory : Factory<StaffUserDetails> {
   private var forenames: Yielded<String> = { randomStringUpperCase(8) }
   private var surname: Yielded<String> = { randomStringUpperCase(8) }
   private var teams: Yielded<List<StaffUserTeamMembership>> = { listOf() }
+  private var probationAreaCode: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
 
   fun withUsername(username: String) = apply {
     this.username = { username }
@@ -54,6 +57,10 @@ class StaffUserDetailsFactory : Factory<StaffUserDetails> {
     this.teams = { teams }
   }
 
+  fun withProbationAreaCode(probationAreaCode: String) = apply {
+    this.probationAreaCode = { probationAreaCode }
+  }
+
   override fun produce(): StaffUserDetails = StaffUserDetails(
     username = this.username(),
     email = this.email(),
@@ -64,6 +71,7 @@ class StaffUserDetailsFactory : Factory<StaffUserDetails> {
       forenames = this.forenames(),
       surname = this.surname()
     ),
-    teams = this.teams()
+    teams = this.teams(),
+    probationArea = StaffProbationArea(this.probationAreaCode()),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
@@ -22,6 +23,7 @@ class UserEntityFactory : Factory<UserEntity> {
   private var applications: Yielded<MutableList<ApplicationEntity>> = { mutableListOf() }
   private var roles: Yielded<MutableList<UserRoleAssignmentEntity>> = { mutableListOf() }
   private var qualifications: Yielded<MutableList<UserQualificationAssignmentEntity>> = { mutableListOf() }
+  private var probationRegion: Yielded<ProbationRegionEntity>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -67,6 +69,14 @@ class UserEntityFactory : Factory<UserEntity> {
     this.telephoneNumber = { telephoneNumber }
   }
 
+  fun withProbationRegion(probationRegion: ProbationRegionEntity) = apply {
+    this.probationRegion = { probationRegion }
+  }
+
+  fun withYieldedProbationRegion(probationRegion: Yielded<ProbationRegionEntity>) = apply {
+    this.probationRegion = probationRegion
+  }
+
   override fun produce(): UserEntity = UserEntity(
     id = this.id(),
     name = this.name(),
@@ -76,6 +86,7 @@ class UserEntityFactory : Factory<UserEntity> {
     deliusStaffIdentifier = this.deliusStaffIdentifier(),
     applications = this.applications(),
     roles = this.roles(),
-    qualifications = this.qualifications()
+    qualifications = this.qualifications(),
+    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided"),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -27,6 +27,11 @@ class AllocationQueryTest : IntegrationTestBase() {
   private fun `Given a User that is not an Assessor`(): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("NON-ASSESSOR")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     return user
@@ -35,6 +40,11 @@ class AllocationQueryTest : IntegrationTestBase() {
   private fun `Given a User that is an Assessor with no Qualifications`(): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("ASSESSOR-NO-QUALIFICATIONS")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -48,6 +58,11 @@ class AllocationQueryTest : IntegrationTestBase() {
   private fun `Given a User that is an Assessor with both Qualifications and one pending allocated Assessment`(): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("ASSESSOR-ONE-ALLOCATION")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -83,6 +98,11 @@ class AllocationQueryTest : IntegrationTestBase() {
   private fun `Given a User that is an Assessor with both Qualifications and zero pending allocated Assessments`(): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("ASSESSOR-ZERO-ALLOCATIONS")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
@@ -42,7 +42,14 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
     val username = "PROBATIONPERSON"
     val crn = "CRN123"
 
-    val user = userEntityFactory.produceAndPersist { withDeliusUsername(username) }
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt(username)
     val owner = userEntityFactory.produceAndPersist { withDeliusUsername("DIFFERENTPROBATIONPERSON") }
 
@@ -79,7 +86,14 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
     val username = "PROBATIONPERSON"
     val crn = "CRN123"
 
-    val user = userEntityFactory.produceAndPersist { withDeliusUsername(username) }
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt(username)
 
     mockStaffUserInfoCommunityApiCall(
@@ -147,7 +161,14 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
 
   @Test
   fun `Download document returns 404 when not found in documents meta data`() {
-    val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -194,7 +215,14 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
 
   @Test
   fun `Download document returns 200 with correct body and headers`() {
-    val user = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -119,8 +119,21 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     val username = "PROBATIONPERSON2"
-    val otherUser = userEntityFactory.produceAndPersist()
-    val user = userEntityFactory.produceAndPersist { withDeliusUsername(username) }
+    val otherUser = userEntityFactory.produceAndPersist {
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     val upToDateApplicationEntityCreatedByUser = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(newestJsonSchema)
@@ -207,8 +220,21 @@ class ApplicationTest : IntegrationTestBase() {
   @EnumSource(value = UserRole::class, names = [ "WORKFLOW_MANAGER", "ASSESSOR", "MATCHER", "MANAGER" ])
   fun `Get all applications returns 200 with correct body - when user has one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER returns all applications`(role: UserRole) {
     val username = "PROBATIONPERSON"
-    val otherUser = userEntityFactory.produceAndPersist()
-    val user = userEntityFactory.produceAndPersist { withDeliusUsername(username) }
+    val otherUser = userEntityFactory.produceAndPersist {
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     approvedPremisesApplicationJsonSchemaRepository.deleteAll()
 
@@ -497,7 +523,14 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     val applicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(newestJsonSchema)
@@ -558,6 +591,11 @@ class ApplicationTest : IntegrationTestBase() {
     val username = "PROBATIONPERSON2"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val application = produceAndPersistBasicApplication(crn)
@@ -715,7 +753,14 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     val nonUpgradableApplicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(olderJsonSchema)
@@ -770,6 +815,11 @@ class ApplicationTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -1088,10 +1138,18 @@ class ApplicationTest : IntegrationTestBase() {
         .withForenames("Jim")
         .withSurname("Jimmerson")
         .withStaffIdentifier(5678)
-        .produce()
+        .produce(),
+      false
     )
 
-    val assessor = userEntityFactory.produceAndPersist { withDeliusUsername("ASSESSOR") }
+    val assessor = userEntityFactory.produceAndPersist {
+      withDeliusUsername("ASSESSOR")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(assessor)
@@ -1128,6 +1186,11 @@ class ApplicationTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -1188,10 +1251,18 @@ class ApplicationTest : IntegrationTestBase() {
         .withForenames("Jim")
         .withSurname("Jimmerson")
         .withStaffIdentifier(5678)
-        .produce()
+        .produce(),
+      false
     )
 
-    val assessor = userEntityFactory.produceAndPersist { withDeliusUsername("ASSESSOR") }
+    val assessor = userEntityFactory.produceAndPersist {
+      withDeliusUsername("ASSESSOR")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(assessor)
@@ -1239,6 +1310,11 @@ class ApplicationTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -1327,6 +1403,11 @@ class ApplicationTest : IntegrationTestBase() {
 
     val requestUser = userEntityFactory.produceAndPersist {
       withDeliusUsername(requestUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(requestUser)
@@ -1336,21 +1417,33 @@ class ApplicationTest : IntegrationTestBase() {
     mockStaffUserInfoCommunityApiCall(
       StaffUserDetailsFactory()
         .withUsername(requestUsername)
-        .produce()
+        .produce(),
+      false
     )
 
     val otherUser = userEntityFactory.produceAndPersist {
       withDeliusUsername(otherUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     mockStaffUserInfoCommunityApiCall(
       StaffUserDetailsFactory()
         .withUsername(otherUsername)
-        .produce()
+        .produce(),
+      false
     )
 
     val assigneeUser = userEntityFactory.produceAndPersist {
       withDeliusUsername(assigneeUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     mockStaffUserInfoCommunityApiCall(
@@ -1444,7 +1537,14 @@ class ApplicationTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(jsonSchema)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -52,6 +52,11 @@ class AssessmentTest : IntegrationTestBase() {
   fun `Get all assessments returns 200 with correct body`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
@@ -121,6 +126,11 @@ class AssessmentTest : IntegrationTestBase() {
   fun `Get assessment by ID returns 200 with correct body`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
@@ -189,6 +199,11 @@ class AssessmentTest : IntegrationTestBase() {
   fun `Accept assessment returns 200, persists decision`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
@@ -257,6 +272,11 @@ class AssessmentTest : IntegrationTestBase() {
   fun `Reject assessment returns 200, persists decision`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
@@ -315,6 +335,11 @@ class AssessmentTest : IntegrationTestBase() {
   fun `Create clarification note returns 200 with correct body`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
@@ -371,6 +396,11 @@ class AssessmentTest : IntegrationTestBase() {
   fun `Update clarification note returns 201 with correct body`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -50,6 +51,11 @@ class BookingTest : IntegrationTestBase() {
 
       val user = userEntityFactory.produceAndPersist {
         withDeliusUsername(username)
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
       }
 
       userRoleAssignmentEntityFactory.produceAndPersist {
@@ -64,7 +70,8 @@ class BookingTest : IntegrationTestBase() {
       mockStaffUserInfoCommunityApiCall(
         StaffUserDetailsFactory()
           .withUsername(username)
-          .produce()
+          .produce(),
+        false
       )
 
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -125,7 +132,12 @@ class BookingTest : IntegrationTestBase() {
 
     val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          withDeliusCode(randomStringMultiCaseWithNumbers(3))
+        }
+      }
     }
 
     val bed = bedEntityFactory.produceAndPersist {
@@ -200,7 +212,13 @@ class BookingTest : IntegrationTestBase() {
         withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
       }
 
-      val user = userEntityFactory.produceAndPersist()
+      val user = userEntityFactory.produceAndPersist {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
 
       userRoleAssignmentEntityFactory.produceAndPersist {
         withUser(user)
@@ -214,7 +232,8 @@ class BookingTest : IntegrationTestBase() {
       mockStaffUserInfoCommunityApiCall(
         StaffUserDetailsFactory()
           .withUsername(user.deliusUsername)
-          .produce()
+          .produce(),
+        false
       )
 
       webTestClient.get()
@@ -232,7 +251,13 @@ class BookingTest : IntegrationTestBase() {
   fun `Get all Bookings returns OK with correct body when user has one of roles MANAGER, MATCHER`() {
     listOf(UserRole.MANAGER, UserRole.MATCHER).forEach { role ->
       val crn = "CRN123-${role.name}"
-      val user = userEntityFactory.produceAndPersist()
+      val user = userEntityFactory.produceAndPersist {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
 
       userRoleAssignmentEntityFactory.produceAndPersist {
         withUser(user)
@@ -252,7 +277,8 @@ class BookingTest : IntegrationTestBase() {
       mockStaffUserInfoCommunityApiCall(
         StaffUserDetailsFactory()
           .withUsername(user.deliusUsername)
-          .produce()
+          .produce(),
+        false
       )
 
       val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
@@ -886,6 +912,11 @@ class BookingTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -948,6 +979,11 @@ class BookingTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -961,7 +997,8 @@ class BookingTest : IntegrationTestBase() {
     mockStaffUserInfoCommunityApiCall(
       StaffUserDetailsFactory()
         .withUsername(username)
-        .produce()
+        .produce(),
+      false
     )
 
     val booking = bookingEntityFactory.produceAndPersist {
@@ -1047,6 +1084,7 @@ class BookingTest : IntegrationTestBase() {
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist {
           withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          withDeliusCode(randomStringMultiCaseWithNumbers(3))
         }
       }
     }
@@ -1119,6 +1157,11 @@ class BookingTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -1192,6 +1235,11 @@ class BookingTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -1389,6 +1437,11 @@ class BookingTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -1538,6 +1591,11 @@ class BookingTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
@@ -1613,6 +1671,11 @@ class BookingTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
@@ -1708,6 +1771,11 @@ class BookingTest : IntegrationTestBase() {
 
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -45,6 +45,11 @@ class CapacityTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
@@ -87,6 +92,11 @@ class CapacityTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
@@ -136,6 +146,11 @@ class CapacityTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -49,6 +49,11 @@ class LostBedsTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -125,6 +130,11 @@ class LostBedsTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     userRoleAssignmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -868,6 +868,11 @@ class PremisesTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
@@ -937,6 +942,11 @@ class PremisesTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
@@ -1007,6 +1017,11 @@ class PremisesTest : IntegrationTestBase() {
     val username = "PROBATIONUSER"
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -61,6 +61,11 @@ class ReallocationAtomicTest : IntegrationTestBase() {
 
     val requestUser = userEntityFactory.produceAndPersist {
       withDeliusUsername(requestUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(requestUser)
@@ -70,27 +75,40 @@ class ReallocationAtomicTest : IntegrationTestBase() {
     mockStaffUserInfoCommunityApiCall(
       StaffUserDetailsFactory()
         .withUsername(requestUsername)
-        .produce()
+        .produce(),
+      false
     )
 
     val otherUser = userEntityFactory.produceAndPersist {
       withDeliusUsername(otherUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     mockStaffUserInfoCommunityApiCall(
       StaffUserDetailsFactory()
         .withUsername(otherUsername)
-        .produce()
+        .produce(),
+      false
     )
 
     val assigneeUser = userEntityFactory.produceAndPersist {
       withDeliusUsername(assigneeUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     mockStaffUserInfoCommunityApiCall(
       StaffUserDetailsFactory()
         .withUsername(assigneeUsername)
-        .produce()
+        .produce(),
+      false
     )
 
     userRoleAssignmentEntityFactory.produceAndPersist {
@@ -179,7 +197,14 @@ class ReallocationAtomicTest : IntegrationTestBase() {
       )
     }
 
-    val userEntity = userEntityFactory.produceAndPersist { withDeliusUsername("PROBATIONPERSON") }
+    val userEntity = userEntityFactory.produceAndPersist {
+      withDeliusUsername("PROBATIONPERSON")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(jsonSchema)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
@@ -85,6 +85,11 @@ class SeedUserRoleAssignmentsTest : SeedTestBase() {
   fun `Attempting to assign roles to a currently known user succeeds`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("KNOWN-USER")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     withCsv(
@@ -118,6 +123,11 @@ class SeedUserRoleAssignmentsTest : SeedTestBase() {
   fun `Attempting to assign a non-existent role logs an error`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("known-user")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     withCsv(
@@ -148,6 +158,11 @@ class SeedUserRoleAssignmentsTest : SeedTestBase() {
   fun `Attempting to assign a non-existent qualification logs an error`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("known-user")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
     }
 
     withCsv(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -9,12 +9,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -80,6 +82,11 @@ class ApplicationServiceTest {
     val userEntity = UserEntityFactory()
       .withId(userId)
       .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
     val applicationEntities = listOf(
       ApprovedPremisesApplicationEntityFactory()
@@ -122,9 +129,23 @@ class ApplicationServiceTest {
     val distinguishedName = "SOMEPERSON"
     val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
-    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns UserEntityFactory().produce()
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(UserEntityFactory().produce())
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.Unauthorised).isTrue
@@ -143,6 +164,11 @@ class ApplicationServiceTest {
     val userEntity = UserEntityFactory()
       .withId(userId)
       .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val applicationEntity = ApprovedPremisesApplicationEntityFactory()
@@ -176,9 +202,20 @@ class ApplicationServiceTest {
       val userEntity = UserEntityFactory()
         .withId(userId)
         .withDeliusUsername(distinguishedName)
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
         .produce()
 
-      val otherUserEntity = UserEntityFactory().produce()
+      val otherUserEntity = UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .produce()
 
       userEntity.roles.add(
         UserRoleAssignmentEntityFactory()
@@ -256,7 +293,13 @@ class ApplicationServiceTest {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
-    val user = UserEntityFactory().produce()
+    val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
     val schema = ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
@@ -326,11 +369,24 @@ class ApplicationServiceTest {
 
     val application = ApprovedPremisesApplicationEntityFactory()
       .withId(applicationId)
-      .withYieldedCreatedByUser { UserEntityFactory().produce() }
+      .withYieldedCreatedByUser {
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      }
       .produce()
 
     every { mockUserService.getUserForRequest() } returns UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
@@ -345,6 +401,11 @@ class ApplicationServiceTest {
 
     val user = UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val application = ApprovedPremisesApplicationEntityFactory()
@@ -380,6 +441,11 @@ class ApplicationServiceTest {
 
     val user = UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val application = ApprovedPremisesApplicationEntityFactory()
@@ -414,6 +480,11 @@ class ApplicationServiceTest {
 
     val user = UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val newestSchema = ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
@@ -467,11 +538,24 @@ class ApplicationServiceTest {
 
     val application = ApprovedPremisesApplicationEntityFactory()
       .withId(applicationId)
-      .withYieldedCreatedByUser { UserEntityFactory().produce() }
+      .withYieldedCreatedByUser {
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      }
       .produce()
 
     every { mockUserService.getUserForRequest() } returns UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
@@ -486,6 +570,11 @@ class ApplicationServiceTest {
 
     val user = UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val application = ApprovedPremisesApplicationEntityFactory()
@@ -521,6 +610,11 @@ class ApplicationServiceTest {
 
     val user = UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val application = ApprovedPremisesApplicationEntityFactory()
@@ -557,6 +651,11 @@ class ApplicationServiceTest {
 
     val user = UserEntityFactory()
       .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val application = ApprovedPremisesApplicationEntityFactory()
@@ -612,6 +711,11 @@ class ApplicationServiceTest {
     val userEntity = UserEntityFactory()
       .withId(userId)
       .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
     val offlineApplicationEntities = listOf(
       OfflineApplicationEntityFactory()
@@ -640,6 +744,11 @@ class ApplicationServiceTest {
     val userEntity = UserEntityFactory()
       .withId(userId)
       .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -681,7 +790,13 @@ class ApplicationServiceTest {
     val distinguishedName = "SOMEPERSON"
     val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
-    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns UserEntityFactory().produce()
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
     every { mockOfflineApplicationRepository.findByIdOrNull(applicationId) } returns OfflineApplicationEntityFactory()
       .produce()
 
@@ -698,6 +813,11 @@ class ApplicationServiceTest {
     val userEntity = UserEntityFactory()
       .withId(userId)
       .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -728,6 +848,11 @@ class ApplicationServiceTest {
       val userEntity = UserEntityFactory()
         .withId(userId)
         .withDeliusUsername(distinguishedName)
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
         .produce()
         .apply {
           roles += UserRoleAssignmentEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
@@ -55,6 +57,11 @@ class AssessmentServiceTest {
   @Test
   fun `getVisibleAssessmentsForUser fetches all assessments for workflow managers`() {
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     user.roles.add(
@@ -67,11 +74,25 @@ class AssessmentServiceTest {
     val allAssessments = listOf(
       AssessmentEntityFactory()
         .withAllocatedToUser(
-          UserEntityFactory().produce()
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce()
         )
         .withApplication(
           ApprovedPremisesApplicationEntityFactory()
-            .withCreatedByUser(UserEntityFactory().produce())
+            .withCreatedByUser(
+              UserEntityFactory()
+                .withYieldedProbationRegion {
+                  ProbationRegionEntityFactory()
+                    .withYieldedApArea { ApAreaEntityFactory().produce() }
+                    .produce()
+                }
+                .produce()
+            )
             .produce()
         )
         .produce()
@@ -90,6 +111,11 @@ class AssessmentServiceTest {
   @Test
   fun `getVisibleAssessmentsForUser fetches only allocated assessments`() {
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val allocatedAssessments = listOf(
@@ -97,7 +123,15 @@ class AssessmentServiceTest {
         .withAllocatedToUser(user)
         .withApplication(
           ApprovedPremisesApplicationEntityFactory()
-            .withCreatedByUser(UserEntityFactory().produce())
+            .withCreatedByUser(
+              UserEntityFactory()
+                .withYieldedProbationRegion {
+                  ProbationRegionEntityFactory()
+                    .withYieldedApArea { ApAreaEntityFactory().produce() }
+                    .produce()
+                }
+                .produce()
+            )
             .produce()
         )
         .produce()
@@ -118,6 +152,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     user.roles.add(
@@ -131,11 +170,25 @@ class AssessmentServiceTest {
       AssessmentEntityFactory()
         .withId(assessmentId)
         .withAllocatedToUser(
-          UserEntityFactory().produce()
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce()
         )
         .withApplication(
           ApprovedPremisesApplicationEntityFactory()
-            .withCreatedByUser(UserEntityFactory().produce())
+            .withCreatedByUser(
+              UserEntityFactory()
+                .withYieldedProbationRegion {
+                  ProbationRegionEntityFactory()
+                    .withYieldedApArea { ApAreaEntityFactory().produce() }
+                    .produce()
+                }
+                .produce()
+            )
             .produce()
         )
         .produce()
@@ -155,17 +208,36 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val assessment =
       AssessmentEntityFactory()
         .withId(assessmentId)
         .withAllocatedToUser(
-          UserEntityFactory().produce()
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce()
         )
         .withApplication(
           ApprovedPremisesApplicationEntityFactory()
-            .withCreatedByUser(UserEntityFactory().produce())
+            .withCreatedByUser(
+              UserEntityFactory()
+                .withYieldedProbationRegion {
+                  ProbationRegionEntityFactory()
+                    .withYieldedApArea { ApAreaEntityFactory().produce() }
+                    .produce()
+                }
+                .produce()
+            )
             .produce()
         )
         .produce()
@@ -183,6 +255,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns null
@@ -198,6 +275,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns null
@@ -213,16 +295,37 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
@@ -237,6 +340,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     user.roles.add(
@@ -250,10 +358,26 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { assessmentClarificationNoteRepositoryMock.save(any()) } answers {
@@ -274,13 +398,26 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -304,16 +441,37 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
@@ -328,13 +486,26 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(OffsetDateTime.now())
@@ -358,6 +529,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -370,7 +546,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(OffsetDateTime.now())
@@ -395,6 +579,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -407,7 +596,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(null)
@@ -433,6 +630,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -445,7 +647,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -470,16 +680,37 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
@@ -494,13 +725,26 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(OffsetDateTime.now())
@@ -524,6 +768,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -536,7 +785,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(OffsetDateTime.now())
@@ -561,6 +818,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -573,7 +835,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(null)
@@ -599,6 +869,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -611,7 +886,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -641,6 +924,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -653,7 +941,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -683,16 +979,37 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
@@ -707,13 +1024,26 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(OffsetDateTime.now())
@@ -737,6 +1067,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -749,7 +1084,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(OffsetDateTime.now())
@@ -774,6 +1117,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -786,7 +1134,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withSubmittedAt(null)
@@ -812,6 +1168,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -824,7 +1185,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -854,6 +1223,11 @@ class AssessmentServiceTest {
     val assessmentId = UUID.randomUUID()
 
     val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -866,7 +1240,15 @@ class AssessmentServiceTest {
       .withId(assessmentId)
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -895,6 +1277,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns Unauthorised when requestUser does not have WORKFLOW_MANAGER role`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val result = assessmentService.reallocateAssessment(requestUser, UUID.randomUUID(), UUID.randomUUID())
@@ -905,6 +1292,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns Not Found when assignee user does not exist`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -925,6 +1317,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns Not Found when application does not exist`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -937,6 +1334,11 @@ class AssessmentServiceTest {
 
     every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
       UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
         .produce()
     )
 
@@ -952,6 +1354,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns General Validation Error when application already has a submitted assessment`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -964,20 +1371,41 @@ class AssessmentServiceTest {
 
     every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
       UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
         .produce()
     )
 
     val applicationId = UUID.fromString("95c7175f-451a-47e0-af16-6bf9175b5581")
 
     val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(UserEntityFactory().produce())
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { applicationRepositoryMock.findByIdOrNull(applicationId) } returns application
 
     val previousAssessment = AssessmentEntityFactory()
       .withApplication(application)
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
@@ -996,6 +1424,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns Field Validation Error when user to assign to is not an ASSESSOR`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -1008,20 +1441,41 @@ class AssessmentServiceTest {
 
     every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
       UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
         .produce()
     )
 
     val applicationId = UUID.fromString("95c7175f-451a-47e0-af16-6bf9175b5581")
 
     val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(UserEntityFactory().produce())
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { applicationRepositoryMock.findByIdOrNull(applicationId) } returns application
 
     val previousAssessment = AssessmentEntityFactory()
       .withApplication(application)
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(applicationId) } returns previousAssessment
@@ -1039,6 +1493,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns Field Validation Error when user to assign to does not have relevant qualifications`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -1050,6 +1509,11 @@ class AssessmentServiceTest {
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
 
     val assigneeUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -1065,7 +1529,15 @@ class AssessmentServiceTest {
     val applicationId = UUID.fromString("95c7175f-451a-47e0-af16-6bf9175b5581")
 
     val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(UserEntityFactory().produce())
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .withIsPipeApplication(true)
       .produce()
 
@@ -1073,7 +1545,15 @@ class AssessmentServiceTest {
 
     val previousAssessment = AssessmentEntityFactory()
       .withApplication(application)
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(applicationId) } returns previousAssessment
@@ -1091,6 +1571,11 @@ class AssessmentServiceTest {
   @Test
   fun `reallocateAssessment returns Success, deallocates old assessment and creates a new one`() {
     val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -1102,6 +1587,11 @@ class AssessmentServiceTest {
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
 
     val assigneeUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
       .apply {
         roles += UserRoleAssignmentEntityFactory()
@@ -1122,7 +1612,15 @@ class AssessmentServiceTest {
     val applicationId = UUID.fromString("95c7175f-451a-47e0-af16-6bf9175b5581")
 
     val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(UserEntityFactory().produce())
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .withIsPipeApplication(true)
       .produce()
 
@@ -1130,7 +1628,15 @@ class AssessmentServiceTest {
 
     val previousAssessment = AssessmentEntityFactory()
       .withApplication(application)
-      .withAllocatedToUser(UserEntityFactory().produce())
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
       .produce()
 
     every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(applicationId) } returns previousAssessment
@@ -1176,6 +1682,11 @@ class AssessmentServiceTest {
     )
 
     private val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     private val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -1187,7 +1698,15 @@ class AssessmentServiceTest {
     private val assessment = AssessmentEntityFactory()
       .withApplication(
         ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().produce())
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withYieldedProbationRegion {
+                ProbationRegionEntityFactory()
+                  .withYieldedApArea { ApAreaEntityFactory().produce() }
+                  .produce()
+              }
+              .produce()
+          )
           .produce()
       )
       .withAllocatedToUser(user)
@@ -1299,7 +1818,15 @@ class AssessmentServiceTest {
         )
       } returns AssessmentClarificationNoteEntityFactory()
         .withAssessment(assessment)
-        .withCreatedBy(UserEntityFactory().produce())
+        .withCreatedBy(
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce()
+        )
         .produce()
 
       val result = assessmentService.updateAssessmentClarificationNote(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -5,8 +5,10 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
@@ -69,6 +71,11 @@ class JsonSchemaServiceTest {
     val userEntity = UserEntityFactory()
       .withId(userId)
       .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
       .produce()
 
     val upToDateApplication = ApprovedPremisesApplicationEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -32,7 +34,13 @@ class AssessmentTransformerTest {
     mockAssessmentClarificationNoteTransformer
   )
 
-  private val allocatedToUser = UserEntityFactory().produce()
+  private val allocatedToUser = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
 
   private val assessmentFactory = AssessmentEntityFactory()
     .withApplication(mockk<ApprovedPremisesApplicationEntity>())
@@ -80,11 +88,27 @@ class AssessmentTransformerTest {
       AssessmentClarificationNoteEntityFactory()
         .withAssessment(assessment)
         .withResponse("Some text")
-        .withCreatedBy(UserEntityFactory().produce())
+        .withCreatedBy(
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce()
+        )
         .produce(),
       AssessmentClarificationNoteEntityFactory()
         .withAssessment(assessment)
-        .withCreatedBy(UserEntityFactory().produce())
+        .withCreatedBy(
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce()
+        )
         .produce()
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -84,6 +84,7 @@ class BookingTransformerTest {
     probationRegion = ProbationRegionEntity(
       id = UUID.fromString("4eae0059-af28-4436-a4d8-7106523866d9"),
       name = "region",
+      deliusCode = "ABC",
       premises = mutableListOf(),
       apArea = ApAreaEntity(
         id = UUID.fromString("a005f122-a0e9-4d93-b5bb-f7c5bd82a015"),


### PR DESCRIPTION
> See [ticket #714 on the CAS3 Trello board](https://trello.com/c/p0UPjpJn/714-api-can-retrieve-regional-information-about-a-member-of-staff).

This PR introduces probation regions for users. This is to enable upcoming work to restrict users' access to premises depending on their region.

Changes in this PR:
- The `GET users/{id}` and `GET /profile` endpoints now expect an `X-Service-Name` header with a value of either `temporary-accommodation` or `approved-premises`. This returns either a complete user object for Approved Premises, or a stripped-down user object for Temporary Accommodation (as TA does not have a requirement for personal information from this endpoint).
- The above endpoints also include the ID and name of the probation region for the user in their response.
- The `UserService.getUserForUsername` method now inspects the value of `probationArea.code` from the Community API response, and uses this to retrieve the appropriate probation region from the database to assign to the user.
- The `IntegrationTestBase.mockStaffUserInfoCommunityApiCall` method now accepts an optional boolean parameter, `createProbationRegionForStaffAreaCode`, which can be used to ensure a probation region exists with the same Delius code as the returned response for this mocked Community API call. The parameter's default value is `true` but can be set to `false` in situations where other parts of the test create an appropriate probation region.
- Many tests require a user entity to be created to pass. All such tests have been updated to ensure that they have a suitable probation region for the user. This has been made into its own commit to make reviewing easier.