### PR TITLE
(1382) Allow placement requests to be reallocated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -278,14 +278,8 @@ class ApplicationsController(
       is ValidatableActionResult.Success -> validationResult.entity
     }
 
-    val reallocation = Reallocation(
-      taskType = taskType,
-      user = userTransformer.transformJpaToApi(reallocatedTask.allocatedToUser, ServiceName.approvedPremises)
-    )
-
-    return ResponseEntity(reallocation, HttpStatus.CREATED)
+    return ResponseEntity(reallocatedTask, HttpStatus.CREATED)
   }
-
 
   private fun getPersonDetail(crn: String): Pair<OffenderDetailSummary, InmateDetail> {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -71,5 +71,5 @@ data class PlacementRequestEntity(
   @JoinColumn(name = "allocated_to_user_id")
   val allocatedToUser: UserEntity,
 
-  val reallocatedAt: OffsetDateTime?
+  var reallocatedAt: OffsetDateTime?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.util.UUID
+
+@Service
+class TaskService(
+  private val assessmentService: AssessmentService,
+  private val applicationRepository: ApplicationRepository,
+  private val userService: UserService
+) {
+  fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, applicationId: UUID): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
+    if (!requestUser.hasRole(UserRole.WORKFLOW_MANAGER)) {
+      return AuthorisableActionResult.Unauthorised()
+    }
+
+    val assigneeUser = when (val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId)) {
+      is AuthorisableActionResult.Success -> assigneeUserResult.entity
+      else -> return AuthorisableActionResult.NotFound()
+    }
+
+    val application = applicationRepository.findByIdOrNull(applicationId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    if (application !is ApprovedPremisesApplicationEntity) {
+      throw RuntimeException("Only CAS1 Applications are currently supported")
+    }
+
+    return when (taskType) {
+      TaskType.assessment -> {
+        assessmentService.reallocateAssessment(assigneeUser, application)
+      }
+      else -> {
+        throw NotAllowedProblem(detail = "The Task Type $taskType is not currently supported")
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -2,24 +2,30 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import java.util.UUID
 
 @Service
 class TaskService(
   private val assessmentService: AssessmentService,
   private val applicationRepository: ApplicationRepository,
-  private val userService: UserService
+  private val userService: UserService,
+  private val placementRequestService: PlacementRequestService,
+  private val userTransformer: UserTransformer
 ) {
-  fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, applicationId: UUID): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
+  fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, applicationId: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
     if (!requestUser.hasRole(UserRole.WORKFLOW_MANAGER)) {
       return AuthorisableActionResult.Unauthorised()
     }
@@ -36,13 +42,46 @@ class TaskService(
       throw RuntimeException("Only CAS1 Applications are currently supported")
     }
 
-    return when (taskType) {
+    val result = when (taskType) {
       TaskType.assessment -> {
         assessmentService.reallocateAssessment(assigneeUser, application)
+      }
+      TaskType.placementRequest -> {
+        placementRequestService.reallocatePlacementRequest(assigneeUser, application)
       }
       else -> {
         throw NotAllowedProblem(detail = "The Task Type $taskType is not currently supported")
       }
     }
+
+    val validationResult = when (result) {
+      is AuthorisableActionResult.NotFound -> return AuthorisableActionResult.NotFound()
+      is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised()
+      is AuthorisableActionResult.Success -> result.entity
+    }
+
+    return when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> AuthorisableActionResult.Success(ValidatableActionResult.GeneralValidationError(validationResult.message))
+      is ValidatableActionResult.FieldValidationError -> AuthorisableActionResult.Success(ValidatableActionResult.FieldValidationError(validationResult.validationMessages))
+      is ValidatableActionResult.ConflictError -> AuthorisableActionResult.Success(ValidatableActionResult.ConflictError(validationResult.conflictingEntityId, validationResult.message))
+      is ValidatableActionResult.Success -> AuthorisableActionResult.Success(
+        ValidatableActionResult.Success(
+          entityToReallocation(validationResult.entity, taskType)
+        )
+      )
+    }
+  }
+
+  private fun entityToReallocation(entity: Any, taskType: TaskType): Reallocation {
+    val allocatedToUser = when (entity) {
+      is PlacementRequestEntity -> entity.allocatedToUser
+      is AssessmentEntity -> entity.allocatedToUser
+      else -> throw RuntimeException("Unexpected type")
+    }
+
+    return Reallocation(
+      taskType = taskType,
+      user = userTransformer.transformJpaToApi(allocatedToUser, ServiceName.approvedPremises)
+    )
   }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1618,11 +1618,11 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
-  /applications/{applicationId}/allocations:
+  /applications/{applicationId}/tasks/{taskType}/allocations:
     post:
       tags:
         - Operations on applications
-      summary: Reallocates an application
+      summary: Reallocates a task for an application
       parameters:
         - name: applicationId
           in: path
@@ -1631,6 +1631,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - in: path
+          name: taskType
+          required: true
+          description: Task type
+          schema:
+            type: string
       requestBody:
         content:
           'application/json':
@@ -3845,11 +3851,8 @@ components:
         userId:
           type: string
           format: uuid
-        taskType:
-          $ref: '#/components/schemas/TaskType'
       required:
         - userId
-        - taskType
     Reallocation:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -5,7 +5,6 @@ import io.mockk.every
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -36,12 +35,11 @@ class ReallocationAtomicTest : IntegrationTestBase() {
           every { realAssessmentRepository.save(match { it.id != existingAssessment.id }) } throws RuntimeException("I am a database error")
 
           webTestClient.post()
-            .uri("/applications/${application.id}/allocations")
+            .uri("/applications/${application.id}/tasks/assessment/allocations")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewReallocation(
-                userId = assigneeUser.id,
-                taskType = TaskType.assessment
+                userId = assigneeUser.id
               )
             )
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1,18 +1,28 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import java.util.UUID
 
 class TasksTest : IntegrationTestBase() {
   @Autowired
   lateinit var taskTransformer: TaskTransformer
+
+  @Autowired
+  lateinit var userTransformer: UserTransformer
 
   @Test
   fun `Get all tasks without JWT returns 401`() {
@@ -171,6 +181,135 @@ class TasksTest : IntegrationTestBase() {
             .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
         }
       }
+    }
+  }
+
+  @Test
+  fun `Reallocate application to different assessor without JWT returns 401`() {
+    webTestClient.post()
+      .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/assessment/allocations")
+      .bodyValue(
+        NewReallocation(
+          userId = UUID.randomUUID()
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Reallocate application to different assessor without WORKFLOW_MANAGER role returns 403`() {
+    `Given a User` { _, jwt ->
+      webTestClient.post()
+        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/assessment/allocations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewReallocation(
+            userId = UUID.randomUUID()
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `Reallocate assessment to different assessor returns 201, creates new assessment, deallocates old one`() {
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.ASSESSOR)) { user, _ ->
+        `Given a User`(
+          roles = listOf(UserRole.ASSESSOR)
+        ) { assigneeUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            `Given an Assessment`(
+              allocatedToUser = user,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn
+            ) { existingAssessment, application ->
+
+              webTestClient.post()
+                .uri("/applications/${application.id}/tasks/assessment/allocations")
+                .header("Authorization", "Bearer $jwt")
+                .bodyValue(
+                  NewReallocation(
+                    userId = assigneeUser.id
+                  )
+                )
+                .exchange()
+                .expectStatus()
+                .isCreated
+                .expectBody()
+                .json(
+                  objectMapper.writeValueAsString(
+                    Reallocation(
+                      user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises),
+                      taskType = TaskType.assessment
+                    )
+                  )
+                )
+
+              val assessments = assessmentRepository.findAll()
+
+              Assertions.assertThat(assessments.first { it.id == existingAssessment.id }.reallocatedAt).isNotNull
+              Assertions.assertThat(assessments)
+                .anyMatch { it.application.id == application.id && it.allocatedToUser.id == assigneeUser.id }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `Reallocating a placement request returns a NotAllowedProblem`() {
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/placement-request/allocations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewReallocation(
+            userId = UUID.randomUUID()
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+    }
+  }
+
+  @Test
+  fun `Reallocating a placement request review returns a NotAllowedProblem`() {
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/placement-request-review/allocations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewReallocation(
+            userId = UUID.randomUUID()
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+    }
+  }
+
+  @Test
+  fun `Reallocating a booking appeal returns a NotAllowedProblem`() {
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/booking-appeal/allocations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewReallocation(
+            userId = UUID.randomUUID()
+          )
+        )
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -264,52 +265,64 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Reallocating a placement request returns a NotAllowedProblem`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
-      webTestClient.post()
-        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/placement-request/allocations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewReallocation(
-            userId = UUID.randomUUID()
-          )
-        )
-        .exchange()
-        .expectStatus()
-        .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+      `Given a User` { userToReallocate, _ ->
+        `Given an Application`(createdByUser = user) { application ->
+          webTestClient.post()
+            .uri("/applications/${application.id}/tasks/placement-request/allocations")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewReallocation(
+                userId = userToReallocate.id
+              )
+            )
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+        }
+      }
     }
   }
 
   @Test
   fun `Reallocating a placement request review returns a NotAllowedProblem`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
-      webTestClient.post()
-        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/placement-request-review/allocations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewReallocation(
-            userId = UUID.randomUUID()
-          )
-        )
-        .exchange()
-        .expectStatus()
-        .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+      `Given a User` { userToReallocate, _ ->
+        `Given an Application`(createdByUser = user) { application ->
+          webTestClient.post()
+            .uri("/applications/${application.id}/tasks/placement-request-review/allocations")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewReallocation(
+                userId = userToReallocate.id
+              )
+            )
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+        }
+      }
     }
   }
 
   @Test
   fun `Reallocating a booking appeal returns a NotAllowedProblem`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
-      webTestClient.post()
-        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/booking-appeal/allocations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewReallocation(
-            userId = UUID.randomUUID()
-          )
-        )
-        .exchange()
-        .expectStatus()
-        .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+      `Given a User` { userToReallocate, _ ->
+        `Given an Application`(createdByUser = user) { application ->
+          webTestClient.post()
+            .uri("/applications/${application.id}/tasks/booking-appeal/allocations")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewReallocation(
+                userId = userToReallocate.id
+              )
+            )
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+        }
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+fun IntegrationTestBase.`Given an Application`(
+  createdByUser: UserEntity,
+  crn: String = randomStringMultiCaseWithNumbers(8),
+  block: (application: ApplicationEntity) -> Unit
+) {
+  val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+    withPermissiveSchema()
+  }
+
+  val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+    withCrn(crn)
+    withCreatedByUser(createdByUser)
+    withApplicationSchema(applicationSchema)
+  }
+
+  block(application)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -1,0 +1,172 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostcodeDistrictRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+
+class PlacementRequestServiceTest {
+  private val placementRequestRepository = mockk<PlacementRequestRepository>()
+  private val postcodeDistrictRepository = mockk<PostcodeDistrictRepository>()
+  private val characteristicRepository = mockk<CharacteristicRepository>()
+  private val userRepository = mockk<UserRepository>()
+
+  private val placementRequestService = PlacementRequestService(
+    placementRequestRepository,
+    postcodeDistrictRepository,
+    characteristicRepository,
+    userRepository
+  )
+
+  private val previousUser = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+
+  private val assigneeUser = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+
+  private val application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(
+      UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .produce()
+    )
+    .produce()
+
+  @Test
+  fun `reallocatePlacementRequest returns General Validation Error when request already has an associated booking`() {
+    val premisesEntity = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withYieldedPremises { premisesEntity }
+      .produce()
+
+    val previousPlacementRequest = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(previousUser)
+      .withBooking(booking)
+      .produce()
+
+    every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
+
+    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+
+    Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+
+    Assertions.assertThat(validationResult is ValidatableActionResult.GeneralValidationError).isTrue
+    validationResult as ValidatableActionResult.GeneralValidationError
+    Assertions.assertThat(validationResult.message).isEqualTo("This placement request has already been completed")
+  }
+
+  @Test
+  fun `reallocatePlacementRequest returns Field Validation Error when user to assign to is not a MATCHER`() {
+    val previousPlacementRequest = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(previousUser)
+      .produce()
+
+    every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
+
+    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+
+    Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+
+    Assertions.assertThat(validationResult is ValidatableActionResult.FieldValidationError).isTrue
+    validationResult as ValidatableActionResult.FieldValidationError
+    Assertions.assertThat(validationResult.validationMessages).containsEntry("$.userId", "lackingMatcherRole")
+  }
+
+  @Test
+  fun `reallocatePlacementRequest returns Success, deallocates old placementRequest and creates a new one`() {
+    val assigneeUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+      .apply {
+        roles += UserRoleAssignmentEntityFactory()
+          .withUser(this)
+          .withRole(UserRole.MATCHER)
+          .produce()
+      }
+
+    val previousPlacementRequest = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(previousUser)
+      .produce()
+
+    every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
+
+    every { placementRequestRepository.save(previousPlacementRequest) } answers { it.invocation.args[0] as PlacementRequestEntity }
+    every { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementRequestEntity }
+
+    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+
+    Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+
+    Assertions.assertThat(validationResult is ValidatableActionResult.Success).isTrue
+    validationResult as ValidatableActionResult.Success
+
+    Assertions.assertThat(previousPlacementRequest.reallocatedAt).isNotNull
+
+    verify { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) }
+
+    val newPlacementRequest = validationResult.entity
+
+    Assertions.assertThat(newPlacementRequest.application).isEqualTo(application)
+    Assertions.assertThat(newPlacementRequest.allocatedToUser).isEqualTo(assigneeUser)
+    Assertions.assertThat(newPlacementRequest.radius).isEqualTo(previousPlacementRequest.radius)
+    Assertions.assertThat(newPlacementRequest.postcodeDistrict).isEqualTo(previousPlacementRequest.postcodeDistrict)
+    Assertions.assertThat(newPlacementRequest.gender).isEqualTo(previousPlacementRequest.gender)
+    Assertions.assertThat(newPlacementRequest.expectedArrival).isEqualTo(previousPlacementRequest.expectedArrival)
+    Assertions.assertThat(newPlacementRequest.mentalHealthSupport).isEqualTo(previousPlacementRequest.mentalHealthSupport)
+    Assertions.assertThat(newPlacementRequest.apType).isEqualTo(previousPlacementRequest.apType)
+    Assertions.assertThat(newPlacementRequest.duration).isEqualTo(previousPlacementRequest.duration)
+    Assertions.assertThat(newPlacementRequest.desirableCriteria).isEqualTo(previousPlacementRequest.desirableCriteria)
+    Assertions.assertThat(newPlacementRequest.essentialCriteria).isEqualTo(previousPlacementRequest.essentialCriteria)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -1,0 +1,158 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class TaskServiceTest {
+  private val assessmentServiceMock = mockk<AssessmentService>()
+  private val applicationRepositoryMock = mockk<ApplicationRepository>()
+  private val userServiceMock = mockk<UserService>()
+
+  private val taskService = TaskService(
+    assessmentServiceMock,
+    applicationRepositoryMock,
+    userServiceMock
+  )
+
+  private val requestUserWithPermission = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+    .apply {
+      roles += UserRoleAssignmentEntityFactory()
+        .withRole(UserRole.WORKFLOW_MANAGER)
+        .withUser(this)
+        .produce()
+    }
+
+  @Test
+  fun `reallocateTask returns Unauthorised when requestUser does not have WORKFLOW_MANAGER role`() {
+    val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val result = taskService.reallocateTask(requestUser, TaskType.assessment, UUID.randomUUID(), UUID.randomUUID())
+
+    Assertions.assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `reallocateTask returns Not Found when assignee user does not exist`() {
+    val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
+
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.NotFound()
+
+    val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUserId, UUID.randomUUID())
+
+    Assertions.assertThat(result is AuthorisableActionResult.NotFound).isTrue
+  }
+
+  @Test
+  fun `reallocateTask returns Not Found when application does not exist`() {
+    val assigneeUser = generateAndStubAssigneeUser()
+
+    val applicationId = UUID.fromString("95c7175f-451a-47e0-af16-6bf9175b5581")
+
+    every { applicationRepositoryMock.findByIdOrNull(applicationId) } returns null
+
+    val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUser.id, applicationId)
+
+    Assertions.assertThat(result is AuthorisableActionResult.NotFound).isTrue
+  }
+
+  @Test
+  fun `reallocateTask reallocates an assessment`() {
+    val assigneeUser = generateAndStubAssigneeUser()
+    val application = generateAndStubApplication()
+
+    val assessment = AssessmentEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
+      .produce()
+
+    every { assessmentServiceMock.reallocateAssessment(assigneeUser, application) } returns AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(
+        assessment
+      )
+    )
+
+    val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUser.id, application.id)
+
+    Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+
+    Assertions.assertThat(validationResult is ValidatableActionResult.Success).isTrue
+    validationResult as ValidatableActionResult.Success
+
+    Assertions.assertThat(validationResult.entity).isEqualTo(assessment)
+  }
+
+  private fun generateAndStubAssigneeUser(): UserEntity {
+    val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    every { userServiceMock.updateUserFromCommunityApiById(user.id) } returns AuthorisableActionResult.Success(user)
+
+    return user
+  }
+
+  private fun generateAndStubApplication(): ApprovedPremisesApplicationEntity {
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      )
+      .produce()
+
+    every { applicationRepositoryMock.findByIdOrNull(application.id) } returns application
+
+    return application
+  }
+}


### PR DESCRIPTION
This tweaks the reallocation endpoint to include the task type in the URL, as well as adding support for Placement Requests to be reallocated, as well as some quality of life improvements.