### PR TITLE
Fix `assessmentId` in the OpenAPI spec

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4205,7 +4205,6 @@ components:
       type: object
       properties:
         assessmentId:
-          type: object
           $ref: '#/components/schemas/OASysAssessmentId'
         assessmentState:
           $ref: '#/components/schemas/OASysAssessmentState'


### PR DESCRIPTION
This should be an integer, not an object