### PR TITLE
Add checks for conflicting lost beds when creating or updating a lost bed or booking in Temporary Accommodation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
@@ -98,6 +99,7 @@ class ApplicationsController(
     val application = when (val applicationResult = applicationService.createApplication(body.crn, user, deliusPrincipal.token.tokenValue, serviceName, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = applicationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = applicationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = applicationResult.conflictingEntityId, conflictReason = applicationResult.message)
       is ValidatableActionResult.Success -> applicationResult.entity
     }
 
@@ -124,6 +126,7 @@ class ApplicationsController(
     val updatedApplication = when (validationResult) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
       is ValidatableActionResult.Success -> validationResult.entity
     }
 
@@ -148,6 +151,7 @@ class ApplicationsController(
     when (validationResult) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
       is ValidatableActionResult.Success -> Unit
     }
 
@@ -194,6 +198,7 @@ class ApplicationsController(
         val assessment = when (validationResult) {
           is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
           is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+          is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
           is ValidatableActionResult.Success -> validationResult.entity
         }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -106,6 +107,7 @@ class AssessmentController(
     val assessment = when (assessmentValidationResult) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = assessmentValidationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = assessmentValidationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = assessmentValidationResult.conflictingEntityId, conflictReason = assessmentValidationResult.message)
       is ValidatableActionResult.Success -> assessmentValidationResult.entity
     }
 
@@ -149,6 +151,7 @@ class AssessmentController(
     val assessment = when (assessmentValidationResult) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = assessmentValidationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = assessmentValidationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = assessmentValidationResult.conflictingEntityId, conflictReason = assessmentValidationResult.message)
       is ValidatableActionResult.Success -> assessmentValidationResult.entity
     }
 
@@ -176,6 +179,7 @@ class AssessmentController(
     when (assessmentValidationResult) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = assessmentValidationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = assessmentValidationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = assessmentValidationResult.conflictingEntityId, conflictReason = assessmentValidationResult.message)
       is ValidatableActionResult.Success -> Unit
     }
 
@@ -234,5 +238,6 @@ class AssessmentController(
     is ValidatableActionResult.Success -> result.entity
     is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
     is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages)
+    is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.util.UUID
 
 @JvmInline
 value class ValidationErrors(private val errorMap: MutableMap<String, String>) : MutableMap<String, String> by errorMap {
@@ -18,6 +19,7 @@ class ValidatedScope<EntityType> {
   infix fun generalError(message: String) = ValidatableActionResult.GeneralValidationError<EntityType>(message)
   infix fun String.hasValidationError(message: String) = validationErrors.put(this, message)
   infix fun String.hasSingleValidationError(message: String) = ValidatableActionResult.FieldValidationError<EntityType>(singleValidationErrorOf(this to message))
+  infix fun UUID.hasConflictError(message: String) = ValidatableActionResult.ConflictError<EntityType>(this, message)
 }
 
 inline fun <EntityType> validated(scope: ValidatedScope<EntityType>.() -> ValidatableActionResult<EntityType>): ValidatableActionResult<EntityType> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
@@ -4,7 +4,7 @@ import org.zalando.problem.AbstractThrowableProblem
 import org.zalando.problem.Exceptional
 import org.zalando.problem.Status
 
-class ConflictProblem(id: Any, entityType: String, conflictReason: String) : AbstractThrowableProblem(null, "Conflict", Status.CONFLICT, "A $entityType already exists for $conflictReason: $id") {
+class ConflictProblem(id: Any, conflictReason: String) : AbstractThrowableProblem(null, "Conflict", Status.CONFLICT, "$conflictReason: $id") {
   override fun getCause(): Exceptional? {
     return null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.results
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
+import java.util.UUID
 
 sealed interface ValidatableActionResult<EntityType> {
   data class Success<EntityType>(val entity: EntityType) : ValidatableActionResult<EntityType>
   data class FieldValidationError<EntityType>(val validationMessages: ValidationErrors) :
     ValidatableActionResult<EntityType>
   data class GeneralValidationError<EntityType>(val message: String) : ValidatableActionResult<EntityType>
+  data class ConflictError<EntityType>(val conflictingEntityId: UUID, val message: String) : ValidatableActionResult<EntityType>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -49,7 +49,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.overlaps
@@ -235,9 +234,11 @@ class BookingService(
     departureDate: LocalDate,
     bedId: UUID
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
-    throwIfBookingDatesConflict(arrivalDate, departureDate, null, bedId, premises)
-
     val validationResult = validated {
+      getBookingWithConflictingDates(arrivalDate, departureDate, null, bedId, premises)?.let {
+        return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates"
+      }
+
       val bed = premises.rooms
         .flatMap { it.beds }
         .find { it.id == bedId }
@@ -782,30 +783,21 @@ class BookingService(
     }
   }
 
-  private fun throwIfBookingDatesConflict(
+  fun getBookingWithConflictingDates(
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     thisBookingId: UUID?,
     bedId: UUID,
     premises: PremisesEntity,
-  ) {
-    // TODO: Ideally we wouldn't throw ConflictProblem from the service layer as its HTTP specific
-
+  ): BookingEntity? {
     val desiredRange = arrivalDate..departureDate
-    premises.bookings
+    return premises.bookings
       .filter { it.id != thisBookingId }
       .filter { it.bed?.id == bedId }
       .filter { it.cancellation == null }
       .map { it to (it.arrivalDate..it.departureDate) }
       .find { (_, range) -> range overlaps desiredRange }
       ?.first
-      ?.let {
-        throw ConflictProblem(
-          it.id,
-          "Booking",
-          "dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates"
-        )
-      }
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProvi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
@@ -74,6 +75,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationPr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
@@ -117,6 +119,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationPr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DomainEventTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExtensionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.MoveOnCategoryTestRepository
@@ -207,6 +210,9 @@ abstract class IntegrationTestBase {
   lateinit var lostBedsRepository: LostBedsTestRepository
 
   @Autowired
+  lateinit var lostBedCancellationRepository: LostBedCancellationTestRepository
+
+  @Autowired
   lateinit var extensionRepository: ExtensionTestRepository
 
   @Autowired
@@ -280,6 +286,7 @@ abstract class IntegrationTestBase {
   lateinit var cancellationReasonEntityFactory: PersistedFactory<CancellationReasonEntity, UUID, CancellationReasonEntityFactory>
   lateinit var lostBedsEntityFactory: PersistedFactory<LostBedsEntity, UUID, LostBedsEntityFactory>
   lateinit var lostBedReasonEntityFactory: PersistedFactory<LostBedReasonEntity, UUID, LostBedReasonEntityFactory>
+  lateinit var lostBedCancellationEntityFactory: PersistedFactory<LostBedCancellationEntity, UUID, LostBedCancellationEntityFactory>
   lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
   lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
@@ -344,6 +351,7 @@ abstract class IntegrationTestBase {
     cancellationReasonEntityFactory = PersistedFactory({ CancellationReasonEntityFactory() }, cancellationReasonRepository)
     lostBedsEntityFactory = PersistedFactory({ LostBedsEntityFactory() }, lostBedsRepository)
     lostBedReasonEntityFactory = PersistedFactory({ LostBedReasonEntityFactory() }, lostBedReasonRepository)
+    lostBedCancellationEntityFactory = PersistedFactory({ LostBedCancellationEntityFactory() }, lostBedCancellationRepository)
     extensionEntityFactory = PersistedFactory({ ExtensionEntityFactory() }, extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory({ NonArrivalReasonEntityFactory() }, nonArrivalReasonRepository)
     approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LostBedCancellationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LostBedCancellationTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedCancellationEntity
+import java.util.UUID
+
+@Repository
+interface LostBedCancellationTestRepository : JpaRepository<LostBedCancellationEntity, UUID>


### PR DESCRIPTION
> See [ticket #906 on the CAS3 Trello board](https://trello.com/c/PhHRtAyn/906-a-user-cannot-create-a-booking-or-another-void-if-an-existing-void-is-occupying-any-of-those-dates).

This PR extends the existing validation for Temporary Accommodation bookings that prevent double booking a room to lost beds. This allows for the following situations to be prevented:
- Double booking a lost bed
- Creating a lost bed to take place while a bed is occupied
- Creating a booking on a bed to take place while the bed is out of commission
- Changing the dates of a lost bed such that it overlaps with another lost bed or a booking
- Changing the dates of a booking (either through an arrival or an extension) such that it overlaps with a lost bed
