### PR TITLE
OpenAPI specification for Bed Search endpoint

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1651,6 +1651,36 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /beds/search:
+    post:
+      summary: Searches for available Beds within the given parameters
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/BedSearchParameters'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BedSearchResult'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /reference-data/departure-reasons:
     get:
       tags:
@@ -4378,3 +4408,158 @@ components:
         - pipe
         - esap
         - rfap
+    BedSearchParameters:
+      type: object
+      properties:
+        service:
+          type: string
+        start_date:
+          type: string
+          format: date
+          description: The date the Bed will need to be free from
+        duration_days:
+          type: integer
+          description: The number of days the Bed will need to be free from the start_date until
+      required:
+        - start_date
+        - duration_days
+      discriminator:
+        propertyName: service
+        mapping:
+          approved-premises: '#/components/schemas/ApprovedPremisesBedSearchParameters'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
+    ApprovedPremisesBedSearchParameters:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchParameters'
+        - type: object
+          properties:
+            postcode_district:
+              type: string
+              description: The postcode district to search outwards from
+            max_distance_miles:
+              type: integer
+              description: Maximum number of miles from the postcode district to search, only required if more than 50 miles which is the default
+            required_premises_characteristics:
+              type: array
+              items:
+                type: string
+            required_bed_characteristics:
+              type: array
+              items:
+                type: string
+      required:
+        - postcode_district
+        - max_distance_miles
+        - required_premises_characteristics
+        - required_bed_characteristics
+    TemporaryAccommodationBedSearchParameters:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchParameters'
+        - type: object
+          properties:
+            probation_delivery_unit:
+              type: string
+              description: The pdu to search within
+      required:
+        - probation_delivery_unit
+    BedSearchResults:
+      type: object
+      properties:
+        results_room_count:
+          type: integer
+          description: How many distinct Rooms the Beds in the results belong to
+        results_premises_count:
+          type: integer
+          description: How many distinct Premises the Beds in the results belong to
+        results_bed_count:
+          type: integer
+          description: How many Beds are in the results
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BedSearchResult'
+    BedSearchResult:
+      type: object
+      properties:
+        service:
+          type: string
+        premises:
+          $ref: '#/components/schemas/BedSearchResultPremisesSummary'
+        room:
+          $ref: '#/components/schemas/BedSearchResultRoomSummary'
+        bed:
+          $ref: '#/components/schemas/BedSearchResultBedSummary'
+      required:
+        - premises
+        - room
+        - bed
+      discriminator:
+        propertyName: service
+        mapping:
+          approved-premises: '#/components/schemas/ApprovedPremisesBedSearchResult'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchResult'
+    ApprovedPremisesBedSearchResult:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchResult'
+        - type: object
+          properties:
+            distance_miles:
+              type: number
+              description: how many miles away from the postcode district the Premises this Bed belongs to is
+      required:
+        - distance_miles
+    TemporaryAccommodationBedSearchResult:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchResult'
+    BedSearchResultPremisesSummary:
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        characteristic_property_names:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - name
+        - addressLine1
+        - addressLine2
+        - town
+        - postcode
+        - characteristic_property_names
+    BedSearchResultRoomSummary:
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        characteristic_property_names:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - name
+        - characteristic_property_names
+    BedSearchResultBedSummary:
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name


### PR DESCRIPTION
Adds OpenAPI specification for a POST /beds/search endpoint.

The request body format is split between CAS1 and CAS3 due to the different nature of the searches:
- CAS1 on Postcode District
- CAS3 on PDU

I had considered supporting both approaches regardless of service but since PDU only exists on `temporary_accommodation_premises` at the moment and I don't know if CAS3 has the lat/long for each Premises recorded anywhere it seems more sensible to just support what we need for now.