### PR TITLE
1226 - Migration process to update users from Community API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
 
 COPY --from=builder --chown=appuser:appgroup /app/script/run_seed_job /app
-RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job
+COPY --from=builder --chown=appuser:appgroup /app/script/run_migration_job /app
+RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job && chmod +x /app/run_migration_job
 
 USER 2000
 

--- a/doc/how-to/run_migration_job_remotely.md
+++ b/doc/how-to/run_migration_job_remotely.md
@@ -1,0 +1,18 @@
+# How to run a migration job remotely
+
+To run a migration job against a non-local environment:
+
+- Ensure nobody is deploying a change (or is going to deploy a change shortly.)
+- Run `kubectl get pod` against the namespace for the environment you wish to run the seed job in.
+- Copy the name of one of the running `hmpps-approved-premises-api` pods.
+- Run the helper script from within the container to trigger the migration job:
+  ```
+  kubectl exec --stdin --tty {pod name} -- /bin/bash
+  /app/run_migration_job {job type}
+  ```
+  Where `job type` is a value from the `MigrationJobType` enum in the OpenAPI spec.  e.g.
+  ```
+  kubectl exec --stdin --tty {pod name} -- /bin/bash
+  /app/run_migration_job update_all_users_from_community_api
+  ```
+- Check the logs via `kubectl logs {pod name}` to see how processing is progressing.

--- a/script/run_migration_job
+++ b/script/run_migration_job
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# script/run_migration_job: Run a migration job for given type.  e.g.
+#                           script/run_migration_job update_all_users_from_community_api
+
+set -e
+
+curl --location --request POST 'http://127.0.0.1:8080/migration-job' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jobType": "'$1'"
+}'
+
+echo "Requested job - check the application logs for processing status"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -44,6 +44,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
         authorize(HttpMethod.POST, "/seed", permitAll)
+        authorize(HttpMethod.POST, "/migration-job", permitAll)
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/MigrationJobController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/MigrationJobController.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.MigrationJobApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.UnauthenticatedProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+
+@Service
+class MigrationJobController(private val migrationJobService: MigrationJobService) : MigrationJobApiDelegate {
+  override fun migrationJobPost(migrationJobRequest: MigrationJobRequest): ResponseEntity<Unit> {
+    throwIfNotLoopbackRequest()
+
+    migrationJobService.runMigrationJob(migrationJobRequest.jobType)
+
+    return ResponseEntity(HttpStatus.ACCEPTED)
+  }
+
+  private fun throwIfNotLoopbackRequest() {
+    val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+    val remoteAddress = request.remoteAddr
+
+    if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
+      throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -23,7 +23,7 @@ class UsersController(
 ) : UsersApiDelegate {
 
   override fun usersIdGet(id: UUID, xServiceName: ServiceName): ResponseEntity<User> {
-    val userEntity = when (val result = userService.getUserForId(id)) {
+    val userEntity = when (val result = userService.updateUserFromCommunityApiById(id)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> result.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJob.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import java.util.UUID
+
+abstract class MigrationJob(
+  val id: UUID = UUID.randomUUID(),
+) {
+  abstract fun process()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationLogger.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationLogger.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class MigrationLogger {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun info(message: String) = log.info(message)
+  fun error(message: String) = log.error(message)
+  fun error(message: String, throwable: Throwable) = log.error(message, throwable)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
@@ -11,6 +11,14 @@ class UpdateAllUsersFromCommunityApiJob(
   private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun process() {
-    // TODO
+    userRepository.findAll().forEach {
+      log.info("Updating user ${it.id}")
+      try {
+        userService.updateUserFromCommunityApiById(it.id)
+      } catch (exception: Exception) {
+        log.error("Unable to update user ${it.id}", exception)
+      }
+      Thread.sleep(500)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class UpdateAllUsersFromCommunityApiJob(
+  private val userRepository: UserRepository,
+  private val userService: UserService
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun process() {
+    // TODO
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -256,7 +256,7 @@ class AssessmentService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    val assigneeUserResult = userService.getUserForId(userToAllocateToId)
+    val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId)
 
     val assigneeUser = when (assigneeUserResult) {
       is AuthorisableActionResult.Success -> assigneeUserResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.context.ApplicationContext
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
+
+@Service
+class MigrationJobService(
+  private val applicationContext: ApplicationContext,
+  private val transactionTemplate: TransactionTemplate,
+  private val migrationLogger: MigrationLogger
+) {
+  @Async
+  fun runMigrationJobAsync(migrationJobType: MigrationJobType) = runMigrationJob(migrationJobType)
+
+  fun runMigrationJob(migrationJobType: MigrationJobType) {
+    migrationLogger.info("Starting migration job request: $migrationJobType")
+
+    try {
+      val job: MigrationJob = when (migrationJobType) {
+        MigrationJobType.updateAllUsersFromCommunityApi -> UpdateAllUsersFromCommunityApiJob(
+          applicationContext.getBean(UserRepository::class.java),
+          applicationContext.getBean(UserService::class.java)
+        )
+      }
+
+      transactionTemplate.executeWithoutResult { job.process() }
+
+      migrationLogger.info("Finished migration job: $migrationJobType")
+    } catch (exception: Exception) {
+      migrationLogger.error("Unable to complete Migration Job", exception)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -45,7 +45,7 @@ class UserService(
     return userRepository.findAll(hasQualificationsAndRoles(qualifications, roles), Sort.by(Sort.Direction.ASC, "name"))
   }
 
-  fun getUserForId(id: java.util.UUID): AuthorisableActionResult<UserEntity> {
+  fun updateUserFromCommunityApiById(id: UUID): AuthorisableActionResult<UserEntity> {
     var user = userRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
     val staffUserDetailsResponse = communityApiClient.getStaffUserDetails(user.deliusUsername)
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2075,6 +2075,24 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /migration-job:
+    post:
+      summary: Starts a migration job (process for data migrations that can't be achieved solely via SQL migrations), can only be called from a local connection
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/MigrationJobRequest'
+        required: true
+      responses:
+        202:
+          description: successfully requested task
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /reports/bookings:
     get:
       tags:
@@ -3869,3 +3887,14 @@ components:
         - temporary_accommodation_premises
         - temporary_accommodation_bedspace
         - user
+    MigrationJobRequest:
+      type: object
+      properties:
+        jobType:
+          $ref: '#/components/schemas/MigrationJobType'
+      required:
+        - jobType
+    MigrationJobType:
+      type: string
+      enum:
+        - update_all_users_from_community_api

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class MigrationJobScaffoldingTest : SeedTestBase() {
+  @Test
+  fun `Requesting a Seed operation returns 202`() {
+    webTestClient.post()
+      .uri("/migration-job")
+      .bodyValue(
+        MigrationJobRequest(
+          jobType = MigrationJobType.updateAllUsersFromCommunityApi
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isAccepted
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobTestBase.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+abstract class MigrationJobTestBase : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @MockkBean
+  lateinit var mockMigrationLogger: MigrationLogger
+  protected val logEntries = mutableListOf<LogEntry>()
+
+  @BeforeEach
+  fun setUp() {
+    every { mockMigrationLogger.info(any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "info", null)
+    }
+    every { mockMigrationLogger.error(any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "error", null)
+    }
+    every { mockMigrationLogger.error(any(), any()) } answers {
+      logEntries += LogEntry(it.invocation.args[0] as String, "error", it.invocation.args[1] as Throwable)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundStaffUserDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
+
+class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
+  @Test
+  fun `All users are updated from Community API with a 500ms artificial delay`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val userOne = userEntityFactory.produceAndPersist {
+      withDeliusUsername("USER1")
+      withDeliusStaffCode(null)
+      withProbationRegion(probationRegion)
+    }
+
+    val userTwo = userEntityFactory.produceAndPersist {
+      withDeliusUsername("USER2")
+      withDeliusStaffCode(null)
+      withProbationRegion(probationRegion)
+    }
+
+    CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+      StaffUserDetailsFactory()
+        .withUsername(userOne.deliusUsername)
+        .withStaffCode("STAFFCODE1")
+        .produce()
+    )
+
+    CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+      StaffUserDetailsFactory()
+        .withUsername(userTwo.deliusUsername)
+        .withStaffCode("STAFFCODE2")
+        .produce()
+    )
+
+    val startTime = System.currentTimeMillis()
+    migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi)
+    val endTime = System.currentTimeMillis()
+
+    assertThat(endTime - startTime).isGreaterThan(500 * 2)
+
+    val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
+    val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!
+
+    assertThat(userOneAfterUpdate.deliusStaffCode).isEqualTo("STAFFCODE1")
+    assertThat(userTwoAfterUpdate.deliusStaffCode).isEqualTo("STAFFCODE2")
+  }
+
+  @Test
+  fun `Failure to update individual user does not stop processing`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val userOne = userEntityFactory.produceAndPersist {
+      withDeliusUsername("USER1")
+      withDeliusStaffCode(null)
+      withProbationRegion(probationRegion)
+    }
+
+    val userTwo = userEntityFactory.produceAndPersist {
+      withDeliusUsername("USER2")
+      withDeliusStaffCode(null)
+      withProbationRegion(probationRegion)
+    }
+
+    CommunityAPI_mockNotFoundStaffUserDetailsCall(userOne.deliusUsername)
+
+    CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+      StaffUserDetailsFactory()
+        .withUsername(userTwo.deliusUsername)
+        .withStaffCode("STAFFCODE2")
+        .produce()
+    )
+
+    migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi)
+
+    val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
+    val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!
+
+    assertThat(userOneAfterUpdate.deliusStaffCode).isEqualTo(null)
+    assertThat(userTwoAfterUpdate.deliusStaffCode).isEqualTo("STAFFCODE2")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CommunityAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CommunityAPI.kt
@@ -15,6 +15,12 @@ fun IntegrationTestBase.CommunityAPI_mockSuccessfulStaffUserDetailsCall(staffUse
     responseBody = staffUserDetails
   )
 
+fun IntegrationTestBase.CommunityAPI_mockNotFoundStaffUserDetailsCall(username: String) =
+  mockUnsuccessfulGetCall(
+    url = "/secure/staff/username/$username",
+    responseStatus = 404
+  )
+
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails: OffenderDetailSummary) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/offenders/crn/${offenderDetails.otherIds.crn}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1307,7 +1307,7 @@ class AssessmentServiceTest {
 
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
 
-    every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.NotFound()
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.NotFound()
 
     val result = assessmentService.reallocateAssessment(requestUser, assigneeUserId, UUID.randomUUID())
 
@@ -1332,7 +1332,7 @@ class AssessmentServiceTest {
 
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
 
-    every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.Success(
       UserEntityFactory()
         .withYieldedProbationRegion {
           ProbationRegionEntityFactory()
@@ -1369,7 +1369,7 @@ class AssessmentServiceTest {
 
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
 
-    every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.Success(
       UserEntityFactory()
         .withYieldedProbationRegion {
           ProbationRegionEntityFactory()
@@ -1439,7 +1439,7 @@ class AssessmentServiceTest {
 
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
 
-    every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.Success(
       UserEntityFactory()
         .withYieldedProbationRegion {
           ProbationRegionEntityFactory()
@@ -1522,7 +1522,7 @@ class AssessmentServiceTest {
           .produce()
       }
 
-    every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.Success(
       assigneeUser
     )
 
@@ -1605,7 +1605,7 @@ class AssessmentServiceTest {
           .produce()
       }
 
-    every { userServiceMock.getUserForId(assigneeUserId) } returns AuthorisableActionResult.Success(
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.Success(
       assigneeUser
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -145,7 +145,7 @@ class UserServiceTest {
   }
 
   @Nested
-  class GetUserForId {
+  class UpdateUserFromCommunityApiById {
     private val mockHttpAuthService = mockk<HttpAuthService>()
     private val mockCommunityApiClient = mockk<CommunityApiClient>()
     private val mockUserRepository = mockk<UserRepository>()
@@ -205,7 +205,7 @@ class UserServiceTest {
         deliusUser
       )
 
-      val result = userService.getUserForId(id)
+      val result = userService.updateUserFromCommunityApiById(id)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
       result as AuthorisableActionResult.Success
@@ -237,7 +237,7 @@ class UserServiceTest {
         deliusUser
       )
 
-      val result = userService.getUserForId(id)
+      val result = userService.updateUserFromCommunityApiById(id)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
       result as AuthorisableActionResult.Success
@@ -280,7 +280,7 @@ class UserServiceTest {
         deliusUser
       )
 
-      val result = userService.getUserForId(id)
+      val result = userService.updateUserFromCommunityApiById(id)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
       result as AuthorisableActionResult.Success
@@ -297,7 +297,7 @@ class UserServiceTest {
     fun `it returns not found when there is no user for that ID`() {
       every { mockUserRepository.findByIdOrNull(id) } returns null
 
-      val result = userService.getUserForId(id)
+      val result = userService.updateUserFromCommunityApiById(id)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
     }


### PR DESCRIPTION
This adds scaffolding for running ad-hoc data migation tasks that require kotlin code (e.g. where calls to upstream services need to be made.)

These can be called in a similar way to the seeding jobs - via a POST to `/migration-job` with the type of migration.  This does not require a JWT but can only be done locally.

Implemented is the first such task which updates all of the users in our `users` table from Community API.  The need for which is shown here: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/414#discussion_r1101781763