### PR TITLE
Revert to empty JSON schema for AP Applications

### DIFF
--- a/src/main/resources/db/migration/all/20230216104604__move_back_to_blank_ap_applications_schema.sql
+++ b/src/main/resources/db/migration/all/20230216104604__move_back_to_blank_ap_applications_schema.sql
@@ -1,0 +1,8 @@
+UPDATE json_schemas SET "schema" = '{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "title": "Assessment Placeholder Schema",
+ "description": "An application schema that requires no properties",
+ "type": "object",
+ "properties": {},
+ "required": []
+}' WHERE id = '49df96e4-f1b6-4622-9355-729f5adaf042';


### PR DESCRIPTION
Since we will move the work done by the JSON logic expressions into the frontend in due time, we have decided to stop validating the JSON schema.  The fastest route to do this in the meantime is to use the empty schema (which all valid JSON validates against) again.