### PR TITLE
(1276) Optionally check caseload on user search

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -858,6 +858,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: checkCaseload
+          in: query
+          description: Additionally check the user's caseload
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
This adds a `checkCaseload` option to the /people/search endpoint. If this is provided, then we also call the `getTeamsManagingCase` endpoint to check if the offender is part of the logged in user’s caseload. If they aren’t then we return a 403 response.