### PR TITLE
Make username optional on Domain Events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedD
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffWithoutUsernameUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
 import java.io.OutputStream
 
@@ -43,7 +44,7 @@ class CommunityApiClient(
     path = "/secure/staff/username/$deliusUsername"
   }
 
-  fun getStaffUserDetailsForStaffCode(staffCode: String) = getRequest<StaffUserDetails> {
+  fun getStaffUserDetailsForStaffCode(staffCode: String) = getRequest<StaffWithoutUsernameUserDetails> {
     path = "/secure/staff/staffCode/$staffCode"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
@@ -10,7 +10,15 @@ data class StaffUserDetails(
   val staffIdentifier: Long,
   val staff: StaffNames,
   val teams: List<StaffUserTeamMembership>?,
-  val probationArea: StaffProbationArea,
+  val probationArea: StaffProbationArea
+)
+
+data class StaffWithoutUsernameUserDetails(
+  val staffCode: String,
+  val staffIdentifier: Long,
+  val staff: StaffNames,
+  val teams: List<StaffUserTeamMembership>?,
+  val probationArea: StaffProbationArea
 )
 
 data class StaffNames(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -373,7 +373,7 @@ class BookingService(
                 staffIdentifier = keyWorkerStaffDetails.staffIdentifier,
                 forenames = keyWorkerStaffDetails.staff.forenames,
                 surname = keyWorkerStaffDetails.staff.surname,
-                username = keyWorkerStaffDetails.username
+                username = null
               ),
               arrivedAt = arrivalDate.toLocalDateTime(), // TODO: Endpoint should accept a date-time instead
               expectedDepartureOn = expectedDepartureDate,

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -328,7 +328,6 @@ components:
         - staffIdentifier
         - forenames
         - surname
-        - username
     Cru:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffWithoutUsernameUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffWithoutUsernameUserDetailsFactory.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffNames
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserTeamMembership
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffWithoutUsernameUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+
+class StaffWithoutUsernameUserDetailsFactory : Factory<StaffWithoutUsernameUserDetails> {
+  private var staffCode: Yielded<String> = { randomStringUpperCase(8) }
+  private var staffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
+  private var forenames: Yielded<String> = { randomStringUpperCase(8) }
+  private var surname: Yielded<String> = { randomStringUpperCase(8) }
+  private var teams: Yielded<List<StaffUserTeamMembership>> = { listOf() }
+  private var probationAreaCode: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var probationAreaDescription: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withStaffCode(staffCode: String) = apply {
+    this.staffCode = { staffCode }
+  }
+
+  fun withStaffIdentifier(staffIdentifier: Long) = apply {
+    this.staffIdentifier = { staffIdentifier }
+  }
+
+  fun withForenames(forenames: String) = apply {
+    this.forenames = { forenames }
+  }
+
+  fun withSurname(surname: String) = apply {
+    this.surname = { surname }
+  }
+
+  fun withTeams(teams: List<StaffUserTeamMembership>) = apply {
+    this.teams = { teams }
+  }
+
+  fun withProbationAreaCode(probationAreaCode: String) = apply {
+    this.probationAreaCode = { probationAreaCode }
+  }
+
+  fun withProbationAreaDescription(probationAreaDescription: String) = apply {
+    this.probationAreaDescription = { probationAreaDescription }
+  }
+
+  override fun produce() = StaffWithoutUsernameUserDetails(
+    staffCode = this.staffCode(),
+    staffIdentifier = this.staffIdentifier(),
+    staff = StaffNames(
+      forenames = this.forenames(),
+      surname = this.surname()
+    ),
+    teams = this.teams(),
+    probationArea = StaffProbationArea(
+      code = this.probationAreaCode(),
+      description = this.probationAreaDescription()
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffWithoutUsernameUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -775,7 +776,7 @@ class BookingServiceTest {
 
     every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-    val keyWorkerStaffUserDetails = StaffUserDetailsFactory().produce()
+    val keyWorkerStaffUserDetails = StaffWithoutUsernameUserDetailsFactory().produce()
 
     every { mockCommunityApiClient.getStaffUserDetailsForStaffCode(keyWorker.code) } returns ClientResult.Success(
       HttpStatus.OK,


### PR DESCRIPTION
Some Delius staff do not have an account to sign in with and therefore don't have a username/email.