### PR TITLE
(1216) Fetch assessment for application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -19,7 +19,7 @@ import javax.persistence.Table
 @Repository
 interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   fun findAllByAllocatedToUser_Id(userId: UUID): List<AssessmentEntity>
-  fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity
+  fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 }
 
 @Entity

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1476,6 +1476,32 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /applications/{applicationId}/assessment:
+    get:
+      tags:
+        - Operations on applications
+      summary: Get the assessment for an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Assessment'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /reference-data/departure-reasons:
     get:
       tags:


### PR DESCRIPTION
This adds a new `applications/{id}/assessment` endpoint to allow us to get an application's correct assessment. This will allow us to easily fetch the latest assessment for an application together with the application data, which we need for allocations.