### PR TITLE
847 - Hard Delete Booking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /
 
 COPY --from=builder --chown=appuser:appgroup /app/script/run_seed_job /app
 COPY --from=builder --chown=appuser:appgroup /app/script/run_migration_job /app
-RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job && chmod +x /app/run_migration_job
+COPY --from=builder --chown=appuser:appgroup /app/script/delete_booking /app
+RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job && chmod +x /app/run_migration_job && chmod +x /app/delete_booking
 
 USER 2000
 

--- a/doc/how-to/delete_booking_remotely.md
+++ b/doc/how-to/delete_booking_remotely.md
@@ -1,0 +1,10 @@
+# How to delete a Booking remotely
+
+To delete a Booking against a non-local environment:
+
+- Run `kubectl get pod` against the namespace for the environment you wish to delete the Booking from.
+- Copy the name of one of the running `hmpps-approved-premises-api` pods.
+- Run the helper script from within the container to trigger the deletion:
+  ```
+  kubectl exec --stdin --tty {pod name} -- /app/delete_booking {booking id}
+  ```

--- a/script/delete_booking
+++ b/script/delete_booking
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# script/delete_booking:    Use internal endpoint to delete a booking.  e.g.
+#                           script/delete_booking {booking id}
+
+set -e
+
+curl --location --request DELETE "http://127.0.0.1:8080/internal/booking/$1"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -45,6 +45,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/info", permitAll)
         authorize(HttpMethod.POST, "/seed", permitAll)
         authorize(HttpMethod.POST, "/migration-job", permitAll)
+        authorize(HttpMethod.DELETE, "/internal/booking/*", permitAll)
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DeleteBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DeleteBookingController.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
+import java.util.UUID
+
+@Controller
+class DeleteBookingController(private val bookingService: BookingService) {
+  @RequestMapping(method = [RequestMethod.DELETE], value = ["/internal/booking/{bookingId}"])
+  fun internalDeleteBooking(@PathVariable("bookingId") bookingId: UUID): ResponseEntity<Unit> {
+    throwIfNotLoopbackRequest()
+
+    val booking = bookingService.getBooking(bookingId)
+      ?: throw NotFoundProblem(bookingId, "Booking")
+
+    bookingService.deleteBooking(booking)
+
+    return ResponseEntity(HttpStatus.OK)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/LoopbackUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/LoopbackUtils.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.UnauthenticatedProblem
+
+fun throwIfNotLoopbackRequest() {
+  val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+  val remoteAddress = request.remoteAddr
+
+  if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
+    throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/MigrationJobController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/MigrationJobController.kt
@@ -3,11 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
-import org.springframework.web.context.request.RequestContextHolder
-import org.springframework.web.context.request.ServletRequestAttributes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.MigrationJobApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobRequest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.UnauthenticatedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
 
 @Service
@@ -18,14 +15,5 @@ class MigrationJobController(private val migrationJobService: MigrationJobServic
     migrationJobService.runMigrationJob(migrationJobRequest.jobType)
 
     return ResponseEntity(HttpStatus.ACCEPTED)
-  }
-
-  private fun throwIfNotLoopbackRequest() {
-    val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
-    val remoteAddress = request.remoteAddr
-
-    if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
-      throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
@@ -3,11 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
-import org.springframework.web.context.request.RequestContextHolder
-import org.springframework.web.context.request.ServletRequestAttributes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.SeedApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.UnauthenticatedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
 
 @Service
@@ -18,14 +15,5 @@ class SeedController(private val seedService: SeedService) : SeedApiDelegate {
     seedService.seedDataAsync(seedRequest.seedType, seedRequest.fileName)
 
     return ResponseEntity(HttpStatus.ACCEPTED)
-  }
-
-  private fun throwIfNotLoopbackRequest() {
-    val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
-    val remoteAddress = request.remoteAddr
-
-    if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
-      throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -318,6 +318,35 @@ class BookingService(
     return GetBookingForPremisesResult.Success(booking)
   }
 
+  @Transactional
+  fun deleteBooking(booking: BookingEntity) {
+    if (booking.arrival != null) {
+      arrivalRepository.delete(booking.arrival!!)
+    }
+
+    if (booking.departure != null) {
+      departureRepository.delete(booking.departure!!)
+    }
+
+    if (booking.nonArrival != null) {
+      nonArrivalRepository.delete(booking.nonArrival!!)
+    }
+
+    if (booking.cancellation != null) {
+      cancellationRepository.delete(booking.cancellation!!)
+    }
+
+    if (booking.confirmation != null) {
+      confirmationRepository.delete(booking.confirmation!!)
+    }
+
+    booking.extensions.forEach {
+      extensionRepository.delete(it)
+    }
+
+    bookingRepository.delete(booking)
+  }
+
   private fun serviceScopeMatches(scope: String, booking: BookingEntity): Boolean {
     return when (scope) {
       "*" -> true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteBookingTest.kt
@@ -1,0 +1,141 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.every
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionRepository
+
+class DeleteBookingTest : IntegrationTestBase() {
+  @SpykBean
+  lateinit var realExtensionRepository: ExtensionRepository
+
+  @Test
+  fun `Deleting a Booking successfully deletes all related entities and deletes the Booking itself`() {
+    val booking = bookingEntityFactory.produceAndPersist {
+      withPremises(createPremises())
+    }
+
+    val arrival = arrivalEntityFactory.produceAndPersist {
+      withBooking(booking)
+    }
+
+    val departure = departureEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withReason(departureReasonEntityFactory.produceAndPersist())
+      withMoveOnCategory(moveOnCategoryEntityFactory.produceAndPersist())
+      withDestinationProvider(destinationProviderEntityFactory.produceAndPersist())
+    }
+
+    val nonArrival = nonArrivalEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withReason(nonArrivalReasonEntityFactory.produceAndPersist())
+    }
+
+    val cancellation = cancellationEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withReason(cancellationReasonEntityFactory.produceAndPersist())
+    }
+
+    val confirmation = confirmationEntityFactory.produceAndPersist {
+      withBooking(booking)
+    }
+
+    val extensions = extensionEntityFactory.produceAndPersistMultiple(3) {
+      withBooking(booking)
+    }
+
+    webTestClient.delete()
+      .uri("/internal/booking/${booking.id}")
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    val bookingFromDatabase = bookingRepository.findByIdOrNull(booking.id)
+    val arrivalFromDatabase = arrivalRepository.findByIdOrNull(arrival.id)
+    val departureFromDatabase = departureRepository.findByIdOrNull(departure.id)
+    val nonArrivalFromDatabase = nonArrivalRepository.findByIdOrNull(nonArrival.id)
+    val cancellationFromDatabase = cancellationRepository.findByIdOrNull(cancellation.id)
+    val confirmationFromDatabase = confirmationRepository.findByIdOrNull(confirmation.id)
+    val extensionsFromDatabase = extensions.map { extensionRepository.findByIdOrNull(it.id) }
+
+    assertThat(bookingFromDatabase).isNull()
+    assertThat(arrivalFromDatabase).isNull()
+    assertThat(departureFromDatabase).isNull()
+    assertThat(nonArrivalFromDatabase).isNull()
+    assertThat(cancellationFromDatabase).isNull()
+    assertThat(confirmationFromDatabase).isNull()
+    extensionsFromDatabase.forEach { assertThat(it).isNull() }
+  }
+
+  @Test
+  fun `Deleting a Booking is transactional - failure to delete last extension results in all previous deletes being rolled back`() {
+    val booking = bookingEntityFactory.produceAndPersist {
+      withPremises(createPremises())
+    }
+
+    val arrival = arrivalEntityFactory.produceAndPersist {
+      withBooking(booking)
+    }
+
+    val departure = departureEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withReason(departureReasonEntityFactory.produceAndPersist())
+      withMoveOnCategory(moveOnCategoryEntityFactory.produceAndPersist())
+      withDestinationProvider(destinationProviderEntityFactory.produceAndPersist())
+    }
+
+    val nonArrival = nonArrivalEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withReason(nonArrivalReasonEntityFactory.produceAndPersist())
+    }
+
+    val cancellation = cancellationEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withReason(cancellationReasonEntityFactory.produceAndPersist())
+    }
+
+    val confirmation = confirmationEntityFactory.produceAndPersist {
+      withBooking(booking)
+    }
+
+    val extensions = extensionEntityFactory.produceAndPersistMultiple(3) {
+      withBooking(booking)
+    }
+
+    every { realExtensionRepository.delete(match { it.id == extensions.last().id }) } throws RuntimeException("Database Exception")
+
+    webTestClient.delete()
+      .uri("/internal/booking/${booking.id}")
+      .exchange()
+      .expectStatus()
+      .is5xxServerError
+
+    val bookingFromDatabase = bookingRepository.findByIdOrNull(booking.id)
+    val arrivalFromDatabase = arrivalRepository.findByIdOrNull(arrival.id)
+    val departureFromDatabase = departureRepository.findByIdOrNull(departure.id)
+    val nonArrivalFromDatabase = nonArrivalRepository.findByIdOrNull(nonArrival.id)
+    val cancellationFromDatabase = cancellationRepository.findByIdOrNull(cancellation.id)
+    val confirmationFromDatabase = confirmationRepository.findByIdOrNull(confirmation.id)
+    val extensionsFromDatabase = extensions.map { extensionRepository.findByIdOrNull(it.id) }
+
+    assertThat(bookingFromDatabase).isNotNull
+    assertThat(arrivalFromDatabase).isNotNull
+    assertThat(departureFromDatabase).isNotNull
+    assertThat(nonArrivalFromDatabase).isNotNull
+    assertThat(cancellationFromDatabase).isNotNull
+    assertThat(confirmationFromDatabase).isNotNull
+    assertThat(extensionsFromDatabase).isNotNull
+  }
+
+  private fun createPremises() = approvedPremisesEntityFactory.produceAndPersist {
+    withProbationRegion(
+      probationRegionEntityFactory.produceAndPersist {
+        withApArea(apAreaEntityFactory.produceAndPersist())
+      }
+    )
+
+    withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
@@ -64,6 +65,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
@@ -103,6 +105,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentTes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
@@ -166,6 +169,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var arrivalRepository: ArrivalTestRepository
+
+  @Autowired
+  lateinit var confirmationRepository: ConfirmationTestRepository
 
   @Autowired
   lateinit var departureRepository: DepartureTestRepository
@@ -252,6 +258,7 @@ abstract class IntegrationTestBase {
   lateinit var temporaryAccommodationPremisesEntityFactory: PersistedFactory<TemporaryAccommodationPremisesEntity, UUID, TemporaryAccommodationPremisesEntityFactory>
   lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
   lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
+  lateinit var confirmationEntityFactory: PersistedFactory<ConfirmationEntity, UUID, ConfirmationEntityFactory>
   lateinit var departureEntityFactory: PersistedFactory<DepartureEntity, UUID, DepartureEntityFactory>
   lateinit var destinationProviderEntityFactory: PersistedFactory<DestinationProviderEntity, UUID, DestinationProviderEntityFactory>
   lateinit var departureReasonEntityFactory: PersistedFactory<DepartureReasonEntity, UUID, DepartureReasonEntityFactory>
@@ -313,6 +320,7 @@ abstract class IntegrationTestBase {
     temporaryAccommodationPremisesEntityFactory = PersistedFactory({ TemporaryAccommodationPremisesEntityFactory() }, temporaryAccommodationPremisesRepository)
     bookingEntityFactory = PersistedFactory({ BookingEntityFactory() }, bookingRepository)
     arrivalEntityFactory = PersistedFactory({ ArrivalEntityFactory() }, arrivalRepository)
+    confirmationEntityFactory = PersistedFactory({ ConfirmationEntityFactory() }, confirmationRepository)
     departureEntityFactory = PersistedFactory({ DepartureEntityFactory() }, departureRepository)
     destinationProviderEntityFactory = PersistedFactory({ DestinationProviderEntityFactory() }, destinationProviderRepository)
     departureReasonEntityFactory = PersistedFactory({ DepartureReasonEntityFactory() }, departureReasonRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ConfirmationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ConfirmationTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+import java.util.UUID
+
+@Repository
+interface ConfirmationTestRepository : JpaRepository<ConfirmationEntity, UUID>


### PR DESCRIPTION
This adds an endpoint at DELETE `/internal/booking/{booking id}` that can only be called from localhost.

This will delete the Booking and all dependent entities such as arrivals, nonarrivals, extensions etc.