### PR TITLE
(1216) Allow users to be filtered by role and qualification

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -38,9 +38,27 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
+    var roles = roles?.map(::transformApiRole)
+    var qualifications = qualifications?.map(::transformApiQualification)
+
     return ResponseEntity.ok(
-      userService.getAllUsers()
+      userService.getUsersWithQualificationsAndRoles(qualifications, roles)
         .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
     )
+  }
+
+  private fun transformApiRole(apiRole: UserRole): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole = when (apiRole) {
+    UserRole.roleAdmin -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.ROLE_ADMIN
+    UserRole.applicant -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.APPLICANT
+    UserRole.assessor -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.ASSESSOR
+    UserRole.manager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.MANAGER
+    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.MATCHER
+    UserRole.workflowManager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.WORKFLOW_MANAGER
+    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.MATCHER
+  }
+
+  private fun transformApiQualification(apiQualification: uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification = when (apiQualification) {
+    UserQualification.pipe -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.PIPE
+    UserQualification.womens -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.WOMENS
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.specification
+
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.Root
+
+fun hasQualificationsAndRoles(qualifications: List<UserQualification>?, roles: List<UserRole>?): Specification<UserEntity> {
+  return Specification { root: Root<UserEntity>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+    val predicates = mutableListOf<Predicate>()
+
+    if (qualifications?.isNotEmpty() == true) {
+      val userQualifications = root
+        .join<UserEntity, MutableList<UserQualificationAssignmentEntity>>(UserEntity::qualifications.name)
+        .get<UserQualificationAssignmentEntity>(UserQualificationAssignmentEntity::qualification.name)
+
+      predicates.add(
+        criteriaBuilder.and(
+          userQualifications.`in`(qualifications)
+        )
+      )
+    }
+
+    if (roles?.isNotEmpty() == true) {
+      val userRoles = root
+        .join<UserEntity, MutableList<UserEntity>>(UserEntity::roles.name)
+        .get<UserRole>(UserRoleAssignmentEntity::role.name)
+
+      predicates.add(
+        criteriaBuilder.and(
+          userRoles.`in`(roles)
+        )
+      )
+    }
+
+    criteriaBuilder.and(*predicates.toTypedArray())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -14,7 +15,7 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
-interface UserRepository : JpaRepository<UserEntity, UUID> {
+interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExecutor<UserEntity> {
   fun findByDeliusUsername(deliusUsername: String): UserEntity?
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepositor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.specification.hasQualificationsAndRoles
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -40,8 +41,8 @@ class UserService(
     return getUserForUsername(username)
   }
 
-  fun getAllUsers(): List<UserEntity> {
-    return userRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))
+  fun getUsersWithQualificationsAndRoles(qualifications: List<UserQualification>?, roles: List<UserRole>?): List<UserEntity> {
+    return userRepository.findAll(hasQualificationsAndRoles(qualifications, roles), Sort.by(Sort.Direction.ASC, "name"))
   }
 
   fun getUserForId(id: java.util.UUID): AuthorisableActionResult<UserEntity> {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1990,7 +1990,7 @@ paths:
         - Auth
       summary: Returns a list of users
       parameters:
-        - in: path
+        - in: query
           name: roles
           required: false
           description: Only return users with the provided role(s)
@@ -1998,7 +1998,7 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/UserRole'
-        - in: path
+        - in: query
           name: qualifications
           required: false
           description: Only return users with the provided qualification(s)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -10,6 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import java.util.UUID
@@ -225,132 +227,142 @@ class UsersTest : IntegrationTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
     fun `GET to users with a role other than ROLE_ADMIN or WORKFLOW_MANAGER is forbidden`(role: UserRole) {
-      val deliusUsername = "AnyUser"
-
-      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-        subject = deliusUsername,
-        authSource = "delius",
-        roles = listOf("ROLE_PROBATION")
-      )
-
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        webTestClient.get()
+          .uri("/users")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isForbidden
       }
-
-      val user = userEntityFactory.produceAndPersist {
-        withDeliusUsername(deliusUsername)
-        withName("Any User")
-        withYieldedProbationRegion { region }
-      }
-
-      user.roles += userRoleAssignmentEntityFactory.produceAndPersist {
-        withUser(user)
-        withRole(role)
-      }
-
-      mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
-
-      webTestClient.get()
-        .uri("/users")
-        .header("Authorization", "Bearer $jwt")
-        .header("X-Service-Name", ServiceName.approvedPremises.value)
-        .exchange()
-        .expectStatus()
-        .isForbidden
     }
 
     @Test
     fun `GET to users with no internal role (aka the Applicant pseudo-role) is forbidden`() {
-      val deliusUsername = "ProbationPractitioner"
-
-      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-        subject = deliusUsername,
-        authSource = "delius",
-        roles = listOf("ROLE_PROBATION")
-      )
-
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      `Given a User`() { _, jwt ->
+        webTestClient.get()
+          .uri("/users")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isForbidden
       }
-
-      val user = userEntityFactory.produceAndPersist {
-        withDeliusUsername(deliusUsername)
-        withName("Probation Practitioner")
-        withYieldedProbationRegion { region }
-      }
-
-      mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
-
-      webTestClient.get()
-        .uri("/users")
-        .header("Authorization", "Bearer $jwt")
-        .header("X-Service-Name", ServiceName.approvedPremises.value)
-        .exchange()
-        .expectStatus()
-        .isForbidden
     }
 
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
     fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER returns full list ordered by name`(role: UserRole) {
-      val deliusUsername = "ArthurAdmin"
-
-      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-        subject = deliusUsername,
-        authSource = "delius",
-        roles = listOf("ROLE_PROBATION")
-      )
-
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
-
-      val arthurAdmin = userEntityFactory.produceAndPersist {
-        withDeliusUsername(deliusUsername)
-        withName("Arthur Admin")
-        withYieldedProbationRegion { region }
-      }
-
-      arthurAdmin.roles += userRoleAssignmentEntityFactory.produceAndPersist {
-        withUser(arthurAdmin)
-        withRole(role)
-      }
-
-      val ben = userEntityFactory.produceAndPersist {
-        withDeliusUsername("BenJones")
-        withName("Ben Jones")
-        withYieldedProbationRegion { region }
-      }
-
-      val cary = userEntityFactory.produceAndPersist {
-        withDeliusUsername("CaryJones")
-        withName("Cary Jones")
-        withYieldedProbationRegion { region }
-      }
-
-      val avril = userEntityFactory.produceAndPersist {
-        withDeliusUsername("AvrilJones")
-        withName("Avril Jones")
-        withYieldedProbationRegion { region }
-      }
-
-      mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
-
-      webTestClient.get()
-        .uri("/users")
-        .header("Authorization", "Bearer $jwt")
-        .header("X-Service-Name", ServiceName.approvedPremises.value)
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectBody()
-        .json(
-          objectMapper.writeValueAsString(
-            listOf(arthurAdmin, avril, ben, cary).map {
-              userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
+      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher, _ ->
+        `Given a User`(roles = listOf(UserRole.MANAGER)) { manager, _ ->
+          `Given a User` { userWithNoRole, _ ->
+            `Given a User`(roles = listOf(role)) { requestUser, jwt ->
+              webTestClient.get()
+                .uri("/users")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(
+                  objectMapper.writeValueAsString(
+                    listOf(requestUser, userWithNoRole, matcher, manager).map {
+                      userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
+                    }
+                  )
+                )
             }
-          )
-        )
+          }
+        }
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by roles`(role: UserRole) {
+      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher, _ ->
+        `Given a User`(roles = listOf(UserRole.MANAGER)) { manager, _ ->
+          `Given a User` { _, _ ->
+            `Given a User`(roles = listOf(role)) { _, jwt ->
+              webTestClient.get()
+                .uri("/users?roles=matcher,manager")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(
+                  objectMapper.writeValueAsString(
+                    listOf(matcher, manager).map {
+                      userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
+                    }
+                  )
+                )
+            }
+          }
+        }
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by qualifications`(role: UserRole) {
+      `Given a User`(qualifications = listOf(UserQualification.WOMENS)) { womensUser, _ ->
+        `Given a User`(qualifications = listOf(UserQualification.PIPE)) { _, _ ->
+          `Given a User` { _, _ ->
+            `Given a User`(roles = listOf(role)) { _, jwt ->
+              webTestClient.get()
+                .uri("/users?qualifications=womens")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(
+                  objectMapper.writeValueAsString(
+                    listOf(womensUser).map {
+                      userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
+                    }
+                  )
+                )
+            }
+          }
+        }
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by role and qualifications`(role: UserRole) {
+      `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.WOMENS)) { womensAssessor1, _ ->
+        `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.WOMENS)) { womensAssessor2, _ ->
+          `Given a User`(roles = listOf(UserRole.ASSESSOR)) { _, _ ->
+            `Given a User` { _, _ ->
+              `Given a User`(roles = listOf(role)) { _, jwt ->
+                webTestClient.get()
+                  .uri("/users?roles=assessor&qualifications=womens")
+                  .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.approvedPremises.value)
+                  .exchange()
+                  .expectStatus()
+                  .isOk
+                  .expectBody()
+                  .json(
+                    objectMapper.writeValueAsString(
+                      listOf(womensAssessor1, womensAssessor2).map {
+                        userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
+                      }
+                    )
+                  )
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This adds the missing filtering functionality to the `/users` endpoint, to allow us to filter by role and qualification. To allow for us to optionally append to the query depending on what arguments are provided, I've added a JPA `Specification`, which builds up a list of predicates based on the user input. It took a bit of wailing and gnashing of teeth, but it seems to work pretty well!