### PR TITLE
Implement user access controls for premises endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -2,7 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.util.UUID
 import javax.servlet.http.HttpServletRequest
 
@@ -11,10 +15,10 @@ class UserAccessService(
   private val userService: UserService,
   private val currentRequest: HttpServletRequest,
 ) {
-  fun currentUserCanAccessRegion(probationRegionId: UUID) =
+  fun currentUserCanAccessRegion(probationRegionId: UUID?) =
     userCanAccessRegion(userService.getUserForRequest(), probationRegionId)
 
-  fun userCanAccessRegion(user: UserEntity, probationRegionId: UUID) =
+  fun userCanAccessRegion(user: UserEntity, probationRegionId: UUID?) =
     userHasAllRegionsAccess(user) || user.probationRegion.id == probationRegionId
 
   fun currentUserHasAllRegionsAccess() = userHasAllRegionsAccess(userService.getUserForRequest())
@@ -26,4 +30,58 @@ class UserAccessService(
       // TODO: Revisit if Approved Premises introduces region-limited access
       else -> true
     }
+
+  fun currentUserCanViewPremises(premises: PremisesEntity) =
+    userCanViewPremises(userService.getUserForRequest(), premises)
+
+  fun userCanViewPremises(user: UserEntity, premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> true
+    is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
+    else -> false
+  }
+
+  fun currentUserCanManagePremises(premises: PremisesEntity) =
+    userCanManagePremises(userService.getUserForRequest(), premises)
+
+  fun userCanManagePremises(user: UserEntity, premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> true
+    is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
+    else -> false
+  }
+
+  fun currentUserCanManagePremisesBookings(premises: PremisesEntity) =
+    userCanManagePremisesBookings(userService.getUserForRequest(), premises)
+
+  fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
+    else -> false
+  }
+
+  fun currentUserCanManagePremisesLostBeds(premises: PremisesEntity) =
+    userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)
+
+  fun userCanManagePremisesLostBeds(user: UserEntity, premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
+    else -> false
+  }
+
+  fun currentUserCanViewPremisesCapacity(premises: PremisesEntity) =
+    userCanViewPremisesCapacity(userService.getUserForRequest(), premises)
+
+  fun userCanViewPremisesCapacity(user: UserEntity, premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
+    else -> false
+  }
+
+  fun currentUserCanViewPremisesStaff(premises: PremisesEntity) =
+    userCanViewPremisesStaff(userService.getUserForRequest(), premises)
+
+  fun userCanViewPremisesStaff(user: UserEntity, premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
+    else -> false
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -38,931 +38,950 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Create new premises returns 201`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "test-premises",
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB123CD",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.pending,
-          pdu = "Some Location"
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "test-premises",
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB123CD",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.pending,
+            pdu = "Some Location",
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isCreated
+        .exchange()
+        .expectStatus()
+        .isCreated
+    }
   }
 
   @Test
   fun `When a new premises is created then all field data is persisted`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB123CD",
-          notes = "some arbitrary notes",
-          name = "some arbitrary name",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.pending,
-          pdu = "Some Location",
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB123CD",
+            notes = "some arbitrary notes",
+            name = "some arbitrary name",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.pending,
+            pdu = "Some Location",
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isCreated
-      .expectBody()
-      .jsonPath("addressLine1").isEqualTo("1 somewhere")
-      .jsonPath("addressLine2").isEqualTo("Some district")
-      .jsonPath("town").isEqualTo("Somewhere")
-      .jsonPath("postcode").isEqualTo("AB123CD")
-      .jsonPath("service").isEqualTo(ServiceName.temporaryAccommodation.value)
-      .jsonPath("notes").isEqualTo("some arbitrary notes")
-      .jsonPath("name").isEqualTo("some arbitrary name")
-      .jsonPath("localAuthorityArea.id").isEqualTo("a5f52443-6b55-498c-a697-7c6fad70cc3f")
-      .jsonPath("probationRegion.id").isEqualTo("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891")
-      .jsonPath("status").isEqualTo("pending")
-      .jsonPath("pdu").isEqualTo("Some Location")
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody()
+        .jsonPath("addressLine1").isEqualTo("1 somewhere")
+        .jsonPath("addressLine2").isEqualTo("Some district")
+        .jsonPath("town").isEqualTo("Somewhere")
+        .jsonPath("postcode").isEqualTo("AB123CD")
+        .jsonPath("service").isEqualTo(ServiceName.temporaryAccommodation.value)
+        .jsonPath("notes").isEqualTo("some arbitrary notes")
+        .jsonPath("name").isEqualTo("some arbitrary name")
+        .jsonPath("localAuthorityArea.id").isEqualTo("a5f52443-6b55-498c-a697-7c6fad70cc3f")
+        .jsonPath("probationRegion.id").isEqualTo(user.probationRegion.id.toString())
+        .jsonPath("status").isEqualTo("pending")
+        .jsonPath("pdu").isEqualTo("Some Location")
+    }
   }
 
   @Test
   fun `When an Approved Premises is updated then all field data is persisted`() {
-
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
-    }
 
-    val premisesToGet = premises[0]
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+      val premisesToGet = premises[0]
 
-    webTestClient.put()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdatePremises(
-          addressLine1 = "1 somewhere updated",
-          addressLine2 = "Some other district",
-          town = "Somewhere Else",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes updated",
-          localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
-          probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.archived
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            addressLine2 = "Some other district",
+            town = "Somewhere Else",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
+            probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.archived,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("addressLine1").isEqualTo("1 somewhere updated")
-      .jsonPath("addressLine2").isEqualTo("Some other district")
-      .jsonPath("town").isEqualTo("Somewhere Else")
-      .jsonPath("postcode").isEqualTo("AB456CD")
-      .jsonPath("notes").isEqualTo("some arbitrary notes updated")
-      .jsonPath("localAuthorityArea.id").isEqualTo("d1bd139b-7b90-4aae-87aa-9f93e183a7ff")
-      .jsonPath("localAuthorityArea.name").isEqualTo("Allerdale")
-      .jsonPath("probationRegion.id").isEqualTo("a02b7727-63aa-46f2-80f1-e0b05b31903c")
-      .jsonPath("probationRegion.name").isEqualTo("North West")
-      .jsonPath("status").isEqualTo("archived")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("addressLine1").isEqualTo("1 somewhere updated")
+        .jsonPath("addressLine2").isEqualTo("Some other district")
+        .jsonPath("town").isEqualTo("Somewhere Else")
+        .jsonPath("postcode").isEqualTo("AB456CD")
+        .jsonPath("notes").isEqualTo("some arbitrary notes updated")
+        .jsonPath("localAuthorityArea.id").isEqualTo("d1bd139b-7b90-4aae-87aa-9f93e183a7ff")
+        .jsonPath("localAuthorityArea.name").isEqualTo("Allerdale")
+        .jsonPath("probationRegion.id").isEqualTo("a02b7727-63aa-46f2-80f1-e0b05b31903c")
+        .jsonPath("probationRegion.name").isEqualTo("North West")
+        .jsonPath("status").isEqualTo("archived")
+    }
   }
 
   @Test
   fun `When a Temporary Accommodation Premises is updated then all field data is persisted`() {
-
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
+        withPdu("Some Location")
       }
-      withTotalBeds(20)
-      withPdu("Some Location")
-    }
 
-    val premisesToGet = premises[0]
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+      val premisesToGet = premises[0]
 
-    webTestClient.put()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdatePremises(
-          addressLine1 = "1 somewhere updated",
-          addressLine2 = "Some other district",
-          town = "Somewhere Else",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes updated",
-          localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
-          probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.archived,
-          pdu = "Some New Location",
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            addressLine2 = "Some other district",
+            town = "Somewhere Else",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
+            probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.archived,
+            pdu = "Some New Location",
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("addressLine1").isEqualTo("1 somewhere updated")
-      .jsonPath("addressLine2").isEqualTo("Some other district")
-      .jsonPath("town").isEqualTo("Somewhere Else")
-      .jsonPath("postcode").isEqualTo("AB456CD")
-      .jsonPath("notes").isEqualTo("some arbitrary notes updated")
-      .jsonPath("localAuthorityArea.id").isEqualTo("d1bd139b-7b90-4aae-87aa-9f93e183a7ff")
-      .jsonPath("localAuthorityArea.name").isEqualTo("Allerdale")
-      .jsonPath("probationRegion.id").isEqualTo("a02b7727-63aa-46f2-80f1-e0b05b31903c")
-      .jsonPath("probationRegion.name").isEqualTo("North West")
-      .jsonPath("status").isEqualTo("archived")
-      .jsonPath("pdu").isEqualTo("Some New Location")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("addressLine1").isEqualTo("1 somewhere updated")
+        .jsonPath("addressLine2").isEqualTo("Some other district")
+        .jsonPath("town").isEqualTo("Somewhere Else")
+        .jsonPath("postcode").isEqualTo("AB456CD")
+        .jsonPath("notes").isEqualTo("some arbitrary notes updated")
+        .jsonPath("localAuthorityArea.id").isEqualTo("d1bd139b-7b90-4aae-87aa-9f93e183a7ff")
+        .jsonPath("localAuthorityArea.name").isEqualTo("Allerdale")
+        .jsonPath("probationRegion.id").isEqualTo("a02b7727-63aa-46f2-80f1-e0b05b31903c")
+        .jsonPath("probationRegion.name").isEqualTo("North West")
+        .jsonPath("status").isEqualTo("archived")
+        .jsonPath("pdu").isEqualTo("Some New Location")
+    }
+  }
+
+  @Test
+  fun `Updating a Temporary Accommodation Premises that's not in the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withId(UUID.randomUUID())
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+        withTotalBeds(20)
+        withPdu("Some Location")
+      }
+
+      val premisesToGet = premises[0]
+
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            addressLine2 = "Some other district",
+            town = "Somewhere Else",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
+            probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.archived,
+            pdu = "Some New Location",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 
   @Test
   fun `Trying to create a new premises without a name returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "",
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB123CD",
-          notes = "some arbitrary notes",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "",
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB123CD",
+            notes = "some arbitrary notes",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
+
   @Test
   fun `Trying to update a premises with an invalid local authority area id returns 400`() {
-
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
-    }
 
-    val premisesToGet = premises[0]
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+      val premisesToGet = premises[0]
 
-    webTestClient.put()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdatePremises(
-          addressLine1 = "1 somewhere updated",
-          addressLine2 = "Some other district",
-          town = "Somewhere Else",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes updated",
-          localAuthorityAreaId = UUID.fromString("878217f0-6db5-49d8-a5a1-c40fdecd6060"), // not in db
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            addressLine2 = "Some other district",
+            town = "Somewhere Else",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = UUID.fromString("878217f0-6db5-49d8-a5a1-c40fdecd6060"), // not in db
+            probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
   }
 
   @Test
   fun `Trying to update an Approved Premises with no local authority area id returns 400`() {
-
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
-    }
 
-    val premisesToGet = premises[0]
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+      val premisesToGet = premises[0]
 
-    webTestClient.put()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdatePremises(
-          addressLine1 = "1 somewhere updated",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes updated",
-          localAuthorityAreaId = null,
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = null,
+            probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
   fun `Trying to update a premises with an invalid probation region id returns 400`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
-    }
 
-    val premisesToGet = premises[0]
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+      val premisesToGet = premises[0]
 
-    webTestClient.put()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdatePremises(
-          addressLine1 = "1 somewhere updated",
-          addressLine2 = "Some other district",
-          town = "Somewhere Else",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes updated",
-          localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"),
-          probationRegionId = UUID.fromString("48f96076-e911-4419-bceb-95a3e7f417eb"), // not in db
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            addressLine2 = "Some other district",
+            town = "Somewhere Else",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"),
+            probationRegionId = UUID.fromString("48f96076-e911-4419-bceb-95a3e7f417eb"), // not in db
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
   }
 
   @Test
   fun `Trying to update a Temporary Accommodation Premises without a PDU returns 400`() {
-
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
-    }
 
-    val premisesToGet = premises[0]
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
+      val premisesToGet = premises[0]
 
-    webTestClient.put()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdatePremises(
-          addressLine1 = "1 somewhere updated",
-          addressLine2 = "Some other district",
-          town = "Somewhere Else",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes updated",
-          localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
-          probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.archived,
-          pdu = null,
+      webTestClient.put()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdatePremises(
+            addressLine1 = "1 somewhere updated",
+            addressLine2 = "Some other district",
+            town = "Somewhere Else",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes updated",
+            localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
+            probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.archived,
+            pdu = null,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
   fun `Trying to create a new premises with a non-unique name returns 400`() {
-    temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { user, jwt ->
+      temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withName("premises-name-conflict")
       }
-      withName("premises-name-conflict")
-    }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "premises-name-conflict",
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB123CD",
-          notes = "some arbitrary notes",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "premises-name-conflict",
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB123CD",
+            notes = "some arbitrary notes",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("notUnique")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("notUnique")
+    }
   }
 
   @Test
   fun `When a new premises is created with no notes then it defaults to empty`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB123CD",
-          name = "some arbitrary name",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active,
-          pdu = "Some Location"
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB123CD",
+            name = "some arbitrary name",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+            pdu = "Some Location",
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isCreated
-      .expectBody()
-      .jsonPath("notes").isEqualTo("")
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody()
+        .jsonPath("notes").isEqualTo("")
+    }
   }
 
   @Test
   fun `Trying to create a new premises without an address returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises?service=temporary-accommodation")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "arbitrary_test_name",
-          postcode = "AB123CD",
-          addressLine1 = "",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          notes = "some notes",
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises?service=temporary-accommodation")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "arbitrary_test_name",
+            postcode = "AB123CD",
+            addressLine1 = "",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            notes = "some notes",
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
   fun `Trying to create a new premises without a postcode returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises?service=temporary-accommodation")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "arbitrary_test_name",
-          postcode = "",
-          addressLine1 = "FIRST LINE OF THE ADDRESS",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          notes = "some notes",
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises?service=temporary-accommodation")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "arbitrary_test_name",
+            postcode = "",
+            addressLine1 = "FIRST LINE OF THE ADDRESS",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            notes = "some notes",
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
   fun `Trying to create a new premises without a service returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises?service=temporary-accommodation")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewPremises(
-          name = "arbitrary_test_name",
-          postcode = "AB123CD",
-          addressLine1 = "FIRST LINE OF THE ADDRESS",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          notes = "some notes",
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+    `Given a User` { _, jwt ->
+      webTestClient.post()
+        .uri("/premises?service=temporary-accommodation")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewPremises(
+            name = "arbitrary_test_name",
+            postcode = "AB123CD",
+            addressLine1 = "FIRST LINE OF THE ADDRESS",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
+            notes = "some notes",
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("onlyCas3Supported")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("onlyCas3Supported")
+    }
   }
 
   @Test
   fun `Trying to create a new premises with an invalid local authority area id returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "arbitrary_test_name",
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes",
-          localAuthorityAreaId = UUID.fromString("878217f0-6db5-49d8-a5a1-c40fdecd6060"), // not in db
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "arbitrary_test_name",
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes",
+            localAuthorityAreaId = UUID.fromString("878217f0-6db5-49d8-a5a1-c40fdecd6060"), // not in db
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
   }
 
   @Test
   fun `Trying to create a new Approved Premises with no local authority area id returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.approvedPremises.value)
-      .bodyValue(
-        NewPremises(
-          name = "arbitrary_test_name",
-          addressLine1 = "1 somewhere",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes",
-          localAuthorityAreaId = null,
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+    `Given a User` { _, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .bodyValue(
+          NewPremises(
+            name = "arbitrary_test_name",
+            addressLine1 = "1 somewhere",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes",
+            localAuthorityAreaId = null,
+            probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
-  fun `Trying to create a new premises with an invalid probation region id returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          name = "arbitrary_test_name",
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB456CD",
-          notes = "some arbitrary notes",
-          localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"),
-          probationRegionId = UUID.fromString("48f96076-e911-4419-bceb-95a3e7f417eb"), // not in db
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.active
+  fun `Trying to create a new Temporary Accommodation premises with a probation region that's not the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            name = "arbitrary_test_name",
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB456CD",
+            notes = "some arbitrary notes",
+            localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"),
+            probationRegionId = UUID.fromString("48f96076-e911-4419-bceb-95a3e7f417eb"), // not in db
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.active,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 
   @Test
   fun `Trying to create a Temporary Accommodation Premises without a PDU returns 400`() {
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("PROBATIONPERSON")
-
-    webTestClient.post()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(
-        NewPremises(
-          addressLine1 = "1 somewhere",
-          addressLine2 = "Some district",
-          town = "Somewhere",
-          postcode = "AB123CD",
-          notes = "some arbitrary notes",
-          name = "some arbitrary name",
-          localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
-          probationRegionId = UUID.fromString("c5acff6c-d0d2-4b89-9f4d-89a15cfa3891"),
-          characteristicIds = mutableListOf(),
-          status = PropertyStatus.pending,
-          pdu = null,
+    `Given a User` { user, jwt ->
+      webTestClient.post()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewPremises(
+            addressLine1 = "1 somewhere",
+            addressLine2 = "Some district",
+            town = "Somewhere",
+            postcode = "AB123CD",
+            notes = "some arbitrary notes",
+            name = "some arbitrary name",
+            localAuthorityAreaId = UUID.fromString("a5f52443-6b55-498c-a697-7c6fad70cc3f"),
+            probationRegionId = user.probationRegion.id,
+            characteristicIds = mutableListOf(),
+            status = PropertyStatus.pending,
+            pdu = null,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
   fun `Get all Premises returns OK with correct body`() {
-    val cas1Premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val cas1Premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS1")
+        withTotalBeds(20)
       }
-      withService("CAS1")
-      withTotalBeds(20)
+
+      val cas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS3")
+        withTotalBeds(20)
+      }
+
+      val premises = cas1Premises + cas3Premises
+
+      val expectedJson = objectMapper.writeValueAsString(
+        premises.map {
+          premisesTransformer.transformJpaToApi(it, 20)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
     }
-
-    val cas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
-      withService("CAS3")
-      withTotalBeds(20)
-    }
-
-    val premises = cas1Premises + cas3Premises
-
-    val expectedJson = objectMapper.writeValueAsString(
-      premises.map {
-        premisesTransformer.transformJpaToApi(it, 20)
-      }
-    )
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
   }
 
   @Test
   fun `Get Premises for CAS1 returns OK with correct body`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS1")
+        withTotalBeds(20)
       }
-      withService("CAS1")
-      withTotalBeds(20)
+
+      // Add some extra premises for the other service that shouldn't be returned
+      temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS3")
+        withTotalBeds(20)
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(
+        premises.map {
+          premisesTransformer.transformJpaToApi(it, 20)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "approved-premises")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
     }
-
-    // Add some extra premises for the other service that shouldn't be returned
-    temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
-      withService("CAS3")
-      withTotalBeds(20)
-    }
-
-    val expectedJson = objectMapper.writeValueAsString(
-      premises.map {
-        premisesTransformer.transformJpaToApi(it, 20)
-      }
-    )
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", "approved-premises")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
   }
 
   @Test
-  fun `Get Premises for CAS3 returns OK with correct body`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
-      withService("CAS3")
-      withTotalBeds(20)
-      withPdu("Some Location")
+  fun `Get Premises for all regions in CAS3 returns 403 Forbidden`() {
+    `Given a User` { user, jwt ->
+      webTestClient.get()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "temporary-accommodation")
+        .exchange()
+        .expectStatus()
+        .isForbidden
     }
+  }
 
-    // Add some extra premises for the other service that shouldn't be returned
-    approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
-      withService("CAS1")
-      withTotalBeds(20)
+  @Test
+  fun `Get Premises in CAS3 for a region that's not the user's region returns 403 Forbidden`() {
+    `Given a User` { user, jwt ->
+      webTestClient.get()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "temporary-accommodation")
+        .header("X-User-Region", UUID.randomUUID().toString())
+        .exchange()
+        .expectStatus()
+        .isForbidden
     }
-
-    val expectedJson = objectMapper.writeValueAsString(
-      premises.map {
-        premisesTransformer.transformJpaToApi(it, 20)
-      }
-    )
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", "temporary-accommodation")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
   }
 
   @Test
   fun `Get Premises for a single region returns OK with correct body`() {
-    val regionId = UUID.randomUUID()
+    `Given a User` { _, jwt ->
+      val regionId = UUID.randomUUID()
 
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withId(regionId)
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
-
-    val cas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { region }
-      withService("CAS3")
-      withTotalBeds(20)
-      withPdu("Some Location")
-    }
-
-    val cas1Premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { region }
-      withService("CAS1")
-      withTotalBeds(20)
-    }
-
-    // Add some extra premises in both services for other regions that shouldn't be returned
-    temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withId(regionId)
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
       }
-      withService("CAS3")
-      withTotalBeds(20)
-      withPdu("Some Other Location")
-    }
 
-    approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      val cas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion { region }
+        withService("CAS3")
+        withTotalBeds(20)
+        withPdu("Some Location")
       }
-      withService("CAS1")
-      withTotalBeds(20)
-    }
 
-    val expectedPremises = cas1Premises + cas3Premises
-
-    val expectedJson = objectMapper.writeValueAsString(
-      expectedPremises.map {
-        premisesTransformer.transformJpaToApi(it, 20)
+      val cas1Premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion { region }
+        withService("CAS1")
+        withTotalBeds(20)
       }
-    )
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+      // Add some extra premises in both services for other regions that shouldn't be returned
+      temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS3")
+        withTotalBeds(20)
+        withPdu("Some Other Location")
+      }
 
-    webTestClient.get()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-User-Region", "$regionId")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
+      approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS1")
+        withTotalBeds(20)
+      }
+
+      val expectedPremises = cas1Premises + cas3Premises
+
+      val expectedJson = objectMapper.writeValueAsString(
+        expectedPremises.map {
+          premisesTransformer.transformJpaToApi(it, 20)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-User-Region", "$regionId")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
   }
 
   @Test
   fun `Get Premises for a single region and particular service returns OK with correct body`() {
-    val regionId = UUID.randomUUID()
-
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withId(regionId)
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
-
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { region }
-      withService("CAS3")
-      withTotalBeds(20)
-      withPdu("Some Location")
-    }
-
-    // Add some extra premises in the same region but in Approved Premises that shouldn't be returned
-    approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { region }
-      withService("CAS1")
-      withTotalBeds(20)
-    }
-
-    // Add some extra premises in both services for other regions that shouldn't be returned
-    temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { user, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withProbationRegion(user.probationRegion)
+        withService("CAS3")
+        withTotalBeds(20)
+        withPdu("Some Location")
       }
-      withService("CAS3")
-      withTotalBeds(20)
-      withPdu("Some Other Location")
-    }
 
-    approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      // Add some extra premises in the same region but in Approved Premises that shouldn't be returned
+      approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withProbationRegion(user.probationRegion)
+        withService("CAS1")
+        withTotalBeds(20)
       }
-      withService("CAS1")
-      withTotalBeds(20)
-    }
 
-    val expectedJson = objectMapper.writeValueAsString(
-      premises.map {
-        premisesTransformer.transformJpaToApi(it, 20)
+      // Add some extra premises in both services for other regions that shouldn't be returned
+      temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS3")
+        withTotalBeds(20)
+        withPdu("Some Other Location")
       }
-    )
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+      approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withService("CAS1")
+        withTotalBeds(20)
+      }
 
-    webTestClient.get()
-      .uri("/premises")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", "temporary-accommodation")
-      .header("X-User-Region", "$regionId")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
+      val expectedJson = objectMapper.writeValueAsString(
+        premises.map {
+          premisesTransformer.transformJpaToApi(it, 20)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/premises")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "temporary-accommodation")
+        .header("X-User-Region", "${user.probationRegion.id}")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
   }
 
   @Test
   fun `Get Premises by ID returns OK with correct body`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
+
+      val premisesToGet = premises[2]
+      val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 20))
+
+      webTestClient.get()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
     }
-
-    val premisesToGet = premises[2]
-    val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 20))
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
   }
 
   @Test
   fun `Get Premises by ID returns OK with correct body when capacity is used`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
+
+      val keyWorker = ContextStaffMemberFactory().produce()
+      premises.forEach {
+        APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, it.qCode)
+      }
+
+      bookingEntityFactory.produceAndPersist {
+        withPremises(premises[2])
+        withArrivalDate(LocalDate.now().minusDays(2))
+        withDepartureDate(LocalDate.now().plusDays(4))
+        withStaffKeyWorkerCode(keyWorker.code)
+      }
+
+      val premisesToGet = premises[2]
+      val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 19))
+
+      webTestClient.get()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
     }
-
-    val keyWorker = ContextStaffMemberFactory().produce()
-    premises.forEach {
-      APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, it.qCode)
-    }
-
-    bookingEntityFactory.produceAndPersist {
-      withPremises(premises[2])
-      withArrivalDate(LocalDate.now().minusDays(2))
-      withDepartureDate(LocalDate.now().plusDays(4))
-      withStaffKeyWorkerCode(keyWorker.code)
-    }
-
-    val premisesToGet = premises[2]
-    val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 19))
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises/${premisesToGet.id}")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
   }
 
   @Test
@@ -982,6 +1001,29 @@ class PremisesTest : IntegrationTestBase() {
       .jsonPath("title").isEqualTo("Not Found")
       .jsonPath("status").isEqualTo(404)
       .jsonPath("detail").isEqualTo("No Premises with an ID of $idToRequest could be found")
+  }
+
+  @Test
+  fun `Get Temporary Accommodation Premises by ID for a premises not in the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
+      }
+
+      val premisesToGet = premises[2]
+
+      webTestClient.get()
+        .uri("/premises/${premisesToGet.id}")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 
   @Test
@@ -1012,8 +1054,8 @@ class PremisesTest : IntegrationTestBase() {
           .willReturn(
             WireMock.aResponse()
               .withHeader("Content-Type", "application/json")
-              .withStatus(404)
-          )
+              .withStatus(404),
+          ),
       )
 
       webTestClient.get()
@@ -1027,22 +1069,46 @@ class PremisesTest : IntegrationTestBase() {
     }
   }
 
+  @Test
   fun `Get Premises Staff for Temporary Accommodation Premises returns 501`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { user, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withProbationRegion(user.probationRegion)
       }
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/staff")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.NOT_IMPLEMENTED)
     }
+  }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+  @Test
+  fun `Get Premises Staff for Temporary Accommodation Premises not in the user's region returns 403 Forbidden`() {
+    `Given a User` { user, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withId(UUID.randomUUID())
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+      }
 
-    webTestClient.get()
-      .uri("/premises/${premises.id}/staff")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isEqualTo(HttpStatus.NOT_IMPLEMENTED)
+      webTestClient.get()
+        .uri("/premises/${premises.id}/staff")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 
   @ParameterizedTest
@@ -1064,7 +1130,7 @@ class PremisesTest : IntegrationTestBase() {
         ContextStaffMemberFactory().produce(),
         ContextStaffMemberFactory().produce(),
         ContextStaffMemberFactory().produce(),
-        ContextStaffMemberFactory().produce()
+        ContextStaffMemberFactory().produce(),
       )
 
       wiremockServer.stubFor(
@@ -1076,11 +1142,11 @@ class PremisesTest : IntegrationTestBase() {
               .withBody(
                 objectMapper.writeValueAsString(
                   StaffMembersPage(
-                    content = staffMembers
-                  )
-                )
-              )
-          )
+                    content = staffMembers,
+                  ),
+                ),
+              ),
+          ),
       )
 
       webTestClient.get()
@@ -1092,8 +1158,8 @@ class PremisesTest : IntegrationTestBase() {
         .expectBody()
         .json(
           objectMapper.writeValueAsString(
-            staffMembers.map(staffMemberTransformer::transformDomainToApi)
-          )
+            staffMembers.map(staffMemberTransformer::transformDomainToApi),
+          ),
         )
     }
   }
@@ -1117,7 +1183,7 @@ class PremisesTest : IntegrationTestBase() {
         ContextStaffMemberFactory().produce(),
         ContextStaffMemberFactory().produce(),
         ContextStaffMemberFactory().produce(),
-        ContextStaffMemberFactory().produce()
+        ContextStaffMemberFactory().produce(),
       )
 
       wiremockServer.stubFor(
@@ -1129,11 +1195,11 @@ class PremisesTest : IntegrationTestBase() {
               .withBody(
                 objectMapper.writeValueAsString(
                   StaffMembersPage(
-                    content = staffMembers
-                  )
-                )
-              )
-          )
+                    content = staffMembers,
+                  ),
+                ),
+              ),
+          ),
       )
 
       repeat(2) {
@@ -1146,8 +1212,8 @@ class PremisesTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              staffMembers.map(staffMemberTransformer::transformDomainToApi)
-            )
+              staffMembers.map(staffMemberTransformer::transformDomainToApi),
+            ),
           )
       }
 
@@ -1157,498 +1223,607 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Rooms for Premises returns OK with correct body`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
-    val rooms = roomEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedPremises { premises }
-    }
-
-    val expectedJson = objectMapper.writeValueAsString(
-      rooms.map {
-        roomTransformer.transformJpaToApi(it)
+      val rooms = roomEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedPremises { premises }
       }
-    )
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+      val expectedJson = objectMapper.writeValueAsString(
+        rooms.map {
+          roomTransformer.transformJpaToApi(it)
+        },
+      )
 
-    webTestClient.get()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
+      webTestClient.get()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
+  }
+
+  @Test
+  fun `Get all Rooms for a Temporary Accommodation Premises that's not in the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withId(UUID.randomUUID())
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
+      val rooms = roomEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedPremises { premises }
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(
+        rooms.map {
+          roomTransformer.transformJpaToApi(it)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 
   @Test
   fun `The total bedspaces on a Temporary Accommodation Premises is equal to the sum of the bedspaces in all Rooms attached to the Premises`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedRoom { room }
+      }
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("$.bedCount").isEqualTo(5)
     }
-
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-    }
-
-    bedEntityFactory.produceAndPersistMultiple(5) {
-      withYieldedRoom { room }
-    }
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises/${premises.id}")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("$.bedCount").isEqualTo(5)
   }
 
   @Test
   fun `Create new Room for Premises returns 201 Created with correct body when given valid data`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
-      withModelScope("room")
-      withServiceScope("temporary-accommodation")
-      withName("Floor level access")
-    }.map { it.id }
+      val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
+        withModelScope("room")
+        withServiceScope("temporary-accommodation")
+        withName("Floor level access")
+      }.map { it.id }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.post()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewRoom(
-          notes = "test notes",
-          name = "test-room",
-          characteristicIds = characteristicIds
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewRoom(
+            notes = "test notes",
+            name = "test-room",
+            characteristicIds = characteristicIds,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isCreated
-      .expectBody()
-      .jsonPath("name").isEqualTo("test-room")
-      .jsonPath("notes").isEqualTo("test notes")
-      .jsonPath("characteristics[*].id").isEqualTo(characteristicIds.map { it.toString() })
-      .jsonPath("characteristics[*].modelScope").isEqualTo(MutableList(5) { "room" })
-      .jsonPath("characteristics[*].serviceScope").isEqualTo(MutableList(5) { "temporary-accommodation" })
-      .jsonPath("characteristics[*].name").isEqualTo(MutableList(5) { "Floor level access" })
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody()
+        .jsonPath("name").isEqualTo("test-room")
+        .jsonPath("notes").isEqualTo("test notes")
+        .jsonPath("characteristics[*].id").isEqualTo(characteristicIds.map { it.toString() })
+        .jsonPath("characteristics[*].modelScope").isEqualTo(MutableList(5) { "room" })
+        .jsonPath("characteristics[*].serviceScope").isEqualTo(MutableList(5) { "temporary-accommodation" })
+        .jsonPath("characteristics[*].name").isEqualTo(MutableList(5) { "Floor level access" })
+    }
   }
 
   @Test
   fun `When a new room is created with no notes then it defaults to empty`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.post()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewRoom(
-          notes = null,
-          name = "test-room",
-          characteristicIds = mutableListOf()
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewRoom(
+            notes = null,
+            name = "test-room",
+            characteristicIds = mutableListOf(),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isCreated
-      .expectBody()
-      .jsonPath("notes").isEqualTo("")
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody()
+        .jsonPath("notes").isEqualTo("")
+    }
   }
 
   @Test
   fun `Trying to create a room without a name returns 400`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.post()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewRoom(
-          notes = "test notes",
-          name = "",
-          characteristicIds = mutableListOf()
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewRoom(
+            notes = "test notes",
+            name = "",
+            characteristicIds = mutableListOf(),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+    }
   }
 
   @Test
   fun `Trying to create a room with an unknown characteristic returns 400`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.post()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewRoom(
-          notes = "test notes",
-          name = "test-room",
-          characteristicIds = mutableListOf(UUID.randomUUID())
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewRoom(
+            notes = "test notes",
+            name = "test-room",
+            characteristicIds = mutableListOf(UUID.randomUUID()),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
   }
 
   @Test
   fun `Trying to create a room with a characteristic of the wrong service scope returns 400`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val characteristicId = characteristicEntityFactory.produceAndPersist {
-      withModelScope("room")
-      withServiceScope("approved-premises")
-    }.id
+      val characteristicId = characteristicEntityFactory.produceAndPersist {
+        withModelScope("room")
+        withServiceScope("approved-premises")
+      }.id
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.post()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewRoom(
-          notes = "test notes",
-          name = "test-room",
-          characteristicIds = mutableListOf(characteristicId)
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewRoom(
+            notes = "test notes",
+            name = "test-room",
+            characteristicIds = mutableListOf(characteristicId),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicServiceScope")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicServiceScope")
+    }
   }
 
   @Test
   fun `Trying to create a room with a characteristic of the wrong model scope returns 400`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val characteristicId = characteristicEntityFactory.produceAndPersist {
-      withModelScope("premises")
-      withServiceScope("approved-premises")
-    }.id
+      val characteristicId = characteristicEntityFactory.produceAndPersist {
+        withModelScope("premises")
+        withServiceScope("approved-premises")
+      }.id
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.post()
-      .uri("/premises/${premises.id}/rooms")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        NewRoom(
-          notes = "test notes",
-          name = "test-room",
-          characteristicIds = mutableListOf(characteristicId)
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewRoom(
+            notes = "test notes",
+            name = "test-room",
+            characteristicIds = mutableListOf(characteristicId),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicModelScope")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicModelScope")
+    }
   }
+
+  @Test
+  fun `Create new Room for Temporary Accommodation Premises that's not in the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withId(UUID.randomUUID())
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
+
+      val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
+        withModelScope("room")
+        withServiceScope("temporary-accommodation")
+        withName("Floor level access")
+      }.map { it.id }
+
+      webTestClient.post()
+        .uri("/premises/${premises.id}/rooms")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          NewRoom(
+            notes = "test notes",
+            name = "test-room",
+            characteristicIds = characteristicIds,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
   @Test
   fun `Updating a Room returns OK with correct body when given valid data`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-      withName("test-room")
-    }
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+      }
 
-    val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
-      withModelScope("room")
-      withServiceScope("temporary-accommodation")
-      withName("Floor level access")
-    }.map { it.id }
+      val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
+        withModelScope("room")
+        withServiceScope("temporary-accommodation")
+        withName("Floor level access")
+      }.map { it.id }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.put()
-      .uri("/premises/${premises.id}/rooms/${room.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdateRoom(
-          notes = "test notes",
-          characteristicIds = characteristicIds
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateRoom(
+            notes = "test notes",
+            characteristicIds = characteristicIds,
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("name").isEqualTo("test-room")
-      .jsonPath("notes").isEqualTo("test notes")
-      .jsonPath("characteristics[*].id").isEqualTo(characteristicIds.map { it.toString() })
-      .jsonPath("characteristics[*].modelScope").isEqualTo(MutableList(5) { "room" })
-      .jsonPath("characteristics[*].serviceScope").isEqualTo(MutableList(5) { "temporary-accommodation" })
-      .jsonPath("characteristics[*].name").isEqualTo(MutableList(5) { "Floor level access" })
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("name").isEqualTo("test-room")
+        .jsonPath("notes").isEqualTo("test notes")
+        .jsonPath("characteristics[*].id").isEqualTo(characteristicIds.map { it.toString() })
+        .jsonPath("characteristics[*].modelScope").isEqualTo(MutableList(5) { "room" })
+        .jsonPath("characteristics[*].serviceScope").isEqualTo(MutableList(5) { "temporary-accommodation" })
+        .jsonPath("characteristics[*].name").isEqualTo(MutableList(5) { "Floor level access" })
+    }
   }
 
   @Test
   fun `When a room is updated with no notes then it defaults to empty`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-      withName("test-room")
-    }
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+      }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.put()
-      .uri("/premises/${premises.id}/rooms/${room.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdateRoom(
-          notes = null,
-          characteristicIds = mutableListOf()
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateRoom(
+            notes = null,
+            characteristicIds = mutableListOf(),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("notes").isEqualTo("")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("notes").isEqualTo("")
+    }
   }
 
   @Test
   fun `Trying to update a room that does not exist returns 404`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+      val id = UUID.randomUUID()
 
-    val id = UUID.randomUUID()
-
-    webTestClient.put()
-      .uri("/premises/${premises.id}/rooms/$id")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdateRoom(
-          notes = "test notes",
-          characteristicIds = mutableListOf(UUID.randomUUID())
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/$id")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateRoom(
+            notes = "test notes",
+            characteristicIds = mutableListOf(UUID.randomUUID()),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Not Found")
-      .jsonPath("status").isEqualTo(404)
-      .jsonPath("detail").isEqualTo("No Room with an ID of $id could be found")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Not Found")
+        .jsonPath("status").isEqualTo(404)
+        .jsonPath("detail").isEqualTo("No Room with an ID of $id could be found")
+    }
   }
 
   @Test
   fun `Trying to update a room with an unknown characteristic returns 400`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-      withName("test-room")
-    }
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+      }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.put()
-      .uri("/premises/${premises.id}/rooms/${room.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdateRoom(
-          notes = "test notes",
-          characteristicIds = mutableListOf(UUID.randomUUID())
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateRoom(
+            notes = "test notes",
+            characteristicIds = mutableListOf(UUID.randomUUID()),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
   }
 
   @Test
   fun `Trying to update a room with a characteristic of the wrong service scope returns 400`() {
-    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-      withName("test-room")
-    }
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+      }
 
-    val characteristicId = characteristicEntityFactory.produceAndPersist {
-      withModelScope("room")
-      withServiceScope("approved-premises")
-    }.id
+      val characteristicId = characteristicEntityFactory.produceAndPersist {
+        withModelScope("room")
+        withServiceScope("approved-premises")
+      }.id
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.put()
-      .uri("/premises/${premises.id}/rooms/${room.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdateRoom(
-          notes = "test notes",
-          characteristicIds = mutableListOf(characteristicId)
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateRoom(
+            notes = "test notes",
+            characteristicIds = mutableListOf(characteristicId),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicServiceScope")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicServiceScope")
+    }
   }
 
   @Test
   fun `Trying to update a room with a characteristic of the wrong model scope returns 400`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
       }
-    }
 
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-      withName("test-room")
-    }
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+      }
 
-    val characteristicId = characteristicEntityFactory.produceAndPersist {
-      withModelScope("premises")
-      withServiceScope("approved-premises")
-    }.id
+      val characteristicId = characteristicEntityFactory.produceAndPersist {
+        withModelScope("premises")
+        withServiceScope("approved-premises")
+      }.id
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.put()
-      .uri("/premises/${premises.id}/rooms/${room.id}")
-      .header("Authorization", "Bearer $jwt")
-      .bodyValue(
-        UpdateRoom(
-          notes = "test notes",
-          characteristicIds = mutableListOf(characteristicId)
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateRoom(
+            notes = "test notes",
+            characteristicIds = mutableListOf(characteristicId),
+          ),
         )
-      )
-      .exchange()
-      .expectStatus()
-      .is4xxClientError
-      .expectBody()
-      .jsonPath("title").isEqualTo("Bad Request")
-      .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicModelScope")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("title").isEqualTo("Bad Request")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("incorrectCharacteristicModelScope")
+    }
+  }
+
+  @Test
+  fun `Updating a Room on a Temporary Accommodation premises that's not in the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withId(UUID.randomUUID())
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+      }
+
+      val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
+        withModelScope("room")
+        withServiceScope("temporary-accommodation")
+        withName("Floor level access")
+      }.map { it.id }
+
+      webTestClient.put()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .bodyValue(
+          UpdateRoom(
+            notes = "test notes",
+            characteristicIds = characteristicIds,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 
   @Test
   fun `Get Room by ID returns OK with correct body`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
+
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+        withNotes("test notes")
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(roomTransformer.transformJpaToApi(room))
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
     }
-
-    val room = roomEntityFactory.produceAndPersist {
-      withYieldedPremises { premises }
-      withName("test-room")
-      withNotes("test notes")
-    }
-
-    val expectedJson = objectMapper.writeValueAsString(roomTransformer.transformJpaToApi(room))
-
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
-
-    webTestClient.get()
-      .uri("/premises/${premises.id}/rooms/${room.id}")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(expectedJson)
   }
 
   @Test
@@ -1686,28 +1861,57 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Get Room by ID returns Not Found with correct body when Room does not exist`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+        withTotalBeds(20)
       }
-      withTotalBeds(20)
+
+      val roomIdToRequest = UUID.randomUUID().toString()
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/rooms/$roomIdToRequest")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectHeader().contentType("application/problem+json")
+        .expectStatus()
+        .isNotFound
+        .expectBody()
+        .jsonPath("title").isEqualTo("Not Found")
+        .jsonPath("status").isEqualTo(404)
+        .jsonPath("detail").isEqualTo("No Room with an ID of $roomIdToRequest could be found")
     }
+  }
 
-    val roomIdToRequest = UUID.randomUUID().toString()
+  @Test
+  fun `Get Room by ID for a room on a Temporary Accommodation premises that's not in the user's region returns 403 Forbidden`() {
+    `Given a User` { _, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withId(UUID.randomUUID())
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
 
-    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { premises }
+        withName("test-room")
+        withNotes("test notes")
+      }
 
-    webTestClient.get()
-      .uri("/premises/${premises.id}/rooms/$roomIdToRequest")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectHeader().contentType("application/problem+json")
-      .expectStatus()
-      .isNotFound
-      .expectBody()
-      .jsonPath("title").isEqualTo("Not Found")
-      .jsonPath("status").isEqualTo(404)
-      .jsonPath("detail").isEqualTo("No Room with an ID of $roomIdToRequest could be found")
+      webTestClient.get()
+        .uri("/premises/${premises.id}/rooms/${room.id}")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -3,12 +3,21 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
 import java.util.UUID
 import javax.servlet.http.HttpServletRequest
 
@@ -22,105 +31,475 @@ class UserAccessServiceTest {
   )
 
   private val probationRegionId = UUID.randomUUID()
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withId(probationRegionId)
+    .withApArea(
+      ApAreaEntityFactory()
+        .produce()
+    )
+    .produce()
+
   private val user = UserEntityFactory()
+    .withProbationRegion(probationRegion)
+    .produce()
+
+  val approvedPremises = ApprovedPremisesEntityFactory()
+    .withProbationRegion(probationRegion)
+    .withLocalAuthorityArea(
+      LocalAuthorityEntityFactory()
+        .produce()
+    )
+    .produce()
+
+  val temporaryAccommodationPremisesInUserRegion = TemporaryAccommodationPremisesEntityFactory()
+    .withProbationRegion(probationRegion)
+    .withLocalAuthorityArea(
+      LocalAuthorityEntityFactory()
+        .produce()
+    )
+    .produce()
+
+  val temporaryAccommodationPremisesNotInUserRegion = TemporaryAccommodationPremisesEntityFactory()
     .withProbationRegion(
       ProbationRegionEntityFactory()
-        .withId(probationRegionId)
         .withApArea(
           ApAreaEntityFactory()
             .produce()
         )
         .produce()
     )
+    .withLocalAuthorityArea(
+      LocalAuthorityEntityFactory()
+        .produce()
+    )
     .produce()
+
+  private fun currentRequestIsFor(service: ServiceName) {
+    every { currentRequest.getHeader("X-Service-Name") } returns service.value
+  }
+
+  private fun currentRequestIsForArbitraryService() {
+    every { currentRequest.getHeader("X-Service-Name") } returns "arbitrary-value"
+  }
+
+  @BeforeEach
+  fun setup() {
+    every { userService.getUserForRequest() } returns user
+  }
 
   @Test
   fun `userHasAllRegionsAccess returns false if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.userHasAllRegionsAccess(user)).isFalse
   }
 
   @Test
   fun `userHasAllRegionsAccess returns true if the current request has 'X-Service-Name' header with value 'approved-premises'`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
+    currentRequestIsFor(ServiceName.approvedPremises)
 
     assertThat(userAccessService.userHasAllRegionsAccess(user)).isTrue
   }
 
   @Test
   fun `userHasAllRegionsAccess returns true by default`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "arbitrary-value"
+    currentRequestIsForArbitraryService()
 
     assertThat(userAccessService.userHasAllRegionsAccess(user)).isTrue
   }
 
   @Test
   fun `currentUserHasAllRegionsAccess returns false if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
-    every { userService.getUserForRequest() } returns user
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.currentUserHasAllRegionsAccess()).isFalse
   }
 
   @Test
   fun `currentUserHasAllRegionsAccess returns true if the current request has 'X-Service-Name' header with value 'approved-premises'`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
-    every { userService.getUserForRequest() } returns user
+    currentRequestIsFor(ServiceName.approvedPremises)
 
     assertThat(userAccessService.currentUserHasAllRegionsAccess()).isTrue
   }
 
   @Test
   fun `currentUserHasAllRegionsAccess returns true by default`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "arbitrary-value"
-    every { userService.getUserForRequest() } returns user
+    currentRequestIsForArbitraryService()
 
     assertThat(userAccessService.currentUserHasAllRegionsAccess()).isTrue
   }
 
   @Test
   fun `userCanAccessRegion returns false if the current user does not have all regions access and their probation region ID does not equal the specified ID`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.userCanAccessRegion(user, UUID.randomUUID())).isFalse
   }
 
   @Test
   fun `userCanAccessRegion returns true if the current user has all regions access`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
+    currentRequestIsFor(ServiceName.approvedPremises)
 
     assertThat(userAccessService.userCanAccessRegion(user, UUID.randomUUID())).isTrue
   }
 
   @Test
   fun `userCanAccessRegion returns true if the current user's probation region ID is equal to the specified ID`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.userCanAccessRegion(user, probationRegionId)).isTrue
   }
 
   @Test
   fun `currentUserCanAccessRegion returns false if the current user does not have all regions access and their probation region ID does not equal the specified ID`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
-    every { userService.getUserForRequest() } returns user
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.currentUserCanAccessRegion(UUID.randomUUID())).isFalse
   }
 
   @Test
   fun `currentUserCanAccessRegion returns true if the current user has all regions access`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "approved-premises"
-    every { userService.getUserForRequest() } returns user
+    currentRequestIsFor(ServiceName.approvedPremises)
 
     assertThat(userAccessService.currentUserCanAccessRegion(UUID.randomUUID())).isTrue
   }
 
   @Test
   fun `currentUserCanAccessRegion returns true if the current user's probation region ID is equal to the specified ID`() {
-    every { currentRequest.getHeader("X-Service-Name") } returns "temporary-accommodation"
-    every { userService.getUserForRequest() } returns user
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.currentUserCanAccessRegion(probationRegionId)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremises returns true if the given premises is an Approved Premises`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanViewPremises(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremises returns true if the given premises is a Temporary Accommodation premises and the user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremises(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremises returns false if the given premises is a Temporary Accommodation premises and the user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremises(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanViewPremises returns true if the given premises is an Approved Premises`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanViewPremises(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremises returns true if the given premises is a Temporary Accommodation premises and the current user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremises(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremises returns false if the given premises is a Temporary Accommodation premises and the current user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremises(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
+  fun `userCanManagePremises returns true if the given premises is an Approved Premises`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanManagePremises(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremises returns true if the given premises is a Temporary Accommodation premises and the user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremises(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremises returns false if the given premises is a Temporary Accommodation premises and the user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremises(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanManagePremises returns true if the given premises is an Approved Premises`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanManagePremises(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremises returns true if the given premises is a Temporary Accommodation premises and the current user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremises(temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremises returns false if the given premises is a Temporary Accommodation premises and the current user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremises(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `userCanManagePremisesBookings returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.userCanManagePremisesBookings(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremisesBookings returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanManagePremisesBookings(user, approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `userCanManagePremisesBookings returns true if the given premises is a Temporary Accommodation premises and the user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremisesBookings(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremisesBookings returns false if the given premises is a Temporary Accommodation premises and the user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremisesBookings(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `currentUserCanManagePremisesBookings returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.currentUserCanManagePremisesBookings(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesBookings returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanManagePremisesBookings(approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesBookings returns true if the given premises is a Temporary Accommodation premises and the current user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesBookings returns false if the given premises is a Temporary Accommodation premises and the current user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `userCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.userCanManagePremisesLostBeds(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremisesLostBeds returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanManagePremisesLostBeds(user, approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `userCanManagePremisesLostBeds returns true if the given premises is a Temporary Accommodation premises and the user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremisesLostBeds(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremisesLostBeds returns false if the given premises is a Temporary Accommodation premises and the user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremisesLostBeds(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `currentUserCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.currentUserCanManagePremisesLostBeds(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesLostBeds returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanManagePremisesLostBeds(approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesLostBeds returns true if the given premises is a Temporary Accommodation premises and the current user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremisesLostBeds(temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesLostBeds returns false if the given premises is a Temporary Accommodation premises and the current user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremisesLostBeds(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `userCanViewPremisesCapacity returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.userCanViewPremisesCapacity(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremisesCapacity returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanViewPremisesCapacity(user, approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `userCanViewPremisesCapacity returns true if the given premises is a Temporary Accommodation premises and the user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremisesCapacity(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremisesCapacity returns false if the given premises is a Temporary Accommodation premises and the user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremisesCapacity(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `currentUserCanViewPremisesCapacity returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.currentUserCanViewPremisesCapacity(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremisesCapacity returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanViewPremisesCapacity(approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanViewPremisesCapacity returns true if the given premises is a Temporary Accommodation premises and the current user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanViewPremisesCapacity(temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremisesCapacity returns false if the given premises is a Temporary Accommodation premises and the current user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanViewPremisesCapacity(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `userCanViewPremisesStaff returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.userCanViewPremisesStaff(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremisesStaff returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanViewPremisesStaff(user, approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `userCanViewPremisesStaff returns true if the given premises is a Temporary Accommodation premises and the user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremisesStaff(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanViewPremisesStaff returns false if the given premises is a Temporary Accommodation premises and the user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanViewPremisesStaff(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  fun `currentUserCanViewPremisesStaff returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.currentUserCanViewPremisesStaff(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremisesStaff returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanViewPremisesStaff(approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanViewPremisesStaff returns true if the given premises is a Temporary Accommodation premises and the current user can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremisesStaff returns false if the given premises is a Temporary Accommodation premises and the current user cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesNotInUserRegion)).isFalse
   }
 }


### PR DESCRIPTION
> See [ticket #770 on the CAS3 Trello board](https://trello.com/c/mDxlIttG/770-protect-against-users-circumventing-property-filtering).

This PR is the second part of the additional work to restrict users of the Temporary Accommodation service from accessing data belong to regions they are not in. It adds new methods to the `UserAccessService` which can be used to determine whether the current user can perform a particular action (which will be more important once the TA service distinguishes users by role).

Changes in this PR:
- Refactoring existing user access checks for Approved Premises to use the `UserAccessService`. The new methods have been written to be able to take into account both the current user and the service.
- Introducing new user access checks for endpoints that Approved Premises doesn't restrict. These methods trivially return `true` for Approved Premises to preserve the current behaviour.

The list of new user actions that can be checked by the `UserAccessService` are:
- **Viewing premises** (`userCanViewPremises`/`currentUserCanViewPremises`)
- **Managing premises** (`userCanManagePremises`/`currentUserCanManagePremises`)
- **Managing bookings on a premises** (`userCanManagePremisesBookings`/`currentUserCanManagePremisesBookings`)
- **Managing lost beds on a premises** (`userCanManagePremisesLostBeds`/`currentUserCanManagePremisesLostBeds`)
- **Viewing the capacity of a premises** (`userCanViewPremisesCapacity`/`currentUserCanViewPremisesCapacity`)
- **Viewing staff members associated with a premises** (`userCanViewPremisesStaff`/`currentUserCanViewPremisesStaff`)