### PR TITLE
(1315) Allow a task to be allocated to a user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotAllowedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotAllowedProblem.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.Exceptional
+import org.zalando.problem.Status
+
+class NotAllowedProblem(detail: String) : AbstractThrowableProblem(null, "Not Allowed", Status.METHOD_NOT_ALLOWED, detail) {
+  override fun getCause(): Exceptional? {
+    return null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.Status
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1603,7 +1603,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/Reallocation'
+              $ref: '#/components/schemas/NewReallocation'
         required: true
       responses:
         201:
@@ -1611,7 +1611,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/Assessment'
+                $ref: '#/components/schemas/Reallocation'
         400:
           description: invalid params
           content:
@@ -2476,12 +2476,14 @@ components:
             - in_progress
             - complete
         taskType:
-          type: string
-          enum:
-            - Assessment
-            - PlacementRequest
-            - PlacementRequestReview
-            - BookingAppeal
+          $ref: '#/components/schemas/TaskType'
+    TaskType:
+      type: string
+      enum:
+        - Assessment
+        - PlacementRequest
+        - PlacementRequestReview
+        - BookingAppeal
     LocalAuthorityArea:
       type: object
       properties:
@@ -3824,14 +3826,27 @@ components:
           type: string
       required:
         - query
-    Reallocation:
+    NewReallocation:
       type: object
       properties:
         userId:
           type: string
           format: uuid
+        taskType:
+          $ref: '#/components/schemas/TaskType'
       required:
         - userId
+        - taskType
+    Reallocation:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+      required:
+        - userId
+        - taskType
     User:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -4,7 +4,8 @@ import com.ninjasquad.springmockk.SpykBean
 import io.mockk.every
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -38,8 +39,9 @@ class ReallocationAtomicTest : IntegrationTestBase() {
             .uri("/applications/${application.id}/allocations")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
-              Reallocation(
-                userId = assigneeUser.id
+              NewReallocation(
+                userId = assigneeUser.id,
+                taskType = TaskType.assessment
               )
             )
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -30,6 +30,7 @@ fun IntegrationTestBase.`Given a User`(
     withDeliusUsername(staffUserDetails.username)
     withEmail(staffUserDetails.email)
     withTelephoneNumber(staffUserDetails.telephoneNumber)
+    withName("${staffUserDetails.staff.forenames} ${staffUserDetails.staff.surname}")
     if (probationRegion == null) {
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.Status
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory


### PR DESCRIPTION
This updates the reallocate endpoint to support multiple tasks. I’ve updated the body to accept a NewRellocation object with a Task Type and user ID. Rather than returning the Assessment object (which we don’t need), the endpoint now returns a Reallocation object with the Task Type and the user who the task has been reallocated to.

As we don’t currently support any task type other than assessements, we return a 405 method not allowed response. I’ve also added some tests for all the other types to serve as placeholders, which can be replaced as we add support for the other task types.