### PR TITLE
Domain events scaffolding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,23 @@ openApiGenerate {
   }
 }
 
+tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openApiGenerateDomainEvents") {
+  generatorName.set("kotlin-spring")
+  inputSpec.set("$rootDir/src/main/resources/static/domain-events-api.yml")
+  outputDir.set("$buildDir/generated")
+  apiPackage.set("uk.gov.justice.digital.hmpps.approvedpremisesapi.api")
+  modelPackage.set("uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model")
+  configOptions.apply {
+    put("basePackage", "uk.gov.justice.digital.hmpps.approvedpremisesapi")
+    put("delegatePattern", "true")
+    put("gradleBuildFile", "false")
+    put("exceptionHandler", "false")
+    put("useBeanValidation", "false")
+  }
+}
+
+tasks.get("openApiGenerate").dependsOn("openApiGenerateDomainEvents")
+
 tasks.get("openApiGenerate").doLast {
   // This is a workaround to allow us to have the `/documents/{crn}/{documentId}` endpoint specified in api.yml but not use
   // OpenAPI Generate for the scaffolding.  This is because we need to properly stream the files

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -44,6 +44,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
         authorize(HttpMethod.POST, "/seed", permitAll)
+        authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.hibernate.annotations.Type
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID>
+
+@Entity
+@Table(name = "domain_events")
+data class DomainEventEntity(
+  @Id
+  val id: UUID,
+  val applicationId: UUID,
+  val crn: String,
+  @Enumerated(value = EnumType.STRING)
+  val type: DomainEventType,
+  val occurredAt: OffsetDateTime,
+  val createdAt: OffsetDateTime,
+  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
+  val data: String
+)
+
+enum class DomainEventType {
+  APPROVED_PREMISES_APPLICATION_SUBMITTED,
+  APPROVED_PREMISES_APPLICATION_ASSESSED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class DomainEvent <T> (
+  val id: UUID,
+  val applicationId: UUID,
+  val crn: String,
+  val occurredAt: OffsetDateTime,
+  val data: T
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.transaction.Transactional
+
+@Service
+class DomainEventService(
+  private val objectMapper: ObjectMapper,
+  private val domainEventRepository: DomainEventRepository
+) {
+  fun getApplicationSubmittedDomainEvent(id: UUID) = get<ApplicationSubmittedEnvelope>(id)
+
+  private inline fun <reified T> get(id: UUID): DomainEvent<T>? {
+    val domainEventEntity = domainEventRepository.findByIdOrNull(id) ?: return null
+
+    val data = when {
+      T::class == ApplicationSubmittedEnvelope::class && domainEventEntity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED ->
+        objectMapper.readValue(domainEventEntity.data, T::class.java)
+      else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${domainEventEntity.type.name}")
+    }
+
+    return DomainEvent(
+      id = domainEventEntity.id,
+      applicationId = domainEventEntity.applicationId,
+      crn = domainEventEntity.crn,
+      occurredAt = domainEventEntity.occurredAt,
+      data = data
+    )
+  }
+
+  @Transactional
+  fun save(domainEvent: DomainEvent<*>) {
+    domainEventRepository.save(
+      DomainEventEntity(
+        id = domainEvent.id,
+        applicationId = domainEvent.applicationId,
+        crn = domainEvent.crn,
+        type = enumTypeFromDataType(domainEvent.data!!::class.java),
+        occurredAt = domainEvent.occurredAt,
+        createdAt = OffsetDateTime.now(),
+        data = objectMapper.writeValueAsString(domainEvent.data)
+      )
+    )
+
+    // TODO: Emit certain types of event to SNS for downstream consumption
+  }
+
+  private fun <T> enumTypeFromDataType(type: Class<T>) = when (type) {
+    ApplicationSubmittedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED
+    else -> throw RuntimeException("Unrecognised domain event type: ${type.name}")
+  }
+}

--- a/src/main/resources/db/migration/all/20230130160546__domain_events.sql
+++ b/src/main/resources/db/migration/all/20230130160546__domain_events.sql
@@ -1,0 +1,10 @@
+CREATE TABLE domain_events (
+    id UUID NOT NULL,
+    application_id UUID NOT NULL,
+    crn TEXT NOT NULL,
+    type TEXT NOT NULL,
+    occurred_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    data JSON NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -3,10 +3,8 @@ info:
   version: '0.1.0'
   title: 'AP Domain events'
   description: Get information about events in the Approved Premises domain
-servers:
-  - url: /events
 paths:
-  /application-submitted/{eventId}:
+  /events/application-submitted/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -24,34 +22,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.application.submitted
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/ApplicationSubmitted'
-
+                $ref: '#/components/schemas/ApplicationSubmittedEnvelope'
         404:
           description: No application-submitted event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /application-withdrawn/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/application-withdrawn/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -69,34 +49,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.application.withdrawn
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/ApplicationWithdrawn'
-
+                $ref: '#/components/schemas/ApplicationWithdrawnEnvelope'
         404:
           description: No application-withdrawn event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /application-assessed/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/application-assessed/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -114,34 +76,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.application.assessed
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/ApplicationAssessed'
-
+                $ref: '#/components/schemas/ApplicationAssessedEnvelope'
         404:
           description: No application-assessed event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /booking-made/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/booking-made/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -159,34 +103,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.booking.made
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/BookingMade'
-
+                $ref: '#/components/schemas/BookingMadeEnvelope'
         404:
           description: No 'booking-made' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /booking-extended/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/booking-extended/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -204,34 +130,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.booking.extended
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/BookingExtended'
-
+                $ref: '#/components/schemas/BookingExtendedEnvelope'
         404:
           description: No 'booking-extended' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /booking-cancelled/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/booking-cancelled/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -249,34 +157,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.booking.cancelled
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/BookingCancelled'
-
+                $ref: '#/components/schemas/BookingCancelledEnvelope'
         404:
           description: No 'booking-made' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /booking-not-made/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/booking-not-made/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -294,34 +184,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.booking.not-made
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/BookingNotMade'
-
+                $ref: '#/components/schemas/BookingNotMadeEnvelope'
         404:
           description: No 'booking-not-made' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /person-arrived/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/person-arrived/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -339,34 +211,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.person.arrived
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/PersonArrived'
-
+                $ref: '#/components/schemas/PersonArrivedEnvelope'
         404:
           description: No 'person-arrived' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /person-not-arrived/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/person-not-arrived/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -384,34 +238,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.person.not-arrived
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/PersonNotArrived'
-
+                $ref: '#/components/schemas/PersonNotArrivedEnvelope'
         404:
           description: No 'person-not-arrived' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /person-departed/{eventId}:
+          $ref: '#/components/responses/500Response'
+  /events/person-departed/{eventId}:
     parameters:
       - name: eventId
         description: UUID of the event
@@ -429,65 +265,41 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  id:
-                    $ref: '#/components/schemas/EventId'
-                  timestamp:
-                    type: string
-                    example: '2022-11-30T14:53:44'
-                    format: date-time
-                  eventType:
-                    type: string
-                    example: approved-premises.person.departed
-                    readOnly: true
-                  eventDetails:
-                    $ref: '#/components/schemas/PersonDeparted'
-
+                $ref: '#/components/schemas/PersonDepartedEnvelope'
         404:
           description: No 'person-not-arrived' event found for the provided `eventId`
           content:
-            application/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Problem'
         500:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
+          $ref: '#/components/responses/500Response'
 components:
   schemas:
     EventId:
       description: The UUID of an event
       type: string
       example: 364145f9-0af8-488e-9901-b4c46cd9ba37
-
     DeliusEventNumber:
       description: Used in Delius to identify the 'event' via the first active conviction's 'index'
       type: string
       example: "7"
-
     ApplicationId:
       description: The UUID of an application for an AP place
       type: string
       example: 484b8b5e-6c3b-4400-b200-425bbe410713
-
     ApplicationUrl:
       description: The URL on the Approved Premises service at which a user can view a representation of an AP application and related resources, including bookings
       type: string
       example: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713
-
     BookingId:
       description: The UUID of booking for an AP place
       type: string
       example: 14c80733-4b6d-4f35-b724-66955aac320c
-
     LegacyApCode:
       description: The 'Q code' used in Delius to identify an Approved Premises
       type: string
       example: Q057
-
     StaffMember:
       description: A member of probation or AP staff
       type: object
@@ -575,6 +387,21 @@ components:
           type: string
           example: A1234ZX
           readOnly: true
+    ApplicationSubmittedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.application.submitted
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/ApplicationSubmitted'
     ApplicationSubmitted:
       type: object
       properties:
@@ -635,7 +462,21 @@ components:
               $ref: '#/components/schemas/Ldu'
             region:
               $ref: '#/components/schemas/Region'
-
+    ApplicationWithdrawnEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.application.withdrawn
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/ApplicationWithdrawn'
     ApplicationWithdrawn:
       type: object
       properties:
@@ -656,7 +497,21 @@ components:
           $ref: '#/components/schemas/StaffMember'
         withdrawalReason:
           $ref: '#/components/schemas/CancellationReason'
-
+    ApplicationAssessedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.application.assessed
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/ApplicationAssessed'
     ApplicationAssessed:
       type: object
       properties:
@@ -688,7 +543,21 @@ components:
         decisionRationale:
           type: string
           example: Risk too low
-
+    BookingMadeEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.booking.made
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/BookingMade'
     BookingMade:
       type: object
       properties:
@@ -728,7 +597,21 @@ components:
           readOnly: true
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
-
+    BookingNotMadeEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.booking.not-made
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/BookingNotMade'
     BookingNotMade:
       type: object
       properties:
@@ -755,7 +638,21 @@ components:
         failureDescription:
           type: string
           example: No availability
-
+    BookingCancelledEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.booking.cancelled
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/BookingCancelled'
     BookingCancelled:
       type: object
       properties:
@@ -780,7 +677,21 @@ components:
           $ref: '#/components/schemas/StaffMember'
         cancellationReason:
           $ref: '#/components/schemas/CancellationReason'
-
+    BookingExtendedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.booking.extended
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/BookingExtended'
     BookingExtended:
       type: object
       properties:
@@ -816,7 +727,21 @@ components:
           example: '2023-02-12'
           format: date
           readOnly: true
-
+    PersonArrivedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.person.arrived
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/PersonArrived'
     PersonArrived:
       type: object
       properties:
@@ -850,7 +775,21 @@ components:
         notes:
           type: string
           example: Arrived a day late due to rail strike. Informed in advance by COM.
-
+    PersonNotArrivedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.person.not-arrived
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/PersonNotArrived'
     PersonNotArrived:
       type: object
       properties:
@@ -875,7 +814,21 @@ components:
         notes:
           type: string
           example: We learnt that Mr Smith is in hospital.
-
+    PersonDepartedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.person.departed
+          readOnly: true
+        eventDetails:
+          $ref: '#/components/schemas/PersonDeparted'
     PersonDeparted:
       type: object
       properties:
@@ -946,8 +899,6 @@ components:
               $ref: '#/components/schemas/MoveOnCategory'
             destinationProvider:
               $ref: '#/components/schemas/DestinationProvider'
-
-
     Premises:
       type: object
       properties:
@@ -964,7 +915,6 @@ components:
           $ref: '#/components/schemas/LegacyApCode'
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
-
     DestinationPremises:
       type: object
       properties:
@@ -982,7 +932,6 @@ components:
           example: Q061
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
-
     CancellationReason:
       type: object
       properties:
@@ -1002,7 +951,6 @@ components:
             - D
             - 4I
             - C
-
     MoveOnCategory:
       type: object
       properties:
@@ -1039,7 +987,6 @@ components:
         code:
           type: string
           example: ABC123
-
     DestinationProvider:
       type: object
       properties:
@@ -1049,12 +996,21 @@ components:
         code:
           type: string
           example: XYZ456
-
-    Error:
+    Problem:
       type: object
-      required:
-        - message
       properties:
-        message:
-          description: A human readable error message
+        type:
           type: string
+          example: https://example.net/validation-error
+        title:
+          type: string
+          example: Invalid request parameters
+        status:
+          type: integer
+          example: 400
+        detail:
+          type: string
+          example: You provided invalid request parameters
+        instance:
+          type: string
+          example: f7493e12-546d-42c3-b838-06c12671ab5b

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -310,11 +310,9 @@ components:
         staffCode:
           type: string
           example: N54A999
-          readOnly: true
         staffIdentifier:
           type: integer
           example: 1501234567
-          readOnly: true
         forenames:
           type: string
           example: John
@@ -324,72 +322,84 @@ components:
         username:
           type: string
           example: JohnSmithNPS
+      required:
+        - staffCode
+        - staffIdentifier
+        - forenames
+        - surname
+        - username
     Cru:
       type: object
       properties:
         code:
           type: string
           example: N02
-          readOnly: true
         name:
           type: string
           example: NPS North East
-          readOnly: true
+      required:
+        - code
+        - name
     Ldu:
       type: object
       properties:
         code:
           type: string
           example: N54PPU
-          readOnly: true
         name:
           type: string
           example: Public Protection NE
-          readOnly: true
+      required:
+        - code
+        - name
     Region:
       type: object
       properties:
         code:
           type: string
           example: NE
-          readOnly: true
         name:
           type: string
           example: North East
-          readOnly: true
+      required:
+        - code
+        - name
     Team:
       type: object
       properties:
         code:
           type: string
           example: N54NGH
-          readOnly: true
         name:
           type: string
           example: Gateshead 1
-          readOnly: true
+      required:
+        - code
+        - name
     ProbationArea:
       type: object
       properties:
         code:
           type: string
           example: N02
-          readOnly: true
         name:
           type: string
           example: NPS North East
-          readOnly: true
+      required:
+        - code
+        - name
     PersonReference:
       type: object
       properties:
         crn:
           type: string
           example: C123456
-          readOnly: true
         noms:
           type: string
           example: A1234ZX
-          readOnly: true
+      required:
+        - crn
+        - noms
     ApplicationSubmittedEnvelope:
       type: object
       properties:
@@ -402,9 +412,13 @@ components:
         eventType:
           type: string
           example: approved-premises.application.submitted
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/ApplicationSubmitted'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     ApplicationSubmitted:
       type: object
       properties:
@@ -419,26 +433,20 @@ components:
         mappaCategories:
           type: string
           example: 'M2'
-          readOnly: true
         sentenceLengthInMonths:
           type: integer
           example: 57
-          readOnly: true
         offenceDescription:
           type: string
           example: 'Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801'
-          readOnly: true
         releaseType:
           type: string
           example: 'Release on Temporary Licence (ROTL)'
-          readOnly: true
         age:
           type: integer
           example: 43
-          readOnly: true
         gender:
           type: string
-          readOnly: true
           enum:
             - Male
             - Female
@@ -449,7 +457,6 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         submittedBy:
           type: object
           properties:
@@ -465,6 +472,26 @@ components:
               $ref: '#/components/schemas/Ldu'
             region:
               $ref: '#/components/schemas/Region'
+          required:
+            - staffMember
+            - probationArea
+            - cru
+            - team
+            - ldu
+            - region
+      required:
+        - applicationId
+        - applicationUrl
+        - personReference
+        - deliusEventNumber
+        - mappaCategories
+        - offenceDescription
+        - releaseType
+        - age
+        - gender
+        - targetLocation
+        - submittedAt
+        - submittedBy
     ApplicationWithdrawnEnvelope:
       type: object
       properties:
@@ -477,9 +504,13 @@ components:
         eventType:
           type: string
           example: approved-premises.application.withdrawn
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/ApplicationWithdrawn'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     ApplicationWithdrawn:
       type: object
       properties:
@@ -495,11 +526,18 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         withdrawnBy:
           $ref: '#/components/schemas/StaffMember'
         withdrawalReason:
           $ref: '#/components/schemas/CancellationReason'
+      required:
+        - applicationId
+        - applicationUrl
+        - personReference
+        - deliusEventNumber
+        - withdrawnAt
+        - withdrawnBy
+        - withdrawalReason
     ApplicationAssessedEnvelope:
       type: object
       properties:
@@ -512,9 +550,13 @@ components:
         eventType:
           type: string
           example: approved-premises.application.assessed
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/ApplicationAssessed'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     ApplicationAssessed:
       type: object
       properties:
@@ -530,7 +572,6 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         assessedBy:
           type: object
           properties:
@@ -546,6 +587,15 @@ components:
         decisionRationale:
           type: string
           example: Risk too low
+      required:
+        - applicationId
+        - applicationUrl
+        - personReference
+        - deliusEventNumber
+        - assessedAt
+        - assessedBy
+        - decision
+        - decisionRationale
     BookingMadeEnvelope:
       type: object
       properties:
@@ -558,9 +608,13 @@ components:
         eventType:
           type: string
           example: approved-premises.booking.made
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/BookingMade'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     BookingMade:
       type: object
       properties:
@@ -578,7 +632,6 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         bookedBy:
           type: object
           properties:
@@ -592,14 +645,24 @@ components:
           type: string
           example: '2023-01-30'
           format: date
-          readOnly: true
         departureOn:
           type: string
           example: '2023-04-30'
           format: date
-          readOnly: true
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
+      required:
+        - applicationId
+        - applicationUrl
+        - bookingId
+        - personReference
+        - deliusEventNumber
+        - createdAt
+        - bookedBy
+        - premises
+        - arrivalOn
+        - departureOn
+        - keyWorker
     BookingNotMadeEnvelope:
       type: object
       properties:
@@ -612,9 +675,13 @@ components:
         eventType:
           type: string
           example: approved-premises.booking.not-made
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/BookingNotMade'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     BookingNotMade:
       type: object
       properties:
@@ -630,7 +697,6 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         attemptedBy:
           type: object
           properties:
@@ -641,6 +707,14 @@ components:
         failureDescription:
           type: string
           example: No availability
+      required:
+        - personReference
+        - deliusEventNumber
+        - applicationId
+        - applicationUrl
+        - attemptedAt
+        - attemptedBy
+        - failureDescription
     BookingCancelledEnvelope:
       type: object
       properties:
@@ -653,9 +727,13 @@ components:
         eventType:
           type: string
           example: approved-premises.booking.cancelled
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/BookingCancelled'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     BookingCancelled:
       type: object
       properties:
@@ -675,11 +753,20 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         cancelledBy:
           $ref: '#/components/schemas/StaffMember'
         cancellationReason:
           $ref: '#/components/schemas/CancellationReason'
+      required:
+        - personReference
+        - deliusEventNumber
+        - applicationId
+        - applicationUrl
+        - bookingId
+        - premises
+        - cancelledAt
+        - cancelledBy
+        - cancellationReason
     BookingExtendedEnvelope:
       type: object
       properties:
@@ -692,9 +779,13 @@ components:
         eventType:
           type: string
           example: approved-premises.booking.extended
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/BookingExtended'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     BookingExtended:
       type: object
       properties:
@@ -714,7 +805,6 @@ components:
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
-          readOnly: true
         extendedBy:
           $ref: '#/components/schemas/StaffMember'
         extensionReason:
@@ -724,12 +814,22 @@ components:
           type: string
           example: '2023-01-30'
           format: date
-          readOnly: true
         newDepartureOn:
           type: string
           example: '2023-02-12'
           format: date
-          readOnly: true
+      required:
+        - personReference
+        - deliusEventNumber
+        - applicationId
+        - applicationUrl
+        - bookingId
+        - premises
+        - extendedAt
+        - extendedBy
+        - extensionReason
+        - previousDepartureOn
+        - newDepartureOn
     PersonArrivedEnvelope:
       type: object
       properties:
@@ -742,9 +842,13 @@ components:
         eventType:
           type: string
           example: approved-premises.person.arrived
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/PersonArrived'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     PersonArrived:
       type: object
       properties:
@@ -760,7 +864,6 @@ components:
           type: string
           example: '2022-08-21'
           format: date
-          readOnly: true
         bookingId:
           $ref: '#/components/schemas/BookingId'
         premises:
@@ -778,6 +881,18 @@ components:
         notes:
           type: string
           example: Arrived a day late due to rail strike. Informed in advance by COM.
+      required:
+        - personReference
+        - deliusEventNumber
+        - applicationId
+        - applicationUrl
+        - applicationSubmittedOn
+        - bookingId
+        - premises
+        - keyWorker
+        - arrivedAt
+        - expectedDepartureOn
+        - notes
     PersonNotArrivedEnvelope:
       type: object
       properties:
@@ -790,9 +905,13 @@ components:
         eventType:
           type: string
           example: approved-premises.person.not-arrived
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/PersonNotArrived'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     PersonNotArrived:
       type: object
       properties:
@@ -817,6 +936,16 @@ components:
         notes:
           type: string
           example: We learnt that Mr Smith is in hospital.
+      required:
+        - personReference
+        - deliusEventNumber
+        - applicationId
+        - applicationUrl
+        - bookingId
+        - premises
+        - expectedArrivalOn
+        - recordedBy
+        - notes
     PersonDepartedEnvelope:
       type: object
       properties:
@@ -829,9 +958,13 @@ components:
         eventType:
           type: string
           example: approved-premises.person.departed
-          readOnly: true
         eventDetails:
           $ref: '#/components/schemas/PersonDeparted'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
     PersonDeparted:
       type: object
       properties:
@@ -902,6 +1035,18 @@ components:
               $ref: '#/components/schemas/MoveOnCategory'
             destinationProvider:
               $ref: '#/components/schemas/DestinationProvider'
+      required:
+        - personReference
+        - deliusEventNumber
+        - applicationId
+        - applicationUrl
+        - bookingId
+        - keyWorker
+        - premises
+        - departedAt
+        - reason
+        - legacyReasonCode
+        - destination
     Premises:
       type: object
       properties:
@@ -918,6 +1063,12 @@ components:
           $ref: '#/components/schemas/LegacyApCode'
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
+      required:
+        - id
+        - name
+        - apCode
+        - legacyApCode
+        - probationArea
     DestinationPremises:
       type: object
       properties:
@@ -935,6 +1086,12 @@ components:
           example: Q061
         probationArea:
           $ref: '#/components/schemas/ProbationArea'
+      required:
+        - id
+        - name
+        - apCode
+        - legacyApCode
+        - probationArea
     CancellationReason:
       type: object
       properties:
@@ -954,6 +1111,9 @@ components:
             - D
             - 4I
             - C
+      required:
+        - description
+        - legacyCancellationCode
     MoveOnCategory:
       type: object
       properties:
@@ -990,6 +1150,10 @@ components:
         code:
           type: string
           example: ABC123
+      required:
+        - description
+        - legacyMoveOnCategoryCode
+        - code
     DestinationProvider:
       type: object
       properties:
@@ -999,6 +1163,9 @@ components:
         code:
           type: string
           example: XYZ456
+      required:
+        - description
+        - code
     Problem:
       type: object
       properties:

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -312,6 +312,7 @@ components:
           example: N54A999
         staffIdentifier:
           type: integer
+          format: int64
           example: 1501234567
         forenames:
           type: string
@@ -430,18 +431,18 @@ components:
           $ref: '#/components/schemas/PersonReference'
         deliusEventNumber:
           $ref: '#/components/schemas/DeliusEventNumber'
-        mappaCategories:
+        mappa:
           type: string
-          example: 'M2'
+          example: 'CAT C3/LEVEL L2'
         sentenceLengthInMonths:
           type: integer
           example: 57
-        offenceDescription:
+        offenceId:
           type: string
-          example: 'Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801'
+          example: 'AB43782'
         releaseType:
           type: string
-          example: 'Release on Temporary Licence (ROTL)'
+          example: 'rotl'
         age:
           type: integer
           example: 43

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -279,6 +279,7 @@ components:
     EventId:
       description: The UUID of an event
       type: string
+      format: uuid
       example: 364145f9-0af8-488e-9901-b4c46cd9ba37
     DeliusEventNumber:
       description: Used in Delius to identify the 'event' via the first active conviction's 'index'
@@ -287,6 +288,7 @@ components:
     ApplicationId:
       description: The UUID of an application for an AP place
       type: string
+      format: uuid
       example: 484b8b5e-6c3b-4400-b200-425bbe410713
     ApplicationUrl:
       description: The URL on the Approved Premises service at which a user can view a representation of an AP application and related resources, including bookings
@@ -295,6 +297,7 @@ components:
     BookingId:
       description: The UUID of booking for an AP place
       type: string
+      format: uuid
       example: 14c80733-4b6d-4f35-b724-66955aac320c
     LegacyApCode:
       description: The 'Q code' used in Delius to identify an Approved Premises

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class DomainEventEntityFactory : Factory<DomainEventEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var type: Yielded<DomainEventType> = { DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
+  private var occurredAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var data: Yielded<String> = { "{}" }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withType(type: DomainEventType) = apply {
+    this.type = { type }
+  }
+
+  fun withOccurredAt(occurredAt: OffsetDateTime) = apply {
+    this.occurredAt = { occurredAt }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withData(data: String) = apply {
+    this.data = { data }
+  }
+
+  override fun produce(): DomainEventEntity = DomainEventEntity(
+    id = this.id(),
+    applicationId = this.applicationId(),
+    crn = this.crn(),
+    type = this.type(),
+    occurredAt = this.occurredAt(),
+    createdAt = this.createdAt(),
+    data = this.data()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationSubmittedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationSubmittedFactory.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmitted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedSubmittedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Ldu
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Region
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Team
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApplicationSubmittedFactory : Factory<ApplicationSubmitted> {
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
+  private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var mappa: Yielded<String> = { "CAT C3/LEVEL L2" }
+  private var offenceId: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
+  private var releaseType: Yielded<String> = { "rotl" }
+  private var age: Yielded<Int> = { randomInt(18, 99) }
+  private var gender: Yielded<ApplicationSubmitted.Gender> = { randomOf(listOf(ApplicationSubmitted.Gender.male, ApplicationSubmitted.Gender.female)) }
+  private var targetLocation: Yielded<String> = { randomOf(listOf("AB", "KY", "L")) }
+  private var submittedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var submittedByStaffMember: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var submittedByProbationArea: Yielded<ProbationArea> = { ProbationAreaFactory().produce() }
+  private var submittedByCru: Yielded<Cru> = { CruFactory().produce() }
+  private var submittedByTeam: Yielded<Team> = { TeamFactory().produce() }
+  private var submittedByLdu: Yielded<Ldu> = { LduFactory().produce() }
+  private var submittedByRegion: Yielded<Region> = { RegionFactory().produce() }
+  private var sentenceLengthInMonths: Yielded<Int?> = { null }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withApplicationUrl(applicationUrl: String) = apply {
+    this.applicationUrl = { applicationUrl }
+  }
+
+  fun withPersonReference(personReference: PersonReference) = apply {
+    this.personReference = { personReference }
+  }
+
+  fun withDeliusEventNumber(deliusEventNumber: String) = apply {
+    this.deliusEventNumber = { deliusEventNumber }
+  }
+
+  fun withMappa(mappa: String) = apply {
+    this.mappa = { mappa }
+  }
+
+  fun withOffenceId(offenceId: String) = apply {
+    this.offenceId = { offenceId }
+  }
+
+  fun withReleaseType(releaseType: String) = apply {
+    this.releaseType = { releaseType }
+  }
+
+  fun withAge(age: Int) = apply {
+    this.age = { age }
+  }
+
+  fun withGender(gender: ApplicationSubmitted.Gender) = apply {
+    this.gender = { gender }
+  }
+
+  fun withTargetLocation(targetLocation: String) = apply {
+    this.targetLocation = { targetLocation }
+  }
+
+  fun withSubmittedAt(submittedAt: OffsetDateTime) = apply {
+    this.submittedAt = { submittedAt }
+  }
+
+  fun withSubmittedByStaffMember(staffMember: StaffMember) = apply {
+    this.submittedByStaffMember = { staffMember }
+  }
+
+  fun withSubmittedByProbationArea(probationArea: ProbationArea) = apply {
+    this.submittedByProbationArea = { probationArea }
+  }
+
+  fun withSubmittedByCru(cru: Cru) = apply {
+    this.submittedByCru = { cru }
+  }
+
+  fun withSubmittedByTeam(team: Team) = apply {
+    this.submittedByTeam = { team }
+  }
+
+  fun withSubmittedByLdu(ldu: Ldu) = apply {
+    this.submittedByLdu = { ldu }
+  }
+
+  fun withSubmittedByRegion(region: Region) = apply {
+    this.submittedByRegion = { region }
+  }
+
+  fun withSentenceLengthInMonths(sentenceLengthInMonths: Int?) = apply {
+    this.sentenceLengthInMonths = { sentenceLengthInMonths }
+  }
+
+  override fun produce() = ApplicationSubmitted(
+    applicationId = this.applicationId(),
+    applicationUrl = this.applicationUrl(),
+    personReference = this.personReference(),
+    deliusEventNumber = this.deliusEventNumber(),
+    mappa = this.mappa(),
+    offenceId = this.offenceId(),
+    releaseType = this.releaseType(),
+    age = this.age(),
+    gender = this.gender(),
+    targetLocation = this.targetLocation(),
+    submittedAt = this.submittedAt(),
+    submittedBy = ApplicationSubmittedSubmittedBy(
+      staffMember = this.submittedByStaffMember(),
+      probationArea = this.submittedByProbationArea(),
+      cru = this.submittedByCru(),
+      team = this.submittedByTeam(),
+      ldu = this.submittedByLdu(),
+      region = this.submittedByRegion()
+    ),
+    sentenceLengthInMonths = this.sentenceLengthInMonths()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/CruFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/CruFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class CruFactory : Factory<Cru> {
+  private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce() = Cru(
+    code = this.code(),
+    name = this.name()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/LduFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/LduFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Ldu
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class LduFactory : Factory<Ldu> {
+  private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce() = Ldu(
+    code = this.code(),
+    name = this.name()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonReferenceFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonReferenceFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class PersonReferenceFactory : Factory<PersonReference> {
+  private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var noms: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withNoms(noms: String) = apply {
+    this.noms = { noms }
+  }
+
+  override fun produce() = PersonReference(
+    crn = this.crn(),
+    noms = this.noms()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ProbationAreaFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ProbationAreaFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class ProbationAreaFactory : Factory<ProbationArea> {
+  private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce() = ProbationArea(
+    code = this.code(),
+    name = this.name()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RegionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RegionFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Region
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class RegionFactory : Factory<Region> {
+  private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce() = Region(
+    code = this.code(),
+    name = this.name()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/StaffMemberFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/StaffMemberFactory.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+
+class StaffMemberFactory : Factory<StaffMember> {
+  private var staffCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var staffIdentifier: Yielded<Long> = { randomInt(1000, 5000).toLong() }
+  private var forenames: Yielded<String> = { randomStringUpperCase(6) }
+  private var surname: Yielded<String> = { randomStringUpperCase(6) }
+  private var username: Yielded<String> = { randomStringUpperCase(8) }
+
+  fun withStaffCode(staffCode: String) = apply {
+    this.staffCode = { staffCode }
+  }
+
+  fun withStaffIdentifier(staffIdentifier: Long) = apply {
+    this.staffIdentifier = { staffIdentifier }
+  }
+
+  fun withForenames(forenames: String) = apply {
+    this.forenames = { forenames }
+  }
+
+  fun withSurname(surname: String) = apply {
+    this.surname = { surname }
+  }
+
+  fun withUsername(username: String) = apply {
+    this.username = { username }
+  }
+
+  override fun produce(): StaffMember = StaffMember(
+    staffCode = this.staffCode(),
+    staffIdentifier = this.staffIdentifier(),
+    forenames = this.forenames(),
+    surname = this.surname(),
+    username = this.username()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/TeamFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/TeamFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Team
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class TeamFactory : Factory<Team> {
+  private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce() = Team(
+    code = this.code(),
+    name = this.name()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
@@ -66,6 +67,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Characteristi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
@@ -103,6 +105,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DomainEventTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExtensionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedReasonTestRepository
@@ -235,6 +238,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var bedRepository: BedRepository
 
+  @Autowired
+  lateinit var domainEventRepository: DomainEventTestRepository
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
@@ -266,6 +272,7 @@ abstract class IntegrationTestBase {
   lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
   lateinit var roomEntityFactory: PersistedFactory<RoomEntity, UUID, RoomEntityFactory>
   lateinit var bedEntityFactory: PersistedFactory<BedEntity, UUID, BedEntityFactory>
+  lateinit var domainEventFactory: PersistedFactory<DomainEventEntity, UUID, DomainEventEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -325,6 +332,7 @@ abstract class IntegrationTestBase {
     characteristicEntityFactory = PersistedFactory({ CharacteristicEntityFactory() }, characteristicRepository)
     roomEntityFactory = PersistedFactory({ RoomEntityFactory() }, roomRepository)
     bedEntityFactory = PersistedFactory({ BedEntityFactory() }, bedRepository)
+    domainEventFactory = PersistedFactory({ DomainEventEntityFactory() }, domainEventRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import java.util.UUID
+
+@Repository
+interface DomainEventTestRepository : JpaRepository<DomainEventEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -1,0 +1,136 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationSubmittedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class DomainEventServiceTest {
+  private val domainEventRespositoryMock = mockk<DomainEventRepository>()
+
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
+  private val domainEventService = DomainEventService(
+    objectMapper = objectMapper,
+    domainEventRepository = domainEventRespositoryMock
+  )
+
+  @Test
+  fun `getApplicationSubmittedDomainEvent returns null when no event does not exist`() {
+    val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
+
+    every { domainEventRespositoryMock.findByIdOrNull(id) } returns null
+
+    assertThat(domainEventService.getApplicationSubmittedDomainEvent(id)).isNull()
+  }
+
+  @Test
+  fun `getApplicationSubmittedDomainEvent returns event`() {
+    val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
+    val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
+    val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
+    val crn = "CRN"
+
+    val data = ApplicationSubmittedEnvelope(
+      id = id,
+      timestamp = occurredAt,
+      eventType = "approved-premises.application.submitted",
+      eventDetails = ApplicationSubmittedFactory().produce()
+    )
+
+    every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
+      .withId(id)
+      .withApplicationId(applicationId)
+      .withCrn(crn)
+      .withType(DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED)
+      .withData(objectMapper.writeValueAsString(data))
+      .withOccurredAt(occurredAt)
+      .produce()
+
+    val event = domainEventService.getApplicationSubmittedDomainEvent(id)
+    assertThat(event).isEqualTo(
+      DomainEvent(
+        id = id,
+        applicationId = applicationId,
+        crn = "CRN",
+        occurredAt = occurredAt,
+        data = data
+      )
+    )
+  }
+
+  @Test
+  fun `save throws for unrecognised event type`() {
+    val exception = assertThrows<RuntimeException> {
+      domainEventService.save(
+        DomainEvent<String>(
+          id = UUID.fromString("1a520974-d5d6-49a4-9ce1-827427dd489f"),
+          applicationId = UUID.fromString("ea100c7f-2e16-4280-b1b2-d2f666a6dcd1"),
+          crn = "CRN123",
+          occurredAt = OffsetDateTime.now(),
+          data = "some data"
+        )
+      )
+    }
+
+    assertThat(exception.message).isEqualTo("Unrecognised domain event type: java.lang.String")
+  }
+
+  @Test
+  fun `save persists event`() {
+    val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
+    val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
+    val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
+    val crn = "CRN"
+
+    every { domainEventRespositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
+
+    val domainEventToSave = DomainEvent(
+      id = id,
+      applicationId = applicationId,
+      crn = crn,
+      occurredAt = OffsetDateTime.now(),
+      data = ApplicationSubmittedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = "approved-premises.application.submitted",
+        eventDetails = ApplicationSubmittedFactory().produce()
+      )
+    )
+
+    domainEventService.save(domainEventToSave)
+
+    verify(exactly = 1) {
+      domainEventRespositoryMock.save(
+        match {
+          it.id == domainEventToSave.id &&
+            it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED &&
+            it.crn == domainEventToSave.crn &&
+            it.occurredAt == domainEventToSave.occurredAt &&
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the groundwork for Domain Events. 

A `DomainEventService` provides a mechanism for saving and retrieving the events.  They are stored in a single database table with the bulk of the event being kept in a JSON column to avoid having to create and maintain a table structure for each type of event.

Perhaps controversially: the data stored in the table is serialized from/deserializes to the same model as is returned by the endpoints to avoid the maintenance overhead of keeping an identical "domain" version of each event and transforming between them.