### PR TITLE
Always return Drug and Alcohol OASys sections

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NeedsDetailsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NeedsDetailsTransformer.kt
@@ -38,18 +38,6 @@ class NeedsDetailsTransformer {
       linkedToReOffending = needsDetails.linksToReOffending?.lifestyleLinkedToReOffending
     ),
     OASysSection(
-      section = 8,
-      name = "Drugs",
-      linkedToHarm = needsDetails.linksToHarm?.drugLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.drugLinkedToReOffending
-    ),
-    OASysSection(
-      section = 9,
-      name = "Alcohol",
-      linkedToHarm = needsDetails.linksToHarm?.alcoholLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.alcoholLinkedToReOffending
-    ),
-    OASysSection(
       section = 10,
       name = "Emotional",
       linkedToHarm = needsDetails.linksToHarm?.emotionalLinkedToHarm,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
@@ -118,27 +118,23 @@ class OASysSectionsTransformer : OASysTransformer() {
       )
     }
 
-    if (needsDetails.linksToHarm?.drugLinkedToHarm == true || requestedOptionalSections.contains(8)) {
-      supportingInformation += OASysSupportingInformationQuestion(
-        label = "Drug misuse issues contributing to risks of offending and harm",
-        questionNumber = "8.9",
-        sectionNumber = 8,
-        linkedToHarm = needsDetails.linksToHarm?.drugLinkedToHarm,
-        linkedToReOffending = needsDetails.linksToReOffending?.drugLinkedToReOffending,
-        answer = needsDetails.needs?.drugIssuesDetails
-      )
-    }
+    supportingInformation += OASysSupportingInformationQuestion(
+      label = "Drug misuse issues contributing to risks of offending and harm",
+      questionNumber = "8.9",
+      sectionNumber = 8,
+      linkedToHarm = needsDetails.linksToHarm?.drugLinkedToHarm,
+      linkedToReOffending = needsDetails.linksToReOffending?.drugLinkedToReOffending,
+      answer = needsDetails.needs?.drugIssuesDetails
+    )
 
-    if (needsDetails.linksToHarm?.alcoholLinkedToHarm == true || requestedOptionalSections.contains(9)) {
-      supportingInformation += OASysSupportingInformationQuestion(
-        label = "Alcohol misuse issues contributing to risks of offending and harm",
-        questionNumber = "9.9",
-        sectionNumber = 9,
-        linkedToHarm = needsDetails.linksToHarm?.alcoholLinkedToHarm,
-        linkedToReOffending = needsDetails.linksToReOffending?.alcoholLinkedToReOffending,
-        answer = needsDetails.needs?.alcoholIssuesDetails
-      )
-    }
+    supportingInformation += OASysSupportingInformationQuestion(
+      label = "Alcohol misuse issues contributing to risks of offending and harm",
+      questionNumber = "9.9",
+      sectionNumber = 9,
+      linkedToHarm = needsDetails.linksToHarm?.alcoholLinkedToHarm,
+      linkedToReOffending = needsDetails.linksToReOffending?.alcoholLinkedToReOffending,
+      answer = needsDetails.needs?.alcoholIssuesDetails
+    )
 
     if (needsDetails.linksToHarm?.emotionalLinkedToHarm == true || requestedOptionalSections.contains(10)) {
       supportingInformation += OASysSupportingInformationQuestion(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/NeedsDetailsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/NeedsDetailsTransformerTest.kt
@@ -40,8 +40,6 @@ class NeedsDetailsTransformerTest {
 
     assertThat(result).containsExactlyInAnyOrder(
       OASysSection(section = 10, name = "Emotional", linkedToHarm = false, linkedToReOffending = false),
-      OASysSection(section = 8, name = "Drugs", linkedToHarm = true, linkedToReOffending = false),
-      OASysSection(section = 9, name = "Alcohol", linkedToHarm = false, linkedToReOffending = true),
       OASysSection(section = 3, name = "Accommodation", linkedToHarm = null, linkedToReOffending = null),
       OASysSection(section = 4, name = "Education, Training and Employment", linkedToHarm = null, linkedToReOffending = null),
       OASysSection(section = 5, name = "Finance", linkedToHarm = null, linkedToReOffending = null),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
@@ -221,7 +221,7 @@ class OASysSectionsTransformerTest {
   }
 
   @Test
-  fun `transformToApi supportingInformation returns only sections explicitly requested and those that are linked to harm`() {
+  fun `transformToApi supportingInformation returns only sections explicitly requested, alcohol and drugs and those that are linked to harm`() {
     val offenceDetailsApiResponse = OffenceDetailsFactory().produce()
     val roshSummaryApiResponse = RoshSummaryFactory().produce()
     val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().produce()
@@ -267,6 +267,22 @@ class OASysSectionsTransformerTest {
         linkedToHarm = true,
         linkedToReOffending = false,
         answer = "Emotional"
+      ),
+      OASysSupportingInformationQuestion(
+        label = "Drug misuse issues contributing to risks of offending and harm",
+        questionNumber = "8.9",
+        sectionNumber = 8,
+        linkedToHarm = needsDetailsApiResponse.linksToHarm?.drugLinkedToHarm,
+        linkedToReOffending = needsDetailsApiResponse.linksToReOffending?.drugLinkedToReOffending,
+        answer = needsDetailsApiResponse.needs?.drugIssuesDetails
+      ),
+      OASysSupportingInformationQuestion(
+        label = "Alcohol misuse issues contributing to risks of offending and harm",
+        questionNumber = "9.9",
+        sectionNumber = 9,
+        linkedToHarm = needsDetailsApiResponse.linksToHarm?.alcoholLinkedToHarm,
+        linkedToReOffending = needsDetailsApiResponse.linksToReOffending?.alcoholLinkedToReOffending,
+        answer = needsDetailsApiResponse.needs?.alcoholIssuesDetails
       )
     )
   }


### PR DESCRIPTION
Don't offer Drug & Alcohol on the selection endpoint, always return them on the sections endpoint.

The selection endpoint is used to build the list of OASys sections that are auto-imported or optionally imported in the UI.  Removing these sections from the selection endpoint will result in them no longer appearing in any of the checkbox lists.

The section endpoint currently only returns the drug and alcohol sections if they are specifically requested, this changes the endpoint to always return the Drug and Alcohol sections.