### PR TITLE
Fix for Lost Beds migration.

### DIFF
--- a/src/main/resources/db/migration/all/20230317123100__use_bed_id_for_ap_lost_beds.sql
+++ b/src/main/resources/db/migration/all/20230317123100__use_bed_id_for_ap_lost_beds.sql
@@ -1,4 +1,4 @@
-DELETE FROM lost_beds WHERE id NOT IN (SELECT id FROM temporary_accommodation_lost_beds);
+DELETE FROM lost_beds WHERE id NOT IN (SELECT lost_bed_id FROM temporary_accommodation_lost_beds);
 
 ALTER TABLE lost_beds ADD COLUMN bed_id UUID CONSTRAINT bed_id_fk REFERENCES beds(id);
 


### PR DESCRIPTION
There is no `id` column on temporary_accommodation_lost_beds, should be `lost_bed_id`