### PR TITLE
Prod deploys use the prepared CircleCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ workflows:
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           context:
             - hmpps-common-vars
-            - approved-premises-api-prod
+            - hmpps-approved-premises-api-prod
           requires:
             - request-prod-approval
 


### PR DESCRIPTION
The bootstrap creates a CircleCI context that includes the hmpps prefix.

By using the old api name here we are effectively not providing a context so circleci uses the default environment variables, which are dev ones.

Therefore, prod containers try to deploy to the dev namespace.

You'll see this set correctly for [preprod here](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/.circleci/config.yml#L58) along with the other environments.