### PR TITLE
1135 - Publish Domain Events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
   }
 
   testImplementation("com.ninja-squad:springmockk:4.0.0")
+
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.2.0")
 }
 
 java {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,3 +16,19 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
       - "6377:6379"
+
+  localstack:
+    image: localstack/localstack:1.3.1
+    container_name: approved-premises-api-test-localstack
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - 8999:8080
+    environment:
+      - SERVICES=sns,sqs
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DEFAULT_REGION=eu-west-2
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,5 +87,21 @@ services:
     ports:
       - "6379:6379"
 
+  localstack:
+    image: localstack/localstack:1.3.1
+    container_name: approved-premises-api-localstack
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - 8999:8080
+    environment:
+      - SERVICES=sns,sqs
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DEFAULT_REGION=eu-west-2
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
 volumes:
   database-data-development:

--- a/helm_deploy/hmpps-approved-premises-api/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/values.yaml
@@ -34,6 +34,7 @@ generic-service:
     SPRING_REDIS_SSL: true
     SENTRY_SAMPLE-RATE: 1
     SENTRY_TRACES-SAMPLE-RATE: 0.2
+    HMPPS_SQS_PROVIDER: "aws"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,6 +26,12 @@ generic-service:
     APPLICATION-URL-TEMPLATE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
     DOMAIN-EVENTS_EMIT-ENABLED: true
 
+  namespace_secrets:
+    hmpps-approved-premises-api:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "DOMAIN_EVENTS_ARN"
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ACCESS_KEY_ID: "DOMAIN_EVENTS_ACCESS_KEY_ID"
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_SECRET_ACCESS_KEY: "DOMAIN_EVENTS_ACCESS_KEY_SECRET"
+
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"
     unilink-aovpn2: "83.98.63.176/29"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,7 @@ generic-service:
     SENTRY_ENVIRONMENT: dev
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
+    DOMAIN-EVENTS_EMIT-ENABLED: true
 
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,7 +22,7 @@ generic-service:
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
-    DOMAIN-EVENTS_EMIT-ENABLED: true
+    DOMAIN-EVENTS_EMIT-ENABLED: false
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,6 +22,7 @@ generic-service:
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
+    DOMAIN-EVENTS_EMIT-ENABLED: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,3 +22,4 @@ generic-service:
     SENTRY_ENVIRONMENT: prod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
     SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.hmpps.service.justice.gov.uk
+    DOMAIN-EVENTS_EMIT-ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,4 +22,4 @@ generic-service:
     SENTRY_ENVIRONMENT: prod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
     SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.hmpps.service.justice.gov.uk
-    DOMAIN-EVENTS_EMIT-ENABLED: true
+    DOMAIN-EVENTS_EMIT-ENABLED: false

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -24,6 +24,7 @@ generic-service:
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
+    DOMAIN-EVENTS_EMIT-ENABLED: false
 
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class SnsEvent(
+  val eventType: String,
+  val version: Int,
+  val description: String,
+  val detailUrl: String,
+  val occurredAt: OffsetDateTime,
+  val additionalInformation: SnsEventAdditionalInformation,
+  val personReference: SnsEventPersonReferenceCollection
+)
+
+data class SnsEventPersonReferenceCollection(
+  val identifiers: List<SnsEventPersonReference>
+)
+
+data class SnsEventPersonReference(
+  val type: String,
+  val value: String
+)
+
+data class SnsEventAdditionalInformation(
+  val applicationId: UUID
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -343,7 +343,7 @@ class ApplicationService(
     val releaseType = jsonLogicService.resolveString(schema.releaseTypeJsonLogicRule, applicationData)
     val targetLocation = jsonLogicService.resolveString(schema.targetLocationJsonLogicRule, applicationData)
 
-    domainEventService.save(
+    domainEventService.saveApplicationSubmittedDomainEvent(
       DomainEvent(
         id = domainEventId,
         applicationId = application.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import com.amazonaws.services.sns.model.MessageAttributeValue
+import com.amazonaws.services.sns.model.PublishRequest
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
@@ -8,6 +12,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.MissingTopicException
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
@@ -15,8 +25,17 @@ import javax.transaction.Transactional
 @Service
 class DomainEventService(
   private val objectMapper: ObjectMapper,
-  private val domainEventRepository: DomainEventRepository
+  private val domainEventRepository: DomainEventRepository,
+  private val hmppsQueueService: HmppsQueueService,
+  @Value("\${domain-events.emit-enabled}") private val emitDomainEventsEnabled: Boolean
 ) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  private val domainTopic by lazy {
+    hmppsQueueService.findByTopicId("domain-events")
+      ?: throw MissingTopicException("domain-events not found")
+  }
+
   fun getApplicationSubmittedDomainEvent(id: UUID) = get<ApplicationSubmittedEnvelope>(id)
 
   private inline fun <reified T> get(id: UUID): DomainEvent<T>? {
@@ -38,7 +57,24 @@ class DomainEventService(
   }
 
   @Transactional
-  fun save(domainEvent: DomainEvent<*>) {
+  fun saveApplicationSubmittedDomainEvent(domainEvent: DomainEvent<ApplicationSubmittedEnvelope>) =
+    saveAndEmit(
+      domainEvent = domainEvent,
+      typeName = "approved-premises.application.submitted",
+      typeDescription = "An application has been submitted for an Approved Premises placement",
+      detailUrl = domainEvent.data.eventDetails.applicationUrl,
+      crn = domainEvent.data.eventDetails.personReference.crn,
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+    )
+
+  private fun saveAndEmit(
+    domainEvent: DomainEvent<*>,
+    typeName: String,
+    typeDescription: String,
+    detailUrl: String,
+    crn: String,
+    nomsNumber: String
+  ) {
     domainEventRepository.save(
       DomainEventEntity(
         id = domainEvent.id,
@@ -51,7 +87,31 @@ class DomainEventService(
       )
     )
 
-    // TODO: Emit certain types of event to SNS for downstream consumption
+    if (emitDomainEventsEnabled) {
+      val snsEvent = SnsEvent(
+        eventType = typeName,
+        version = 1,
+        description = typeDescription,
+        detailUrl = detailUrl,
+        occurredAt = domainEvent.occurredAt,
+        additionalInformation = SnsEventAdditionalInformation(
+          applicationId = domainEvent.applicationId
+        ),
+        personReference = SnsEventPersonReferenceCollection(
+          identifiers = listOf(
+            SnsEventPersonReference("CRN", crn),
+            SnsEventPersonReference("NOMS", nomsNumber)
+          )
+        )
+      )
+
+      domainTopic.snsClient.publish(
+        PublishRequest(domainTopic.arn, objectMapper.writeValueAsString(snsEvent))
+          .withMessageAttributes(mapOf("eventType" to MessageAttributeValue().withDataType("String").withStringValue(snsEvent.eventType)))
+      )
+    } else {
+      log.info("Not emitting SNS event for domain event because domain-events.emit-enabled is not enabled")
+    }
   }
 
   private fun <T> enumTypeFromDataType(type: Class<T>) = when (type) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -32,8 +32,8 @@ class DomainEventService(
   private val log = LoggerFactory.getLogger(this::class.java)
 
   private val domainTopic by lazy {
-    hmppsQueueService.findByTopicId("domain-events")
-      ?: throw MissingTopicException("domain-events not found")
+    hmppsQueueService.findByTopicId("domainevents")
+      ?: throw MissingTopicException("domainevents not found")
   }
 
   fun getApplicationSubmittedDomainEvent(id: UUID) = get<ApplicationSubmittedEnvelope>(id)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,9 @@ hmpps.sqs:
     domain-events:
       arn: arn:aws:sns:eu-west-2:000000000000:domain-events
 
+domain-events:
+  emit-enabled: true
+
 log-client-credentials-jwt-info: true
 
 seed:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,8 +16,8 @@ spring:
 hmpps.sqs:
   provider: localstack
   topics:
-    domain-events:
-      arn: arn:aws:sns:eu-west-2:000000000000:domain-events
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents
 
 domain-events:
   emit-enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,12 @@ spring:
     port: 6379
     password: ""
 
+hmpps.sqs:
+  provider: localstack
+  topics:
+    domain-events:
+      arn: arn:aws:sns:eu-west-2:000000000000:domain-events
+
 log-client-credentials-jwt-info: true
 
 seed:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1364,7 +1364,7 @@ class InboundMessageListener(private val objectMapper: ObjectMapper) {
   private val log = LoggerFactory.getLogger(this::class.java)
   val messages = Collections.synchronizedList(mutableListOf<SnsEvent>())
 
-  @JmsListener(destination = "domain-events-queue", containerFactory = "hmppsQueueContainerFactoryProxy")
+  @JmsListener(destination = "domaineventsqueue", containerFactory = "hmppsQueueContainerFactoryProxy")
   fun processMessage(rawMessage: String?) {
     val (Message) = objectMapper.readValue(rawMessage, Message::class.java)
     val event = objectMapper.readValue(Message, SnsEvent::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -797,7 +797,7 @@ class ApplicationServiceTest {
     every { mockJsonLogicService.resolveString(schema.releaseTypeJsonLogicRule, application.data!!) } returns "release-type"
     every { mockJsonLogicService.resolveString(schema.targetLocationJsonLogicRule, application.data!!) } returns "LN1"
 
-    every { mockDomainEventService.save(any()) } just Runs
+    every { mockDomainEventService.saveApplicationSubmittedDomainEvent(any()) } just Runs
 
     val result = applicationService.submitApplication(applicationId, "{}", username, "jwt")
 
@@ -814,7 +814,7 @@ class ApplicationServiceTest {
     verify(exactly = 1) { mockAssessmentService.createAssessment(application) }
 
     verify(exactly = 1) {
-      mockDomainEventService.save(
+      mockDomainEventService.saveApplicationSubmittedDomainEvent(
         match {
           val data = (it.data as ApplicationSubmittedEnvelope).eventDetails
           val firstTeam = staffUserDetails.teams!!.first()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -97,7 +97,7 @@ class DomainEventServiceTest {
 
     val mockHmppsTopic = mockk<HmppsTopic>()
 
-    every { hmppsQueueServieMock.findByTopicId("domain-events") } returns mockHmppsTopic
+    every { hmppsQueueServieMock.findByTopicId("domainevents") } returns mockHmppsTopic
 
     val domainEventToSave = DomainEvent(
       id = id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
+import com.amazonaws.services.sns.model.PublishResult
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -9,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
@@ -18,12 +18,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.HmppsTopic
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class DomainEventServiceTest {
   private val domainEventRespositoryMock = mockk<DomainEventRepository>()
+  private val hmppsQueueServieMock = mockk<HmppsQueueService>()
 
   private val objectMapper = ObjectMapper().apply {
     registerModule(Jdk8Module())
@@ -33,7 +37,9 @@ class DomainEventServiceTest {
 
   private val domainEventService = DomainEventService(
     objectMapper = objectMapper,
-    domainEventRepository = domainEventRespositoryMock
+    domainEventRepository = domainEventRespositoryMock,
+    hmppsQueueService = hmppsQueueServieMock,
+    emitDomainEventsEnabled = true
   )
 
   @Test
@@ -81,30 +87,17 @@ class DomainEventServiceTest {
   }
 
   @Test
-  fun `save throws for unrecognised event type`() {
-    val exception = assertThrows<RuntimeException> {
-      domainEventService.save(
-        DomainEvent<String>(
-          id = UUID.fromString("1a520974-d5d6-49a4-9ce1-827427dd489f"),
-          applicationId = UUID.fromString("ea100c7f-2e16-4280-b1b2-d2f666a6dcd1"),
-          crn = "CRN123",
-          occurredAt = OffsetDateTime.now(),
-          data = "some data"
-        )
-      )
-    }
-
-    assertThat(exception.message).isEqualTo("Unrecognised domain event type: java.lang.String")
-  }
-
-  @Test
-  fun `save persists event`() {
+  fun `saveApplicationSubmittedDomainEvent persists event, emits event to SNS`() {
     val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
 
     every { domainEventRespositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
+
+    val mockHmppsTopic = mockk<HmppsTopic>()
+
+    every { hmppsQueueServieMock.findByTopicId("domain-events") } returns mockHmppsTopic
 
     val domainEventToSave = DomainEvent(
       id = id,
@@ -119,7 +112,10 @@ class DomainEventServiceTest {
       )
     )
 
-    domainEventService.save(domainEventToSave)
+    every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
+    every { mockHmppsTopic.snsClient.publish(any()) } returns PublishResult()
+
+    domainEventService.saveApplicationSubmittedDomainEvent(domainEventToSave)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
@@ -131,6 +127,73 @@ class DomainEventServiceTest {
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
         }
       )
+    }
+
+    verify(exactly = 1) {
+      mockHmppsTopic.snsClient.publish(
+        match {
+          val deserializedMessage = objectMapper.readValue(it.message, SnsEvent::class.java)
+
+          deserializedMessage.eventType == "approved-premises.application.submitted" &&
+            deserializedMessage.version == 1 &&
+            deserializedMessage.description == "An application has been submitted for an Approved Premises placement" &&
+            deserializedMessage.detailUrl == domainEventToSave.data.eventDetails.applicationUrl &&
+            deserializedMessage.occurredAt == domainEventToSave.occurredAt &&
+            deserializedMessage.additionalInformation.applicationId == applicationId &&
+            deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
+            deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
+        }
+      )
+    }
+  }
+
+  @Test
+  fun `saveApplicationSubmittedDomainEvent does not emit event to SNS if event fails to persist to database`() {
+    val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
+    val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
+    val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
+    val crn = "CRN"
+
+    every { domainEventRespositoryMock.save(any()) } throws RuntimeException("A database exception")
+
+    val mockHmppsTopic = mockk<HmppsTopic>()
+
+    every { hmppsQueueServieMock.findByTopicId("domain-events") } returns mockHmppsTopic
+
+    val domainEventToSave = DomainEvent(
+      id = id,
+      applicationId = applicationId,
+      crn = crn,
+      occurredAt = OffsetDateTime.now(),
+      data = ApplicationSubmittedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = "approved-premises.application.submitted",
+        eventDetails = ApplicationSubmittedFactory().produce()
+      )
+    )
+
+    every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
+    every { mockHmppsTopic.snsClient.publish(any()) } returns PublishResult()
+
+    try {
+      domainEventService.saveApplicationSubmittedDomainEvent(domainEventToSave)
+    } catch (_: Exception) { }
+
+    verify(exactly = 1) {
+      domainEventRespositoryMock.save(
+        match {
+          it.id == domainEventToSave.id &&
+            it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED &&
+            it.crn == domainEventToSave.crn &&
+            it.occurredAt == domainEventToSave.occurredAt &&
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+        }
+      )
+    }
+
+    verify(exactly = 0) {
+      mockHmppsTopic.snsClient.publish(any())
     }
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,6 +44,9 @@ hmpps.sqs:
     domain-events:
       arn: arn:aws:sns:eu-west-2:000000000000:domain-events-int-test
 
+domain-events:
+  emit-enabled: true
+
 hmpps:
   auth:
     url: http://localhost:57839/auth

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -43,6 +43,11 @@ hmpps.sqs:
   topics:
     domain-events:
       arn: arn:aws:sns:eu-west-2:000000000000:domain-events-int-test
+  queues:
+    domain-events-queue:
+      dlqName: ${random.uuid}
+      queueName: ${random.uuid}
+      subscribeTopicId: domain-events
 
 domain-events:
   emit-enabled: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -41,13 +41,13 @@ spring:
 hmpps.sqs:
   provider: localstack
   topics:
-    domain-events:
-      arn: arn:aws:sns:eu-west-2:000000000000:domain-events-int-test
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-int-test
   queues:
-    domain-events-queue:
+    domaineventsqueue:
       dlqName: ${random.uuid}
       queueName: ${random.uuid}
-      subscribeTopicId: domain-events
+      subscribeTopicId: domainevents
 
 domain-events:
   emit-enabled: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,6 +38,12 @@ spring:
             client-authentication-method: client_secret_jwt
             authorization-grant-type: client_credentials
 
+hmpps.sqs:
+  provider: localstack
+  topics:
+    domain-events:
+      arn: arn:aws:sns:eu-west-2:000000000000:domain-events-int-test
+
 hmpps:
   auth:
     url: http://localhost:57839/auth


### PR DESCRIPTION
This is the same work as in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/421 with some tweaks to the config to hopefully resolve the binding issues that caused it to be rolled back.

Namely:
 - remove dash from topic name, I'm not sure this should matter but the docs say lowercase only
 - only mount secrets in dev (as this is the only place they currently exist)