### PR TITLE
Reallocation returns an ApprovedPremisesUser

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
@@ -81,7 +82,7 @@ class TaskService(
 
     return Reallocation(
       taskType = taskType,
-      user = userTransformer.transformJpaToApi(allocatedToUser, ServiceName.approvedPremises)
+      user = userTransformer.transformJpaToApi(allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser
     )
   }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2565,6 +2565,11 @@ components:
           $ref: '#/components/schemas/TaskType'
       required: 
         - applicationId
+        - person
+        - dueDate
+        - allocatedToStaffMember
+        - status
+        - taskType
     TaskType:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3857,11 +3857,11 @@ components:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/ApprovedPremisesUser'
         taskType:
           $ref: '#/components/schemas/TaskType'
       required:
-        - userId
+        - user
         - taskType
     User:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -245,7 +246,7 @@ class TasksTest : IntegrationTestBase() {
                 .json(
                   objectMapper.writeValueAsString(
                     Reallocation(
-                      user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises),
+                      user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
                       taskType = TaskType.assessment
                     )
                   )
@@ -290,7 +291,7 @@ class TasksTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   Reallocation(
-                    user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises),
+                    user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
                     taskType = TaskType.placementRequest
                   )
                 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -5,10 +5,10 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
@@ -113,7 +113,7 @@ class TaskServiceTest {
       )
     )
 
-    val transformedUser = mockk<User>()
+    val transformedUser = mockk<ApprovedPremisesUser>()
 
     every { userTransformerMock.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) } returns transformedUser
 
@@ -149,7 +149,7 @@ class TaskServiceTest {
       )
     )
 
-    val transformedUser = mockk<User>()
+    val transformedUser = mockk<ApprovedPremisesUser>()
 
     every { userTransformerMock.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) } returns transformedUser
 


### PR DESCRIPTION
This represents reality, and will fix an issue we have with our typing. If CAS3 choose to use tasks and allocations further down the line, we can use a discriminator.