### PR TITLE
(1314) Add a tasks endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -5,11 +5,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.TasksApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapAndTransformAssessments
 
 @Service
 class TasksController(
@@ -23,36 +23,13 @@ class TasksController(
   override fun tasksGet(): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
-    val assessments = assessmentService.getVisibleAssessmentsForUser(user).mapNotNull {
-      val applicationCrn = it.application.crn
-
-      val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(applicationCrn, user.deliusUsername)) {
-        is AuthorisableActionResult.Success -> offenderDetailsResult.entity
-        is AuthorisableActionResult.NotFound -> {
-          log.error("Could not get Offender Details for CRN: $applicationCrn")
-          return@mapNotNull null
-        }
-
-        is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
-      }
-
-      if (offenderDetails.otherIds.nomsNumber == null) {
-        log.error("No NOMS number for CRN: $applicationCrn")
-        return@mapNotNull null
-      }
-
-      val inmateDetails = when (val inmateDetailsResult = offenderService.getInmateDetailByNomsNumber(offenderDetails.otherIds.nomsNumber)) {
-        is AuthorisableActionResult.Success -> inmateDetailsResult.entity
-        is AuthorisableActionResult.NotFound -> {
-          log.error("Could not get Inmate Details for NOMS number: ${offenderDetails.otherIds.nomsNumber}")
-          return@mapNotNull null
-        }
-
-        is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
-      }
-
-      taskTransformer.transformAssessmentToTask(it, offenderDetails, inmateDetails)
-    }
+    val assessments = mapAndTransformAssessments(
+      log,
+      assessmentService.getVisibleAssessmentsForUser(user),
+      user.deliusUsername,
+      offenderService,
+      taskTransformer::transformAssessmentToTask
+    ) as List<Task>
 
     return ResponseEntity.ok(assessments)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.TasksApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
+
+@Service
+class TasksController(
+  private val userService: UserService,
+  private val assessmentService: AssessmentService,
+  private val taskTransformer: TaskTransformer,
+  private val offenderService: OffenderService,
+) : TasksApiDelegate {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun tasksGet(): ResponseEntity<List<Task>> {
+    val user = userService.getUserForRequest()
+
+    val assessments = assessmentService.getVisibleAssessmentsForUser(user).mapNotNull {
+      val applicationCrn = it.application.crn
+
+      val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(applicationCrn, user.deliusUsername)) {
+        is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+        is AuthorisableActionResult.NotFound -> {
+          log.error("Could not get Offender Details for CRN: $applicationCrn")
+          return@mapNotNull null
+        }
+
+        is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
+      }
+
+      if (offenderDetails.otherIds.nomsNumber == null) {
+        log.error("No NOMS number for CRN: $applicationCrn")
+        return@mapNotNull null
+      }
+
+      val inmateDetails = when (val inmateDetailsResult = offenderService.getInmateDetailByNomsNumber(offenderDetails.otherIds.nomsNumber)) {
+        is AuthorisableActionResult.Success -> inmateDetailsResult.entity
+        is AuthorisableActionResult.NotFound -> {
+          log.error("Could not get Inmate Details for NOMS number: ${offenderDetails.otherIds.nomsNumber}")
+          return@mapNotNull null
+        }
+
+        is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
+      }
+
+      taskTransformer.transformAssessmentToTask(it, offenderDetails, inmateDetails)
+    }
+
+    return ResponseEntity.ok(assessments)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.Status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+
+@Component
+class TaskTransformer(
+  private val personTransformer: PersonTransformer,
+  private val userTransformer: UserTransformer
+) {
+  fun transformAssessmentToTask(assessment: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Task(
+    applicationId = assessment.application.id,
+    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+    dueDate = assessment.createdAt.plusDays(10).toLocalDate(),
+    allocatedToStaffMember = userTransformer.transformJpaToApi(assessment.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
+    status = getStatus(assessment),
+    taskType = TaskType.assessment
+  )
+
+  private fun getStatus(entity: AssessmentEntity): Status = when {
+    entity.data.isNullOrEmpty() -> Status.notStarted
+    entity.decision !== null -> Status.complete
+    else -> Status.inProgress
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.slf4j.Logger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+
+fun mapAndTransformAssessments(
+  log: Logger,
+  assessments: List<AssessmentEntity>,
+  deliusUsername: String,
+  offenderService: OffenderService,
+  transformer: (AssessmentEntity, OffenderDetailSummary, InmateDetail) -> Any
+): List<Any> {
+  return assessments.mapNotNull {
+    val applicationCrn = it.application.crn
+
+    val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(applicationCrn, deliusUsername)) {
+      is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+      is AuthorisableActionResult.NotFound -> {
+        log.error("Could not get Offender Details for CRN: $applicationCrn")
+        return@mapNotNull null
+      }
+
+      is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
+    }
+
+    if (offenderDetails.otherIds.nomsNumber == null) {
+      log.error("No NOMS number for CRN: $applicationCrn")
+      return@mapNotNull null
+    }
+
+    val inmateDetails = when (val inmateDetailsResult = offenderService.getInmateDetailByNomsNumber(offenderDetails.otherIds.nomsNumber)) {
+      is AuthorisableActionResult.Success -> inmateDetailsResult.entity
+      is AuthorisableActionResult.NotFound -> {
+        log.error("Could not get Inmate Details for NOMS number: ${offenderDetails.otherIds.nomsNumber}")
+        return@mapNotNull null
+      }
+
+      is AuthorisableActionResult.Unauthorised -> return@mapNotNull null
+    }
+
+    transformer(it, offenderDetails, inmateDetails)
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1926,6 +1926,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /tasks:
+    get:
+      tags:
+        - Task data
+      summary: List all tasks
+      responses:
+        200:
+          description: successfully retrieved tasks
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Task'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -2435,6 +2455,33 @@ components:
         - probationRegionId
         - characteristicIds
         - status
+    Task:
+      type: object
+      properties:
+        applicationId:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        person:
+          $ref: '#/components/schemas/Person'
+        dueDate:
+          type: string
+          format: date
+        allocatedToStaffMember:
+          $ref: '#/components/schemas/ApprovedPremisesUser'
+        status:
+          type: string
+          enum:
+            - not_started
+            - in_progress
+            - complete
+        taskType:
+          type: string
+          enum:
+            - Assessment
+            - PlacementRequest
+            - PlacementRequestReview
+            - BookingAppeal
     LocalAuthorityArea:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
+import java.time.OffsetDateTime
+
+class TasksTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var taskTransformer: TaskTransformer
+
+  @Test
+  fun `Get all tasks without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/tasks")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get all tasks returns 200 with correct body`() {
+    `Given a User` { user, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+          withAddedAt(OffsetDateTime.now())
+        }
+
+        val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+        }
+
+        val assessment = assessmentEntityFactory.produceAndPersist {
+          withAllocatedToUser(user)
+          withApplication(application)
+          withAssessmentSchema(assessmentSchema)
+        }
+
+        assessment.schemaUpToDate = true
+
+        val reallocatedAssessment = assessmentEntityFactory.produceAndPersist {
+          withAllocatedToUser(user)
+          withApplication(application)
+          withAssessmentSchema(assessmentSchema)
+          withReallocatedAt(OffsetDateTime.now())
+        }
+
+        reallocatedAssessment.schemaUpToDate = true
+
+        webTestClient.get()
+          .uri("/tasks")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              listOf(
+                taskTransformer.transformAssessmentToTask(assessment, offenderDetails, inmateDetails)
+              )
+            )
+          )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.Status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class TaskTransformerTest {
+  private val mockPersonTransformer = mockk<PersonTransformer>()
+  private val mockUserTransformer = mockk<UserTransformer>()
+
+  private val mockPerson = mockk<Person>()
+  private val mockUser = mockk<ApprovedPremisesUser>()
+  private val mockOffenderDetailSummary = mockk<OffenderDetailSummary>()
+  private val mockInmateDetail = mockk<InmateDetail>()
+
+  private val user = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+
+  private val application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .produce()
+
+  private val assessmentFactory = AssessmentEntityFactory()
+    .withApplication(application)
+    .withAllocatedToUser(user)
+    .withCreatedAt(OffsetDateTime.parse("2022-12-07T10:40:00Z"))
+
+  private val taskTransformer = TaskTransformer(mockPersonTransformer, mockUserTransformer)
+
+  @BeforeEach
+  fun setup() {
+    every { mockPersonTransformer.transformModelToApi(mockOffenderDetailSummary, mockInmateDetail) } returns mockPerson
+    every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockUser
+  }
+
+  @Test
+  fun `Not started assessment is correctly transformed`() {
+    var assessment = assessmentFactory.produce()
+
+    assessment.data = null
+
+    var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+
+    assertThat(result.status).isEqualTo(Status.notStarted)
+    assertThat(result.taskType).isEqualTo(TaskType.assessment)
+    assertThat(result.applicationId).isEqualTo(application.id)
+    assertThat(result.dueDate).isEqualTo(LocalDate.parse("2022-12-17"))
+    assertThat(result.person).isEqualTo(mockPerson)
+    assertThat(result.allocatedToStaffMember).isEqualTo(mockUser)
+  }
+
+  @Test
+  fun `In Progress assessment is correctly transformed`() {
+    var assessment = assessmentFactory
+      .withDecision(null)
+      .withData("{\"test\": \"data\"}")
+      .produce()
+
+    var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+
+    assertThat(result.status).isEqualTo(Status.inProgress)
+  }
+
+  @Test
+  fun `Complete assessment is correctly transformed`() {
+    var assessment = assessmentFactory
+      .withDecision(AssessmentDecision.ACCEPTED)
+      .withData("{\"test\": \"data\"}")
+      .produce()
+
+    var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+
+    assertThat(result.status).isEqualTo(Status.complete)
+  }
+}


### PR DESCRIPTION
This adds a /tasks endpoint to the API, which transforms any open Assessments into a more generic Tasks interface, which will eventually cover other types of "assignable" tasks, such as Placement Requests, Appeals etc.