### PR TITLE
Introduce service scope for lost bed reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -98,8 +98,11 @@ class ReferenceDataController(
     return ResponseEntity.ok(cancellationReasons.map(cancellationReasonTransformer::transformJpaToApi))
   }
 
-  override fun referenceDataLostBedReasonsGet(): ResponseEntity<List<LostBedReason>> {
-    val lostBedReasons = lostBedReasonRepository.findAll()
+  override fun referenceDataLostBedReasonsGet(xServiceName: ServiceName?): ResponseEntity<List<LostBedReason>> {
+    val lostBedReasons = when (xServiceName != null) {
+      true -> lostBedReasonRepository.findAllByServiceScope(xServiceName.value)
+      false -> lostBedReasonRepository.findAll()
+    }
 
     return ResponseEntity.ok(lostBedReasons.map(lostBedReasonTransformer::transformJpaToApi))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedReasonEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -8,7 +9,10 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface LostBedReasonRepository : JpaRepository<LostBedReasonEntity, UUID>
+interface LostBedReasonRepository : JpaRepository<LostBedReasonEntity, UUID> {
+  @Query("SELECT l FROM LostBedReasonEntity l WHERE l.serviceScope = :serviceName OR l.serviceScope = '*'")
+  fun findAllByServiceScope(serviceName: String): List<LostBedReasonEntity>
+}
 
 @Entity
 @Table(name = "lost_bed_reasons")
@@ -16,7 +20,8 @@ data class LostBedReasonEntity(
   @Id
   val id: UUID,
   val name: String,
-  val isActive: Boolean
+  val isActive: Boolean,
+  val serviceScope: String,
 ) {
   override fun toString() = "LostBedReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -105,6 +105,8 @@ class PremisesService(
       val reason = lostBedReasonRepository.findByIdOrNull(reasonId)
       if (reason == null) {
         "$.reason" hasValidationError "doesNotExist"
+      } else if (!serviceScopeMatches(reason.serviceScope, premises)) {
+        "$.reason" hasValidationError "incorrectLostBedReasonServiceScope"
       }
 
       if (validationErrors.any()) {
@@ -322,5 +324,12 @@ class PremisesService(
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(savedPremises)
     )
+  }
+
+  private fun serviceScopeMatches(scope: String, premises: PremisesEntity) = when (scope) {
+    "*" -> true
+    ServiceName.approvedPremises.value -> premises is ApprovedPremisesEntity
+    ServiceName.temporaryAccommodation.value -> premises is TemporaryAccommodationPremisesEntity
+    else -> false
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedReasonTransformer.kt
@@ -9,6 +9,7 @@ class LostBedReasonTransformer() {
   fun transformJpaToApi(jpa: LostBedReasonEntity) = LostBedReason(
     id = jpa.id,
     name = jpa.name,
-    isActive = jpa.isActive
+    isActive = jpa.isActive,
+    serviceScope = jpa.serviceScope,
   )
 }

--- a/src/main/resources/db/migration/all/20230222140817__add_service_scope_to_lost_bed_reasons.sql
+++ b/src/main/resources/db/migration/all/20230222140817__add_service_scope_to_lost_bed_reasons.sql
@@ -1,0 +1,6 @@
+ALTER TABLE lost_bed_reasons ADD COLUMN service_scope TEXT;
+
+UPDATE lost_bed_reasons
+SET service_scope = 'approved-premises';
+
+ALTER TABLE lost_bed_reasons ALTER COLUMN service_scope SET NOT NULL;

--- a/src/main/resources/db/migration/all/20230222140921__seed_temporary_accommodation_lost_bed_reasons.sql
+++ b/src/main/resources/db/migration/all/20230222140921__seed_temporary_accommodation_lost_bed_reasons.sql
@@ -1,0 +1,12 @@
+INSERT INTO lost_bed_reasons (id, "name", is_active, service_scope)
+VALUES
+    ('040dce03-24f8-4fc4-8536-c1a311a307b3', 'Deep clean', true, 'temporary-accommodation'),
+    ('1cfd451c-afde-4dba-a157-c1cf3289299f', 'Needle sweep', true, 'temporary-accommodation'),
+    ('6697bb59-5b2b-48c7-82b1-d73013018602', 'PoP damage/repairs', true, 'temporary-accommodation'),
+    ('ae8cfadf-b556-4119-a471-baa87d316ef9', 'Supplier maintenance/repairs', true, 'temporary-accommodation'),
+    ('479e8765-a978-4343-9eba-34f5e055bd30', 'Stolen goods/furniture replacement', true, 'temporary-accommodation'),
+    ('607c5526-e101-4b8b-b26d-dfefb4173e1d', 'Cooling off (e.g. following an incident)', true, 'temporary-accommodation');
+
+UPDATE lost_bed_reasons
+SET service_scope = '*'
+WHERE "name" = 'Other';

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1641,6 +1641,13 @@ paths:
       tags:
         - Reference Data
       summary: Lists all reasons for losing beds
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only lost bed reasons for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation
@@ -2912,10 +2919,13 @@ components:
           example: Double Room with Single Occupancy - Other (Non-FM)
         isActive:
           type: boolean
+        serviceScope:
+          type: string
       required:
         - id
         - name
         - isActive
+        - serviceScope
     CancellationReason:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedReasonEntityFactory.kt
@@ -4,12 +4,14 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class LostBedReasonEntityFactory : Factory<LostBedReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -23,9 +25,14 @@ class LostBedReasonEntityFactory : Factory<LostBedReasonEntity> {
     this.isActive = { isActive }
   }
 
+  fun withServiceScope(serviceScope: String) = apply {
+    this.serviceScope = { serviceScope }
+  }
+
   override fun produce(): LostBedReasonEntity = LostBedReasonEntity(
     id = this.id(),
     name = this.name(),
-    isActive = this.isActive()
+    isActive = this.isActive(),
+    serviceScope = this.serviceScope(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
@@ -113,7 +114,9 @@ class LostBedsTest : IntegrationTestBase() {
         }
       }
 
-      val reason = lostBedReasonEntityFactory.produceAndPersist()
+      val reason = lostBedReasonEntityFactory.produceAndPersist {
+        withServiceScope(ServiceName.approvedPremises.value)
+      }
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -399,6 +399,58 @@ class ReferenceDataTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get Lost Bed Reasons for only Approved Premises returns 200 with correct body`() {
+    lostBedReasonRepository.deleteAll()
+
+    lostBedReasonEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedLostBedReasons = lostBedReasonEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.approvedPremises.value)
+    }
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedLostBedReasons.map(lostBedReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/lost-bed-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "approved-premises")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Lost Bed Reasons for only Temporary Accommodation returns 200 with correct body`() {
+    lostBedReasonRepository.deleteAll()
+
+    lostBedReasonEntityFactory.produceAndPersistMultiple(10)
+
+    val expectedLostBedReasons = lostBedReasonEntityFactory.produceAndPersistMultiple(10) {
+      withServiceScope(ServiceName.temporaryAccommodation.value)
+    }
+    val expectedJson = objectMapper.writeValueAsString(
+      expectedLostBedReasons.map(lostBedReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/lost-bed-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "temporary-accommodation")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
   fun `Get Probation Regions returns 200 with correct body`() {
     probationRegionRepository.deleteAll()
 


### PR DESCRIPTION
> See [ticket #809 on the CAS3 Trello board](https://trello.com/c/BckxYLXE/809-make-lost-bed-reasons-service-specific).

This PR is part of the work to implement support for lost beds within the Temporary Accommodation service. It introduces a service scope to lost bed reasons to allow each service to provide a different set of reasons for lost beds.

Changes in this PR:
- Existing lost bed reasons have been given a service scope of `"approved-premises"`, except "Other", which has a scope of `"*"`
- The list of reasons for Temporary Accommodation has been seeded using a Flyway migration
- The `GET /reference-data/lost-bed-reasons` endpoint now accepts an `X-Service-Name` header, which allows for filtering of the returned list of reasons if provided
- The `PremisesService.createLostBeds` method returns `"incorrectLostBedReasonServiceScope"` as a validation error if the provided lost bed reason does not have a valid scope for the premises.