### PR TITLE
Move and add to infrastructure documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 This is the shared backend for the Community Accommodation services, currently:
 
-- [Approved Premises (CAS1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui)
-- [Temporary Accommodation (CAS3)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui)
+- [Approved Premises
+  (CAS1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui)
+- [Temporary Accommodation
+  (CAS3)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui)
 
 ## Prerequisites
 
@@ -17,7 +19,8 @@ When running the application for the first time, run the following command:
 script/setup # TODO - this script is currently a stub
 ```
 
-If you're coming back to the application after a certain amount of time, you can run:
+If you're coming back to the application after a certain amount of time, you can
+run:
 
 ```bash
 script/bootstrap # TODO - this script is currently a stub
@@ -41,21 +44,25 @@ To run from IntelliJ, first start the database:
 script/development_database
 ```
 
-Then in the "Gradle" panel (`View->Tool Windows->Gradle` if not visible), expand `approved-premises-api`, `Tasks`, 
-`application` and right click on `bootRunLocal` and select either Run or Debug.
+Then in the "Gradle" panel (`View->Tool Windows->Gradle` if not visible), expand
+`approved-premises-api`, `Tasks`, `application` and right click on
+`bootRunLocal` and select either Run or Debug.
 
 ## Making requests to the application
 
-Most endpoints require a JWT from HMPPS Auth - an instance of this runs in Docker locally (started alongside the database) 
-on port 9091.  You can get a JWT by running:
+Most endpoints require a JWT from HMPPS Auth - an instance of this runs in
+Docker locally (started alongside the database) on port 9091.  You can get a JWT
+by running:
 
 ```
 script/get_client_credentials_jwt
 ```
 
-The `access_token` value in the output is the JWT.  These are valid for 20 minutes.
+The `access_token` value in the output is the JWT.  These are valid for 20
+minutes.
 
-This value is then included in the Authorization header on requests to the API, as a bearer token, e.g.
+This value is then included in the Authorization header on requests to the API,
+as a bearer token, e.g.
 
 ```
 Authorization: Bearer {the JWT}
@@ -78,21 +85,29 @@ script/test_database
 ```
 
 Then either:
- - Run or Debug the `verification`, `test` Task from the "Gradle" panel
- - Open an individual test class and click the green play icon in the gutter at the class level or on a specific test method
+
+- Run or Debug the `verification`, `test` Task from the "Gradle" panel
+- Open an individual test class and click the green play icon in the gutter at
+  the class level or on a specific test method
 
 ## OpenAPI documentation
 
-The API which is offered to front-end UI apps is documented using Swagger/OpenAPI.
-The initial contract covers the migration of certain bed-management functions from Delius into the new service.
+The API which is offered to front-end UI apps is documented using
+Swagger/OpenAPI. The initial contract covers the migration of certain
+bed-management functions from Delius into the new service.
 
-This is available in development at [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+This is available in development at
+[http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
 
 ## Manage infrastructure & view logs
 
-This application is hosted on the MoJ Cloud Platform. For further details
-head over to [our infrastructure documentation](/doc/how-to/manage-infrastructure.md).
+This application is hosted on the MoJ Cloud Platform. For further details head
+over to [our infrastructure
+documentation](/doc/how-to/manage-infrastructure.md).
 
 ## Release process
 
-Our release process aligns with the other CAS teams and as such [lives in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process). The steps are also available in the [PULL_REQUEST_TEMPLATE](/.github/PULL_REQUEST_TEMPLATE.md#release-checklist).
+Our release process aligns with the other CAS teams and as such [lives in
+Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process).
+The steps are also available in the
+[PULL_REQUEST_TEMPLATE](/.github/PULL_REQUEST_TEMPLATE.md#release-checklist).

--- a/README.md
+++ b/README.md
@@ -88,30 +88,10 @@ The initial contract covers the migration of certain bed-management functions fr
 
 This is available in development at [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
 
-## Infrastructure
+## Manage infrastructure & view logs
 
-The service is deployed to the [MoJ Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk). This is 
-managed by Kubernetes and Helm Charts which reside within this repo at [`./helm_deploy`](./helm_deploy/approved-premises-api/).
-
-
-To get set up with Kubernetes and configure your system so that the `kubectl` command authenticates, see this 
-[[MoJ guide to generating a 'kube' config](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#generating-a-kubeconfig-file)].
-
-You should then be able to run `kubectl` commands, e.g. to list the 'pods' in a given 'namespace':
-
-```bash
-$ kubectl -n hmpps-community-accommodation-dev get pods
-
-NAME                                                READY   STATUS    RESTARTS   AGE
-hmpps-approved-premises-api-655968557b-5qlbc        1/1     Running   0          83m
-hmpps-approved-premises-api-655968557b-bp7v9        1/1     Running   0          83m
-hmpps-approved-premises-ui-5cf65777bf-bqtlc         1/1     Running   0          74m
-hmpps-approved-premises-ui-5cf65777bf-n4j89         1/1     Running   0          74m
-hmpps-temporary-accommodation-ui-67b49b8dcd-p85pt   1/1     Running   0          125m
-hmpps-temporary-accommodation-ui-67b49b8dcd-tgjd5   1/1     Running   0          125m
-```
-**NB**: this [`kubectl` cheatsheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) is a good reference to 
-other commands you may need.
+This application is hosted on the MoJ Cloud Platform. For further details
+head over to [our infrastructure documentation](/doc/how-to/manage-infrastructure.md).
 
 ## Release process
 

--- a/doc/how-to/manage-infrastructure.md
+++ b/doc/how-to/manage-infrastructure.md
@@ -1,0 +1,130 @@
+# Manage Infrastructure
+
+The service is hosted on the [MoJ Cloud
+Platform](https://user-guide.cloud-platform.service.justice.gov.uk/#getting-started).
+It's a platform where we can host our applications and interact with them
+through Kubernetes. This requires our applications to all be Dockerised.
+
+Each repository will have a `helm_deploy` directory that specifies configuration
+for this service in each of the environments.
+
+When this app deploys via merging to `main`, CircleCI will automatically
+propagate those changes to the cluster. This happens through the
+`hmpps/deploy_env` job that is provided by the [MoJ CircleCI
+Orb](https://github.com/ministryofjustice/hmpps-circleci-orb).
+
+Each environment will correspond to a Cloud Platform 'namespace'. The namespace
+is an isolated cluster. We can use the [Cloud Platform Environments
+repository](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk)
+to define our backing services, certificates etc.
+
+## Prerequisites
+
+* Be a part of the Ministry of Justice GitHub organisation. This should be done
+  as part of your your team onboarding process.
+* Be a part of the `hmpps-community-accommodation` team. This should be done as
+  part of your team onboarding process.
+* [Follow the Cloud Platform guidance to connect to the Kubernetes
+  cluster](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#connecting-to-the-cloud-platform-39-s-kubernetes-cluster)
+
+## Kubernetes cheat sheet
+
+To use Kubernetes to interact with the cluster there's [a cheat
+sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/). Keep reading
+for tasks we commonly use.
+
+## Common Kubernetes tasks
+
+### View the application logs of a pod
+
+#### Dev
+
+Find the name of the pod you'd like to get the logs for:
+
+```bash
+kubectl --namespace hmpps-community-accommodation-<env> get pods
+```
+
+Follow the logs:
+
+```bash
+kubectl -n hmpps-community-accommodation-<env> logs --follow <pod name> --all-containers
+```
+
+#### Prod
+
+The API logs available directly from containers are minimal. We believe this is
+by design to limit the information being surfaced for security purposes.
+
+##### App Insights
+
+Stack traces for failures can be found using Microsoft Application Insights.
+
+1. Complete your security clearance
+1. Receive your MoJ laptop
+1. Get an account following [this
+   guidance](https://github.com/ministryofjustice/dso-infra-azure-ad/tree/main/users-groups#self-service-workflow)
+   for prod
+1. [Visit App
+   Insights](https://portal.azure.com/#@nomsdigitechoutlook.onmicrosoft.com/resource/subscriptions/a5ddf257-3b21-4ba9-a28c-ab30f751b383/resourceGroups/nomisapi-prod-rg/providers/Microsoft.Insights/components/nomisapi-prod/failures)
+1. Use the filter to find events of interest. These events will probably be
+   requests that the API sends downstream such as `/secure/offenders/crn/`
+
+##### Sentry
+
+We also use
+[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-approved-premises-api-k1/?project=4503931792392192)
+to track and alert on errors and performance of the API itself.
+
+### View/change the value of an environment variable
+
+Environment variables are themselves [defined with
+Helm](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/main/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml#L50).
+
+For environment variables that aren't secrets we can set these values in our
+[Helm
+charts](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/main/helm_deploy/values-prod.yaml#L12).
+
+For environment variables that contain secrets we can't set these in GitHub so
+we have to set the values by hand.
+
+First find the secret set you'd like to view/change:
+
+```bash
+kubectl --namespace hmpps-community-accommodation-<env> get secrets
+```
+
+Add the secret name and view or make the change:
+
+```bash
+kubectl --namespace hmpps-community-accommodation-<env> edit secret <secret set name>
+```
+
+Consider a [rolling restart](#rolling-restart) to apply this change.
+
+### Rolling restart
+
+Restart an individual service without downtime. Each service will have multiple
+containers running. This process will attempt to start a new replica set
+alongside the existing set that's currently serving real requests. If
+the new set is healthy, Kubernetes will gracefully replace the existing set and
+then remove the old. Useful as one way to refresh environment
+variables.
+
+First find the service name you'd like to restart:
+
+```bash
+kubectl --namespace hmpps-community-accommodation-<env> get services
+```
+
+Start the restart:
+
+```bash
+kubectl --namespace hmpps-community-accommodation-<env> rollout restart deployment <service name>
+```
+
+You can observe the progress if you like:
+
+```bash
+watch kubectl --namespace hmpps-community-accommodation-<env> get pods
+```


### PR DESCRIPTION
Includes notes on the way accessing API logs is different from the frontend. If there wasn't this difference and potential for further divergences I would have chosen to add this in once in Confluence. We may still want to do this.

[We've added a similar bit of documentation to the TA frontend recently](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/155).

Includes some automatic markdown linting which I noticed my editor found as an optional contribution that's riding on this proposals coat tails. 