### PR TITLE
Filter premises by user region

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -121,7 +121,7 @@ class PremisesController(
     return ResponseEntity.ok(premisesTransformer.transformJpaToApi(updatedPremises, updatedPremises.totalBeds))
   }
 
-  override fun premisesGet(xServiceName: ServiceName?): ResponseEntity<List<Premises>> {
+  override fun premisesGet(xServiceName: ServiceName?, xUserRegion: UUID?): ResponseEntity<List<Premises>> {
     val premises = if (xServiceName == null) {
       premisesService.getAllPremises()
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -122,10 +122,11 @@ class PremisesController(
   }
 
   override fun premisesGet(xServiceName: ServiceName?, xUserRegion: UUID?): ResponseEntity<List<Premises>> {
-    val premises = if (xServiceName == null) {
-      premisesService.getAllPremises()
-    } else {
-      premisesService.getAllPremisesForService(xServiceName)
+    val premises = when {
+      xServiceName == null && xUserRegion == null -> premisesService.getAllPremises()
+      xServiceName != null && xUserRegion != null -> premisesService.getAllPremisesInRegionForService(xUserRegion, xServiceName)
+      xServiceName != null -> premisesService.getAllPremisesForService(xServiceName)
+      else -> premisesService.getAllPremisesInRegion(xUserRegion!!)
     }
 
     return ResponseEntity.ok(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -23,8 +23,13 @@ import javax.persistence.Table
 
 @Repository
 interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
+  fun findAllByProbationRegion_Id(probationRegionId: UUID): List<PremisesEntity>
+
   @Query("SELECT p FROM PremisesEntity p WHERE TYPE(p) = :type")
   fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesEntity>
+
+  @Query("SELECT p FROM PremisesEntity p WHERE p.probationRegion.id = :probationRegionId AND TYPE(p) = :type")
+  fun <T : PremisesEntity> findAllByProbationRegion_IdAndType(probationRegionId: UUID, type: Class<T>): List<PremisesEntity>
 
   @Query("SELECT COUNT(p) = 0 FROM PremisesEntity p WHERE name = :name AND TYPE(p) = :type")
   fun <T : PremisesEntity> nameIsUniqueForType(name: String, type: Class<T>): Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -40,8 +40,17 @@ class PremisesService(
 
   fun getAllPremises(): List<PremisesEntity> = premisesRepository.findAll()
 
+  fun getAllPremisesInRegion(probationRegionId: UUID): List<PremisesEntity> = premisesRepository.findAllByProbationRegion_Id(probationRegionId)
+
   fun getAllPremisesForService(service: ServiceName) = serviceNameToEntityType[service]?.let {
     premisesRepository.findAllByType(it)
+  } ?: listOf()
+
+  fun getAllPremisesInRegionForService(
+    probationRegionId: UUID,
+    service: ServiceName
+  ): List<PremisesEntity> = serviceNameToEntityType[service]?.let {
+    premisesRepository.findAllByProbationRegion_IdAndType(probationRegionId, it)
   } ?: listOf()
 
   fun getPremises(premisesId: UUID): PremisesEntity? = premisesRepository.findByIdOrNull(premisesId)

--- a/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
+++ b/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
@@ -7,6 +7,14 @@ insert into "premises" ("address_line1", "id", "local_authority_area_id", "name"
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('2 Somewhere', 'e03c82e9-f335-414a-87a0-866060397d4a', '7de4177b-9177-4c28-9bb6-5f5292619546', 'Bedford AP', 'Notes', 'GL56 0QQ', '0544d95a-f6bb-43f8-9be7-aae66e3bf244', 'approved-premises', 'active', 30) ON CONFLICT (id) DO NOTHING;
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 4', 'b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'f66f8c8d-e811-471a-9f4d-45d4046c6f79', 'Fourth Avenue', NULL, 'FY1 7VG', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
 
+-- Premises for Temporary Accommodation E2E tests
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('1 Bishop St', 'd6447105-4bfe-4f1e-add7-4668e1ca28b0', '463bd776-6466-48b9-a4fa-d77b8fd869f5', 'BISHOP1', NULL, 'CT22 4BH', 'db82d408-d440-4eb5-960b-119cb33427cd', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('2 Bishop St', 'e2543d2f-33a9-454b-ae15-03ca0475faa3', '463bd776-6466-48b9-a4fa-d77b8fd869f5', 'BISHOP2', NULL, 'CT22 4BH', 'db82d408-d440-4eb5-960b-119cb33427cd', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('3 Bishop St', '0ad5999f-a07c-4605-b875-81d7a17e9f70', '463bd776-6466-48b9-a4fa-d77b8fd869f5', 'BISHOP3', NULL, 'CT22 4BH', 'db82d408-d440-4eb5-960b-119cb33427cd', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('11 Pavilion Rise', '70a6046c-23fc-4a30-b151-582ffd509e6a', '0dd9476c-4058-4574-a35d-f846588b047c', 'PAVILION11', NULL, 'SS18 3PK', 'ca979718-b15d-4318-9944-69aaff281cad', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('12 Pavilion Rise', '6aa177cb-617f-4abb-be46-056ea7e4a59d', '0dd9476c-4058-4574-a35d-f846588b047c', 'PAVILION12', NULL, 'SS18 3PK', 'ca979718-b15d-4318-9944-69aaff281cad', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
+insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('13 Pavilion Rise', '773431cd-f560-4be8-9e6f-b582a4ebf204', '0dd9476c-4058-4574-a35d-f846588b047c', 'PAVILION13', NULL, 'SS18 3PK', 'ca979718-b15d-4318-9944-69aaff281cad', 'temporary-accommodation', 'active', 0) ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO approved_premises (premises_id, q_code, ap_code) VALUES
     ('459eeaba-55ac-4a1f-bae2-bad810d4016b', 'Q022', 'BCKNHAM'),
     ('e03c82e9-f335-414a-87a0-866060397d4a', 'Q005', 'BDFORD')
@@ -17,5 +25,11 @@ INSERT INTO temporary_accommodation_premises (premises_id, pdu) VALUES
     ('d33006b7-55d9-4a8e-b722-5e18093dbcdf', 'Cumbria'),
     ('ada106c7-e1fb-409a-a38e-0002ea8e7e45', 'Camden and Islington'),
     ('36c7b1f2-5a4b-467b-838c-2970c9c253cf', 'Swansea, Neath Port Talbot'),
-    ('b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'North West Lancashire (Blackpool and lower tier LAs in Lancashire - Fylde, Wyre and Lancaster)')
+    ('b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d', 'North West Lancashire (Blackpool and lower tier LAs in Lancashire - Fylde, Wyre and Lancaster)'),
+    ('d6447105-4bfe-4f1e-add7-4668e1ca28b0', 'East Kent (Swale, Ashford, Canterbury, Folkstone and Hythe, Thanet and Dover)'),
+    ('e2543d2f-33a9-454b-ae15-03ca0475faa3', 'East Kent (Swale, Ashford, Canterbury, Folkstone and Hythe, Thanet and Dover)'),
+    ('0ad5999f-a07c-4605-b875-81d7a17e9f70', 'East Kent (Swale, Ashford, Canterbury, Folkstone and Hythe, Thanet and Dover)'),
+    ('70a6046c-23fc-4a30-b151-582ffd509e6a', 'Essex South (Basildon, Brentwood, Rochford and Castlepoint, Southend-on-Sea)'),
+    ('6aa177cb-617f-4abb-be46-056ea7e4a59d', 'Essex South (Basildon, Brentwood, Rochford and Castlepoint, Southend-on-Sea)'),
+    ('773431cd-f560-4be8-9e6f-b582a4ebf204', 'Essex South (Basildon, Brentwood, Rochford and Castlepoint, Southend-on-Sea)')
 ON CONFLICT (premises_id) DO NOTHING;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -17,6 +17,13 @@ paths:
           description: If given, only premises for this service will be returned
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: X-User-Region
+          in: header
+          required: false
+          description: If given, only premises within this region will be returned
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
> See [ticket #765 on the CAS3 Trello board](https://trello.com/c/xv01P30x/765-minimal-api-authorisation-work-for-regional-filtering).

Currently, the API does not provide a way to restrict users to only be able to access premises within their probation region. This is needed in order to onboard the Greater Manchester team so that they do not interact with East of England premises (and vice versa).

This PR introduces the ability for filtering premises by region in the `GET /premises` endpoint. This filtering is enabled by setting the value of the `X-User-Region` header to the ID of the probation region for the current user. The existing behaviour (i.e. no filtering) is preserved if this header is not supplied to avoid a breaking change.

Currently, the API trusts that the client (in this case, the Temporary Accommodation UI) supplies the correct probation region ID for the user, and does not check for correctness. Further work to prevent circumventing the region restriction is planned soon (see: [ticket #770 on the CAS3 Trello board](https://trello.com/c/mDxlIttG/770-protect-against-users-circumventing-property-filtering)), but these extra precautions are not considered to be blocking the onboarding of a second regional team to the TA service.