### PR TITLE
Set order of characteristics for a 'deterministic' assertion

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationBedspaceTest.kt
@@ -119,7 +119,7 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
     assertThat(persistedPremises!!.rooms.size).isEqualTo(1)
     val room = persistedPremises.rooms.first()
     assertThat(room.name).isEqualTo(csvRow.bedspaceName)
-    assertThat(room.characteristics.map { it.name }).isEqualTo(csvRow.characteristics)
+    assertThat(room.characteristics.map { it.name }.sorted()).isEqualTo(csvRow.characteristics.sorted())
     assertThat(room.notes).isEqualTo(csvRow.notes)
     assertThat(room.beds.size).isEqualTo(1)
   }


### PR DESCRIPTION
This assertion was failing inconsistently due to changes in the ordering of characteristics. By sorting the lists prior to comparison we make the assertion "deterministic" or reliably repeatable.