### PR TITLE
Add applicationId and assessmentId to Placement Request responses

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
-val springDocVersion = "1.6.15"
+val springDocVersion = "1.7.0"
 val sentryVersion = "6.16.0"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ configurations {
 }
 
 val springDocVersion = "1.7.0"
-val sentryVersion = "6.16.0"
+val sentryVersion = "6.17.0"
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -42,6 +42,10 @@ data class PlacementRequestEntity(
   @JoinColumn(name = "application_id")
   val application: ApprovedPremisesApplicationEntity,
 
+  @ManyToOne
+  @JoinColumn(name = "assessment_id")
+  val assessment: AssessmentEntity,
+
   val radius: Int,
 
   @ManyToMany

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.EnumType
@@ -104,7 +105,9 @@ data class UserRoleAssignmentEntity(
   val user: UserEntity,
   @Enumerated(value = EnumType.STRING)
   val role: UserRole
-)
+) {
+  override fun hashCode() = Objects.hash(id, role)
+}
 
 enum class UserRole {
   ASSESSOR,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -120,6 +120,7 @@ class PlacementRequestService(
           mentalHealthSupport = requirements.mentalHealthSupport,
           createdAt = OffsetDateTime.now(),
           application = application,
+          assessment = assessment,
           allocatedToUser = user,
           booking = null,
           reallocatedAt = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -26,7 +26,9 @@ class PlacementRequestTransformer(
       desirableCriteria = jpa.desirableCriteria.mapNotNull { characteristicToCriteria(it) },
       mentalHealthSupport = jpa.mentalHealthSupport,
       person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
-      risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn)
+      risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn),
+      applicationId = jpa.application.id,
+      assessmentId = jpa.assessment.id
     )
   }
 

--- a/src/main/resources/db/migration/all/20230331103832__add_assessment_id_to_placement_request.sql
+++ b/src/main/resources/db/migration/all/20230331103832__add_assessment_id_to_placement_request.sql
@@ -1,0 +1,3 @@
+DELETE FROM placement_requests;
+ALTER TABLE placement_requests ADD COLUMN assessment_id UUID NOT NULL;
+ALTER TABLE placement_requests ADD FOREIGN KEY (assessment_id) REFERENCES assessments (id);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4518,10 +4518,18 @@ components:
               $ref: '#/components/schemas/Person'
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
       required:
         - person
         - risks
         - id
+        - applicationId
+        - assessmentId
     PlacementCriteria:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -5,6 +5,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
@@ -21,7 +22,8 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
   private var expectedArrival: Yielded<LocalDate> = { LocalDate.now() }
   private var duration: Yielded<Int> = { 12 }
   private var postcodeDistrict: Yielded<PostCodeDistrictEntity> = { PostCodeDistrictEntityFactory().produce() }
-  private var application: Yielded<ApprovedPremisesApplicationEntity> = { ApprovedPremisesApplicationEntityFactory().produce() }
+  private var application: Yielded<ApprovedPremisesApplicationEntity>? = null
+  private var assessment: Yielded<AssessmentEntity>? = null
   private var radius: Yielded<Int> = { 50 }
   private var essentialCriteria: Yielded<List<CharacteristicEntity>> = { listOf(CharacteristicEntityFactory().produce()) }
   private var desirableCriteria: Yielded<List<CharacteristicEntity>> = { listOf(CharacteristicEntityFactory().produce(), CharacteristicEntityFactory().produce()) }
@@ -44,6 +46,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
 
   fun withApplication(application: ApprovedPremisesApplicationEntity) = apply {
     this.application = { application }
+  }
+
+  fun withAssessment(assessment: AssessmentEntity) = apply {
+    this.assessment = { assessment }
   }
 
   fun withReallocatedAt(reallocatedAt: OffsetDateTime) = apply {
@@ -69,7 +75,8 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     expectedArrival = this.expectedArrival(),
     duration = this.duration(),
     postcodeDistrict = this.postcodeDistrict(),
-    application = this.application(),
+    application = this.application?.invoke() ?: throw RuntimeException("Must provide an Application"),
+    assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an Assessment"),
     radius = this.radius(),
     essentialCriteria = this.essentialCriteria(),
     desirableCriteria = this.desirableCriteria(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -31,8 +32,11 @@ class PlacementRequestsTest : IntegrationTestBase() {
     `Given a User` { user, jwt ->
       `Given an Offender` { offenderDetails1, inmateDetails1 ->
         `Given an Offender` { offenderDetails2, _ ->
-
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          }
+
+          val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           }
 
@@ -42,15 +46,32 @@ class PlacementRequestsTest : IntegrationTestBase() {
             withApplicationSchema(applicationSchema)
           }
 
+          val assessment1 = assessmentEntityFactory.produceAndPersist {
+            withAssessmentSchema(assessmentSchema)
+            withApplication(application1)
+            withSubmittedAt(OffsetDateTime.now())
+            withAllocatedToUser(user)
+            withDecision(AssessmentDecision.ACCEPTED)
+          }
+
           val application2 = approvedPremisesApplicationEntityFactory.produceAndPersist {
             withCrn(offenderDetails2.otherIds.crn)
             withCreatedByUser(user)
             withApplicationSchema(applicationSchema)
           }
 
+          val assessment2 = assessmentEntityFactory.produceAndPersist {
+            withAssessmentSchema(assessmentSchema)
+            withApplication(application2)
+            withSubmittedAt(OffsetDateTime.now())
+            withAllocatedToUser(user)
+            withDecision(AssessmentDecision.ACCEPTED)
+          }
+
           val placementRequest = placementRequestFactory.produceAndPersist {
             withAllocatedToUser(user)
             withApplication(application1)
+            withAssessment(assessment1)
             withPostcodeDistrict(
               postCodeDistrictRepository.findAll()[0]
             )
@@ -66,6 +87,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
             withAllocatedToUser(user)
             withReallocatedAt(OffsetDateTime.now())
             withApplication(application2)
+            withAssessment(assessment2)
             withPostcodeDistrict(
               postCodeDistrictRepository.findAll()[0]
             )
@@ -112,7 +134,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           `Given an Application`(createdByUser = otherUser) {
             `Given a Placement Request`(
-              allocatedToUser = otherUser,
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn
             ) { placementRequest, _ ->
@@ -136,7 +159,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           `Given an Application`(createdByUser = otherUser) {
             `Given a Placement Request`(
-              allocatedToUser = user,
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn
             ) { placementRequest, _ ->
@@ -184,7 +208,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           `Given an Application`(createdByUser = otherUser) {
             `Given a Placement Request`(
-              allocatedToUser = otherUser,
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn
             ) { placementRequest, _ ->
@@ -215,7 +240,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           `Given an Application`(createdByUser = otherUser) {
             `Given a Placement Request`(
-              allocatedToUser = user,
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn
             ) { placementRequest, _ ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -2,13 +2,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
 fun IntegrationTestBase.`Given a Placement Request`(
-  allocatedToUser: UserEntity,
+  placementRequestAllocatedTo: UserEntity,
+  assessmentAllocatedTo: UserEntity,
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
@@ -24,9 +26,22 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withApplicationSchema(applicationSchema)
   }
 
-  val placementRequest = placementRequestFactory.produceAndPersist {
-    withAllocatedToUser(allocatedToUser)
+  val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+    withPermissiveSchema()
+  }
+
+  val assessment = assessmentEntityFactory.produceAndPersist {
+    withAssessmentSchema(assessmentSchema)
     withApplication(application)
+    withSubmittedAt(OffsetDateTime.now())
+    withAllocatedToUser(placementRequestAllocatedTo)
+    withDecision(AssessmentDecision.ACCEPTED)
+  }
+
+  val placementRequest = placementRequestFactory.produceAndPersist {
+    withAllocatedToUser(placementRequestAllocatedTo)
+    withApplication(application)
+    withAssessment(assessment)
     withPostcodeDistrict(
       postCodeDistrictRepository.findAll()[0]
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
@@ -2071,10 +2072,16 @@ class BookingServiceTest {
       .withUnitTestControlProbationRegion()
       .produce()
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(otherUser)
+      .produce()
+
     val placementRequest = PlacementRequestEntityFactory()
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(otherUser)
+      .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(otherUser)
           .produce()
       )
       .withAllocatedToUser(otherUser)
@@ -2105,10 +2112,16 @@ class BookingServiceTest {
       .withUnitTestControlProbationRegion()
       .produce()
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(otherUser)
+      .produce()
+
     val placementRequest = PlacementRequestEntityFactory()
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(otherUser)
+      .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(otherUser)
           .produce()
       )
       .withAllocatedToUser(user)
@@ -2159,11 +2172,17 @@ class BookingServiceTest {
       .withUnitTestControlProbationRegion()
       .produce()
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCrn(crn)
+      .withCreatedByUser(otherUser)
+      .produce()
+
     val placementRequest = PlacementRequestEntityFactory()
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCrn(crn)
-          .withCreatedByUser(otherUser)
+      .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(otherUser)
           .produce()
       )
       .withAllocatedToUser(user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -9,6 +9,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
@@ -82,10 +83,20 @@ class PlacementRequestServiceTest {
       .withYieldedPremises { premisesEntity }
       .produce()
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(assigneeUser)
+      .produce()
+
     val previousPlacementRequest = PlacementRequestEntityFactory()
       .withApplication(application)
-      .withAllocatedToUser(previousUser)
       .withBooking(booking)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(assigneeUser)
+          .produce()
+      )
+      .withAllocatedToUser(previousUser)
       .produce()
 
     every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
@@ -102,8 +113,18 @@ class PlacementRequestServiceTest {
 
   @Test
   fun `reallocatePlacementRequest returns Field Validation Error when user to assign to is not a MATCHER`() {
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(assigneeUser)
+      .produce()
+
     val previousPlacementRequest = PlacementRequestEntityFactory()
       .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(assigneeUser)
+          .produce()
+      )
       .withAllocatedToUser(previousUser)
       .produce()
 
@@ -135,8 +156,18 @@ class PlacementRequestServiceTest {
           .produce()
       }
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(assigneeUser)
+      .produce()
+
     val previousPlacementRequest = PlacementRequestEntityFactory()
       .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(assigneeUser)
+          .produce()
+      )
       .withAllocatedToUser(previousUser)
       .produce()
 
@@ -189,13 +220,23 @@ class PlacementRequestServiceTest {
 
   @Test
   fun `getPlacementRequestForUser returns Unauthorised when PlacementRequest not allocated to User and User does not have WORKFLOW_MANAGER role`() {
-    val placementRequest = PlacementRequestEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(assigneeUser)
-      .produce()
-
     val requestingUser = UserEntityFactory()
       .withUnitTestControlProbationRegion()
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(requestingUser)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(requestingUser)
+          .produce()
+      )
+      .withAllocatedToUser(assigneeUser)
       .produce()
 
     every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
@@ -211,8 +252,18 @@ class PlacementRequestServiceTest {
       .withUnitTestControlProbationRegion()
       .produce()
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(assigneeUser)
+      .produce()
+
     val placementRequest = PlacementRequestEntityFactory()
       .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(assigneeUser)
+          .produce()
+      )
       .withAllocatedToUser(requestingUser)
       .produce()
 
@@ -235,8 +286,18 @@ class PlacementRequestServiceTest {
           .produce()
       }
 
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(assigneeUser)
+      .produce()
+
     val placementRequest = PlacementRequestEntityFactory()
       .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(assigneeUser)
+          .produce()
+      )
       .withAllocatedToUser(assigneeUser)
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -140,6 +140,12 @@ class TaskServiceTest {
 
     val placementRequest = PlacementRequestEntityFactory()
       .withApplication(application)
+      .withAssessment(
+        AssessmentEntityFactory()
+          .withApplication(application)
+          .withAllocatedToUser(assigneeUser)
+          .produce()
+      )
       .withAllocatedToUser(assigneeUser)
       .produce()
 


### PR DESCRIPTION
- Record which assessment was used to create a Placement Request
- Return the `applicationId` and `assessmentId` with Placement Request response bodies