### PR TITLE
1288: seed AP rooms and beds

### DIFF
--- a/doc/how-to/example_csvs/approved_premises_rooms_seeding_example.csv
+++ b/doc/how-to/example_csvs/approved_premises_rooms_seeding_example.csv
@@ -1,0 +1,2 @@
+﻿apCode,bedCode,roomNumber,bedCount,isSingle,isGroundFloor,isFullyFm,hasCrib7Bedding,hasSmokeDetector,isTopFloorVulnerable,isGroundFloorNrOffice,hasNearbySprinkler,isArsonSuitable,isArsonDesignated,hasArsonInsuranceConditions,isSuitedForSexOffenders,hasEnSuite,isWheelchairAccessible,hasWideDoor,hasStepFreeAccess,hasFixedMobilityAids,hasTurningSpace,hasCallForAssistance,isWheelchairDesignated,isStepFreeDesignated,notes
+NEABC,NEABC01,5,1,Yes,No,Yes,Yes,Yes,no,no,Yes,no,no,NO,Yes,No,no,no,no,no,no,no,no,no,This room could accommodate a second bed.

--- a/doc/how-to/run_seed_job_remotely.md
+++ b/doc/how-to/run_seed_job_remotely.md
@@ -33,6 +33,24 @@ To process a seed CSV against a non-local environment:
   
 - Check the logs via `kubectl logs {pod name}` to see how processing is progressing.
 
+## Run book
+
+For a full seeding, e.g. in a local development environment, you can follow this process:
+
+```sh
+# characteristics for premises
+./script/run_seed_job characteristics premises_characteristics
+
+# characteristics for rooms
+./script/run_seed_job characteristics room_characteristics
+
+# premises and their characteristics
+./script/run_seed_job approved_premises premises_with_characteristics
+
+# rooms and their characteristics, plus beds
+./script/run_seed_job approved_premises_rooms rooms_with_characteristics
+```
+
 ## CSV reference
 
 ### User seed job

--- a/doc/how-to/run_seed_job_remotely.md
+++ b/doc/how-to/run_seed_job_remotely.md
@@ -87,3 +87,38 @@ Required fields:
 - `notes`
 
 [Example CSV](./example_csvs/approved_premises_seeding_example.csv)
+
+### Approved Premises rooms and beds job
+
+"seed type": `approved_premises_rooms`
+
+Required fields:
+
+- `apCode`
+- `bedCode`
+- `roomNumber`
+- `bedCount`
+- `isSingle`
+- `isGroundFloor`
+- `isFullyFm`
+- `hasCrib7Bedding`
+- `hasSmokeDetector`
+- `isTopFloorVulnerable`
+- `isGroundFloorNrOffice`
+- `hasNearbySprinkler`
+- `isArsonSuitable`
+- `isArsonDesignated`
+- `hasArsonInsuranceConditions`
+- `isSuitedForSexOffenders`
+- `hasEnSuite`
+- `isWheelchairAccessible`
+- `hasWideDoor`
+- `hasStepFreeAccess`
+- `hasFixedMobilityAids`
+- `hasTurningSpace`
+- `hasCallForAssistance`
+- `isWheelchairDesignated`
+- `isStepFreeDesignated`
+- `notes`
+  
+[Example CSV](./example_csvs/approved_premises_rooms_seeding_example.csv)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -10,7 +10,9 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
-interface BedRepository : JpaRepository<BedEntity, UUID>
+interface BedRepository : JpaRepository<BedEntity, UUID> {
+  fun findByCode(bedCode: String): BedEntity?
+}
 
 @Entity
 @Table(name = "beds")
@@ -18,6 +20,7 @@ data class BedEntity(
   @Id
   val id: UUID,
   val name: String,
+  val code: String?,
   @ManyToOne
   @JoinColumn(name = "room_id")
   val room: RoomEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -25,5 +25,6 @@ data class BedEntity(
   @JoinColumn(name = "room_id")
   val room: RoomEntity,
 ) {
-  override fun toString() = "BedEntity:$id"
+
+  override fun toString() = "BedEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -37,4 +37,7 @@ data class RoomEntity(
     inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
   )
   val characteristics: MutableList<CharacteristicEntity>,
-)
+) {
+
+  override fun toString() = "RoomEntity: $id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -13,7 +13,9 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
-interface RoomRepository : JpaRepository<RoomEntity, UUID>
+interface RoomRepository : JpaRepository<RoomEntity, UUID> {
+  fun findByCode(roomCode: String): RoomEntity?
+}
 
 @Entity
 @Table(name = "rooms")
@@ -21,7 +23,8 @@ data class RoomEntity(
   @Id
   val id: UUID,
   val name: String,
-  val notes: String?,
+  val code: String?,
+  var notes: String?,
   @ManyToOne
   @JoinColumn(name = "premises_id")
   val premises: PremisesEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+
+class ApprovedPremisesRoomsSeedJob(
+  fileName: String,
+  private val premisesRepository: PremisesRepository,
+  private val characteristicRepository: CharacteristicRepository
+) : SeedJob<ApprovedPremisesRoomsSeedCsvRow>(
+  fileName = fileName,
+  requiredColumns = 26
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun verifyPresenceOfRequiredHeaders(headers: Set<String>) {
+    val missingHeaders = requiredHeaders() - headers
+
+    if (missingHeaders.any()) {
+      throw RuntimeException("required headers: $missingHeaders")
+    }
+  }
+
+  override fun deserializeRow(columns: Map<String, String>) = ApprovedPremisesRoomsSeedCsvRow(
+    apCode = columns["apCode"]!!,
+    bedCode = columns["bedCode"]!!,
+    roomNumber = columns["roomNumber"]!!,
+    bedCount = columns["bedCount"]!!,
+    isSingle = parseBooleanStringOrThrow(columns["isSingle"]!!, "isSingle"),
+    isGroundFloor = parseBooleanStringOrThrow(columns["isGroundFloor"]!!, "isGroundFloor"),
+    isFullyFm = parseBooleanStringOrThrow(columns["isFullyFm"]!!, "isFullyFm"),
+    hasCrib7Bedding = parseBooleanStringOrThrow(columns["hasCrib7Bedding"]!!, "hasCrib7Bedding"),
+    hasSmokeDetector = parseBooleanStringOrThrow(columns["hasSmokeDetector"]!!, "hasSmokeDetector"),
+    isTopFloorVulnerable = parseBooleanStringOrThrow(columns["isTopFloorVulnerable"]!!, "isTopFloorVulnerable"),
+    isGroundFloorNrOffice = parseBooleanStringOrThrow(columns["isGroundFloorNrOffice"]!!, "isGroundFloorNrOffice"),
+    hasNearbySprinkler = parseBooleanStringOrThrow(columns["hasNearbySprinkler"]!!, "hasNearbySprinkler"),
+    isArsonSuitable = parseBooleanStringOrThrow(columns["isArsonSuitable"]!!, "isArsonSuitable"),
+    isArsonDesignated = parseBooleanStringOrThrow(columns["isArsonDesignated"]!!, "isArsonDesignated"),
+    hasArsonInsuranceConditions = parseBooleanStringOrThrow(columns["hasArsonInsuranceConditions"]!!, "hasArsonInsuranceConditions"),
+    isSuitedForSexOffenders = parseBooleanStringOrThrow(columns["isSuitedForSexOffenders"]!!, "isSuitedForSexOffenders"),
+    hasEnSuite = parseBooleanStringOrThrow(columns["hasEnSuite"]!!, "hasEnSuite"),
+    isWheelchairAccessible = parseBooleanStringOrThrow(columns["isWheelchairAccessible"]!!, "isWheelchairAccessible"),
+    hasWideDoor = parseBooleanStringOrThrow(columns["hasWideDoor"]!!, "hasWideDoor"),
+    hasStepFreeAccess = parseBooleanStringOrThrow(columns["hasStepFreeAccess"]!!, "hasStepFreeAccess"),
+    hasFixedMobilityAids = parseBooleanStringOrThrow(columns["hasFixedMobilityAids"]!!, "hasFixedMobilityAids"),
+    hasTurningSpace = parseBooleanStringOrThrow(columns["hasTurningSpace"]!!, "hasTurningSpace"),
+    hasCallForAssistance = parseBooleanStringOrThrow(columns["hasCallForAssistance"]!!, "hasCallForAssistance"),
+    isWheelchairDesignated = parseBooleanStringOrThrow(columns["isWheelchairDesignated"]!!, "isWheelchairDesignated"),
+    isStepFreeDesignated = parseBooleanStringOrThrow(columns["isStepFreeDesignated"]!!, "isStepFreeDesignated"),
+    notes = columns["notes"]!!,
+  )
+
+  override fun processRow(row: ApprovedPremisesRoomsSeedCsvRow) {
+  }
+
+  private fun parseBooleanStringOrThrow(value: String, fieldName: String): String {
+    val booleanString = listOf("YES", "NO").find { it == value.trim().uppercase() }
+      ?: throw RuntimeException("'$value' is not a recognised boolean for '$fieldName' (use yes | no)")
+
+    return if (booleanString == "YES") "YES" else "NO"
+  }
+}
+
+private fun requiredHeaders(): Set<String> {
+  return setOf(
+    "apCode",
+    "bedCode",
+    "roomNumber",
+    "bedCount",
+    "isSingle",
+    "isGroundFloor",
+    "isFullyFm",
+    "hasCrib7Bedding",
+    "hasSmokeDetector",
+    "isTopFloorVulnerable",
+    "isGroundFloorNrOffice",
+    "hasNearbySprinkler",
+    "isArsonSuitable",
+    "isArsonDesignated",
+    "hasArsonInsuranceConditions",
+    "isSuitedForSexOffenders",
+    "hasEnSuite",
+    "isWheelchairAccessible",
+    "hasWideDoor",
+    "hasStepFreeAccess",
+    "hasFixedMobilityAids",
+    "hasTurningSpace",
+    "hasCallForAssistance",
+    "isWheelchairDesignated",
+    "isStepFreeDesignated",
+    "notes",
+  )
+}
+
+data class ApprovedPremisesRoomsSeedCsvRow(
+  val apCode: String,
+  val bedCode: String,
+  val roomNumber: String,
+  val bedCount: String,
+  val isSingle: String,
+  val isGroundFloor: String,
+  val isFullyFm: String,
+  val hasCrib7Bedding: String,
+  val hasSmokeDetector: String,
+  val isTopFloorVulnerable: String,
+  val isGroundFloorNrOffice: String,
+  val hasNearbySprinkler: String,
+  val isArsonSuitable: String,
+  val isArsonDesignated: String,
+  val hasArsonInsuranceConditions: String,
+  val isSuitedForSexOffenders: String,
+  val hasEnSuite: String,
+  val isWheelchairAccessible: String,
+  val hasWideDoor: String,
+  val hasStepFreeAccess: String,
+  val hasFixedMobilityAids: String,
+  val hasTurningSpace: String,
+  val hasCallForAssistance: String,
+  val isWheelchairDesignated: String,
+  val isStepFreeDesignated: String,
+  val notes: String?
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
@@ -1,16 +1,17 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
 import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 
 class ApprovedPremisesRoomsSeedJob(
   fileName: String,
   private val premisesRepository: PremisesRepository,
-  private val characteristicRepository: CharacteristicRepository
+  private val characteristicRepository: CharacteristicRepository,
 ) : SeedJob<ApprovedPremisesRoomsSeedCsvRow>(
   fileName = fileName,
-  requiredColumns = 26
+  requiredColumns = 26,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -52,6 +53,37 @@ class ApprovedPremisesRoomsSeedJob(
   )
 
   override fun processRow(row: ApprovedPremisesRoomsSeedCsvRow) {
+    val characteristics = characteristicsFromRow(row)
+  }
+
+  private fun characteristicsFromRow(row: ApprovedPremisesRoomsSeedCsvRow): List<CharacteristicEntity> {
+    return listOf(
+      CharacteristicValue("isSingle", castBooleanString(row.isSingle)),
+      CharacteristicValue("isGroundFloor", castBooleanString(row.isGroundFloor)),
+      CharacteristicValue("isFullyFm", castBooleanString(row.isFullyFm)),
+      CharacteristicValue("hasCrib7Bedding", castBooleanString(row.hasCrib7Bedding)),
+      CharacteristicValue("hasSmokeDetector", castBooleanString(row.hasSmokeDetector)),
+      CharacteristicValue("isTopFloorVulnerable", castBooleanString(row.isTopFloorVulnerable)),
+      CharacteristicValue("isGroundFloorNrOffice", castBooleanString(row.isGroundFloorNrOffice)),
+      CharacteristicValue("hasNearbySprinkler", castBooleanString(row.hasNearbySprinkler)),
+      CharacteristicValue("isArsonSuitable", castBooleanString(row.isArsonSuitable)),
+      CharacteristicValue("isArsonDesignated", castBooleanString(row.isArsonDesignated)),
+      CharacteristicValue("hasArsonInsuranceConditions", castBooleanString(row.hasArsonInsuranceConditions)),
+      CharacteristicValue("isSuitedForSexOffenders", castBooleanString(row.isSuitedForSexOffenders)),
+      CharacteristicValue("hasEnSuite", castBooleanString(row.hasEnSuite)),
+      CharacteristicValue("isWheelchairAccessible", castBooleanString(row.isWheelchairAccessible)),
+      CharacteristicValue("hasWideDoor", castBooleanString(row.hasWideDoor)),
+      CharacteristicValue("hasStepFreeAccess", castBooleanString(row.hasStepFreeAccess)),
+      CharacteristicValue("hasFixedMobilityAids", castBooleanString(row.hasFixedMobilityAids)),
+      CharacteristicValue("hasTurningSpace", castBooleanString(row.hasTurningSpace)),
+      CharacteristicValue("hasCallForAssistance", castBooleanString(row.hasCallForAssistance)),
+      CharacteristicValue("isWheelchairDesignated", castBooleanString(row.isWheelchairDesignated)),
+      CharacteristicValue("isStepFreeDesignated", castBooleanString(row.isStepFreeDesignated)),
+    ).filter { it.value }
+      .map {
+        characteristicRepository.findByPropertyNameAndScopes(propertyName = it.propertyName, serviceName = "approved-premises", modelName = "room")
+          ?: throw RuntimeException("Characteristic '${it.propertyName}' does not exist for AP room")
+      }
   }
 
   private fun parseBooleanStringOrThrow(value: String, fieldName: String): String {
@@ -59,6 +91,10 @@ class ApprovedPremisesRoomsSeedJob(
       ?: throw RuntimeException("'$value' is not a recognised boolean for '$fieldName' (use yes | no)")
 
     return if (booleanString == "YES") "YES" else "NO"
+  }
+
+  private fun castBooleanString(booleanString: String): Boolean {
+    return booleanString == "YES"
   }
 }
 
@@ -119,5 +155,5 @@ data class ApprovedPremisesRoomsSeedCsvRow(
   val hasCallForAssistance: String,
   val isWheelchairDesignated: String,
   val isStepFreeDesignated: String,
-  val notes: String?
+  val notes: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
@@ -78,11 +78,19 @@ class ApprovedPremisesRoomsSeedJob(
 
     val room = when (val existingRoom = roomRepository.findByCode(roomCode)) {
       null -> createRoom(row = row, roomCode = roomCode, premises = premises)
-      else -> existingRoom
+      else -> updateExistingRoom(room = existingRoom, row = row)
     }
+
+    room!!.characteristics.clear()
     room!!.characteristics.addAll(characteristics)
+    log.info("Adding characteristics to room: ${room.name}: ${characteristics.map { it.propertyName }}")
+    roomRepository.save(room)
 
     return room
+  }
+
+  private fun updateExistingRoom(room: RoomEntity, row: ApprovedPremisesRoomsSeedCsvRow): RoomEntity {
+    return room.apply { this!!.notes = row.notes }
   }
 
   private fun createRoom(row: ApprovedPremisesRoomsSeedCsvRow, premises: PremisesEntity, roomCode: String): RoomEntity? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
@@ -32,6 +32,7 @@ class RoomService(
     var room = RoomEntity(
       id = UUID.randomUUID(),
       name = roomName,
+      code = null,
       notes = notes,
       premises = premises,
       beds = mutableListOf(),
@@ -113,13 +114,14 @@ class RoomService(
 
     if (validationErrors.any()) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(validationErrors)
+        ValidatableActionResult.FieldValidationError(validationErrors),
       )
     }
 
     room = RoomEntity(
       id = room.id,
       name = room.name,
+      code = null,
       notes = notes,
       premises = room.premises,
       beds = room.beds,
@@ -127,7 +129,7 @@ class RoomService(
     )
 
     return AuthorisableActionResult.Success(
-      ValidatableActionResult.Success(roomRepository.save(room))
+      ValidatableActionResult.Success(roomRepository.save(room)),
     )
   }
 
@@ -153,7 +155,8 @@ class RoomService(
     BedEntity(
       id = UUID.randomUUID(),
       name = bedName,
+      code = null,
       room = room,
-    )
+    ),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -7,10 +7,12 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CharacteristicsSeedJob
@@ -25,7 +27,7 @@ class SeedService(
   @Value("\${seed.file-prefix}") private val seedFilePrefix: String,
   private val applicationContext: ApplicationContext,
   private val transactionTemplate: TransactionTemplate,
-  private val seedLogger: SeedLogger
+  private val seedLogger: SeedLogger,
 ) {
   @Async
   fun seedDataAsync(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename)
@@ -40,33 +42,35 @@ class SeedService(
           applicationContext.getBean(PremisesRepository::class.java),
           applicationContext.getBean(ProbationRegionRepository::class.java),
           applicationContext.getBean(LocalAuthorityAreaRepository::class.java),
-          applicationContext.getBean(CharacteristicRepository::class.java)
+          applicationContext.getBean(CharacteristicRepository::class.java),
         )
         SeedFileType.approvedPremisesRooms -> ApprovedPremisesRoomsSeedJob(
           filename,
           applicationContext.getBean(PremisesRepository::class.java),
-          applicationContext.getBean(CharacteristicRepository::class.java)
+          applicationContext.getBean(RoomRepository::class.java),
+          applicationContext.getBean(BedRepository::class.java),
+          applicationContext.getBean(CharacteristicRepository::class.java),
         )
         SeedFileType.user -> UsersSeedJob(
           filename,
-          applicationContext.getBean(UserService::class.java)
+          applicationContext.getBean(UserService::class.java),
         )
         SeedFileType.characteristics -> CharacteristicsSeedJob(
           filename,
-          applicationContext.getBean(CharacteristicRepository::class.java)
+          applicationContext.getBean(CharacteristicRepository::class.java),
         )
         SeedFileType.temporaryAccommodationPremises -> TemporaryAccommodationPremisesSeedJob(
           filename,
           applicationContext.getBean(PremisesRepository::class.java),
           applicationContext.getBean(ProbationRegionRepository::class.java),
           applicationContext.getBean(LocalAuthorityAreaRepository::class.java),
-          applicationContext.getBean(CharacteristicService::class.java)
+          applicationContext.getBean(CharacteristicService::class.java),
         )
         SeedFileType.temporaryAccommodationBedspace -> TemporaryAccommodationBedspaceSeedJob(
           filename,
           applicationContext.getBean(PremisesRepository::class.java),
           applicationContext.getBean(CharacteristicService::class.java),
-          applicationContext.getBean(RoomService::class.java)
+          applicationContext.getBean(RoomService::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Characteristi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CharacteristicsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
@@ -39,6 +40,11 @@ class SeedService(
           applicationContext.getBean(PremisesRepository::class.java),
           applicationContext.getBean(ProbationRegionRepository::class.java),
           applicationContext.getBean(LocalAuthorityAreaRepository::class.java),
+          applicationContext.getBean(CharacteristicRepository::class.java)
+        )
+        SeedFileType.approvedPremisesRooms -> ApprovedPremisesRoomsSeedJob(
+          filename,
+          applicationContext.getBean(PremisesRepository::class.java),
           applicationContext.getBean(CharacteristicRepository::class.java)
         )
         SeedFileType.user -> UsersSeedJob(

--- a/src/main/resources/db/migration/all/20230321113733__add_code_to_rooms_with_unique_constraint.sql
+++ b/src/main/resources/db/migration/all/20230321113733__add_code_to_rooms_with_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rooms ADD COLUMN "code" text UNIQUE;

--- a/src/main/resources/db/migration/all/20230321114516__add_code_to_beds_with_unique_constraint.sql
+++ b/src/main/resources/db/migration/all/20230321114516__add_code_to_beds_with_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE beds ADD COLUMN "code" text UNIQUE;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4263,6 +4263,7 @@ components:
       type: string
       enum:
         - approved_premises
+        - approved_premises_rooms
         - temporary_accommodation_premises
         - temporary_accommodation_bedspace
         - user

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 class RoomEntityFactory : Factory<RoomEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var code: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
   private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
   private var premises: Yielded<PremisesEntity>? = null
 
@@ -20,6 +21,10 @@ class RoomEntityFactory : Factory<RoomEntity> {
 
   fun withName(name: String) = apply {
     this.name = { name }
+  }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
   }
 
   fun withNotes(notes: String?) = apply {
@@ -37,6 +42,7 @@ class RoomEntityFactory : Factory<RoomEntity> {
   override fun produce() = RoomEntity(
     id = this.id(),
     name = this.name(),
+    code = this.code(),
     notes = this.notes(),
     beds = mutableListOf(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a premises"),
@@ -47,6 +53,7 @@ class RoomEntityFactory : Factory<RoomEntity> {
 class BedEntityFactory : Factory<BedEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var code: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
   private var room: Yielded<RoomEntity>? = null
 
   fun withId(id: UUID) = apply {
@@ -55,6 +62,10 @@ class BedEntityFactory : Factory<BedEntity> {
 
   fun withName(name: String) = apply {
     this.name = { name }
+  }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
   }
 
   fun withRoom(room: RoomEntity) = apply {
@@ -67,6 +78,7 @@ class BedEntityFactory : Factory<BedEntity> {
   override fun produce() = BedEntity(
     id = this.id(),
     name = this.name(),
-    room = this.room?.invoke() ?: throw java.lang.RuntimeException("Must provide a room")
+    code = this.code(),
+    room = this.room?.invoke() ?: throw java.lang.RuntimeException("Must provide a room"),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesRoomsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesRoomsTest.kt
@@ -1,0 +1,192 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesRoomsSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedApprovedPremisesRoomsTest : SeedTestBase() {
+
+  @Test
+  fun `Attempting to create an AP room with an incorrectly service-scoped characteristic logs an error`() {
+  }
+
+  @Test
+  fun `Attempting to create an AP room with an incorrectly model-scoped characteristic logs an error`() {
+  }
+
+  @Test
+  fun `Attempting to create an AP room with an incorrect boolean value logs an error`() {
+  }
+
+  @Test
+  fun `Attempting to create an AP Room missing required headers lists missing fields`() {
+    withCsv(
+      "new-ap-room-missing-headers",
+      "apCode,bedCode,roomNumber,bedCount,isSingle,isGroundFloor,isFullyFm,hasCrib7Bedding\n" +
+        "HOPE,NESPU01,1,1,yes,yes,no,no"
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-missing-headers")
+
+    val expectedErrorMessage = "The headers provided: " +
+      "[apCode, bedCode, roomNumber, bedCount, isSingle, isGroundFloor, isFullyFm, hasCrib7Bedding] " +
+      "did not include required headers: " +
+      "[hasSmokeDetector, isTopFloorVulnerable, isGroundFloorNrOffice, hasNearbySprinkler, isArsonSuitable, " +
+      "isArsonDesignated, hasArsonInsuranceConditions, isSuitedForSexOffenders, hasEnSuite, isWheelchairAccessible, " +
+      "hasWideDoor, hasStepFreeAccess, hasFixedMobilityAids, hasTurningSpace, hasCallForAssistance, " +
+      "isWheelchairDesignated, isStepFreeDesignated, notes]"
+
+    assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Unable to complete Seed Job" &&
+          it.throwable != null &&
+          it.throwable.message!!.contains(expectedErrorMessage)
+      }
+  }
+
+  @Test
+  fun `Creating a new AP room persists correctly`() {
+  }
+
+  @Test
+  fun `Updating an existing AP room persists correctly`() {
+  }
+
+  private fun apRoomsSeedCsvRowsToCsv(rows: List<ApprovedPremisesRoomsSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "apCode",
+        "bedCode",
+        "roomNumber",
+        "bedCount",
+        "isSingle",
+        "isGroundFloor",
+        "isFullyFm",
+        "hasCrib7Bedding",
+        "hasSmokeDetector",
+        "isTopFloorVulnerable",
+        "isGroundFloorNrOffice",
+        "hasNearbySprinkler",
+        "isArsonSuitable",
+        "isArsonDesignated",
+        "hasArsonInsuranceConditions",
+        "isSuitedForSexOffenders",
+        "hasEnSuite",
+        "isWheelchairAccessible",
+        "hasWideDoor",
+        "hasStepFreeAccess",
+        "hasFixedMobilityAids",
+        "hasTurningSpace",
+        "hasCallForAssistance",
+        "isWheelchairDesignated",
+        "isStepFreeDesignated",
+        "notes"
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.apCode)
+        .withQuotedField(it.bedCode)
+        .withQuotedField(it.roomNumber)
+        .withQuotedField(it.bedCount)
+        .withQuotedField(it.isSingle)
+        .withQuotedField(it.isGroundFloor)
+        .withQuotedField(it.isFullyFm)
+        .withQuotedField(it.hasCrib7Bedding)
+        .withQuotedField(it.hasSmokeDetector)
+        .withQuotedField(it.isTopFloorVulnerable)
+        .withQuotedField(it.isGroundFloorNrOffice)
+        .withQuotedField(it.hasNearbySprinkler)
+        .withQuotedField(it.isArsonSuitable)
+        .withQuotedField(it.isArsonDesignated)
+        .withQuotedField(it.hasArsonInsuranceConditions)
+        .withQuotedField(it.isSuitedForSexOffenders)
+        .withQuotedField(it.hasEnSuite)
+        .withQuotedField(it.isWheelchairAccessible)
+        .withQuotedField(it.hasWideDoor)
+        .withQuotedField(it.hasStepFreeAccess)
+        .withQuotedField(it.hasFixedMobilityAids)
+        .withQuotedField(it.hasTurningSpace)
+        .withQuotedField(it.hasCallForAssistance)
+        .withQuotedField(it.isWheelchairDesignated)
+        .withQuotedField(it.isStepFreeDesignated)
+        .withQuotedField(it.notes!!)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}
+
+class ApprovedPremisesRoomsSeedCsvRowFactory : Factory<ApprovedPremisesRoomsSeedCsvRow> {
+  private var apCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var bedCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var roomNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var bedCount: Yielded<String> = { randomInt(1, 2).toString() }
+  private var isSingle: Yielded<String> = { "yes" }
+  private var isGroundFloor: Yielded<String> = { "no" }
+  private var isFullyFm: Yielded<String> = { "no" }
+  private var hasCrib7Bedding: Yielded<String> = { "no" }
+  private var hasSmokeDetector: Yielded<String> = { "no" }
+  private var isTopFloorVulnerable: Yielded<String> = { "no" }
+  private var isGroundFloorNrOffice: Yielded<String> = { "no" }
+  private var hasNearbySprinkler: Yielded<String> = { "no" }
+  private var isArsonSuitable: Yielded<String> = { "no" }
+  private var isArsonDesignated: Yielded<String> = { "no" }
+  private var hasArsonInsuranceConditions: Yielded<String> = { "no" }
+  private var isSuitedForSexOffenders: Yielded<String> = { "no" }
+  private var hasEnSuite: Yielded<String> = { "no" }
+  private var isWheelchairAccessible: Yielded<String> = { "no" }
+  private var hasWideDoor: Yielded<String> = { "no" }
+  private var hasStepFreeAccess: Yielded<String> = { "no" }
+  private var hasFixedMobilityAids: Yielded<String> = { "no" }
+  private var hasTurningSpace: Yielded<String> = { "no" }
+  private var hasCallForAssistance: Yielded<String> = { "no" }
+  private var isWheelchairDesignated: Yielded<String> = { "no" }
+  private var isStepFreeDesignated: Yielded<String> = { "no" }
+  private var notes: Yielded<String?> = { "One bed in room - too small for double" }
+
+  fun withApCode(apCode: String) = apply {
+    this.apCode = { apCode }
+  }
+
+  override fun produce() = ApprovedPremisesRoomsSeedCsvRow(
+    apCode = this.apCode(),
+    bedCode = this.bedCode(),
+    roomNumber = this.roomNumber(),
+    bedCount = this.bedCount(),
+    isSingle = this.isSingle(),
+    isGroundFloor = this.isGroundFloor(),
+    isFullyFm = this.isFullyFm(),
+    hasCrib7Bedding = this.hasCrib7Bedding(),
+    hasSmokeDetector = this.hasSmokeDetector(),
+    isTopFloorVulnerable = this.isTopFloorVulnerable(),
+    isGroundFloorNrOffice = this.isGroundFloorNrOffice(),
+    hasNearbySprinkler = this.hasNearbySprinkler(),
+    isArsonSuitable = this.isArsonSuitable(),
+    isArsonDesignated = this.isArsonDesignated(),
+    hasArsonInsuranceConditions = this.hasArsonInsuranceConditions(),
+    isSuitedForSexOffenders = this.isSuitedForSexOffenders(),
+    hasEnSuite = this.hasEnSuite(),
+    isWheelchairAccessible = this.isWheelchairAccessible(),
+    hasWideDoor = this.hasWideDoor(),
+    hasStepFreeAccess = this.hasStepFreeAccess(),
+    hasFixedMobilityAids = this.hasFixedMobilityAids(),
+    hasTurningSpace = this.hasTurningSpace(),
+    hasCallForAssistance = this.hasCallForAssistance(),
+    isWheelchairDesignated = this.isWheelchairDesignated(),
+    isStepFreeDesignated = this.isStepFreeDesignated(),
+    notes = this.notes()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesRoomsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesRoomsTest.kt
@@ -24,6 +24,29 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an AP room with an incorrect boolean value logs an error`() {
+    val csvRow = ApprovedPremisesRoomsSeedCsvRowFactory()
+      .withIsArsonSuitable("false")
+      .produce()
+
+    withCsv(
+      "new-ap-room-invalid-boolean",
+      approvedPremisesRoomsSeedCsvRowsToCsv(
+        listOf(
+          csvRow,
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-invalid-boolean")
+
+    assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Unable to complete Seed Job" &&
+          it.throwable != null &&
+          it.throwable.message!!.contains("'false' is not a recognised boolean for 'isArsonSuitable' (use yes | no)")
+      }
   }
 
   @Test
@@ -62,7 +85,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
   fun `Updating an existing AP room persists correctly`() {
   }
 
-  private fun apRoomsSeedCsvRowsToCsv(rows: List<ApprovedPremisesRoomsSeedCsvRow>): String {
+  private fun approvedPremisesRoomsSeedCsvRowsToCsv(rows: List<ApprovedPremisesRoomsSeedCsvRow>): String {
     val builder = CsvBuilder()
       .withUnquotedFields(
         "apCode",
@@ -159,6 +182,10 @@ class ApprovedPremisesRoomsSeedCsvRowFactory : Factory<ApprovedPremisesRoomsSeed
 
   fun withApCode(apCode: String) = apply {
     this.apCode = { apCode }
+  }
+
+  fun withIsArsonSuitable(boolString: String) = apply {
+    this.isArsonSuitable = { boolString }
   }
 
   override fun produce() = ApprovedPremisesRoomsSeedCsvRow(


### PR DESCRIPTION
This PR adds an `ApprovedPremisesRoomsSeedJob` which seeds rooms, their characteristics, and beds via the seeding script run on remote pod (or local environment) as:

```sh
./script/run_seed_job approved_premises_rooms rooms_with_characteristics
```

The CSV provided must have the following columns:

- `apCode`
- `bedCode`
- `roomNumber`
- `bedCount`
- `isSingle`
- `isGroundFloor`
- `isFullyFm`
- `hasCrib7Bedding`
- `hasSmokeDetector`
- `isTopFloorVulnerable`
- `isGroundFloorNrOffice`
- `hasNearbySprinkler`
- `isArsonSuitable`
- `isArsonDesignated`
- `hasArsonInsuranceConditions`
- `isSuitedForSexOffenders`
- `hasEnSuite`
- `isWheelchairAccessible`
- `hasWideDoor`
- `hasStepFreeAccess`
- `hasFixedMobilityAids`
- `hasTurningSpace`
- `hasCallForAssistance`
- `isWheelchairDesignated`
- `isStepFreeDesignated`
- `notes`