### PR TITLE
Give users in local, dev, and test environments real probation regions

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ generic-service:
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
+    ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: dev
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
 

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -20,6 +20,7 @@ generic-service:
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://community-accommodation-wiremock.hmpps.service.justice.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev,classpath:db/migration/test
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
+    ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,3 +17,5 @@ log-client-credentials-jwt-info: true
 
 seed:
   file-prefix: "./seed"
+
+assign-default-region-to-users-with-unknown-region: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -161,3 +161,5 @@ caches:
 
 seed:
   file-prefix: "/tmp/seed"
+
+assign-default-region-to-users-with-unknown-region: false

--- a/src/main/resources/db/migration/local+dev/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev/R__1_create_dev_users.sql
@@ -3,6 +3,9 @@
 --These are randomly generated names
 
 INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id) VALUES
+    ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JimSnowLdap', 2500041001, '43606be0-9836-441d-9bc1-5586de9ac931'), -- South West
+    ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad'), -- East of England
+    ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Tester', 'temporary-accommodation-e2e-tester', 2500041003, 'afee0696-8df3-4d9f-9d0c-268f17772e2c'), -- Wales
     ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891'), -- North East
     ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad'), -- East of England
     ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c') -- Wales

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -35,6 +35,7 @@ class UserServiceTest {
   private val mockProbationRegionRepository = mockk<ProbationRegionRepository>()
 
   private val userService = UserService(
+    false,
     mockHttpAuthService,
     mockCommunityApiClient,
     mockUserRepository,
@@ -111,6 +112,7 @@ class UserServiceTest {
     private val mockProbationRegionRepository = mockk<ProbationRegionRepository>()
 
     private val userService = UserService(
+      false,
       mockHttpAuthService,
       mockCommunityApiClient,
       mockUserRepository,


### PR DESCRIPTION
Currently the user `JimSnowLdap` does not exist in our local and dev environments until it is created by a call to `UserService.getUserForUsername`. This calls the Community API, which in the dev environment returns a response with a probation area code of `"GCS"`, which does not correspond to any probation region. This is causing the error `Unknown probation region code 'GCS' for user 'JIMSNOWLDAP'` to appear in the dev environment.

This also appears to be the case for users used for end-to-end tests, as well as personal accounts on the dev and test environments.

It seems that in production-like environments, the Community API will always return codes corresponding to real probation regions, and that this is just a consequence of using dummy data.

This PR adds two mechanisms to avoid this problem in lower environments:
1. Some user accounts used for testing have been added to the repeatable migrations for `local+dev` so that when `UserService.getUserForUsername` is called, it can return early as the user will exist in the database, rather than trying to determine the probation region and failing when the code doesn't match any existing regions.
2. An `assign-default-region-to-users-with-unknown-region` feature flag has been introduced, with a default value of `false` but set to `true` for local, dev, and test environments. This flag instructs the `UserService.getUserForUsername` method to use the North West probation region as a default when the lookup using the Community API's probation area code fails, as well as emit a warning to the logs that the default value is being used.