### PR TITLE
Fix for optional Caseload check on People Search endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -203,9 +203,9 @@ class PeopleController(
       is AuthorisableActionResult.Success -> offenderDetailsResult.entity
     }
 
-    if (checkCaseload === true) {
+    if (checkCaseload) {
       val deliusUser = userService.getUserForUsername(username)
-      val managingTeamCodes = when (val managingTeamsResult = apDeliusContextApiClient.getTeamsManagingCase(crn, deliusUser.deliusUsername)) {
+      val managingTeamCodes = when (val managingTeamsResult = apDeliusContextApiClient.getTeamsManagingCase(crn, deliusUser.deliusStaffCode)) {
         is ClientResult.Success -> managingTeamsResult.body.teamCodes
         is ClientResult.Failure -> managingTeamsResult.throwException()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -142,7 +142,7 @@ class PersonSearchTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, _ ->
 
         APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
-          offenderDetails.otherIds.crn, userEntity.deliusUsername,
+          offenderDetails.otherIds.crn, userEntity.deliusStaffCode,
           ManagingTeamsResponse(
             teamCodes = listOf("TEAM1")
           )
@@ -164,7 +164,7 @@ class PersonSearchTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, _ ->
 
         APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
-          offenderDetails.otherIds.crn, userEntity.deliusUsername,
+          offenderDetails.otherIds.crn, userEntity.deliusStaffCode,
           ManagingTeamsResponse(
             teamCodes = emptyList()
           )


### PR DESCRIPTION
The upstream caseload endpoint requires staff code rather than username