### PR TITLE
Add Temporary Accommodation support for viewing lost beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -580,6 +580,22 @@ class PremisesController(
     return ResponseEntity.ok(premises.lostBeds.map(lostBedsTransformer::transformJpaToApi))
   }
 
+  override fun premisesPremisesIdLostBedsLostBedIdGet(premisesId: UUID, lostBedId: UUID): ResponseEntity<LostBed> {
+    val premises = premisesService.getPremises(premisesId)
+      ?: throw NotFoundProblem(premisesId, "Premises")
+
+    val lostBed = premises.lostBeds.firstOrNull { it.id == lostBedId }
+      ?: throw NotFoundProblem(lostBedId, "LostBed")
+
+    val user = usersService.getUserForRequest()
+
+    if (premises is ApprovedPremisesEntity && !user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)) {
+      throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(lostBedsTransformer.transformJpaToApi(lostBed))
+  }
+
   override fun premisesPremisesIdCapacityGet(premisesId: UUID): ResponseEntity<List<DateCapacity>> {
     val premises = premisesService.getPremises(premisesId)
       ?: throw NotFoundProblem(premisesId, "Premises")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
@@ -1,19 +1,33 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesLostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationLostBedEntity
 
 @Component
 class LostBedsTransformer(private val lostBedReasonTransformer: LostBedReasonTransformer) {
-  fun transformJpaToApi(jpa: LostBedsEntity) = LostBed(
-    id = jpa.id,
-    startDate = jpa.startDate,
-    endDate = jpa.endDate,
-    numberOfBeds = if (jpa is ApprovedPremisesLostBedsEntity) jpa.numberOfBeds else 1,
-    reason = lostBedReasonTransformer.transformJpaToApi(jpa.reason),
-    referenceNumber = jpa.referenceNumber,
-    notes = jpa.notes
-  )
+  fun transformJpaToApi(jpa: LostBedsEntity) = when (jpa) {
+    is ApprovedPremisesLostBedsEntity -> ApprovedPremisesLostBed(
+      id = jpa.id,
+      startDate = jpa.startDate,
+      endDate = jpa.endDate,
+      numberOfBeds = jpa.numberOfBeds,
+      reason = lostBedReasonTransformer.transformJpaToApi(jpa.reason),
+      referenceNumber = jpa.referenceNumber,
+      notes = jpa.notes,
+    )
+    is TemporaryAccommodationLostBedEntity -> TemporaryAccommodationLostBed(
+      id = jpa.id,
+      startDate = jpa.startDate,
+      endDate = jpa.endDate,
+      reason = lostBedReasonTransformer.transformJpaToApi(jpa.reason),
+      referenceNumber = jpa.referenceNumber,
+      bedId = jpa.bed.id,
+      notes = jpa.notes,
+    )
+    else -> throw RuntimeException("Unsupported LostBedsEntity type: ${jpa::class.qualifiedName}")
+  }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1187,6 +1187,45 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/lost-beds/{lostBedId}:
+    get:
+      tags:
+        - Operations on premises
+      summary: Returns a specific lost bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LostBed'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises or lost bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /applications:
     post:
       tags:
@@ -2761,8 +2800,6 @@ components:
         endDate:
           type: string
           format: date
-        numberOfBeds:
-          type: integer
         reason:
           $ref: '#/components/schemas/LostBedReason'
         referenceNumber:
@@ -2773,8 +2810,31 @@ components:
         - id
         - startDate
         - endDate
-        - numberOfBeds
         - reason
+      discriminator:
+        propertyName: service
+        mapping:
+          approved-premises: '#/components/schemas/ApprovedPremisesLostBed'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationLostBed'
+    ApprovedPremisesLostBed:
+      allOf:
+        - $ref: "#/components/schemas/LostBed"
+        - type: object
+          properties:
+            numberOfBeds:
+              type: integer
+          required:
+            - numberOfBeds
+    TemporaryAccommodationLostBed:
+      allOf:
+        - $ref: "#/components/schemas/LostBed"
+        - type: object
+          properties:
+            bedId:
+              type: string
+              format: uuid
+          required:
+            - bedId
     NewLostBed:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationLostBedEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationLostBedEntityFactory.kt
@@ -46,6 +46,10 @@ class TemporaryAccommodationLostBedEntityFactory : Factory<TemporaryAccommodatio
     this.notes = { notes }
   }
 
+  fun withYieldedPremises(premises: Yielded<PremisesEntity>) = apply {
+    this.premises = premises
+  }
+
   fun withPremises(premises: PremisesEntity) = apply {
     this.premises = { premises }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/LostBedsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/LostBedsTransformerTest.kt
@@ -1,0 +1,126 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesLostBedsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationLostBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
+
+class LostBedsTransformerTest {
+  private val lostBedReasonTransformer = mockk<LostBedReasonTransformer>()
+
+  private val lostBedsTransformer = LostBedsTransformer(lostBedReasonTransformer)
+
+  @Test
+  fun `Approved Premises lost bed entity is correctly transformed`() {
+    val lostBed = ApprovedPremisesLostBedsEntityFactory()
+      .withYieldedReason {
+        LostBedReasonEntityFactory()
+          .produce()
+      }
+      .withYieldedPremises {
+        ApprovedPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea {
+                ApAreaEntityFactory()
+                  .produce()
+              }
+              .produce()
+          }
+          .withYieldedLocalAuthorityArea {
+            LocalAuthorityEntityFactory()
+              .produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { lostBedReasonTransformer.transformJpaToApi(lostBed.reason) } returns LostBedReason(
+      id = lostBed.reason.id,
+      name = lostBed.reason.name,
+      isActive = true,
+      serviceScope = "approved-premises",
+    )
+
+    val result = lostBedsTransformer.transformJpaToApi(lostBed)
+
+    assertThat(result.id).isEqualTo(lostBed.id)
+    assertThat(result.startDate).isEqualTo(lostBed.startDate)
+    assertThat(result.endDate).isEqualTo(lostBed.endDate)
+    assertThat(result.reason.id).isEqualTo(lostBed.reason.id)
+    assertThat(result.notes).isEqualTo(lostBed.notes)
+    assertThat(result.referenceNumber).isEqualTo(lostBed.referenceNumber)
+    assertThat(result).isInstanceOf(ApprovedPremisesLostBed::class.java)
+    result as ApprovedPremisesLostBed
+    assertThat(result.numberOfBeds).isEqualTo(lostBed.numberOfBeds)
+  }
+
+  @Test
+  fun `Temporary Accommodation lost bed entity is correctly transformed`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory()
+              .produce()
+          }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea {
+        LocalAuthorityEntityFactory()
+          .produce()
+      }
+      .produce()
+
+    val lostBed = TemporaryAccommodationLostBedEntityFactory()
+      .withYieldedReason {
+        LostBedReasonEntityFactory()
+          .produce()
+      }
+      .withYieldedPremises { premises }
+      .withYieldedBed {
+        BedEntityFactory()
+          .withYieldedRoom {
+            RoomEntityFactory()
+              .withYieldedPremises { premises }
+              .produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { lostBedReasonTransformer.transformJpaToApi(lostBed.reason) } returns LostBedReason(
+      id = lostBed.reason.id,
+      name = lostBed.reason.name,
+      isActive = true,
+      serviceScope = "approved-premises",
+    )
+
+    val result = lostBedsTransformer.transformJpaToApi(lostBed)
+
+    assertThat(result.id).isEqualTo(lostBed.id)
+    assertThat(result.startDate).isEqualTo(lostBed.startDate)
+    assertThat(result.endDate).isEqualTo(lostBed.endDate)
+    assertThat(result.reason.id).isEqualTo(lostBed.reason.id)
+    assertThat(result.notes).isEqualTo(lostBed.notes)
+    assertThat(result.referenceNumber).isEqualTo(lostBed.referenceNumber)
+    assertThat(result).isInstanceOf(TemporaryAccommodationLostBed::class.java)
+    result as TemporaryAccommodationLostBed
+    assertThat(result.bedId).isEqualTo(lostBed.bed.id)
+  }
+}


### PR DESCRIPTION
> See [ticket #810 on the CAS3 Trello board](https://trello.com/c/xrsopbpg/810-a-user-can-view-a-void-booking).

This PR is part of the work to implement support for lost beds within the Temporary Accommodation service. It will allow clients of the API to view Temporary Accommodation lost beds.

Changes in this PR:
- The OpenAPI spec has been updated to provide `ApprovedPremisesLostBed` and `TemporaryAccommodationLostBed` schemas to describe service-specific lost bed information.
- The `LostBedsTransformer.transformJpaToApi` method has been updated to transform `ApprovedPremisesLostBedsEntity` and `TemporaryAccommodationLostBedEntity` into `ApprovedPremisesLostBed` and `TemporaryAccommodationLostBedEntity` respectively.
- The `GET /premises/{premisesId}/lost-beds/{lostBedId}` endpoint has been implemented to view information for a single lost bed.