### PR TITLE
Use DbExtension to manage database for tests to improve performance

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:
+  database:
+    image: "ghcr.io/baosystems/postgis:15-3.3" # Official PostGIS image doesn't have ARM64 support

--- a/docker-compose.test.arm64.yml
+++ b/docker-compose.test.arm64.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:
+  integration_test_database:
+    image: "ghcr.io/baosystems/postgis:15-3.3" # Official PostGIS image doesn't have ARM64 support

--- a/script/development_database
+++ b/script/development_database
@@ -7,4 +7,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "==> Starting database..."
-docker-compose -f docker-compose.yml up -d
+if [ "$(uname -m)" = "arm64" ]; then
+  docker-compose -f docker-compose.yml -f docker-compose.arm64.yml up -d
+else
+  docker-compose -f docker-compose.yml up -d
+fi

--- a/script/test_database
+++ b/script/test_database
@@ -7,4 +7,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "==> Starting integration test database..."
-docker-compose -f docker-compose.test.yml up -d
+if [ "$(uname -m)" = "arm64" ]; then
+  docker-compose -f docker-compose.test.yml -f docker-compose.test.arm64.yml up -d
+else
+  docker-compose -f docker-compose.test.yml up -d
+fi

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -7,9 +7,9 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -133,11 +133,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DbExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.JwtAuthHelper
 import java.time.Duration
 import java.util.TimeZone
 import java.util.UUID
 
+@ExtendWith(DbExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 abstract class IntegrationTestBase {
@@ -146,9 +148,6 @@ abstract class IntegrationTestBase {
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   lateinit var webTestClient: WebTestClient
-
-  @Autowired
-  private lateinit var flyway: Flyway
 
   @Autowired
   private lateinit var jdbcTemplate: JdbcTemplate
@@ -322,12 +321,6 @@ abstract class IntegrationTestBase {
 
     wiremockServer = WireMockServer(57839)
     wiremockServer.start()
-
-    flyway.clean()
-
-    jdbcTemplate.execute("CREATE EXTENSION postgis;")
-
-    flyway.migrate()
 
     cacheManager.cacheNames.forEach {
       cacheManager.getCache(it)!!.clear()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DbExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DbExtension.kt
@@ -1,0 +1,160 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.flywaydb.core.Flyway
+import org.hibernate.internal.SessionFactoryImpl
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.postgresql.ds.PGSimpleDataSource
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.context.ApplicationContext
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.sql.Connection
+import java.sql.SQLException
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.persistence.EntityManagerFactory
+import javax.persistence.metamodel.EntityType
+import javax.sql.DataSource
+
+class DbExtension : BeforeAllCallback, BeforeEachCallback {
+  companion object {
+    private val STARTED = AtomicBoolean(false)
+    private val LOGGER = LoggerFactory.getLogger(DbExtension::class.java)
+
+    private val TABLES_TO_IGNORE = listOf(
+      TableData("flyway_schema_history"),
+      TableData("spatial_ref_sys"),
+    )
+
+    private lateinit var INITIAL_DB_STATE: Map<EntityType<*>, List<Any>>
+  }
+
+  override fun beforeAll(context: ExtensionContext?) {
+    if (STARTED.compareAndSet(false, true)) {
+      val applicationContext = SpringExtension.getApplicationContext(context!!)
+
+      runFlywayMigrations(applicationContext)
+      getInitialDatabaseState(applicationContext)
+    }
+  }
+
+  override fun beforeEach(context: ExtensionContext?) {
+    val applicationContext = SpringExtension.getApplicationContext(context!!)
+    val dataSource = getDatasource(applicationContext)
+    cleanDatabase(dataSource)
+    setInitialDatabaseState(applicationContext)
+  }
+
+  private fun runFlywayMigrations(applicationContext: ApplicationContext) {
+    val flyway = applicationContext.getBean(Flyway::class.java)
+    val jdbcTemplate = applicationContext.getBean(JdbcTemplate::class.java)
+
+    flyway.clean()
+
+    jdbcTemplate.execute("CREATE EXTENSION postgis;")
+
+    flyway.migrate()
+  }
+
+  private fun getInitialDatabaseState(applicationContext: ApplicationContext) {
+    val entityManagerFactory = applicationContext.getBean(EntityManagerFactory::class.java)
+    val sessionFactory = entityManagerFactory.unwrap(SessionFactoryImpl::class.java)
+
+    sessionFactory.openSession().use { session ->
+      INITIAL_DB_STATE = session.metamodel.entities.associateWith {
+        val query = session.criteriaBuilder.createQuery()
+        val root = query.from(it)
+        query.select(root)
+        val results = session.createQuery(query).resultList
+
+        LOGGER.debug("Found ${results.count()} ${it.name} instances")
+
+        results
+      }
+    }
+  }
+
+  private fun setInitialDatabaseState(applicationContext: ApplicationContext) {
+    val entityManagerFactory = applicationContext.getBean(EntityManagerFactory::class.java)
+    val sessionFactory = entityManagerFactory.unwrap(SessionFactoryImpl::class.java)
+
+    sessionFactory.openSession().use { session ->
+      val transaction = session.beginTransaction()
+
+      INITIAL_DB_STATE.forEach { (entityType, entities) ->
+        entities.forEach { session.save(it) }
+        LOGGER.debug("Restoring ${entities.count()} ${entityType.name} instances")
+      }
+
+      session.flush()
+      transaction.commit()
+    }
+  }
+
+  private fun getDatasource(applicationContext: ApplicationContext): DataSource {
+    val configurableEnvironment = applicationContext.environment
+
+    val binder = Binder.get(configurableEnvironment)
+    val dataSourceProperties = binder
+      .bind("spring.datasource", Bindable.of(DataSourceProperties::class.java))
+      .get()
+
+    val pgSimpleDataSource = PGSimpleDataSource()
+    pgSimpleDataSource.setUrl(dataSourceProperties.url)
+    pgSimpleDataSource.user = dataSourceProperties.username
+    pgSimpleDataSource.password = dataSourceProperties.password
+    return pgSimpleDataSource
+  }
+
+  private fun cleanDatabase(dataSource: DataSource) {
+    try {
+      dataSource.connection.use { connection ->
+        connection.autoCommit = false
+        val tablesToClean = loadTablesToClean(connection)
+        cleanTablesData(tablesToClean, connection)
+        connection.commit()
+      }
+    } catch (e: SQLException) {
+      LOGGER.error(String.format("Failed to clean database due to error: \"%s\"", e.message))
+      e.printStackTrace()
+    }
+  }
+
+  private fun loadTablesToClean(connection: Connection): List<TableData> {
+    val databaseMetaData = connection.metaData
+    val resultSet = databaseMetaData.getTables(connection.catalog, null, null, arrayOf("TABLE"))
+
+    val tablesToClean = mutableListOf<TableData>()
+    while (resultSet.next()) {
+      val table = TableData(
+        schema = resultSet.getString("TABLE_SCHEM"),
+        name = resultSet.getString("TABLE_NAME"),
+      )
+
+      if (!TABLES_TO_IGNORE.contains(table)) {
+        tablesToClean.add(table)
+      }
+    }
+
+    return tablesToClean
+  }
+
+  private fun cleanTablesData(tablesNames: List<TableData>, connection: Connection) {
+    if (tablesNames.isEmpty()) {
+      return
+    }
+
+    val statement = tablesNames.joinToString(separator = ", ", prefix = "TRUNCATE ") { it.fullyQualifiedTableName }
+
+    connection.prepareStatement(statement).execute()
+  }
+
+  data class TableData(val name: String, val schema: String? = "public") {
+    val fullyQualifiedTableName =
+      if (schema != null) "$schema.$name" else name
+  }
+}


### PR DESCRIPTION
This PR aims to reduce the time taken to run unit and integration tests.

It introduces a JPA extension (`DbExtension`) that performs the following optimisations:
- Run Flyway migrations once at the start of the test run
- Store data seeded into the database at the start of the test run
- Truncate all tables and reinsert seeded data before each test to ensure the database is in a known state

It also improves the performance of PostGIS on ARM64 machines (such as newer Macs) by providing Docker Compose configurations using a community PostGIS image that run natively, rather than emulating AMD64, bringing the time taken to run the tests in line with the CI pipeline. The `test_database` and `development_database` scripts will automatically use these configurations on an ARM64 environment.