### PR TITLE
Make staffcode non nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -42,7 +42,7 @@ data class UserEntity(
   val id: UUID,
   var name: String,
   val deliusUsername: String,
-  var deliusStaffCode: String?,
+  var deliusStaffCode: String,
   var deliusStaffIdentifier: Long,
   var email: String?,
   var telephoneNumber: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -68,7 +68,6 @@ class UserService(
 
   fun getUserForUsername(username: String): UserEntity {
     val existingUser = userRepository.findByDeliusUsername(username)
-    if (existingUser != null && existingUser.deliusStaffCode == null) return updateUserFromCommunityApi(existingUser)
     if (existingUser != null) return existingUser
 
     val staffUserDetailsResponse = communityApiClient.getStaffUserDetails(username)

--- a/src/main/resources/db/migration/all/20230216171125__staff_code_not_null.sql
+++ b/src/main/resources/db/migration/all/20230216171125__staff_code_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN delius_staff_code SET NOT NULL;

--- a/src/main/resources/db/migration/local+dev/20230216171124__staff_code_for_non_existent_users.sql
+++ b/src/main/resources/db/migration/local+dev/20230216171124__staff_code_for_non_existent_users.sql
@@ -1,0 +1,6 @@
+UPDATE users SET delius_staff_code = 'STAFFCODE' WHERE user IN (
+    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad',
+    'b5825da0-1553-4398-90ac-6a8e0c8a4cae',
+    '695ba399-c407-4b66-aafc-e8835d72b8a7',
+    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -18,7 +18,7 @@ class UserEntityFactory : Factory<UserEntity> {
   private var email: Yielded<String?> = { randomEmailAddress() }
   private var telephoneNumber: Yielded<String?> = { randomNumberChars(12) }
   private var deliusUsername: Yielded<String> = { randomStringUpperCase(12) }
-  private var deliusStaffCode: Yielded<String?> = { randomStringUpperCase(6) }
+  private var deliusStaffCode: Yielded<String> = { randomStringUpperCase(6) }
   private var deliusStaffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
   private var applications: Yielded<MutableList<ApplicationEntity>> = { mutableListOf() }
   private var qualifications: Yielded<MutableList<UserQualificationAssignmentEntity>> = { mutableListOf() }
@@ -36,7 +36,7 @@ class UserEntityFactory : Factory<UserEntity> {
     this.deliusUsername = { deliusUsername }
   }
 
-  fun withDeliusStaffCode(deliusStaffCode: String?) = apply {
+  fun withDeliusStaffCode(deliusStaffCode: String) = apply {
     this.deliusStaffCode = { deliusStaffCode }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
@@ -17,13 +17,13 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
 
     val userOne = userEntityFactory.produceAndPersist {
       withDeliusUsername("USER1")
-      withDeliusStaffCode(null)
+      withDeliusStaffCode("OLDCODE1")
       withProbationRegion(probationRegion)
     }
 
     val userTwo = userEntityFactory.produceAndPersist {
       withDeliusUsername("USER2")
-      withDeliusStaffCode(null)
+      withDeliusStaffCode("OLDCODE2")
       withProbationRegion(probationRegion)
     }
 
@@ -62,13 +62,13 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
 
     val userOne = userEntityFactory.produceAndPersist {
       withDeliusUsername("USER1")
-      withDeliusStaffCode(null)
+      withDeliusStaffCode("OLDCODE1")
       withProbationRegion(probationRegion)
     }
 
     val userTwo = userEntityFactory.produceAndPersist {
       withDeliusUsername("USER2")
-      withDeliusStaffCode(null)
+      withDeliusStaffCode("OLDCODE2")
       withProbationRegion(probationRegion)
     }
 
@@ -86,7 +86,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
     val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
     val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!
 
-    assertThat(userOneAfterUpdate.deliusStaffCode).isEqualTo(null)
+    assertThat(userOneAfterUpdate.deliusStaffCode).isEqualTo("OLDCODE1")
     assertThat(userTwoAfterUpdate.deliusStaffCode).isEqualTo("STAFFCODE2")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -102,48 +102,6 @@ class UserServiceTest {
     verify(exactly = 1) { mockProbationRegionRepository.findByDeliusCode(any()) }
   }
 
-  @Test
-  fun `getUserForUsername updates from Community API for existing user without staff code`() {
-    val username = "SOMEPERSON"
-
-    every { mockUserRepository.findByDeliusUsername(username) } returns UserEntityFactory()
-      .withDeliusUsername(username)
-      .withDeliusStaffCode(null)
-      .withProbationRegion(
-        ProbationRegionEntityFactory()
-          .withApArea(ApAreaEntityFactory().produce())
-          .produce()
-      )
-      .produce()
-
-    every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as UserEntity }
-
-    every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
-      HttpStatus.OK,
-      StaffUserDetailsFactory()
-        .withUsername(username)
-        .withForenames("Jim")
-        .withSurname("Jimmerson")
-        .withStaffIdentifier(5678)
-        .withStaffCode("STAFFCODE123")
-        .produce()
-    )
-
-    assertThat(userService.getUserForUsername(username)).matches {
-      it.name == "Jim Jimmerson" &&
-        it.deliusStaffCode == "STAFFCODE123"
-    }
-
-    verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
-    verify(exactly = 1) {
-      mockUserRepository.save(
-        match {
-          it.deliusStaffCode == "STAFFCODE123"
-        }
-      )
-    }
-  }
-
   @Nested
   class UpdateUserFromCommunityApiById {
     private val mockHttpAuthService = mockk<HttpAuthService>()


### PR DESCRIPTION
This should always be present a user, it was previously nullable to allow us to do a migration.  Now that's complete, we can set this to not nullable.