### PR TITLE
Domain Events Fixes

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,7 @@ generic-service:
     SENTRY_ENVIRONMENT: dev
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
+    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: true
 
   namespace_secrets:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,6 +22,7 @@ generic-service:
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
+    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: false
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,5 +21,7 @@ generic-service:
     LOG-CLIENT-CREDENTIALS-JWT-INFO: false
     SENTRY_ENVIRONMENT: prod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
-    SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.hmpps.service.justice.gov.uk
+    SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius.hmpps.service.justice.gov.uk#
+    APPLICATION-URL-TEMPLATE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
+    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: false

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -24,6 +24,7 @@ generic-service:
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     APPLICATION-URL-TEMPLATE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
+    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: false
 
   allowlist:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -27,7 +27,8 @@ class DomainEventService(
   private val objectMapper: ObjectMapper,
   private val domainEventRepository: DomainEventRepository,
   private val hmppsQueueService: HmppsQueueService,
-  @Value("\${domain-events.emit-enabled}") private val emitDomainEventsEnabled: Boolean
+  @Value("\${domain-events.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
+  @Value("\${application-submitted-detail-url-template}") private val applicationSubmittedDetailUrlTemplate: String
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -62,7 +63,7 @@ class DomainEventService(
       domainEvent = domainEvent,
       typeName = "approved-premises.application.submitted",
       typeDescription = "An application has been submitted for an Approved Premises placement",
-      detailUrl = domainEvent.data.eventDetails.applicationUrl,
+      detailUrl = applicationSubmittedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -106,10 +106,12 @@ class DomainEventService(
         )
       )
 
-      domainTopic.snsClient.publish(
+      val publishResult = domainTopic.snsClient.publish(
         PublishRequest(domainTopic.arn, objectMapper.writeValueAsString(snsEvent))
           .withMessageAttributes(mapOf("eventType" to MessageAttributeValue().withDataType("String").withStringValue(snsEvent.eventType)))
       )
+
+      log.info("Emitted SNS event (Message Id: ${publishResult.messageId}, Sequence Id: ${publishResult.sequenceNumber}) for Domain Event: ${domainEvent.id} of type: ${snsEvent.eventType}")
     } else {
       log.info("Not emitting SNS event for domain event because domain-events.emit-enabled is not enabled")
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -166,3 +166,4 @@ seed:
 
 assign-default-region-to-users-with-unknown-region: false
 application-url-template: http://localhost:3000/applications/#id
+application-submitted-detail-url-template: http://localhost:3000/events/application-submitted/#eventId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1116,7 +1116,7 @@ class ApplicationTest : IntegrationTestBase() {
 
           assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.submitted")
           assertThat(emittedMessage.description).isEqualTo("An application has been submitted for an Approved Premises placement")
-          assertThat(emittedMessage.detailUrl).isEqualTo("http://frontend/applications/$applicationId")
+          assertThat(emittedMessage.detailUrl).matches("http://frontend/events/application-submitted/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
           assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(applicationId)
           assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
             SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -39,7 +39,8 @@ class DomainEventServiceTest {
     objectMapper = objectMapper,
     domainEventRepository = domainEventRespositoryMock,
     hmppsQueueService = hmppsQueueServieMock,
-    emitDomainEventsEnabled = true
+    emitDomainEventsEnabled = true,
+    applicationSubmittedDetailUrlTemplate = "http://frontend/events/application-submitted/#eventId"
   )
 
   @Test
@@ -137,7 +138,7 @@ class DomainEventServiceTest {
           deserializedMessage.eventType == "approved-premises.application.submitted" &&
             deserializedMessage.version == 1 &&
             deserializedMessage.description == "An application has been submitted for an Approved Premises placement" &&
-            deserializedMessage.detailUrl == domainEventToSave.data.eventDetails.applicationUrl &&
+            deserializedMessage.detailUrl.matches(Regex("http://frontend/events/application-submitted/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
             deserializedMessage.occurredAt == domainEventToSave.occurredAt &&
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -108,3 +108,5 @@ seed:
   file-prefix: "./test-seed-csvs"
 
 application-url-template: http://frontend/applications/#id
+application-submitted-detail-url-template: http://frontend/events/application-submitted/#eventId
+


### PR DESCRIPTION
Correct detailUrl for Application Submitted domain events - was previously set to the frontend application URL rather than the event route on the API.

Log SNS receipt info when emitting events - this should help us with debugging etc.