### PR TITLE
Implement 'booking search' endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingSearchController.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.BookingsApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingSearchResultTransformer
+
+@Service
+class BookingSearchController(
+  private val bookingSearchService: BookingSearchService,
+  private val bookingSearchResultTransformer: BookingSearchResultTransformer,
+) : BookingsApiDelegate {
+  override fun bookingsSearchGet(
+    xServiceName: ServiceName,
+    status: BookingStatus?,
+    sortOrder: SortOrder?,
+    sortField: BookingSearchSortField?
+  ): ResponseEntity<BookingSearchResults> {
+    val sortOrder = sortOrder ?: SortOrder.ascending
+    val sortField = sortField ?: BookingSearchSortField.bookingCreatedAt
+
+    val authorisationResult = bookingSearchService.findBookings(xServiceName, status, sortOrder, sortField)
+
+    val validationResult = when (authorisationResult) {
+      is AuthorisableActionResult.Success -> authorisationResult.entity
+      else -> throw ForbiddenProblem()
+    }
+
+    val results = when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.Success -> validationResult.entity
+    }
+
+    return ResponseEntity.ok(
+      bookingSearchResultTransformer.transformDomainToApi(results),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingSearchRepository.kt
@@ -1,0 +1,148 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.jdbc.core.ResultSetExtractor
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Repository
+class BookingSearchRepository(private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate) {
+  private val bookingSearchQuery =
+    """
+      SELECT
+        b.crn AS person_crn,
+        b.id AS booking_id,
+        s.booking_status AS booking_status,
+        b.arrival_date AS booking_start_date,
+        b.departure_date AS booking_end_date,
+        b.created_at AS booking_created_at,
+        p.id AS premises_id,
+        p.name AS premises_name,
+        p.address_line1 AS premises_address_line1,
+        p.address_line2 AS premises_address_line2,
+        p.town AS premises_town,
+        p.postcode AS premises_postcode,
+        r.id AS room_id,
+        r.name AS room_name,
+        b2.id AS bed_id,
+        b2.name AS bed_name
+      FROM bookings b
+      LEFT JOIN (
+        SELECT
+          b.id,
+          (
+            CASE
+              WHEN (SELECT COUNT(1) FROM cancellations c WHERE c.booking_id = b.id) > 0 THEN 'cancelled'
+              WHEN (SELECT COUNT(1) FROM departures d WHERE d.booking_id = b.id) > 0 THEN 'departed'
+              WHEN (SELECT COUNT(1) FROM arrivals a WHERE a.booking_id = b.id) > 0 THEN 'arrived'
+              WHEN (SELECT COUNT(1) FROM confirmations c2 WHERE c2.booking_id = b.id) > 0 THEN 'confirmed'
+              WHEN (SELECT COUNT(1) FROM non_arrivals n WHERE n.booking_id = n.id) > 0 THEN 'not-arrived'
+              WHEN :service = 'approved-premises' THEN 'awaiting-arrival'
+              ELSE 'provisional'
+            END
+          ) AS booking_status
+        FROM bookings b
+      ) as s ON b.id = s.id
+      LEFT JOIN beds b2 ON b.bed_id = b2.id
+      LEFT JOIN rooms r ON b2.room_id = r.id
+      LEFT JOIN premises p ON r.premises_id = p.id
+      WHERE b.service = :service
+      #OPTIONAL_FILTERS;
+    """.trimIndent()
+
+  private val bookingStatusFilter = """
+    s.booking_status = :booking_status
+  """.trimIndent()
+  fun findBookings(
+    serviceName: ServiceName,
+    status: BookingStatus?,
+  ): List<BookingSearchResult> {
+    val params = MapSqlParameterSource().apply {
+      addValue("service", serviceName.value)
+      addValue("booking_status", status?.value)
+    }
+
+    var optionalFilters = ""
+    if (status != null) {
+      optionalFilters += "AND $bookingStatusFilter\n"
+    }
+
+    val query = bookingSearchQuery.replace("#OPTIONAL_FILTERS", optionalFilters)
+
+    val result = namedParameterJdbcTemplate.query(
+      query,
+      params,
+      ResultSetExtractor { resultSet ->
+        val bookings = mutableListOf<BookingSearchResult>()
+
+        while (resultSet.next()) {
+          val personCrn = resultSet.getString("person_crn")
+          val bookingId = UUID.fromString(resultSet.getString("booking_id"))
+          val bookingStatus = resultSet.getString("booking_status")
+          val bookingStartDate = resultSet.getObject("booking_start_date", LocalDate::class.java)
+          val bookingEndDate = resultSet.getObject("booking_end_date", LocalDate::class.java)
+          val bookingCreatedAt = resultSet.getObject("booking_created_at", OffsetDateTime::class.java)
+          val premisesId = UUID.fromString(resultSet.getString("premises_id"))
+          val premisesName = resultSet.getString("premises_name")
+          val premisesAddressLine1 = resultSet.getString("premises_address_line1")
+          val premisesAddressLine2 = resultSet.getString("premises_address_line2")
+          val premisesTown = resultSet.getString("premises_town")
+          val premisesPostcode = resultSet.getString("premises_postcode")
+          val roomId = UUID.fromString(resultSet.getString("room_id"))
+          val roomName = resultSet.getString("room_name")
+          val bedId = UUID.fromString(resultSet.getString("bed_id"))
+          val bedName = resultSet.getString("bed_name")
+
+          bookings += BookingSearchResult(
+            personName = null,
+            personCrn,
+            bookingId,
+            bookingStatus,
+            bookingStartDate,
+            bookingEndDate,
+            bookingCreatedAt,
+            premisesId,
+            premisesName,
+            premisesAddressLine1,
+            premisesAddressLine2,
+            premisesTown,
+            premisesPostcode,
+            roomId,
+            roomName,
+            bedId,
+            bedName,
+          )
+        }
+
+        bookings
+      }
+    )
+
+    return result ?: emptyList()
+  }
+}
+
+data class BookingSearchResult(
+  var personName: String?,
+  val personCrn: String,
+  val bookingId: UUID,
+  val bookingStatus: String,
+  val bookingStartDate: LocalDate,
+  val bookingEndDate: LocalDate,
+  val bookingCreatedAt: OffsetDateTime,
+  val premisesId: UUID,
+  val premisesName: String,
+  val premisesAddressLine1: String,
+  val premisesAddressLine2: String?,
+  val premisesTown: String?,
+  val premisesPostcode: String,
+  val roomId: UUID,
+  val roomName: String,
+  val bedId: UUID,
+  val bedName: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingSearchRepository.kt
@@ -58,18 +58,28 @@ class BookingSearchRepository(private val namedParameterJdbcTemplate: NamedParam
   private val bookingStatusFilter = """
     s.booking_status = :booking_status
   """.trimIndent()
+
+  private val probationRegionFilter = """
+    p.probation_region_id = :probation_region
+  """.trimIndent()
+
   fun findBookings(
     serviceName: ServiceName,
     status: BookingStatus?,
+    probationRegionId: UUID?,
   ): List<BookingSearchResult> {
     val params = MapSqlParameterSource().apply {
       addValue("service", serviceName.value)
       addValue("booking_status", status?.value)
+      addValue("probation_region", probationRegionId)
     }
 
     var optionalFilters = ""
     if (status != null) {
       optionalFilters += "AND $bookingStatusFilter\n"
+    }
+    if (probationRegionId != null) {
+      optionalFilters += "AND $probationRegionFilter\n"
     }
 
     val query = bookingSearchQuery.replace("#OPTIONAL_FILTERS", optionalFilters)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+
+@Service
+class BookingSearchService(
+  private val bookingSearchRepository: BookingSearchRepository,
+  private val offenderService: OffenderService,
+  private val userService: UserService,
+) {
+  fun findBookings(
+    serviceName: ServiceName,
+    status: BookingStatus?,
+    sortOrder: SortOrder,
+    sortField: BookingSearchSortField,
+  ): AuthorisableActionResult<ValidatableActionResult<List<BookingSearchResult>>> {
+    val user = userService.getUserForRequest()
+
+    val results = bookingSearchRepository.findBookings(
+      serviceName,
+      status,
+    )
+
+    results.forEach { result ->
+      val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(result.personCrn, user.deliusUsername)) {
+        is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+        is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised()
+        is AuthorisableActionResult.NotFound -> null
+      }
+
+      result.personName = offenderDetails?.let { "${it.firstName} ${it.surname}" }
+    }
+
+    return AuthorisableActionResult.Success(
+      validated {
+        return@validated success(results)
+      }
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSearchResultTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSearchResultTransformer.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultPersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultRoomSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResult as ApiBookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingSearchResult as DomainBookingSearchResult
+
+@Component
+class BookingSearchResultTransformer {
+  fun transformDomainToApi(results: List<DomainBookingSearchResult>) = BookingSearchResults(
+    resultsCount = results.size,
+    results = results.map(::transformResult),
+  )
+
+  private fun transformResult(result: DomainBookingSearchResult) = ApiBookingSearchResult(
+    person = BookingSearchResultPersonSummary(
+      name = result.personName ?: "",
+      crn = result.personCrn,
+    ),
+    booking = BookingSearchResultBookingSummary(
+      id = result.bookingId,
+      status = BookingStatus.values().find { it.value == result.bookingStatus } ?: throw RuntimeException("Unknown booking status ${result.bookingStatus}"),
+      startDate = result.bookingStartDate,
+      endDate = result.bookingEndDate,
+      createdAt = result.bookingCreatedAt.toInstant(),
+    ),
+    premises = BookingSearchResultPremisesSummary(
+      id = result.premisesId,
+      name = result.premisesName,
+      addressLine1 = result.premisesAddressLine1,
+      addressLine2 = result.premisesAddressLine2,
+      town = result.premisesTown,
+      postcode = result.premisesPostcode,
+    ),
+    room = BookingSearchResultRoomSummary(
+      id = result.roomId,
+      name = result.roomName,
+    ),
+    bed = BookingSearchResultBedSummary(
+      id = result.bedId,
+      name = result.bedName,
+    ),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
@@ -52,20 +53,20 @@ class BookingTransformer(
   }
 
   private fun determineApprovedPremisesStatus(jpa: BookingEntity) = when {
-    jpa.nonArrival != null -> Booking.Status.notMinusArrived
-    jpa.arrival != null && jpa.departure == null -> Booking.Status.arrived
-    jpa.departure != null -> Booking.Status.departed
-    jpa.cancellation != null -> Booking.Status.cancelled
-    jpa.arrival == null && jpa.nonArrival == null -> Booking.Status.awaitingMinusArrival
+    jpa.nonArrival != null -> BookingStatus.notMinusArrived
+    jpa.arrival != null && jpa.departure == null -> BookingStatus.arrived
+    jpa.departure != null -> BookingStatus.departed
+    jpa.cancellation != null -> BookingStatus.cancelled
+    jpa.arrival == null && jpa.nonArrival == null -> BookingStatus.awaitingMinusArrival
     else -> throw RuntimeException("Could not determine status for Booking ${jpa.id}")
   }
 
   private fun determineTemporaryAccommodationStatus(jpa: BookingEntity) = when {
-    jpa.cancellation != null -> Booking.Status.cancelled
-    jpa.departure != null -> Booking.Status.departed
-    jpa.arrival != null -> Booking.Status.arrived
-    jpa.nonArrival != null -> Booking.Status.notMinusArrived
-    jpa.confirmation != null -> Booking.Status.confirmed
-    else -> Booking.Status.provisional
+    jpa.cancellation != null -> BookingStatus.cancelled
+    jpa.departure != null -> BookingStatus.departed
+    jpa.arrival != null -> BookingStatus.arrived
+    jpa.nonArrival != null -> BookingStatus.notMinusArrived
+    jpa.confirmation != null -> BookingStatus.confirmed
+    else -> BookingStatus.provisional
   }
 }

--- a/src/main/resources/db/migration/all/20230411162335__add_indices_for_booking_search.sql
+++ b/src/main/resources/db/migration/all/20230411162335__add_indices_for_booking_search.sql
@@ -1,0 +1,2 @@
+CREATE INDEX ON bookings(service);
+CREATE INDEX ON premises(probation_region_id);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1753,7 +1753,7 @@ paths:
           description: If provided, only search for bookings with the given status
           required: false
           schema:
-            $ref: "#/components/schemas/BookingSearchStatus"
+            $ref: "#/components/schemas/BookingStatus"
         - name: sortOrder
           in: query
           description: If provided, return results in the given order
@@ -1766,6 +1766,12 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/BookingSearchSortField"
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the bookings to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       responses:
         200:
           description: successful operation
@@ -2995,15 +3001,7 @@ components:
         - type: object
           properties:
             status:
-              type: string
-              enum:
-              - arrived
-              - awaiting-arrival
-              - not-arrived
-              - departed
-              - cancelled
-              - provisional
-              - confirmed
+              $ref: '#/components/schemas/BookingStatus'
             extensions:
               type: array
               items:
@@ -4883,14 +4881,16 @@ components:
       enum:
         - ascending
         - descending
-    BookingSearchStatus:
+    BookingStatus:
       type: string
       enum:
+        - arrived
+        - awaiting-arrival
+        - not-arrived
+        - departed
+        - cancelled
         - provisional
         - confirmed
-        - active
-        - closed
-        - cancelled
     BookingSearchSortField:
       type: string
       enum:
@@ -4953,7 +4953,7 @@ components:
           type: string
           format: uuid
         status:
-          $ref: "#/components/schemas/BookingSearchStatus"
+          $ref: "#/components/schemas/BookingStatus"
         startDate:
           type: string
           format: date

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class BookingSearchResultFactory : Factory<BookingSearchResult> {
+  private var personCrn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
+  private var bookingStatus: Yielded<String> = {
+    randomOf(
+      listOf(
+        "arrived",
+        "awaiting-arrival",
+        "not-arrived",
+        "departed",
+        "cancelled",
+        "provisional",
+        "confirmed",
+      )
+    )
+  }
+  private var bookingStartDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var bookingEndDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
+  private var bookingCreatedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(30).randomDateTimeBefore() }
+  private var premisesId: Yielded<UUID> = { UUID.randomUUID() }
+  private var premisesName: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var premisesAddressLine1: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var premisesAddressLine2: Yielded<String>? = null
+  private var premisesTown: Yielded<String>? = null
+  private var premisesPostcode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var roomId: Yielded<UUID> = { UUID.randomUUID() }
+  private var roomName: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var bedId: Yielded<UUID> = { UUID.randomUUID() }
+  private var bedName: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+
+  override fun produce() = BookingSearchResult(
+    personName = null,
+    personCrn = this.personCrn(),
+    bookingId = this.bookingId(),
+    bookingStatus = this.bookingStatus(),
+    bookingStartDate = this.bookingStartDate(),
+    bookingEndDate = this.bookingEndDate(),
+    bookingCreatedAt = this.bookingCreatedAt(),
+    premisesId = this.premisesId(),
+    premisesName = this.premisesName(),
+    premisesAddressLine1 = this.premisesAddressLine1(),
+    premisesAddressLine2 = this.premisesAddressLine2?.invoke(),
+    premisesTown = this.premisesTown?.invoke(),
+    premisesPostcode = this.premisesPostcode(),
+    roomId = this.roomId(),
+    roomName = this.roomName(),
+    bedId = this.bedId(),
+    bedName = this.bedName(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
@@ -13,6 +14,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 class BookingSearchResultFactory : Factory<BookingSearchResult> {
+  private var personName: Yielded<String>? = null
   private var personCrn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
   private var bookingStatus: Yielded<String> = {
@@ -42,8 +44,16 @@ class BookingSearchResultFactory : Factory<BookingSearchResult> {
   private var bedId: Yielded<UUID> = { UUID.randomUUID() }
   private var bedName: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
 
+  fun withPersonName(personName: String) = apply {
+    this.personName = { personName }
+  }
+
+  fun withBookingStatus(bookingStatus: BookingStatus) = apply {
+    this.bookingStatus = { bookingStatus.value }
+  }
+
   override fun produce() = BookingSearchResult(
-    personName = null,
+    personName = this.personName?.invoke(),
     personCrn = this.personCrn(),
     bookingId = this.bookingId(),
     bookingStatus = this.bookingStatus(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
@@ -52,6 +52,10 @@ class BookingSearchResultFactory : Factory<BookingSearchResult> {
     this.bookingStatus = { bookingStatus.value }
   }
 
+  fun withBookingCreatedAt(bookingCreatedAt: OffsetDateTime) = apply {
+    this.bookingCreatedAt = { bookingCreatedAt }
+  }
+
   override fun produce() = BookingSearchResult(
     personName = this.personName?.invoke(),
     personCrn = this.personCrn(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -1,0 +1,338 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultPersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResultRoomSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import java.time.LocalDate
+
+class BookingSearchTest : IntegrationTestBase() {
+  @Test
+  fun `Searching for bookings without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/bookings/search")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Searching for Approved Premises bookings returns 200 with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        val allPremises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationRegion(userEntity.probationRegion)
+          withYieldedLocalAuthorityArea {
+            localAuthorityEntityFactory.produceAndPersist()
+          }
+        }
+
+        val allBeds = mutableListOf<BedEntity>()
+        allPremises.forEach { premises ->
+          val rooms = roomEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+
+          rooms.forEach { room ->
+            val bed = bedEntityFactory.produceAndPersist {
+              withRoom(room)
+            }
+
+            allBeds += bed
+          }
+        }
+
+        val allBookings = mutableListOf<BookingEntity>()
+        allBeds.forEach { bed ->
+          val booking = bookingEntityFactory.produceAndPersist {
+            withPremises(bed.room.premises)
+            withCrn(offenderDetails.otherIds.crn)
+            withBed(bed)
+            withServiceName(ServiceName.approvedPremises)
+          }
+
+          allBookings += booking
+        }
+
+        val expectedResponse = getExpectedResponse(allBookings, offenderDetails)
+
+        webTestClient.get()
+          .uri("/bookings/search")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedResponse))
+      }
+    }
+  }
+
+  @Test
+  fun `Searching for Temporary Accommodation bookings returns 200 with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        val allPremises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationRegion(userEntity.probationRegion)
+          withYieldedLocalAuthorityArea {
+            localAuthorityEntityFactory.produceAndPersist()
+          }
+        }
+
+        val allBeds = mutableListOf<BedEntity>()
+        allPremises.forEach { premises ->
+          val rooms = roomEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+
+          rooms.forEach { room ->
+            val bed = bedEntityFactory.produceAndPersist {
+              withRoom(room)
+            }
+
+            allBeds += bed
+          }
+        }
+
+        val allBookings = mutableListOf<BookingEntity>()
+        allBeds.forEach { bed ->
+          val booking = bookingEntityFactory.produceAndPersist {
+            withPremises(bed.room.premises)
+            withCrn(offenderDetails.otherIds.crn)
+            withBed(bed)
+            withServiceName(ServiceName.temporaryAccommodation)
+          }
+
+          allBookings += booking
+        }
+
+        val expectedResponse = getExpectedResponse(allBookings, offenderDetails)
+
+        webTestClient.get()
+          .uri("/bookings/search")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedResponse))
+      }
+    }
+  }
+
+  @Test
+  fun `Results are filtered by booking status when query parameter is supplied`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        val allPremises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationRegion(userEntity.probationRegion)
+          withYieldedLocalAuthorityArea {
+            localAuthorityEntityFactory.produceAndPersist()
+          }
+        }
+
+        val allBeds = mutableListOf<BedEntity>()
+        allPremises.forEach { premises ->
+          val rooms = roomEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+
+          rooms.forEach { room ->
+            val bed = bedEntityFactory.produceAndPersist {
+              withRoom(room)
+            }
+
+            allBeds += bed
+          }
+        }
+
+        val allBookings = mutableListOf<BookingEntity>()
+        allBeds.forEachIndexed { index, bed ->
+          val booking = bookingEntityFactory.produceAndPersist {
+            withPremises(bed.room.premises)
+            withCrn(offenderDetails.otherIds.crn)
+            withBed(bed)
+            withServiceName(ServiceName.temporaryAccommodation)
+          }
+
+          when (index % 5) {
+            // Provisional
+            0 -> {}
+            // Confirmed
+            1 -> {
+              val confirmation = confirmationEntityFactory.produceAndPersist {
+                withBooking(booking)
+              }
+
+              booking.confirmation = confirmation
+            }
+            // Active
+            2 -> {
+              val arrival = arrivalEntityFactory.produceAndPersist {
+                withBooking(booking)
+              }
+
+              booking.arrival = arrival
+            }
+            // Closed
+            3 -> {
+              val departure = departureEntityFactory.produceAndPersist {
+                withBooking(booking)
+                withYieldedReason {
+                  departureReasonEntityFactory.produceAndPersist()
+                }
+                withYieldedMoveOnCategory {
+                  moveOnCategoryEntityFactory.produceAndPersist()
+                }
+              }
+
+              booking.departures.add(departure)
+            }
+            // Cancelled
+            4 -> {
+              val cancellation = cancellationEntityFactory.produceAndPersist {
+                withBooking(booking)
+                withYieldedReason {
+                  cancellationReasonEntityFactory.produceAndPersist()
+                }
+              }
+
+              booking.cancellations.add(cancellation)
+            }
+          }
+
+          allBookings += booking
+        }
+
+        val expectedBookings = allBookings.filter { it.cancellation != null }
+
+        val expectedResponse = getExpectedResponse(expectedBookings, offenderDetails)
+
+        webTestClient.get()
+          .uri("/bookings/search?status=cancelled")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedResponse))
+      }
+    }
+  }
+
+  @Test
+  fun `Results are ordered by the given field and sort order when the query parameters are supplied`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        val allPremises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationRegion(userEntity.probationRegion)
+          withYieldedLocalAuthorityArea {
+            localAuthorityEntityFactory.produceAndPersist()
+          }
+        }
+
+        val allBeds = mutableListOf<BedEntity>()
+        allPremises.forEach { premises ->
+          val rooms = roomEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+
+          rooms.forEach { room ->
+            val bed = bedEntityFactory.produceAndPersist {
+              withRoom(room)
+            }
+
+            allBeds += bed
+          }
+        }
+
+        val allBookings = mutableListOf<BookingEntity>()
+        allBeds.forEachIndexed { index, bed ->
+          val booking = bookingEntityFactory.produceAndPersist {
+            withPremises(bed.room.premises)
+            withCrn(offenderDetails.otherIds.crn)
+            withBed(bed)
+            withServiceName(ServiceName.temporaryAccommodation)
+            withArrivalDate(LocalDate.now().minusDays((60 - index).toLong()))
+            withDepartureDate(LocalDate.now().minusDays((30 - index).toLong()))
+          }
+
+          allBookings += booking
+        }
+
+        val expectedBookings = allBookings.sortedByDescending { it.departureDate }
+
+        val expectedResponse = getExpectedResponse(expectedBookings, offenderDetails)
+
+        webTestClient.get()
+          .uri("/bookings/search?sortOrder=descending&sortField=endDate")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedResponse), true)
+      }
+    }
+  }
+
+  private fun getExpectedResponse(expectedBookings: List<BookingEntity>, offenderDetails: OffenderDetailSummary): BookingSearchResults {
+    return BookingSearchResults(
+      resultsCount = expectedBookings.size,
+      results = expectedBookings.map { booking ->
+        BookingSearchResult(
+          person = BookingSearchResultPersonSummary(
+            name = "${offenderDetails.firstName} ${offenderDetails.surname}",
+            crn = offenderDetails.otherIds.crn,
+          ),
+          booking = BookingSearchResultBookingSummary(
+            id = booking.id,
+            status = when {
+              booking.cancellation != null -> BookingStatus.cancelled
+              booking.departure != null -> BookingStatus.departed
+              booking.arrival != null -> BookingStatus.arrived
+              booking.nonArrival != null -> BookingStatus.notMinusArrived
+              booking.confirmation != null -> BookingStatus.confirmed
+              booking.service == ServiceName.approvedPremises.value -> BookingStatus.awaitingMinusArrival
+              else -> BookingStatus.provisional
+            },
+            startDate = booking.arrivalDate,
+            endDate = booking.departureDate,
+            createdAt = booking.createdAt.toInstant(),
+          ),
+          premises = BookingSearchResultPremisesSummary(
+            id = booking.premises.id,
+            name = booking.premises.name,
+            addressLine1 = booking.premises.addressLine1,
+            addressLine2 = booking.premises.addressLine2,
+            town = booking.premises.town,
+            postcode = booking.premises.postcode,
+          ),
+          room = BookingSearchResultRoomSummary(
+            id = booking.bed!!.room.id,
+            name = booking.bed!!.room.name,
+          ),
+          bed = BookingSearchResultBedSummary(
+            id = booking.bed!!.id,
+            name = booking.bed!!.name,
+          ),
+        )
+      }
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingSearchServiceTest.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingSearchResultFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class BookingSearchServiceTest {
+  private val mockBookingSearchRepository = mockk<BookingSearchRepository>()
+  private val mockOffenderService = mockk<OffenderService>()
+  private val mockUserService = mockk<UserService>()
+
+  private val bookingSearchService = BookingSearchService(
+    mockBookingSearchRepository,
+    mockOffenderService,
+    mockUserService,
+  )
+
+  @Test
+  fun `findBookings returns results from repository when offender details are found for all bookings`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { mockBookingSearchRepository.findBookings(any(), any()) } returns listOf(
+      BookingSearchResultFactory().produce(),
+      BookingSearchResultFactory().produce(),
+      BookingSearchResultFactory().produce(),
+    )
+
+    every { mockOffenderService.getOffenderByCrn(any(), any()) } returns AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce())
+
+    val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, SortOrder.ascending, BookingSearchSortField.bookingCreatedAt)
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity is ValidatableActionResult.Success).isTrue
+    val validationResult = result.entity as ValidatableActionResult.Success
+    assertThat(validationResult.entity).hasSize(3)
+    assertThat(validationResult.entity).allMatch {
+      it.personName != null
+    }
+  }
+
+  @Test
+  fun `findBookings returns Unauthorised when the user is not authorised to get offender details for a particular CRN`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { mockBookingSearchRepository.findBookings(any(), any()) } returns listOf(
+      BookingSearchResultFactory().produce(),
+      BookingSearchResultFactory().produce(),
+      BookingSearchResultFactory().produce(),
+    )
+
+    every { mockOffenderService.getOffenderByCrn(any(), any()) } returnsMany listOf(
+      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
+      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
+      AuthorisableActionResult.Unauthorised(),
+    )
+
+    val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, SortOrder.ascending, BookingSearchSortField.bookingCreatedAt)
+
+    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `findBookings does not provide a person's name when offender details for a particular CRN could not be found`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { mockBookingSearchRepository.findBookings(any(), any()) } returns listOf(
+      BookingSearchResultFactory().produce(),
+      BookingSearchResultFactory().produce(),
+      BookingSearchResultFactory().produce(),
+    )
+
+    every { mockOffenderService.getOffenderByCrn(any(), any()) } returnsMany listOf(
+      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
+      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
+      AuthorisableActionResult.NotFound(),
+    )
+
+    val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, SortOrder.ascending, BookingSearchSortField.bookingCreatedAt)
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity is ValidatableActionResult.Success).isTrue
+    val validationResult = result.entity as ValidatableActionResult.Success
+    assertThat(validationResult.entity).hasSize(3)
+    assertThat(validationResult.entity.dropLast(1)).allSatisfy {
+      assertThat(it.personName).isNotNull()
+    }
+    assertThat(validationResult.entity.last().personName).isNull()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSearchTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSearchTransformerTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingSearchResultFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingSearchResultTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class BookingSearchTransformerTest {
+  private val bookingSearchResultTransformer = BookingSearchResultTransformer()
+
+  @Test
+  fun `transformDomainToApi transforms correctly`() {
+    val domainResults = listOf(
+      BookingSearchResultFactory()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(BookingStatus.provisional)
+        .produce(),
+      BookingSearchResultFactory()
+        .withBookingStatus(BookingStatus.awaitingMinusArrival)
+        .produce(),
+      BookingSearchResultFactory()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(BookingStatus.confirmed)
+        .produce(),
+      BookingSearchResultFactory()
+        .withBookingStatus(BookingStatus.notMinusArrived)
+        .produce(),
+      BookingSearchResultFactory()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(BookingStatus.arrived)
+        .produce(),
+      BookingSearchResultFactory()
+        .withBookingStatus(BookingStatus.departed)
+        .produce(),
+      BookingSearchResultFactory()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(BookingStatus.cancelled)
+        .produce(),
+    )
+
+    val result = bookingSearchResultTransformer.transformDomainToApi(domainResults)
+
+    assertThat(result.resultsCount).isEqualTo(7)
+
+    result.results.forEachIndexed { index, it ->
+      val domainResult = domainResults[index]
+
+      assertThat(it.person.name).isEqualTo(domainResult.personName ?: "")
+      assertThat(it.person.crn).isEqualTo(domainResult.personCrn)
+      assertThat(it.booking.id).isEqualTo(domainResult.bookingId)
+      assertThat(it.booking.status.value).isEqualTo(domainResult.bookingStatus)
+      assertThat(it.booking.startDate).isEqualTo(domainResult.bookingStartDate)
+      assertThat(it.booking.endDate).isEqualTo(domainResult.bookingEndDate)
+      assertThat(it.booking.createdAt).isEqualTo(domainResult.bookingCreatedAt.toInstant())
+      assertThat(it.premises.id).isEqualTo(domainResult.premisesId)
+      assertThat(it.premises.name).isEqualTo(domainResult.premisesName)
+      assertThat(it.premises.addressLine1).isEqualTo(domainResult.premisesAddressLine1)
+      assertThat(it.premises.addressLine2).isEqualTo(domainResult.premisesAddressLine2)
+      assertThat(it.premises.town).isEqualTo(domainResult.premisesTown)
+      assertThat(it.premises.postcode).isEqualTo(domainResult.premisesPostcode)
+      assertThat(it.room.id).isEqualTo(domainResult.roomId)
+      assertThat(it.room.name).isEqualTo(domainResult.roomName)
+      assertThat(it.bed.id).isEqualTo(domainResult.bedId)
+      assertThat(it.bed.name).isEqualTo(domainResult.bedName)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
@@ -208,7 +209,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
-        status = Booking.Status.awaitingMinusArrival,
+        status = BookingStatus.awaitingMinusArrival,
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
@@ -246,7 +247,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
-        status = Booking.Status.provisional,
+        status = BookingStatus.provisional,
         extensions = listOf(),
         serviceName = ServiceName.temporaryAccommodation,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
@@ -300,7 +301,7 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = null,
-        status = Booking.Status.notMinusArrived,
+        status = BookingStatus.notMinusArrived,
         nonArrival = Nonarrival(
           id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
           bookingId = UUID.fromString("655f72ba-51eb-4965-b6ac-45bcc6271b19"),
@@ -365,7 +366,7 @@ class BookingTransformerTest {
           keyWorker = true,
           name = "first last"
         ),
-        status = Booking.Status.arrived,
+        status = BookingStatus.arrived,
         arrival = Arrival(
           bookingId = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
           arrivalDate = LocalDate.parse("2022-08-10"),
@@ -427,7 +428,7 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = null,
-        status = Booking.Status.cancelled,
+        status = BookingStatus.cancelled,
         cancellation = Cancellation(
           bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
           date = LocalDate.parse("2022-08-10"),
@@ -520,7 +521,7 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = null,
-        status = Booking.Status.cancelled,
+        status = BookingStatus.cancelled,
         cancellation = Cancellation(
           bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
           notes = null,
@@ -653,7 +654,7 @@ class BookingTransformerTest {
           keyWorker = true,
           name = "first last"
         ),
-        status = Booking.Status.departed,
+        status = BookingStatus.departed,
         arrival = Arrival(
           bookingId = bookingId,
           arrivalDate = LocalDate.parse("2022-08-10"),
@@ -879,7 +880,7 @@ class BookingTransformerTest {
           keyWorker = true,
           name = "first last"
         ),
-        status = Booking.Status.departed,
+        status = BookingStatus.departed,
         arrival = Arrival(
           bookingId = bookingId,
           arrivalDate = LocalDate.parse("2022-08-10"),
@@ -1014,7 +1015,7 @@ class BookingTransformerTest {
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = null,
-        status = Booking.Status.confirmed,
+        status = BookingStatus.confirmed,
         cancellation = null,
         confirmation = Confirmation(
           id = UUID.fromString("69fc6350-b2ec-4e99-9a2f-e829e83535e8"),


### PR DESCRIPTION
> See [ticket #971 on the CAS3 Trello board](https://trello.com/c/QeqfZz0s/971-new-api-endpoint-to-get-all-bookings-filtered-by-status).

This PR implements the `GET /bookings/search` endpoint introduced by the OpenAPI specification changes from #533. This enables the delivery of the "find a booking" feature in the Temporary Accommodation service.

Changes in this PR:
- The `X-Service-Name` header in the `GET /bookings/search` endpoint has been added as a required header. This is a formality from the frontend client's point of view as it's already provided for all API requests by default, but allows the API to filter bookings by service type, avoiding the possibility of reporting bookings for the wrong service.
- The `BookingSearchRepository` class has been introduced to perform the actual query against the database for bookings. It allows for optionally filtering the results by booking status and probation region, but is not responsible for sorting the results (see below).
- The `BookingSearchService` class has been introduced. The service determines the user's probation region if the calling service is Temporary Accommodation and queries the repository using the provided or derived filters. It then iterates over the results to retrieve the name of the person the booking is for by calling the Community API using their CRN. Finally, it sorts according to the specified sort field and order - which must happen at this stage rather than in the SQL query as the person's name is required to be one of the sort fields, and is not available any earlier than this.
- The `BookingSearchResultTransformer` class has been introduced to map the results of the `BookingSearchService` to the API model.
- The `BookingSearchController` class has been introduced to handle the API endpoint. It provides default values for the search order and field if they are not provided by the client before delegating to the `BookingSearchService`. 
