### PR TITLE
Fix assessment discrimination

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -33,7 +35,7 @@ class AssessmentTransformer(
       allocatedAt = jpa.allocatedAt,
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
-      allocatedToStaffMember = userTransformer.transformJpaToApi(jpa.allocatedToUser, ServiceName.approvedPremises),
+      allocatedToStaffMember = userTransformer.transformJpaToApi(jpa.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
       submittedAt = jpa.submittedAt,
       decision = transformJpaDecisionToApi(jpa.decision),
       rejectionRationale = jpa.rejectionRationale,
@@ -48,7 +50,7 @@ class AssessmentTransformer(
       allocatedAt = jpa.allocatedAt,
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
-      allocatedToStaffMember = userTransformer.transformJpaToApi(jpa.allocatedToUser, ServiceName.temporaryAccommodation),
+      allocatedToStaffMember = userTransformer.transformJpaToApi(jpa.allocatedToUser, ServiceName.temporaryAccommodation) as TemporaryAccommodationUser,
       submittedAt = jpa.submittedAt,
       decision = transformJpaDecisionToApi(jpa.decision),
       rejectionRationale = jpa.rejectionRationale,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3219,8 +3219,6 @@ components:
         id:
           type: string
           format: uuid
-        allocatedToStaffMember:
-          $ref: '#/components/schemas/User'
         schemaVersion:
           type: string
           format: uuid
@@ -3274,6 +3272,8 @@ components:
           properties:
             application:
               $ref: '#/components/schemas/ApprovedPremisesApplication'
+            allocatedToStaffMember:
+              $ref: '#/components/schemas/ApprovedPremisesUser'
           required:
             - application
     TemporaryAccommodationAssessment:
@@ -3283,6 +3283,8 @@ components:
           properties:
             application:
               $ref: '#/components/schemas/TemporaryAccommodationApplication'
+            allocatedToStaffMember:
+              $ref: '#/components/schemas/TemporaryAccommodationUser'
           required:
             - application
     AssessmentDecision:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -8,9 +8,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
@@ -65,7 +66,7 @@ class AssessmentTransformerTest {
     .withSubmittedAt(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
     .withAllocatedToUser(allocatedToUser)
 
-  private val user = mockk<User>()
+  private val user = mockk<ApprovedPremisesUser>()
 
   @BeforeEach
   fun setup() {
@@ -78,7 +79,7 @@ class AssessmentTransformerTest {
   fun `transformJpaToApi transforms correctly`() {
     val assessment = assessmentFactory.produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk()) as ApprovedPremisesAssessment
 
     assertThat(result.id).isEqualTo(UUID.fromString("7d0d3b38-5bc3-45c7-95eb-4d714cbd0db1"))
     assertThat(result.schemaVersion).isEqualTo(UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"))


### PR DESCRIPTION
We want to return the correct type of user depending on the service. The API is returning the expected user type already, so this is for documentation and ensuring the correct frontend types are generated.