### PR TITLE
Expose Characteristic.propertyName via API

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2540,6 +2540,10 @@ components:
           example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
         name:
           type: string
+          example: Is this premises catered (rather than self-catered)?
+        propertyName:
+          type: string
+          example: isCatered
         serviceScope:
           type: string
           enum:


### PR DESCRIPTION
We now have permanent `propertyName` keys like:

- `acceptsHateCrimeOffenders`
- `isCatered`

This is in contrast to the existing `name` property which can be changed a needed e.g.

`Does this AP accept people who have been convicted of hate crimes?`

The representation of a characteristic via the API needs to include this new property so that the UI can:

- reliably display characteristics and
- request them in search parameters