### PR TITLE
(1242) Only return un-reallocated assessments on list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -18,7 +18,9 @@ import javax.persistence.Table
 
 @Repository
 interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
-  fun findAllByAllocatedToUser_Id(userId: UUID): List<AssessmentEntity>
+  fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<AssessmentEntity>
+
+  fun findAllByReallocatedAtNull(): List<AssessmentEntity>
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -37,9 +37,9 @@ class AssessmentService(
     val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)
 
     val assessments = if (user.hasRole(UserRole.WORKFLOW_MANAGER)) {
-      assessmentRepository.findAll()
+      assessmentRepository.findAllByReallocatedAtNull()
     } else {
-      assessmentRepository.findAllByAllocatedToUser_Id(user.id)
+      assessmentRepository.findAllByAllocatedToUser_IdAndReallocatedAtNull(user.id)
     }
 
     assessments.forEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -55,6 +55,15 @@ class AssessmentTest : IntegrationTestBase() {
 
         assessment.schemaUpToDate = true
 
+        val reallocatedAssessment = assessmentEntityFactory.produceAndPersist {
+          withAllocatedToUser(user)
+          withApplication(application)
+          withAssessmentSchema(assessmentSchema)
+          withReallocatedAt(OffsetDateTime.now())
+        }
+
+        reallocatedAssessment.schemaUpToDate = true
+
         webTestClient.get()
           .uri("/assessments")
           .header("Authorization", "Bearer $jwt")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -98,14 +98,14 @@ class AssessmentServiceTest {
         .produce()
     )
 
-    every { assessmentRepositoryMock.findAll() } returns allAssessments
+    every { assessmentRepositoryMock.findAllByReallocatedAtNull() } returns allAssessments
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
 
     val result = assessmentService.getVisibleAssessmentsForUser(user)
 
     assertThat(result).containsAll(allAssessments)
 
-    verify(exactly = 1) { assessmentRepositoryMock.findAll() }
+    verify(exactly = 1) { assessmentRepositoryMock.findAllByReallocatedAtNull() }
   }
 
   @Test
@@ -137,14 +137,14 @@ class AssessmentServiceTest {
         .produce()
     )
 
-    every { assessmentRepositoryMock.findAllByAllocatedToUser_Id(user.id) } returns allocatedAssessments
+    every { assessmentRepositoryMock.findAllByAllocatedToUser_IdAndReallocatedAtNull(user.id) } returns allocatedAssessments
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
 
     val result = assessmentService.getVisibleAssessmentsForUser(user)
 
     assertThat(result).containsAll(allocatedAssessments)
 
-    verify(exactly = 1) { assessmentRepositoryMock.findAllByAllocatedToUser_Id(user.id) }
+    verify(exactly = 1) { assessmentRepositoryMock.findAllByAllocatedToUser_IdAndReallocatedAtNull(user.id) }
   }
 
   @Test


### PR DESCRIPTION
When an assessment has been reallocated to a new user, the assessments are treated as readonly, so we should not return them in the list of assessments.