### PR TITLE
Fix migration to give existing users a default region

### DIFF
--- a/src/main/resources/db/migration/all/20230123154608__add_probation_region_to_users.sql
+++ b/src/main/resources/db/migration/all/20230123154608__add_probation_region_to_users.sql
@@ -1,2 +1,13 @@
-ALTER TABLE "users" ADD COLUMN probation_region_id UUID NOT NULL;
+ALTER TABLE "users" ADD COLUMN probation_region_id UUID;
 ALTER TABLE "users" ADD FOREIGN KEY (probation_region_id) REFERENCES probation_regions(id);
+
+-- Give existing users a default region.
+UPDATE "users"
+SET probation_region_id = (
+    SELECT id
+    FROM probation_regions
+    WHERE delius_code = 'N51' -- North West
+    LIMIT 1
+);
+
+ALTER TABLE "users" ALTER COLUMN probation_region_id SET NOT NULL;


### PR DESCRIPTION
The `20230123154608__add_probation_region_to_users.sql` migration has been updated to ensure that any existing users have been assigned a default probation region (North West) before enforcing non-nullability on the `probation_region_id` column.

This should allow the migration to succeed in the preprod and test environments.