### PR TITLE
Resolve N+1 queries problem for GET /premises endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -1,19 +1,28 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
+import javax.persistence.QueryHint
 import javax.persistence.Table
+import javax.persistence.Transient
 
 @Repository
 interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID> {
   fun findByName(name: String): ProbationRegionEntity?
   fun findByDeliusCode(deliusCode: String): ProbationRegionEntity?
+
+  @Query("SELECT DISTINCT p FROM ProbationRegionEntity p LEFT JOIN FETCH p.apArea WHERE p IN (:probationRegions)")
+  @QueryHints(value = [QueryHint(name = org.hibernate.jpa.QueryHints.HINT_PASS_DISTINCT_THROUGH, value = "false")], forCounting = false)
+  fun loadApAreas(probationRegions: List<ProbationRegionEntity>): List<ProbationRegionEntity>
 }
 
 @Entity
@@ -22,10 +31,13 @@ data class ProbationRegionEntity(
   @Id
   val id: UUID,
   val name: String,
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "ap_area_id")
   val apArea: ApAreaEntity,
   @OneToMany(mappedBy = "probationRegion")
   val premises: MutableList<PremisesEntity>,
   val deliusCode: String,
-)
+) {
+  @Transient
+  var apAreaLoaded = false
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -10,10 +12,16 @@ import javax.persistence.JoinTable
 import javax.persistence.ManyToMany
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
+import javax.persistence.QueryHint
 import javax.persistence.Table
+import javax.persistence.Transient
 
 @Repository
-interface RoomRepository : JpaRepository<RoomEntity, UUID>
+interface RoomRepository : JpaRepository<RoomEntity, UUID> {
+  @Query("SELECT DISTINCT r FROM RoomEntity r LEFT JOIN FETCH r.beds WHERE r IN (:rooms)")
+  @QueryHints(value = [QueryHint(name = org.hibernate.jpa.QueryHints.HINT_PASS_DISTINCT_THROUGH, value = "false")], forCounting = false)
+  fun loadRoomsBeds(rooms: List<RoomEntity>): List<RoomEntity>
+}
 
 @Entity
 @Table(name = "rooms")
@@ -34,4 +42,7 @@ data class RoomEntity(
     inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
   )
   val characteristics: MutableList<CharacteristicEntity>,
-)
+) {
+  @Transient
+  var bedsLoaded = false
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -25,6 +25,12 @@
         <appender name="logAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
     </springProfile>
 
+    <springProfile name="log-sql">
+        <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+            <appender-ref ref="logAppender"/>
+        </logger>
+    </springProfile>
+
     <logger name="uk.gov.justice.digital.hmpps.approvedpremisesapi.ApprovedPremisesApiKt" additivity="false"
             level="DEBUG">
         <appender-ref ref="logAppender"/>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/NPlus1QueriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/NPlus1QueriesTest.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import kotlin.system.measureTimeMillis
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@ActiveProfiles("test", "log-sql")
+class NPlus1QueriesTest : IntegrationTestBase() {
+  val appender = mockk<Appender<ILoggingEvent>>()
+
+  val capturedLogs = mutableListOf<ILoggingEvent>()
+
+  val log = LoggerFactory.getLogger(this::class.java)
+
+  @BeforeEach
+  fun setup() {
+    val logger = LoggerFactory.getLogger("org.hibernate.SQL") as ch.qos.logback.classic.Logger
+    logger.addAppender(appender)
+
+    every { appender.doAppend(capture(capturedLogs)) } returns Unit
+  }
+
+  @Test
+  fun `Listing a large number of Temporary Accommodation premises does not result in the N+1 queries problem`() {
+    `Given a User` { user, jwt ->
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(200) {
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withProbationRegion(user.probationRegion)
+        withService("CAS3")
+        withPdu("Some Location")
+      }
+
+      premises.forEach { p ->
+        val rooms = roomEntityFactory.produceAndPersistMultiple(20) {
+          withPremises(p)
+        }
+
+        rooms.forEach { r ->
+          bedEntityFactory.produceAndPersist {
+            withRoom(r)
+          }
+        }
+      }
+
+      capturedLogs.clear()
+
+      val requestTime = measureTimeMillis {
+        webTestClient.get()
+          .uri("/premises")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", "temporary-accommodation")
+          .header("X-User-Region", "${user.probationRegion.id}")
+          .exchange()
+          .expectStatus()
+          .isOk
+      }.milliseconds
+
+      log.info("Request took $requestTime (executed ${capturedLogs.size} queries)")
+
+      assertThat(capturedLogs).size().isLessThan(200)
+      assertThat(requestTime).isLessThan(10.seconds)
+    }
+  }
+
+  @Test
+  fun `Listing a large number of Approved Premises does not result in the N+1 queries problem`() {
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(200) {
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist {
+                // Avoid collisions due to the 'identifier_unique' constraint
+                withIdentifier(randomStringMultiCaseWithNumbers(6))
+              }
+            }
+          }
+        }
+        withService("CAS1")
+      }
+
+      premises.forEach { p ->
+        val rooms = roomEntityFactory.produceAndPersistMultiple(20) {
+          withPremises(p)
+        }
+
+        rooms.forEach { r ->
+          bedEntityFactory.produceAndPersist {
+            withRoom(r)
+          }
+        }
+      }
+
+      capturedLogs.clear()
+
+      val requestTime = measureTimeMillis {
+        webTestClient.get()
+          .uri("/premises")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", "approved-premises")
+          .exchange()
+          .expectStatus()
+          .isOk
+      }.milliseconds
+
+      log.info("Request took $requestTime (executed ${capturedLogs.size} queries)")
+
+      assertThat(capturedLogs).size().isLessThan(200)
+      assertThat(requestTime).isLessThan(10.seconds)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -49,6 +50,7 @@ class PremisesServiceTest {
   private val localAuthorityAreaRepositoryMock = mockk<LocalAuthorityAreaRepository>()
   private val probationRegionRepositoryMock = mockk<ProbationRegionRepository>()
   private val lostBedCancellationRepositoryMock = mockk<LostBedCancellationRepository>()
+  private val roomRepositoryMock = mockk<RoomRepository>()
   private val characteristicServiceMock = mockk<CharacteristicService>()
 
   private val premisesService = PremisesService(
@@ -59,6 +61,7 @@ class PremisesServiceTest {
     localAuthorityAreaRepositoryMock,
     probationRegionRepositoryMock,
     lostBedCancellationRepositoryMock,
+    roomRepositoryMock,
     characteristicServiceMock
   )
 


### PR DESCRIPTION
> See [ticket #863 on the CAS3 Trello board](https://trello.com/c/7DZThdtS/863-investigate-api-performance-concerns).

This PR serves as a proof of concept for a solution to the performance issues we've seen in various parts of the API caused by the N+1 queries problem. It focuses on alleviating this problem for the `GET /premises` API endpoint.

Changes in this PR:
- The `PremisesRepository` has new query methods to load dependent entities named along the lines of `loadPremises*`, which accepts a `List<PremisesEntity>` and returns the same list with the dependent entities attached to each premises (e.g. `loadPremisesProbationRegions`, which attaches the `premises.probationRegion` property).
  A few other repositories have also introduced these methods where required to enable `GET /premises` endpoint.
- Properties on entity classes with a `@*ToOne` annotation that can be loaded using one of the above methods have been updated to use lazy fetching rather than eager fetching (which will perform one query per entity with the relevant annotation).
- Properties on entity classes that can be loaded using one of the above methods now have a corresponding `*Loaded` boolean property that defaults to `false`. This enables methods like `PremisesService.getAvailabilityForRange` to determine whether relevant dependent entities have already been loaded and perform a separate dedicated query to fetch them if they have not been, avoiding either an empty collection or a `LazyInitializationException` being thrown.
- The `PremisesService.loadDependentEntities` method has been introduced as a convenience, which accepts a `List<PremisesEntity>` and returns the same list. It accepts several optional boolean parameters which can be used to configure which dependent entities to load onto the given list. If a dependent entity is configured to be loaded, it will execute the relevant `load` repository query method and set the relevant `*Loaded` property to `true`.
- A new `log-sql` Spring profile has been introduced to enable testing that the N+1 problem has been resolved. It is used by `NPlus1QueriesTest`, which hooks into the logger for `org.hibernate.SQL` to count the number of SQL queries dispatched by Hibernate while serving a request to `GET /premises`.