### PR TITLE
Fix tasksGet endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -21,6 +21,8 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<AssessmentEntity>
 
   fun findAllByReallocatedAtNull(): List<AssessmentEntity>
+
+  fun findAllByReallocatedAtNullAndSubmittedAtNull(): List<AssessmentEntity>
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -22,6 +22,8 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
 
   fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<PlacementRequestEntity>
 
+  fun findAllByReallocatedAtNullAndBooking_IdNull(): List<PlacementRequestEntity>
+
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): PlacementRequestEntity?
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -65,6 +65,17 @@ class AssessmentService(
     return assessments
   }
 
+  fun getAllReallocatable(): List<AssessmentEntity> {
+    val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)
+    val assessments = assessmentRepository.findAllByReallocatedAtNullAndSubmittedAtNull()
+
+    assessments.forEach {
+      it.schemaUpToDate = it.schemaVersion.id == latestSchema.id
+    }
+
+    return assessments
+  }
+
   fun getAssessmentForUser(user: UserEntity, assessmentId: UUID): AuthorisableActionResult<AssessmentEntity> {
     // TODO: Potentially needs LAO enforcing too: https://trello.com/c/alNxpm9e/856-investigate-whether-assessors-will-have-access-to-limited-access-offenders
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -50,6 +50,10 @@ class PlacementRequestService(
     return placementRequestRepository.findAllByAllocatedToUser_IdAndReallocatedAtNull(user.id)
   }
 
+  fun getAllReallocatable(): List<PlacementRequestEntity> {
+    return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNull()
+  }
+
   fun getPlacementRequestForUser(user: UserEntity, id: UUID): AuthorisableActionResult<PlacementRequestEntity> {
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()


### PR DESCRIPTION
Before this was fetching assessments regardless of if they’d been submitted or not, as well as only fetching placement requests that had been allocated to the logged in user, which is not what we want.

This adds a `getAllReallocatable` service method to the Assessment service, which only fetches unsubmitted and unreallocated assessments and a `getAllReallocatable` service method to the PlacementRequest service, which only fetches unreallocated Placement Requests without an associated booking.