### PR TITLE
(1059) Add a status to applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -16,6 +16,7 @@ import javax.persistence.Inheritance
 import javax.persistence.InheritanceType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
 
@@ -55,8 +56,13 @@ abstract class ApplicationEntity(
   var submittedAt: OffsetDateTime?,
 
   @Transient
-  var schemaUpToDate: Boolean
-)
+  var schemaUpToDate: Boolean,
+
+  @OneToMany(mappedBy = "application")
+  var assessments: MutableList<AssessmentEntity>,
+) {
+  fun getLatestAssessment(): AssessmentEntity? = this.assessments.maxByOrNull { it.createdAt }
+}
 
 @Entity
 @DiscriminatorValue("approved-premises")
@@ -72,6 +78,7 @@ class ApprovedPremisesApplicationEntity(
   createdAt: OffsetDateTime,
   submittedAt: OffsetDateTime?,
   schemaUpToDate: Boolean,
+  assessments: MutableList<AssessmentEntity>,
   var isWomensApplication: Boolean?,
   var isPipeApplication: Boolean?,
   val convictionId: Long,
@@ -89,7 +96,8 @@ class ApprovedPremisesApplicationEntity(
   schemaVersion,
   createdAt,
   submittedAt,
-  schemaUpToDate
+  schemaUpToDate,
+  assessments,
 )
 
 @Entity
@@ -105,7 +113,8 @@ class TemporaryAccommodationApplicationEntity(
   schemaVersion: JsonSchemaEntity,
   createdAt: OffsetDateTime,
   submittedAt: OffsetDateTime?,
-  schemaUpToDate: Boolean
+  schemaUpToDate: Boolean,
+  assessments: MutableList<AssessmentEntity>,
 ) : ApplicationEntity(
   id,
   crn,
@@ -115,5 +124,6 @@ class TemporaryAccommodationApplicationEntity(
   schemaVersion,
   createdAt,
   submittedAt,
-  schemaUpToDate
+  schemaUpToDate,
+  assessments
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -157,7 +158,8 @@ class ApplicationService(
         eventNumber = deliusEventNumber!!,
         offenceId = offenceId!!,
         schemaUpToDate = true,
-        riskRatings = riskRatings
+        riskRatings = riskRatings,
+        assessments = mutableListOf<AssessmentEntity>(),
       )
     )
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3085,10 +3085,13 @@ components:
               $ref: '#/components/schemas/AnyValue'
             document:
               $ref: '#/components/schemas/AnyValue'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
           required:
             - createdByUserId
             - schemaVersion
             - outdatedSchema
+            - status
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -3106,10 +3109,19 @@ components:
               $ref: '#/components/schemas/AnyValue'
             document:
               $ref: '#/components/schemas/AnyValue'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
           required:
             - createdByUserId
             - schemaVersion
             - outdatedSchema
+            - status
+    ApplicationStatus:
+      type: string
+      enum:
+        - inProgress
+        - submitted
+        - requestedFurtherInformation
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
     NewApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -36,6 +37,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var offenceId: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
   private var riskRatings: Yielded<PersonRisks> = { PersonRisksFactory().produce() }
+  private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf<AssessmentEntity>() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -97,6 +99,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.offenceId = { offenceId }
   }
 
+  fun withAssessments(assessments: MutableList<AssessmentEntity>) = apply {
+    this.assessments = { assessments }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -112,6 +118,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     eventNumber = this.eventNumber(),
     offenceId = this.offenceId(),
     schemaUpToDate = false,
-    riskRatings = this.riskRatings()
+    riskRatings = this.riskRatings(),
+    assessments = this.assessments(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -30,6 +31,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var isWomensApplication: Yielded<Boolean?> = { null }
   private var isPipeApplication: Yielded<Boolean?> = { null }
+  private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf<AssessmentEntity>() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -71,6 +73,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.submittedAt = { submittedAt }
   }
 
+  fun withAssessments(assessments: MutableList<AssessmentEntity>) = apply {
+    this.assessments = { assessments }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -80,6 +86,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     schemaVersion = this.applicationSchema(),
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
-    schemaUpToDate = false
+    schemaUpToDate = false,
+    assessments = this.assessments(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -1,0 +1,228 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
+import java.time.OffsetDateTime
+
+class ApplicationsTransformerTest {
+  private val mockPersonTransformer = mockk<PersonTransformer>()
+  private val mockRisksTransformer = mockk<RisksTransformer>()
+
+  private val applicationsTransformer = ApplicationsTransformer(
+    jacksonObjectMapper(),
+    mockPersonTransformer,
+    mockRisksTransformer
+  )
+
+  private val user = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+
+  private val allocatedToUser = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+
+  private val approvedPremisesApplicationFactory = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(user)
+
+  private val temporaryAccommodationApplicationEntityFactory = TemporaryAccommodationApplicationEntityFactory()
+    .withCreatedByUser(user)
+
+  private val assessmentFactory = AssessmentEntityFactory()
+    .withAllocatedToUser(allocatedToUser)
+
+  private val completedClarificationNoteFactory = AssessmentClarificationNoteEntityFactory()
+    .withResponse("Response")
+    .withCreatedBy(allocatedToUser)
+
+  private val awaitingClarificationNoteFactory = AssessmentClarificationNoteEntityFactory()
+    .withCreatedBy(allocatedToUser)
+
+  private val unSubmittedApprovedPremisesApplicationFactory = approvedPremisesApplicationFactory
+    .withSubmittedAt(null)
+
+  private val submittedApprovedPremisesApplicationFactory = approvedPremisesApplicationFactory
+    .withSubmittedAt(OffsetDateTime.now())
+
+  private val submittedTemporaryAccommodationApplicationFactory = temporaryAccommodationApplicationEntityFactory
+    .withSubmittedAt(OffsetDateTime.now())
+
+  @BeforeEach
+  fun setup() {
+    every { mockPersonTransformer.transformModelToApi(any<OffenderDetailSummary>(), any()) } returns mockk<Person>()
+    every { mockRisksTransformer.transformDomainToApi(any<PersonRisks>(), any<String>()) } returns mockk()
+  }
+
+  @Test
+  fun `transformJpaToApi transforms an in progress Approved Premises application correctly`() {
+    val application = approvedPremisesApplicationFactory.withSubmittedAt(null).produce()
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.id).isEqualTo(application.id)
+    assertThat(result.createdByUserId).isEqualTo(user.id)
+    assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms an in progress Temporary Accommodation application correctly`() {
+    val application = temporaryAccommodationApplicationEntityFactory.withSubmittedAt(null).produce()
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+
+    assertThat(result.id).isEqualTo(application.id)
+    assertThat(result.createdByUserId).isEqualTo(user.id)
+    assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms a submitted Approved Premises application correctly`() {
+    val application = submittedApprovedPremisesApplicationFactory.produce()
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms a submitted Temporary Accommodation application correctly`() {
+    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms an Approved Premises application with requested clarification notes correctly`() {
+    val application = submittedApprovedPremisesApplicationFactory.produce()
+    val assessment = assessmentFactory.withApplication(application).produce()
+
+    application.assessments = mutableListOf(assessment)
+    assessment.clarificationNotes = mutableListOf(
+      completedClarificationNoteFactory
+        .withAssessment(assessment)
+        .produce(),
+      awaitingClarificationNoteFactory
+        .withAssessment(assessment)
+        .produce()
+    )
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.requestedFurtherInformation)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms a Temporary Accommodation application with requested clarification notes correctly`() {
+    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val assessment = assessmentFactory.withApplication(application).produce()
+
+    application.assessments = mutableListOf(assessment)
+    assessment.clarificationNotes = mutableListOf(
+      completedClarificationNoteFactory
+        .withAssessment(assessment)
+        .produce(),
+      awaitingClarificationNoteFactory
+        .withAssessment(assessment)
+        .produce()
+    )
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.requestedFurtherInformation)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms an Approved Premises application with a completed clarification note correctly`() {
+    val application = submittedApprovedPremisesApplicationFactory.produce()
+    val assessment = assessmentFactory.withApplication(application).produce()
+
+    assessment.clarificationNotes = mutableListOf(
+      completedClarificationNoteFactory
+        .withAssessment(assessment)
+        .produce()
+    )
+
+    application.assessments = mutableListOf(assessment)
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms a Temporary Accommodation application with a completed clarification note correctly`() {
+    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val assessment = assessmentFactory.withApplication(application).produce()
+
+    assessment.clarificationNotes = mutableListOf(
+      completedClarificationNoteFactory
+        .withAssessment(assessment)
+        .produce()
+    )
+
+    application.assessments = mutableListOf(assessment)
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+
+  @Test
+  fun `transformJpaToApi uses the latest assessment`() {
+    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val oldAssessment = assessmentFactory.withApplication(application)
+      .withCreatedAt(OffsetDateTime.parse("2022-09-01T12:34:56.789Z"))
+      .produce()
+    val latestAssessment = assessmentFactory.withApplication(application)
+      .withCreatedAt(OffsetDateTime.now())
+      .produce()
+
+    oldAssessment.clarificationNotes = mutableListOf(
+      awaitingClarificationNoteFactory
+        .withAssessment(oldAssessment)
+        .produce()
+    )
+
+    latestAssessment.clarificationNotes = mutableListOf(
+      completedClarificationNoteFactory
+        .withAssessment(latestAssessment)
+        .produce()
+    )
+
+    application.assessments = mutableListOf(oldAssessment, latestAssessment)
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+
+    assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+}


### PR DESCRIPTION
This fetches one of three statuses:

- `inProgress` - if the application is not submitted
- `submitted` - if the application is submitted and all clarificationNotes have responses
- `requestedFurtherInformation` - if the application’s latest assessment has any clarificationNotes without responses

As part of this, we also need to load in assessements for an application, so I've added a new variable to the Application entity, together with a helper to fetch the latest entity.

The transformer tests are a little more long winded than I'd like, but I was getting too bogged down with trying to DRY them up!