### PR TITLE
Add rfap to AP types

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4364,3 +4364,4 @@ components:
         - normal
         - pipe
         - esap
+        - rfap


### PR DESCRIPTION
We’re not currently working with these, but they will be coming down the pipe shortly.