### PR TITLE
Fix for dev migration to add staff code to non-existent users

### DIFF
--- a/src/main/resources/db/migration/local+dev/20230216171124__staff_code_for_non_existent_users_fix.sql
+++ b/src/main/resources/db/migration/local+dev/20230216171124__staff_code_for_non_existent_users_fix.sql
@@ -1,0 +1,6 @@
+UPDATE users SET delius_staff_code = 'STAFFCODE' WHERE id IN (
+    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad',
+    'b5825da0-1553-4398-90ac-6a8e0c8a4cae',
+    '695ba399-c407-4b66-aafc-e8835d72b8a7',
+    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
+);


### PR DESCRIPTION
The previous migration's WHERE clause was incorrect