### PR TITLE
Don't sample health endpoints with Sentry

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/TracesSamplerCallback.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/TracesSamplerCallback.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import io.sentry.SamplingContext
+import io.sentry.SentryOptions
+import org.springframework.http.server.PathContainer
+import org.springframework.stereotype.Component
+import org.springframework.web.util.pattern.PathPatternParser
+
+@Component
+class TracesSamplerCallback() : SentryOptions.TracesSamplerCallback {
+  private val ignoredPathPatterns = listOf("/health/**").let {
+    val parser = PathPatternParser()
+
+    it.map { pattern -> parser.parse(pattern) }
+  }
+
+  override fun sample(context: SamplingContext): Double? {
+    val parentSampled = context.transactionContext.parentSampled
+    if (parentSampled != null) {
+      return if (parentSampled) 1.0 else 0.0
+    }
+
+    val path = PathContainer.parsePath(removeHttpMethodPrefix(context.transactionContext.name))
+
+    if (ignoredPathPatterns.any { it.matches(path) }) {
+      return 0.0
+    }
+
+    return null
+  }
+
+  private fun removeHttpMethodPrefix(transactionName: String) = transactionName
+    .replace("GET ", "")
+    .replace("PUT ", "")
+    .replace("POST ", "")
+    .replace("PATCH ", "")
+    .replace("DELETE ", "")
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/TracesSamplerCallbackTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/TracesSamplerCallbackTest.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.config
+
+import io.mockk.every
+import io.mockk.mockk
+import io.sentry.SamplingContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.TracesSamplerCallback
+
+class TracesSamplerCallbackTest {
+  private val tracesSamplerCallback = TracesSamplerCallback()
+
+  @ParameterizedTest
+  @ValueSource(strings = ["/health", "/health/ping", "/health/readiness", "/health/liveness"])
+  fun `Health endpoints are not sampled`(endpoint: String) {
+    val mockedContext = mockk<SamplingContext>()
+
+    every { mockedContext.transactionContext.parentSampled } returns null
+    every { mockedContext.transactionContext.name } returns "GET $endpoint"
+
+    val result = tracesSamplerCallback.sample(mockedContext)
+
+    assertThat(result).isEqualTo(0.0)
+  }
+
+  @Test
+  fun `No decision is taken on other endpoints (falls back to sample rate config)`() {
+    val mockedContext = mockk<SamplingContext>()
+
+    every { mockedContext.transactionContext.parentSampled } returns null
+    every { mockedContext.transactionContext.name } returns "GET /premises"
+
+    val result = tracesSamplerCallback.sample(mockedContext)
+
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `Child traces are always sampled`() {
+    val mockedContext = mockk<SamplingContext>()
+
+    every { mockedContext.transactionContext.parentSampled } returns true
+    every { mockedContext.transactionContext.name } returns "GET /premises"
+
+    val result = tracesSamplerCallback.sample(mockedContext)
+
+    assertThat(result).isEqualTo(1.0)
+  }
+}


### PR DESCRIPTION
The /health/** endpoints are currently using up too much of our Sentry quota for Distributed Tracing. This prevents them from being sampled.

https://docs.sentry.io/platforms/java/guides/spring-boot/configuration/filtering/#using-platformidentifier-nametraces-sampler-
