### PR TITLE
Create service-specific tables and JPA entities for lost beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
@@ -78,7 +79,7 @@ class PremisesService(
         arrivedBookings = bookingsOnDay.count { it.arrival != null },
         nonArrivedBookings = bookingsOnDay.count { it.nonArrival != null },
         cancelledBookings = bookingsOnDay.count { it.cancellation != null },
-        lostBeds = lostBedsOnDay.sumOf { it.numberOfBeds }
+        lostBeds = lostBedsOnDay.filterIsInstance<ApprovedPremisesLostBedsEntity>().sumOf { it.numberOfBeds }
       )
     }.associateBy { it.date }
   }
@@ -111,7 +112,7 @@ class PremisesService(
       }
 
       val lostBedsEntity = lostBedsRepository.save(
-        LostBedsEntity(
+        ApprovedPremisesLostBedsEntity(
           id = UUID.randomUUID(),
           premises = premises,
           startDate = startDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 
 @Component
@@ -10,7 +11,7 @@ class LostBedsTransformer(private val lostBedReasonTransformer: LostBedReasonTra
     id = jpa.id,
     startDate = jpa.startDate,
     endDate = jpa.endDate,
-    numberOfBeds = jpa.numberOfBeds,
+    numberOfBeds = if (jpa is ApprovedPremisesLostBedsEntity) jpa.numberOfBeds else 1,
     reason = lostBedReasonTransformer.transformJpaToApi(jpa.reason),
     referenceNumber = jpa.referenceNumber,
     notes = jpa.notes

--- a/src/main/resources/db/migration/all/20230221114036__create_service-specific_tables_for_lost_beds.sql
+++ b/src/main/resources/db/migration/all/20230221114036__create_service-specific_tables_for_lost_beds.sql
@@ -1,0 +1,14 @@
+CREATE TABLE approved_premises_lost_beds (
+    lost_bed_id UUID NOT NULL,
+    number_of_beds INT NOT NULL,
+    PRIMARY KEY (lost_bed_id),
+    FOREIGN KEY (lost_bed_id) REFERENCES lost_beds(id)
+);
+
+CREATE TABLE temporary_accommodation_lost_beds (
+    lost_bed_id UUID NOT NULL,
+    bed_id UUID NOT NULL,
+    PRIMARY KEY (lost_bed_id),
+    FOREIGN KEY (lost_bed_id) REFERENCES lost_beds(id),
+    FOREIGN KEY (bed_id) REFERENCES beds(id)
+);

--- a/src/main/resources/db/migration/all/20230221114122__migrate_existing_service-specific_lost_bed_data_to_service-specific_tables.sql
+++ b/src/main/resources/db/migration/all/20230221114122__migrate_existing_service-specific_lost_bed_data_to_service-specific_tables.sql
@@ -1,0 +1,10 @@
+INSERT INTO approved_premises_lost_beds (lost_bed_id, number_of_beds)
+SELECT id, number_of_beds
+FROM lost_beds;
+
+ALTER TABLE lost_beds ADD COLUMN service TEXT;
+
+UPDATE lost_beds
+SET service = 'approved-premises';
+
+ALTER TABLE lost_beds ALTER COLUMN service SET NOT NULL;

--- a/src/main/resources/db/migration/all/20230221114147__drop_service-specific_columns_from_base_lost_bed_table.sql
+++ b/src/main/resources/db/migration/all/20230221114147__drop_service-specific_columns_from_base_lost_bed_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lost_beds DROP COLUMN number_of_beds;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesLostBedsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesLostBedsEntityFactory.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class ApprovedPremisesLostBedsEntityFactory : Factory<ApprovedPremisesLostBedsEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
+  private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
+  private var numberOfBeds: Yielded<Int> = { randomInt(1, 10) }
+  private var reason: Yielded<LostBedReasonEntity>? = null
+  private var referenceNumber: Yielded<String?> = { UUID.randomUUID().toString() }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+  private var premises: Yielded<PremisesEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withEndDate(endDate: LocalDate) = apply {
+    this.endDate = { endDate }
+  }
+
+  fun withNumberOfBeds(numberOfBeds: Int) = apply {
+    this.numberOfBeds = { numberOfBeds }
+  }
+
+  fun withYieldedReason(reason: Yielded<LostBedReasonEntity>) = apply {
+    this.reason = reason
+  }
+
+  fun withReferenceNumber(referenceNumber: String?) = apply {
+    this.referenceNumber = { referenceNumber }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedPremises(premises: Yielded<PremisesEntity>) = apply {
+    this.premises = premises
+  }
+
+  fun withPremises(premises: PremisesEntity) = apply {
+    this.premises = { premises }
+  }
+
+  override fun produce(): ApprovedPremisesLostBedsEntity = ApprovedPremisesLostBedsEntity(
+    id = this.id(),
+    startDate = this.startDate(),
+    endDate = this.endDate(),
+    numberOfBeds = this.numberOfBeds(),
+    reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
+    referenceNumber = this.referenceNumber(),
+    notes = this.notes(),
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationLostBedEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationLostBedEntityFactory.kt
@@ -2,25 +2,25 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationLostBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.util.UUID
 
-class LostBedsEntityFactory : Factory<LostBedsEntity> {
+class TemporaryAccommodationLostBedEntityFactory : Factory<TemporaryAccommodationLostBedEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
   private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
-  private var numberOfBeds: Yielded<Int> = { randomInt(1, 10) }
   private var reason: Yielded<LostBedReasonEntity>? = null
   private var referenceNumber: Yielded<String?> = { UUID.randomUUID().toString() }
   private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
   private var premises: Yielded<PremisesEntity>? = null
+  private var bed: Yielded<BedEntity>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -32,10 +32,6 @@ class LostBedsEntityFactory : Factory<LostBedsEntity> {
 
   fun withEndDate(endDate: LocalDate) = apply {
     this.endDate = { endDate }
-  }
-
-  fun withNumberOfBeds(numberOfBeds: Int) = apply {
-    this.numberOfBeds = { numberOfBeds }
   }
 
   fun withYieldedReason(reason: Yielded<LostBedReasonEntity>) = apply {
@@ -50,22 +46,26 @@ class LostBedsEntityFactory : Factory<LostBedsEntity> {
     this.notes = { notes }
   }
 
-  fun withYieldedPremises(premises: Yielded<PremisesEntity>) = apply {
-    this.premises = premises
-  }
-
   fun withPremises(premises: PremisesEntity) = apply {
     this.premises = { premises }
   }
 
-  override fun produce(): LostBedsEntity = LostBedsEntity(
+  fun withYieldedBed(bed: Yielded<BedEntity>) = apply {
+    this.bed = bed
+  }
+
+  fun withBed(bed: BedEntity) = apply {
+    this.bed = { bed }
+  }
+
+  override fun produce(): TemporaryAccommodationLostBedEntity = TemporaryAccommodationLostBedEntity(
     id = this.id(),
     startDate = this.startDate(),
     endDate = this.endDate(),
-    numberOfBeds = this.numberOfBeds(),
     reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
     referenceNumber = this.referenceNumber(),
     notes = this.notes(),
-    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises")
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
+    bed = this.bed?.invoke() ?: throw RuntimeException("Must provide a Bed"),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesLostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
@@ -37,7 +38,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationLostBedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
@@ -55,6 +56,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
@@ -73,7 +75,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
@@ -82,6 +83,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationLostBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
@@ -98,6 +100,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesAssessmentJsonSchemaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesLostBedsTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentClarificationNoteTestRepository
@@ -113,12 +116,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DomainEventTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExtensionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedReasonTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.MoveOnCategoryTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.OfflineApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationLostBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssignmentTestRepository
@@ -195,7 +198,10 @@ abstract class IntegrationTestBase {
   lateinit var cancellationReasonRepository: CancellationReasonTestRepository
 
   @Autowired
-  lateinit var lostBedsRepository: LostBedsTestRepository
+  lateinit var approvedPremisesLostBedsRepository: ApprovedPremisesLostBedsTestRepository
+
+  @Autowired
+  lateinit var temporaryAccommodationLostBedRepository: TemporaryAccommodationLostBedTestRepository
 
   @Autowired
   lateinit var lostBedReasonRepository: LostBedReasonTestRepository
@@ -266,7 +272,8 @@ abstract class IntegrationTestBase {
   lateinit var nonArrivalEntityFactory: PersistedFactory<NonArrivalEntity, UUID, NonArrivalEntityFactory>
   lateinit var cancellationEntityFactory: PersistedFactory<CancellationEntity, UUID, CancellationEntityFactory>
   lateinit var cancellationReasonEntityFactory: PersistedFactory<CancellationReasonEntity, UUID, CancellationReasonEntityFactory>
-  lateinit var lostBedsEntityFactory: PersistedFactory<LostBedsEntity, UUID, LostBedsEntityFactory>
+  lateinit var approvedPremisesLostBedsEntityFactory: PersistedFactory<ApprovedPremisesLostBedsEntity, UUID, ApprovedPremisesLostBedsEntityFactory>
+  lateinit var temporaryAccommodationLostBedEntityFactory: PersistedFactory<TemporaryAccommodationLostBedEntity, UUID, TemporaryAccommodationLostBedEntityFactory>
   lateinit var lostBedReasonEntityFactory: PersistedFactory<LostBedReasonEntity, UUID, LostBedReasonEntityFactory>
   lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
@@ -328,7 +335,8 @@ abstract class IntegrationTestBase {
     nonArrivalEntityFactory = PersistedFactory({ NonArrivalEntityFactory() }, nonArrivalRepository)
     cancellationEntityFactory = PersistedFactory({ CancellationEntityFactory() }, cancellationRepository)
     cancellationReasonEntityFactory = PersistedFactory({ CancellationReasonEntityFactory() }, cancellationReasonRepository)
-    lostBedsEntityFactory = PersistedFactory({ LostBedsEntityFactory() }, lostBedsRepository)
+    approvedPremisesLostBedsEntityFactory = PersistedFactory({ ApprovedPremisesLostBedsEntityFactory() }, approvedPremisesLostBedsRepository)
+    temporaryAccommodationLostBedEntityFactory = PersistedFactory({ TemporaryAccommodationLostBedEntityFactory() }, temporaryAccommodationLostBedRepository)
     lostBedReasonEntityFactory = PersistedFactory({ LostBedReasonEntityFactory() }, lostBedReasonRepository)
     extensionEntityFactory = PersistedFactory({ ExtensionEntityFactory() }, extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory({ NonArrivalReasonEntityFactory() }, nonArrivalReasonRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -54,7 +54,7 @@ class LostBedsTest : IntegrationTestBase() {
         }
       }
 
-      val lostBeds = lostBedsEntityFactory.produceAndPersist {
+      val lostBeds = approvedPremisesLostBedsEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LostBedsTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LostBedsTestRepository.kt
@@ -2,8 +2,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationLostBedEntity
 import java.util.UUID
 
 @Repository
 interface LostBedsTestRepository : JpaRepository<LostBedsEntity, UUID>
+
+@Repository
+interface ApprovedPremisesLostBedsTestRepository : JpaRepository<ApprovedPremisesLostBedsEntity, UUID>
+
+@Repository
+interface TemporaryAccommodationLostBedTestRepository : JpaRepository<TemporaryAccommodationLostBedEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -8,16 +8,17 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesLostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
@@ -87,7 +88,7 @@ class PremisesServiceTest {
         ProbationRegionEntityFactory().withYieldedApArea { ApAreaEntityFactory().produce() }.produce()
       }.produce()
 
-    val lostBedEntity = LostBedsEntityFactory()
+    val lostBedEntity = ApprovedPremisesLostBedsEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -227,12 +228,14 @@ class PremisesServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
     result as ValidatableActionResult.Success
-    assertThat(result.entity.premises).isEqualTo(premisesEntity)
-    assertThat(result.entity.reason).isEqualTo(lostBedReason)
-    assertThat(result.entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))
-    assertThat(result.entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
-    assertThat(result.entity.numberOfBeds).isEqualTo(5)
-    assertThat(result.entity.referenceNumber).isEqualTo("12345")
-    assertThat(result.entity.notes).isEqualTo("notes")
+    assertThat(result.entity).isInstanceOf(ApprovedPremisesLostBedsEntity::class.java)
+    val entity = result.entity as ApprovedPremisesLostBedsEntity
+    assertThat(entity.premises).isEqualTo(premisesEntity)
+    assertThat(entity.reason).isEqualTo(lostBedReason)
+    assertThat(entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))
+    assertThat(entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
+    assertThat(entity.numberOfBeds).isEqualTo(5)
+    assertThat(entity.referenceNumber).isEqualTo("12345")
+    assertThat(entity.notes).isEqualTo("notes")
   }
 }


### PR DESCRIPTION
>  See [ticket #806 on the CAS3 Trello board](https://trello.com/c/RDiktZxl/806-introduce-service-specific-lost-bed-tables-entities).

This PR is part of the work to implement support for lost beds within the Temporary Accommodation service. It will enable service-specific behaviour such as validation for endpoints concerning lost beds.

Changes in this PR:
- The `approved_premises_lost_beds` and `temporary_accommodation_lost_beds` tables have been introduced to provide service-specific data and the `lost_beds` table now contains common data shared between both services.
- The `LostBedsEntity` now has `ApprovedPremisesLostBedsEntity` and `TemporaryAccommodationLostBedEntity` as subclasses to do likewise within the API itself.
- The existing API logic has been updated to support these changes while preserving the current behaviour.