### PR TITLE
Use a Github app to trigger UI Workflows

### DIFF
--- a/.github/workflows/generate-ui-types.yml
+++ b/.github/workflows/generate-ui-types.yml
@@ -11,12 +11,18 @@ jobs:
   generate-ui:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Trigger AP UI Type Generation Workflow
         if: ${{ github.ref == 'refs/heads/main' }}
         id: ap-trigger-ui-workflow
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.UI_REPO_ACCESS_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
@@ -29,7 +35,7 @@ jobs:
         id: ta-trigger-ui-workflow
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.UI_REPO_ACCESS_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,


### PR DESCRIPTION
We now have a CommunityAccommodationTypeGen app installed on the repo, this means we can use it to generate a one-time only token to trigger the UI workflows, so we don’t have to use personal access tokens.

I've added the relevant secrets to the repo, and the app is installed, so we should be good to go!