### PR TITLE
Identify existing APs by ApCode rather than UUID in seeding

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -36,6 +36,9 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
 
   @Query("SELECT p FROM PremisesEntity p WHERE name = :name AND TYPE(p) = :type")
   fun <T : PremisesEntity> findByName(name: String, type: Class<T>): PremisesEntity?
+
+  @Query("SELECT p FROM PremisesEntity p WHERE ap_code = :apCode AND TYPE(p) = :type")
+  fun <T : PremisesEntity> findByApCode(apCode: String, type: Class<T>): PremisesEntity?
 }
 
 @Entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PremisesTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PremisesTestRepository.kt
@@ -11,7 +11,9 @@ import java.util.UUID
 interface PremisesTestRepository : JpaRepository<PremisesEntity, UUID>
 
 @Repository
-interface ApprovedPremisesTestRepository : JpaRepository<ApprovedPremisesEntity, UUID>
+interface ApprovedPremisesTestRepository : JpaRepository<ApprovedPremisesEntity, UUID> {
+  fun findByApCode(name: String): ApprovedPremisesEntity?
+}
 
 @Repository
 interface TemporaryAccommodationPremisesTestRepository : JpaRepository<TemporaryAccommodationPremisesEntity, UUID> {


### PR DESCRIPTION
ApCodes are unique so we can use these to identify existing APs which will be updated as distinct from new APs which need to be created.

No longer having to manage a list of UUIDs reduces opportunities for errors.