### PR TITLE
(Refactor) Use a service to fetch people

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/AuthorisableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/AuthorisableActionResult.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.results
 
 sealed interface AuthorisableActionResult<EntityType> {
   data class Success<EntityType>(val entity: EntityType) : AuthorisableActionResult<EntityType>
-  class Unauthorised<EntityType> : AuthorisableActionResult<EntityType>
-  class NotFound<EntityType> : AuthorisableActionResult<EntityType>
+  data class Unauthorised<EntityType>(val id: Any? = null, val entityType: String? = null) : AuthorisableActionResult<EntityType>
+  data class NotFound<EntityType>(val id: Any? = null, val entityType: String? = null) : AuthorisableActionResult<EntityType>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PersonService.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+
+@Service
+class PersonService(
+  private val offenderService: OffenderService
+) {
+
+  fun getPersonByCrn(crn: String, userDistinguishedName: String): AuthorisableActionResult<Pair<OffenderDetailSummary, InmateDetail>> {
+    val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(crn, userDistinguishedName)) {
+      is AuthorisableActionResult.NotFound -> return AuthorisableActionResult.NotFound(crn, "Person")
+      is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised(crn, "Person")
+      is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+    }
+
+    if (offenderDetails.otherIds.nomsNumber == null) {
+      throw RuntimeException("No nomsNumber present for CRN: `$crn`")
+    }
+
+    val nomsNumber = offenderDetails.otherIds.nomsNumber
+
+    val inmateDetail = when (val inmateDetailResult = offenderService.getInmateDetailByNomsNumber(nomsNumber)) {
+      is AuthorisableActionResult.NotFound -> return AuthorisableActionResult.NotFound(nomsNumber, "Inmate")
+      is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised(crn, "Inmate")
+      is AuthorisableActionResult.Success -> inmateDetailResult.entity
+    }
+
+    return AuthorisableActionResult.Success(
+      Pair(offenderDetails, inmateDetail)
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -441,7 +441,7 @@ class ApplicationTest : IntegrationTestBase() {
       .expectStatus()
       .is5xxServerError
       .expectBody()
-      .jsonPath("$.detail").isEqualTo("No nomsNumber present for CRN")
+      .jsonPath("$.detail").isEqualTo("No nomsNumber present for CRN: `$crn`")
   }
 
   @Test
@@ -664,7 +664,7 @@ class ApplicationTest : IntegrationTestBase() {
       .expectStatus()
       .is5xxServerError
       .expectBody()
-      .jsonPath("$.detail").isEqualTo("No nomsNumber present for CRN")
+      .jsonPath("$.detail").isEqualTo("No nomsNumber present for CRN: `$crn`")
   }
 
   @Test
@@ -936,7 +936,7 @@ class ApplicationTest : IntegrationTestBase() {
       .expectStatus()
       .is5xxServerError
       .expectBody()
-      .jsonPath("$.detail").isEqualTo("No nomsNumber present for CRN")
+      .jsonPath("$.detail").isEqualTo("No nomsNumber present for CRN: `$crn`")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PersonServiceTest.kt
@@ -1,0 +1,133 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PersonService
+
+class PersonServiceTest {
+  private val mockOffenderService = mockk<OffenderService>()
+
+  private val personService = PersonService(
+    mockOffenderService
+  )
+
+  @Nested
+  inner class GetPersonByCRN {
+    private val crn = "a-crn"
+    private val userDistinguisedName = "distinguished.name"
+    private val nomsNumber = "noms-number"
+
+    private val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withNomsNumber(nomsNumber)
+      .withFirstName("Bob")
+      .withLastName("Doe")
+      .withCurrentExclusion(true)
+      .produce()
+
+    private val inmateDetail = InmateDetail(
+      offenderNo = nomsNumber,
+      inOutStatus = InOutStatus.IN,
+      assignedLivingUnit = AssignedLivingUnit(
+        agencyId = "AGY",
+        locationId = 89,
+        description = "AGENCY DESCRIPTION",
+        agencyName = "AGENCY NAME"
+      )
+    )
+
+    @Test
+    fun `getPersonByCRN returns NotFound result when the offenderDetails cannot be found`() {
+      every { mockOffenderService.getOffenderByCrn(crn, userDistinguisedName) } returns AuthorisableActionResult.NotFound()
+
+      val result = personService.getPersonByCrn(
+        crn,
+        userDistinguisedName
+      )
+
+      Assertions.assertThat(
+        result is AuthorisableActionResult.NotFound && result.id == crn && result.entityType == "Person"
+      ).isTrue
+    }
+
+    @Test
+    fun `getPersonByCRN returns Unauthorised result when the user is not authorised to access the offenderDetails`() {
+      every { mockOffenderService.getOffenderByCrn(crn, userDistinguisedName) } returns AuthorisableActionResult.Unauthorised()
+
+      val result = personService.getPersonByCrn(
+        crn,
+        userDistinguisedName
+      )
+
+      Assertions.assertThat(
+        result is AuthorisableActionResult.Unauthorised
+      ).isTrue
+    }
+
+    @Test
+    fun `getPersonByCRN returns NotFound result when the inmateDetails cannot be found`() {
+      every { mockOffenderService.getOffenderByCrn(crn, userDistinguisedName) } returns AuthorisableActionResult.Success(offenderDetails)
+      every { mockOffenderService.getInmateDetailByNomsNumber(nomsNumber) } returns AuthorisableActionResult.NotFound()
+
+      val result = personService.getPersonByCrn(
+        crn,
+        userDistinguisedName
+      )
+
+      Assertions.assertThat(
+        result is AuthorisableActionResult.NotFound && result.id == nomsNumber && result.entityType == "Inmate"
+      ).isTrue
+    }
+
+    @Test
+    fun `getPersonByCRN returns NotFound result when the user is not authorised to access the inmateDetails`() {
+      every { mockOffenderService.getOffenderByCrn(crn, userDistinguisedName) } returns AuthorisableActionResult.Success(offenderDetails)
+      every { mockOffenderService.getInmateDetailByNomsNumber(nomsNumber) } returns AuthorisableActionResult.Unauthorised()
+
+      val result = personService.getPersonByCrn(
+        crn,
+        userDistinguisedName
+      )
+
+      Assertions.assertThat(
+        result is AuthorisableActionResult.Unauthorised
+      ).isTrue
+    }
+
+    @Test
+    fun `getPersonByCRN throws an error when the offender does not have a NOMS number`() {
+      val offenderWithoutNomsNumber = OffenderDetailsSummaryFactory()
+        .withoutNomsNumber()
+        .produce()
+      every { mockOffenderService.getOffenderByCrn(crn, userDistinguisedName) } returns AuthorisableActionResult.Success(offenderWithoutNomsNumber)
+
+      val exception = assertThrows<RuntimeException> { personService.getPersonByCrn(crn, userDistinguisedName) }
+      Assertions.assertThat(exception.message).isEqualTo("No nomsNumber present for CRN: `$crn`")
+    }
+
+    @Test
+    fun `getPersonByCRN returns a pair of OffenderDetails and InmateDetails`() {
+      every { mockOffenderService.getOffenderByCrn(crn, userDistinguisedName) } returns AuthorisableActionResult.Success(offenderDetails)
+      every { mockOffenderService.getInmateDetailByNomsNumber(nomsNumber) } returns AuthorisableActionResult.Success(inmateDetail)
+
+      val result = personService.getPersonByCrn(
+        crn,
+        userDistinguisedName
+      )
+
+      Assertions.assertThat(
+        result is AuthorisableActionResult.Success && result.entity == Pair(offenderDetails, inmateDetail)
+      ).isTrue
+    }
+  }
+}


### PR DESCRIPTION
While working on https://trello.com/c/wB28GkJC/948-add-in-screens-for-elegibility-screens-if-a-person-doesnt-meet-the-tier-model I noticed there were a lot of places where we were fetching information about a person from Community API and the Prison API, and there was a lot of repetition. To DRY things up, I've created a new Service which fetches from both APIs and returns a `Pair` of the Delius and Prison information. These objects can then be passed into the transformer in the controller