### PR TITLE
Restrict bookings reports based on user region

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
@@ -6,16 +6,24 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReportsApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ReportService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import java.io.ByteArrayOutputStream
 import java.util.UUID
 
 @Service
 class ReportsController(
   private val reportService: ReportService,
+  private val userAccessService: UserAccessService,
 ) : ReportsApiDelegate {
   override fun reportsBookingsGet(xServiceName: ServiceName, probationRegionId: UUID?): ResponseEntity<Resource> {
+    when {
+      probationRegionId == null && !userAccessService.currentUserHasAllRegionsAccess() -> throw ForbiddenProblem()
+      probationRegionId != null && !userAccessService.currentUserCanAccessRegion(probationRegionId) -> throw ForbiddenProblem()
+    }
+
     val properties = BookingsReportProperties(xServiceName, probationRegionId)
     val outputStream = ByteArrayOutputStream()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.util.UUID
+import javax.servlet.http.HttpServletRequest
+
+@Service
+class UserAccessService(
+  private val userService: UserService,
+  private val currentRequest: HttpServletRequest,
+) {
+  fun currentUserCanAccessRegion(probationRegionId: UUID) =
+    userCanAccessRegion(userService.getUserForRequest(), probationRegionId)
+
+  fun userCanAccessRegion(user: UserEntity, probationRegionId: UUID) =
+    userHasAllRegionsAccess(user) || user.probationRegion.id == probationRegionId
+
+  fun currentUserHasAllRegionsAccess() = userHasAllRegionsAccess(userService.getUserForRequest())
+
+  fun userHasAllRegionsAccess(user: UserEntity) =
+    when (currentRequest.getHeader("X-Service-Name")) {
+      // TODO: Revisit once Temporary Accommodation introduces user roles
+      ServiceName.temporaryAccommodation.value -> false
+      // TODO: Revisit if Approved Premises introduces region-limited access
+      else -> true
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -14,8 +14,35 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import java.util.UUID
 
 class ReportsTest : IntegrationTestBase() {
+  @Test
+  fun `Get bookings report for all regions returns 403 Forbidden if user does not have all regions access`() {
+    `Given a User` { _, jwt ->
+      webTestClient.get()
+        .uri("/reports/bookings")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `Get bookings report for a region returns 403 Forbidden if user cannot access the specified region`() {
+    `Given a User` { _, jwt ->
+      webTestClient.get()
+        .uri("/reports/bookings?probationRegionId=${UUID.randomUUID()}")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
   @Test
   fun `Get bookings report returns OK with correct body`() {
     `Given a User` { userEntity, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1,0 +1,126 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
+import javax.servlet.http.HttpServletRequest
+
+class UserAccessServiceTest {
+  private val userService = mockk<UserService>()
+  private val currentRequest = mockk<HttpServletRequest>()
+
+  private val userAccessService = UserAccessService(
+    userService,
+    currentRequest,
+  )
+
+  private val probationRegionId = UUID.randomUUID()
+  private val user = UserEntityFactory()
+    .withProbationRegion(
+      ProbationRegionEntityFactory()
+        .withId(probationRegionId)
+        .withApArea(
+          ApAreaEntityFactory()
+            .produce()
+        )
+        .produce()
+    )
+    .produce()
+
+  @Test
+  fun `userHasAllRegionsAccess returns false if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+
+    assertThat(userAccessService.userHasAllRegionsAccess(user)).isFalse
+  }
+
+  @Test
+  fun `userHasAllRegionsAccess returns true if the current request has 'X-Service-Name' header with value 'approved-premises'`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
+
+    assertThat(userAccessService.userHasAllRegionsAccess(user)).isTrue
+  }
+
+  @Test
+  fun `userHasAllRegionsAccess returns true by default`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "arbitrary-value"
+
+    assertThat(userAccessService.userHasAllRegionsAccess(user)).isTrue
+  }
+
+  @Test
+  fun `currentUserHasAllRegionsAccess returns false if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+    every { userService.getUserForRequest() } returns user
+
+    assertThat(userAccessService.currentUserHasAllRegionsAccess()).isFalse
+  }
+
+  @Test
+  fun `currentUserHasAllRegionsAccess returns true if the current request has 'X-Service-Name' header with value 'approved-premises'`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
+    every { userService.getUserForRequest() } returns user
+
+    assertThat(userAccessService.currentUserHasAllRegionsAccess()).isTrue
+  }
+
+  @Test
+  fun `currentUserHasAllRegionsAccess returns true by default`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "arbitrary-value"
+    every { userService.getUserForRequest() } returns user
+
+    assertThat(userAccessService.currentUserHasAllRegionsAccess()).isTrue
+  }
+
+  @Test
+  fun `userCanAccessRegion returns false if the current user does not have all regions access and their probation region ID does not equal the specified ID`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+
+    assertThat(userAccessService.userCanAccessRegion(user, UUID.randomUUID())).isFalse
+  }
+
+  @Test
+  fun `userCanAccessRegion returns true if the current user has all regions access`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
+
+    assertThat(userAccessService.userCanAccessRegion(user, UUID.randomUUID())).isTrue
+  }
+
+  @Test
+  fun `userCanAccessRegion returns true if the current user's probation region ID is equal to the specified ID`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+
+    assertThat(userAccessService.userCanAccessRegion(user, probationRegionId)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanAccessRegion returns false if the current user does not have all regions access and their probation region ID does not equal the specified ID`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+    every { userService.getUserForRequest() } returns user
+
+    assertThat(userAccessService.currentUserCanAccessRegion(UUID.randomUUID())).isFalse
+  }
+
+  @Test
+  fun `currentUserCanAccessRegion returns true if the current user has all regions access`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
+    every { userService.getUserForRequest() } returns user
+
+    assertThat(userAccessService.currentUserCanAccessRegion(UUID.randomUUID())).isTrue
+  }
+
+  @Test
+  fun `currentUserCanAccessRegion returns true if the current user's probation region ID is equal to the specified ID`() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+    every { userService.getUserForRequest() } returns user
+
+    assertThat(userAccessService.currentUserCanAccessRegion(probationRegionId)).isTrue
+  }
+}


### PR DESCRIPTION
> See [ticket #770 on the CAS3 Trello board](https://trello.com/c/mDxlIttG/770-protect-against-users-circumventing-property-filtering).

This PR is the first part of the additional work to restrict users of the Temporary Accommodation service from accessing data belong to regions they are not in. It introduces the `UserAccessService` which can be used to determine whether the current user can access a particular region's data or all regions' data (which will be more important once the TA service distinguishes users by role).

The new `UserAccessService` is used to restrict requests to the `ReportsController`, such that:
- A Temporary Accommodation user can no longer request reports for a region they are not in if they were able to coerce the frontend UI to do so. A `403 Forbidden` response will be returned instead.
- A Temporary Accommodation user can no longer request reports for all regions. This functionality is needed in the future, but only for users with specific roles, and is essentially disabled until user roles is implemented for TA. The `UserAccessService` has been designed to allow this change to be made in a straightforward way when needed.
- An Approved Premises user can request reports without any restrictions. This is particularly important in this case (as AP does not currently use this report), but allows shared endpoints in upcoming PRs to use the same `UserAccessService` methods while preserving backwards compatibility for AP. Like above, if AP require region restrictions in the future, this change should be straightforward to implement.