### PR TITLE
Trigger CI when adding to the merge group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
At the moment, PRs added to a merge group just keep waiting because the CI check is required, but the `merge_group` action doesn't trigger anything.