### PR TITLE
Make MAPPA nullable on Application Submitted Domain Events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -323,7 +323,7 @@ class ApplicationService(
       is AuthorisableActionResult.NotFound -> throw RuntimeException("Unable to get Risks when creating Application Submitted Domain Event: Not Found")
     }
 
-    val mappaLevel = risks.mappa.value?.level ?: throw RuntimeException("Mappa not present on Risks when creating Application Submitted Domain Event")
+    val mappaLevel = risks.mappa.value?.level
 
     val staffDetailsResult = communityApiClient.getStaffUserDetails(username)
     val staffDetails = when (staffDetailsResult) {

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -483,7 +483,6 @@ components:
         - applicationUrl
         - personReference
         - deliusEventNumber
-        - mappaCategories
         - offenceDescription
         - releaseType
         - age


### PR DESCRIPTION
This is not present for all Offenders so null is a valid value