### PR TITLE
1225 - Limit application access by caseload

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -107,7 +107,10 @@ class ApprovedPremisesApplicationEntity(
   submittedAt,
   schemaUpToDate,
   assessments,
-)
+) {
+  fun hasTeamCode(code: String) = teamCodes.any { it.teamCode == code }
+  fun hasAnyTeamCode(codes: List<String>) = codes.any(::hasTeamCode)
+}
 
 @Repository
 interface ApplicationTeamCodeRepository : JpaRepository<ApplicationTeamCodeEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -25,6 +25,13 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")
   fun <T : ApplicationEntity> findAllByCreatedByUser_Id(id: UUID, type: Class<T>): List<ApplicationEntity>
 
+  @Query(
+    "SELECT a FROM ApplicationEntity a " +
+      "LEFT JOIN ApplicationTeamCodeEntity atc ON a = atc.application " +
+      "WHERE TYPE(a) = :type AND atc.teamCode IN (:managingTeamCodes)"
+  )
+  fun <T : ApplicationEntity> findAllByManagingTeam(managingTeamCodes: List<String>, type: Class<T>): List<ApplicationEntity>
+
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn = :crn")
   fun <T : ApplicationEntity> findByCrn(crn: String, type: Class<T>): List<ApplicationEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -114,6 +114,18 @@ class ApplicationService(
       return AuthorisableActionResult.Success(jsonSchemaService.checkSchemaOutdated(applicationEntity))
     }
 
+    if (applicationEntity is ApprovedPremisesApplicationEntity) {
+      val userDetailsResult = communityApiClient.getStaffUserDetails(userEntity.deliusUsername)
+      val userDetails = when (userDetailsResult) {
+        is ClientResult.Success -> userDetailsResult.body
+        is ClientResult.Failure -> userDetailsResult.throwException()
+      }
+
+      if (applicationEntity.hasAnyTeamCode(userDetails.teams?.map { it.code } ?: emptyList())) {
+        return AuthorisableActionResult.Success(jsonSchemaService.checkSchemaOutdated(applicationEntity))
+      }
+    }
+
     return AuthorisableActionResult.Unauthorised()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -92,6 +92,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Staf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTeamCodeTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesAssessmentJsonSchemaTestRepository
@@ -240,6 +241,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var domainEventRepository: DomainEventTestRepository
+
+  @Autowired
+  lateinit var applicationTeamCodeRepository: ApplicationTeamCodeTestRepository
 
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTeamCodeTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTeamCodeTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
+import java.util.UUID
+
+@Repository
+interface ApplicationTeamCodeTestRepository : JpaRepository<ApplicationTeamCodeEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -170,17 +170,19 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `getApplicationForUsername where application was not created by calller and where caller is not one of one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER returns Unauthorised result`() {
+  fun `getApplicationForUsername where application was not created by caller, not in case load and where caller is not one of one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER returns Unauthorised result`() {
     val distinguishedName = "SOMEPERSON"
     val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns UserEntityFactory()
+      .withDeliusUsername(distinguishedName)
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
           .withYieldedApArea { ApAreaEntityFactory().produce() }
           .produce()
       }
       .produce()
+
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(
         UserEntityFactory()
@@ -192,6 +194,20 @@ class ApplicationServiceTest {
           .produce()
       )
       .produce()
+
+    val staffUserDetails = StaffUserDetailsFactory()
+      .withTeams(
+        listOf(
+          StaffUserTeamMembershipFactory()
+            .produce()
+        )
+      )
+      .produce()
+
+    every { mockCommunityApiClient.getStaffUserDetails(distinguishedName) } returns ClientResult.Success(
+      status = HttpStatus.OK,
+      body = staffUserDetails
+    )
 
     assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -224,6 +240,72 @@ class ApplicationServiceTest {
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns applicationEntity
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
+
+    val result = applicationService.getApplicationForUsername(applicationId, distinguishedName)
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+
+    assertThat(result.entity).isEqualTo(applicationEntity)
+  }
+
+  @Test
+  fun `getApplicationForUsername where application CRN is managed by team caller is in returns Success result with entity from db`() {
+    val distinguishedName = "SOMEPERSON"
+    val userId = UUID.fromString("239b5e41-f83e-409e-8fc0-8f1e058d417e")
+    val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
+
+    val newestJsonSchema = ApprovedPremisesApplicationJsonSchemaEntityFactory()
+      .withSchema("{}")
+      .produce()
+
+    val userEntity = UserEntityFactory()
+      .withId(userId)
+      .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val otherUserEntity = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val applicationEntity = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(otherUserEntity)
+      .withApplicationSchema(newestJsonSchema)
+      .produce()
+
+    applicationEntity.teamCodes += ApplicationTeamCodeEntity(
+      id = UUID.randomUUID(),
+      application = applicationEntity,
+      teamCode = "TEAM1"
+    )
+
+    every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns applicationEntity
+    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
+
+    val staffUserDetails = StaffUserDetailsFactory()
+      .withTeams(
+        listOf(
+          StaffUserTeamMembershipFactory()
+            .withCode("TEAM1")
+            .produce()
+        )
+      )
+      .produce()
+
+    every { mockCommunityApiClient.getStaffUserDetails(distinguishedName) } returns ClientResult.Success(
+      status = HttpStatus.OK,
+      body = staffUserDetails
+    )
 
     val result = applicationService.getApplicationForUsername(applicationId, distinguishedName)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -135,8 +135,21 @@ class ApplicationServiceTest {
         .produce()
     )
 
+    every { mockCommunityApiClient.getStaffUserDetails(distinguishedName) } returns ClientResult.Success(
+      HttpStatus.OK,
+      StaffUserDetailsFactory()
+        .withTeams(
+          listOf(
+            StaffUserTeamMembershipFactory()
+              .withCode("TEAM1")
+              .produce()
+          )
+        )
+        .produce()
+    )
+
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
-    every { mockApplicationRepository.findAllByCreatedByUser_Id(userId, ApprovedPremisesApplicationEntity::class.java) } returns applicationEntities
+    every { mockApplicationRepository.findAllByManagingTeam(listOf("TEAM1"), ApprovedPremisesApplicationEntity::class.java) } returns applicationEntities
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     applicationEntities.forEach {


### PR DESCRIPTION
Allow users to view an Application if they are a member of a team that the CRN was managed by when the Application was created.