### PR TITLE
Implement Temporary Accommodation support for creating and updating lost beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Departure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Extension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApprovedPremisesBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApprovedPremisesLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewNonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewRoom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTemporaryAccommodationBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTemporaryAccommodationLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Room
@@ -515,10 +517,12 @@ class PremisesController(
       premises = premises,
       startDate = body.startDate,
       endDate = body.endDate,
-      numberOfBeds = body.numberOfBeds,
       reasonId = body.reason,
       referenceNumber = body.referenceNumber,
-      notes = body.notes
+      notes = body.notes,
+      service = body.serviceName,
+      numberOfBeds = (body as? NewApprovedPremisesLostBed)?.numberOfBeds,
+      bedId = (body as? NewTemporaryAccommodationLostBed)?.bedId,
     )
 
     val lostBeds = extractResultEntityOrThrow(result)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1226,6 +1226,58 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+    put:
+      tags:
+        - Operations on premises
+      summary: Updates a lost bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the lost bed
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateLostBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LostBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /applications:
     post:
       tags:
@@ -2902,6 +2954,49 @@ components:
               format: uuid
           required:
             - bedId
+    UpdateLostBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+      required:
+        - startDate
+        - endDate
+        - reason
+        - serviceName
+      discriminator:
+        propertyName: serviceName
+        mapping:
+          approved-premises: '#/components/schemas/UpdateApprovedPremisesLostBed'
+          temporary-accommodation: '#/components/schemas/UpdateTemporaryAccommodationLostBed'
+    UpdateApprovedPremisesLostBed:
+      allOf:
+        - $ref: '#/components/schemas/UpdateLostBed'
+        - type: object
+          properties:
+            numberOfBeds:
+              type: integer
+          required:
+            - numberOfBeds
+    UpdateTemporaryAccommodationLostBed:
+      allOf:
+        - $ref: '#/components/schemas/UpdateLostBed'
+        - type: object
+          properties: {}
+          required: []
     DepartureReason:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2864,8 +2864,6 @@ components:
         endDate:
           type: string
           format: date
-        numberOfBeds:
-          type: integer
         reason:
           type: string
           format: uuid
@@ -2873,11 +2871,37 @@ components:
           type: string
         notes:
           type: string
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
       required:
         - startDate
         - endDate
-        - numberOfBeds
         - reason
+        - serviceName
+      discriminator:
+        propertyName: serviceName
+        mapping:
+          approved-premises: '#/components/schemas/NewApprovedPremisesLostBed'
+          temporary-accommodation: '#/components/schemas/NewTemporaryAccommodationLostBed'
+    NewApprovedPremisesLostBed:
+      allOf:
+        - $ref: '#/components/schemas/NewLostBed'
+        - type: object
+          properties:
+            numberOfBeds:
+              type: integer
+          required:
+            - numberOfBeds
+    NewTemporaryAccommodationLostBed:
+      allOf:
+        - $ref: '#/components/schemas/NewLostBed'
+        - type: object
+          properties:
+            bedId:
+              type: string
+              format: uuid
+          required:
+            - bedId
     DepartureReason:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApprovedPremisesLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTemporaryAccommodationLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -253,18 +254,60 @@ class LostBedsTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises/${premises.id}/lost-beds")
       .bodyValue(
-        NewLostBed(
+        NewApprovedPremisesLostBed(
           startDate = LocalDate.parse("2022-08-15"),
           endDate = LocalDate.parse("2022-08-18"),
           numberOfBeds = 1,
           reason = UUID.randomUUID(),
           referenceNumber = "REF-123",
-          notes = null
+          notes = null,
+          serviceName = ServiceName.approvedPremises,
         )
       )
       .exchange()
       .expectStatus()
       .isUnauthorized
+  }
+
+  @Test
+  fun `Create Lost Beds on Temporary Accommodation premises returns 400 Bad Request if the bed ID does not reference a bed on the premises`() {
+    `Given a User` { userEntity, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+      }
+
+      val reason = lostBedReasonEntityFactory.produceAndPersist {
+        withServiceScope(ServiceName.temporaryAccommodation.value)
+      }
+
+      webTestClient.post()
+        .uri("/premises/${premises.id}/lost-beds")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewTemporaryAccommodationLostBed(
+            startDate = LocalDate.parse("2022-08-17"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = reason.id,
+            referenceNumber = "REF-123",
+            notes = "notes",
+            bedId = UUID.randomUUID(),
+            serviceName = ServiceName.temporaryAccommodation,
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("invalid-params[0].propertyName").isEqualTo("$.bedId")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
   }
 
   @ParameterizedTest
@@ -287,13 +330,14 @@ class LostBedsTest : IntegrationTestBase() {
         .uri("/premises/${premises.id}/lost-beds")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
-          NewLostBed(
+          NewApprovedPremisesLostBed(
             startDate = LocalDate.parse("2022-08-17"),
             endDate = LocalDate.parse("2022-08-18"),
             numberOfBeds = 3,
             reason = reason.id,
             referenceNumber = "REF-123",
-            notes = "notes"
+            notes = "notes",
+            serviceName = ServiceName.approvedPremises,
           )
         )
         .exchange()
@@ -303,6 +347,63 @@ class LostBedsTest : IntegrationTestBase() {
         .jsonPath(".startDate").isEqualTo("2022-08-17")
         .jsonPath(".endDate").isEqualTo("2022-08-18")
         .jsonPath(".numberOfBeds").isEqualTo(3)
+        .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+        .jsonPath(".reason.name").isEqualTo(reason.name)
+        .jsonPath(".reason.isActive").isEqualTo(true)
+        .jsonPath(".referenceNumber").isEqualTo("REF-123")
+        .jsonPath(".notes").isEqualTo("notes")
+    }
+  }
+
+  @Test
+  fun `Create Lost Beds on Temporary Accommodation premises returns OK with correct body when correct data is provided`() {
+    `Given a User` { userEntity, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises {
+              premises
+            }
+          }
+        }
+      }
+
+      val reason = lostBedReasonEntityFactory.produceAndPersist {
+        withServiceScope(ServiceName.temporaryAccommodation.value)
+      }
+
+      webTestClient.post()
+        .uri("/premises/${premises.id}/lost-beds")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewTemporaryAccommodationLostBed(
+            startDate = LocalDate.parse("2022-08-17"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = reason.id,
+            referenceNumber = "REF-123",
+            notes = "notes",
+            bedId = bed.id,
+            serviceName = ServiceName.temporaryAccommodation,
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath(".startDate").isEqualTo("2022-08-17")
+        .jsonPath(".endDate").isEqualTo("2022-08-18")
+        .jsonPath(".bedId").isEqualTo(bed.id.toString())
         .jsonPath(".reason.id").isEqualTo(reason.id.toString())
         .jsonPath(".reason.name").isEqualTo(reason.name)
         .jsonPath(".reason.isActive").isEqualTo(true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApprovedPremisesLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTemporaryAccommodationLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
@@ -444,6 +446,209 @@ class LostBedsTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
+    }
+  }
+
+  @Test
+  fun `Update Lost Bed without JWT returns 401`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    val lostBeds = approvedPremisesLostBedsEntityFactory.produceAndPersist {
+      withStartDate(LocalDate.now().plusDays(2))
+      withEndDate(LocalDate.now().plusDays(4))
+      withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+      withNumberOfBeds(5)
+      withPremises(premises)
+    }
+
+    webTestClient.put()
+      .uri("/premises/${premises.id}/lost-beds/${lostBeds.id}")
+      .bodyValue(
+        UpdateApprovedPremisesLostBed(
+          startDate = LocalDate.parse("2022-08-15"),
+          endDate = LocalDate.parse("2022-08-18"),
+          numberOfBeds = 1,
+          reason = UUID.randomUUID(),
+          referenceNumber = "REF-123",
+          notes = null,
+          serviceName = ServiceName.approvedPremises,
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Update Lost Bed for non-existent premises returns 404`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.put()
+      .uri("/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        UpdateApprovedPremisesLostBed(
+          startDate = LocalDate.parse("2022-08-15"),
+          endDate = LocalDate.parse("2022-08-18"),
+          numberOfBeds = 1,
+          reason = UUID.randomUUID(),
+          referenceNumber = "REF-123",
+          notes = null,
+          serviceName = ServiceName.approvedPremises,
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `Update Lost Bed for non-existent lost bed returns 404`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.put()
+      .uri("/premises/${premises.id}/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        UpdateApprovedPremisesLostBed(
+          startDate = LocalDate.parse("2022-08-15"),
+          endDate = LocalDate.parse("2022-08-18"),
+          numberOfBeds = 1,
+          reason = UUID.randomUUID(),
+          referenceNumber = "REF-123",
+          notes = null,
+          serviceName = ServiceName.approvedPremises,
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `Update Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    `Given a User`(roles = listOf(role)) { userEntity, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withTotalBeds(3)
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val lostBeds = approvedPremisesLostBedsEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withNumberOfBeds(5)
+        withPremises(premises)
+      }
+
+      val reason = lostBedReasonEntityFactory.produceAndPersist {
+        withServiceScope(ServiceName.approvedPremises.value)
+      }
+
+      webTestClient.put()
+        .uri("/premises/${premises.id}/lost-beds/${lostBeds.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateApprovedPremisesLostBed(
+            startDate = LocalDate.parse("2022-08-17"),
+            endDate = LocalDate.parse("2022-08-18"),
+            numberOfBeds = 3,
+            reason = reason.id,
+            referenceNumber = "REF-123",
+            notes = "notes",
+            serviceName = ServiceName.approvedPremises,
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath(".startDate").isEqualTo("2022-08-17")
+        .jsonPath(".endDate").isEqualTo("2022-08-18")
+        .jsonPath(".numberOfBeds").isEqualTo(3)
+        .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+        .jsonPath(".reason.name").isEqualTo(reason.name)
+        .jsonPath(".reason.isActive").isEqualTo(true)
+        .jsonPath(".referenceNumber").isEqualTo("REF-123")
+        .jsonPath(".notes").isEqualTo("notes")
+    }
+  }
+
+  @Test
+  fun `Update Lost Beds on Temporary Accommodation premises returns OK with correct body when correct data is provided`() {
+    `Given a User` { userEntity, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { premises }
+          }
+        }
+      }
+
+      val lostBeds = temporaryAccommodationLostBedEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withYieldedBed { bed }
+        withPremises(premises)
+      }
+
+      val reason = lostBedReasonEntityFactory.produceAndPersist {
+        withServiceScope(ServiceName.temporaryAccommodation.value)
+      }
+
+      webTestClient.put()
+        .uri("/premises/${premises.id}/lost-beds/${lostBeds.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateTemporaryAccommodationLostBed(
+            startDate = LocalDate.parse("2022-08-17"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = reason.id,
+            referenceNumber = "REF-123",
+            notes = "notes",
+            serviceName = ServiceName.temporaryAccommodation,
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath(".startDate").isEqualTo("2022-08-17")
+        .jsonPath(".endDate").isEqualTo("2022-08-18")
+        .jsonPath(".bedId").isEqualTo(bed.id.toString())
+        .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+        .jsonPath(".reason.name").isEqualTo(reason.name)
+        .jsonPath(".reason.isActive").isEqualTo(true)
+        .jsonPath(".referenceNumber").isEqualTo("REF-123")
+        .jsonPath(".notes").isEqualTo("notes")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -189,7 +189,9 @@ class PremisesServiceTest {
       numberOfBeds = 0,
       reasonId = reasonId,
       referenceNumber = "12345",
-      notes = "notes"
+      notes = "notes",
+      service = ServiceName.approvedPremises,
+      bedId = null,
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
@@ -224,7 +226,9 @@ class PremisesServiceTest {
       numberOfBeds = 1,
       reasonId = reasonId,
       referenceNumber = "12345",
-      notes = "notes"
+      notes = "notes",
+      service = ServiceName.approvedPremises,
+      bedId = null,
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
@@ -259,7 +263,9 @@ class PremisesServiceTest {
       numberOfBeds = 5,
       reasonId = lostBedReason.id,
       referenceNumber = "12345",
-      notes = "notes"
+      notes = "notes",
+      service = ServiceName.approvedPremises,
+      bedId = null,
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
@@ -272,6 +273,152 @@ class PremisesServiceTest {
     result as ValidatableActionResult.Success
     assertThat(result.entity).isInstanceOf(ApprovedPremisesLostBedsEntity::class.java)
     val entity = result.entity as ApprovedPremisesLostBedsEntity
+    assertThat(entity.premises).isEqualTo(premisesEntity)
+    assertThat(entity.reason).isEqualTo(lostBedReason)
+    assertThat(entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))
+    assertThat(entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
+    assertThat(entity.numberOfBeds).isEqualTo(5)
+    assertThat(entity.referenceNumber).isEqualTo("12345")
+    assertThat(entity.notes).isEqualTo("notes")
+  }
+
+  @Test
+  fun `updateLostBeds returns FieldValidationError with correct param to message map when invalid parameters supplied`() {
+    val premisesEntity = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val reasonId = UUID.randomUUID()
+
+    val lostBedsEntity = ApprovedPremisesLostBedsEntityFactory()
+      .withYieldedPremises { premisesEntity }
+      .withYieldedReason {
+        LostBedReasonEntityFactory()
+          .withServiceScope(ServiceName.approvedPremises.value)
+          .produce()
+      }
+      .produce()
+
+    every { lostBedsRepositoryMock.findByIdOrNull(lostBedsEntity.id) } returns lostBedsEntity
+    every { lostBedReasonRepositoryMock.findByIdOrNull(reasonId) } returns null
+
+    val result = premisesService.updateLostBeds(
+      lostBedId = lostBedsEntity.id,
+      startDate = LocalDate.parse("2022-08-28"),
+      endDate = LocalDate.parse("2022-08-25"),
+      numberOfBeds = 0,
+      reasonId = reasonId,
+      referenceNumber = "12345",
+      notes = "notes",
+      service = ServiceName.approvedPremises,
+    )
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    val resultEntity = (result as AuthorisableActionResult.Success).entity
+    assertThat(resultEntity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+    assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+      entry("$.endDate", "beforeStartDate"),
+      entry("$.numberOfBeds", "isZero"),
+      entry("$.reason", "doesNotExist")
+    )
+  }
+
+  @Test
+  fun `updateLostBeds returns FieldValidationError with correct param to message map when a lost bed reason with the incorrect service scope is supplied`() {
+    val premisesEntity = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val reasonId = UUID.randomUUID()
+
+    val lostBedsEntity = ApprovedPremisesLostBedsEntityFactory()
+      .withYieldedPremises { premisesEntity }
+      .withYieldedReason {
+        LostBedReasonEntityFactory()
+          .withServiceScope(ServiceName.approvedPremises.value)
+          .produce()
+      }
+      .produce()
+
+    every { lostBedsRepositoryMock.findByIdOrNull(lostBedsEntity.id) } returns lostBedsEntity
+    every { lostBedReasonRepositoryMock.findByIdOrNull(reasonId) } returns LostBedReasonEntityFactory()
+      .withServiceScope(ServiceName.temporaryAccommodation.value)
+      .produce()
+
+    val result = premisesService.updateLostBeds(
+      lostBedId = lostBedsEntity.id,
+      startDate = LocalDate.parse("2022-08-25"),
+      endDate = LocalDate.parse("2022-08-28"),
+      numberOfBeds = 1,
+      reasonId = reasonId,
+      referenceNumber = "12345",
+      notes = "notes",
+      service = ServiceName.approvedPremises,
+    )
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    val resultEntity = (result as AuthorisableActionResult.Success).entity
+    assertThat(resultEntity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+    assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+      entry("$.reason", "incorrectLostBedReasonServiceScope")
+    )
+  }
+
+  @Test
+  fun `updateLostBeds returns Success with correct result when validation passed`() {
+    val premisesEntity = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val lostBedReason = LostBedReasonEntityFactory()
+      .withServiceScope(ServiceName.approvedPremises.value)
+      .produce()
+
+    val lostBedsEntity = ApprovedPremisesLostBedsEntityFactory()
+      .withYieldedPremises { premisesEntity }
+      .withYieldedReason {
+        LostBedReasonEntityFactory()
+          .withServiceScope(ServiceName.approvedPremises.value)
+          .produce()
+      }
+      .produce()
+
+    every { lostBedsRepositoryMock.findByIdOrNull(lostBedsEntity.id) } returns lostBedsEntity
+    every { lostBedReasonRepositoryMock.findByIdOrNull(lostBedReason.id) } returns lostBedReason
+
+    every { lostBedsRepositoryMock.save(any()) } answers { it.invocation.args[0] as LostBedsEntity }
+
+    val result = premisesService.updateLostBeds(
+      lostBedId = lostBedsEntity.id,
+      startDate = LocalDate.parse("2022-08-25"),
+      endDate = LocalDate.parse("2022-08-28"),
+      numberOfBeds = 5,
+      reasonId = lostBedReason.id,
+      referenceNumber = "12345",
+      notes = "notes",
+      service = ServiceName.approvedPremises,
+    )
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    val resultEntity = (result as AuthorisableActionResult.Success).entity
+    assertThat(resultEntity).isInstanceOf(ValidatableActionResult.Success::class.java)
+    resultEntity as ValidatableActionResult.Success
+    assertThat(resultEntity.entity).isInstanceOf(ApprovedPremisesLostBedsEntity::class.java)
+    val entity = resultEntity.entity as ApprovedPremisesLostBedsEntity
     assertThat(entity.premises).isEqualTo(premisesEntity)
     assertThat(entity.reason).isEqualTo(lostBedReason)
     assertThat(entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))


### PR DESCRIPTION
> See [ticket #811 on the CAS3 Trello board](https://trello.com/c/n5PqaVQL/811-a-user-can-create-or-update-a-void-booking).

This PR is part of the work to implement support for lost beds within the Temporary Accommodation service. It allows users of the API to create and update Temporary Accommodation lost beds.

Changes in this PR:
- The OpenAPI spec has been updated to provide `NewApprovedPremisesLostBed` and `NewTemporaryAccommodationLostBed` schemas to allow creating service-specific lost beds.
- The `PremisesService.createLostBeds` method has been updated to be able to validate and persist Temporary Accommodation lost beds.
- The OpenAPI spec has been updated to introduce a new `PUT /premises/{premisesId}/lost-beds/{lostBedId}` endpoint accepting an `UpdateApprovedPremisesLostBed` or `UpdateTemporaryAccommodationLostBed` schema to update an existing lost bed.
- The `PremisesService.updateLostBeds` method has been created to validate and persist changes to a lost bed.