### PR TITLE
(1444) Record and return release type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -99,6 +99,7 @@ class ApprovedPremisesApplicationEntity(
   val teamCodes: MutableList<ApplicationTeamCodeEntity>,
   @OneToMany(mappedBy = "application")
   var placementRequests: MutableList<PlacementRequestEntity>,
+  var releaseType: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
@@ -11,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 @Component
 class PlacementRequestTransformer(
   private val personTransformer: PersonTransformer,
-  private val risksTransformer: RisksTransformer
+  private val risksTransformer: RisksTransformer,
 ) {
   fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): PlacementRequest {
     return PlacementRequest(
@@ -28,7 +29,8 @@ class PlacementRequestTransformer(
       person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
       risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn),
       applicationId = jpa.application.id,
-      assessmentId = jpa.assessment.id
+      assessmentId = jpa.assessment.id,
+      releaseType = getReleaseType(jpa.application.releaseType),
     )
   }
 
@@ -49,6 +51,15 @@ class PlacementRequestTransformer(
     "hasTactileFlooring" -> PlacementCriteria.hasTactileFlooring
     "hasBrailleSignage" -> PlacementCriteria.hasBrailleSignage
     "hasHearingLoop" -> PlacementCriteria.hasHearingLoop
+    else -> { null }
+  }
+
+  private fun getReleaseType(releaseType: String?): ReleaseTypeOption? = when (releaseType) {
+    "licence" -> ReleaseTypeOption.licence
+    "rotl" -> ReleaseTypeOption.rotl
+    "hdc" -> ReleaseTypeOption.hdc
+    "pss" -> ReleaseTypeOption.pss
+    "in_community" -> ReleaseTypeOption.inCommunity
     else -> { null }
   }
 }

--- a/src/main/resources/db/migration/all/20230411165209__add_release_type_to_application.sql
+++ b/src/main/resources/db/migration/all/20230411165209__add_release_type_to_application.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN release_type TEXT;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4084,6 +4084,7 @@ components:
           $ref: '#/components/schemas/AnyValue'
         requirements:
           $ref: '#/components/schemas/PlacementRequirements'
+
       required:
         - document
     AssessmentRejection:
@@ -4669,6 +4670,8 @@ components:
             assessmentId:
               type: string
               format: uuid
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
       required:
         - person
         - risks

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -35,6 +35,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf<AssessmentEntity>() }
   private var teamCodes: Yielded<MutableList<ApplicationTeamCodeEntity>> = { mutableListOf() }
   private var placementRequests: Yielded<MutableList<PlacementRequestEntity>> = { mutableListOf() }
+  private var releaseType: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -108,6 +109,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.placementRequests = { placementRequests }
   }
 
+  fun withReleaseType(releaseType: String) = apply {
+    this.releaseType = { releaseType }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -126,6 +131,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     riskRatings = this.riskRatings(),
     assessments = this.assessments(),
     teamCodes = this.teamCodes(),
-    placementRequests = this.placementRequests()
+    placementRequests = this.placementRequests(),
+    releaseType = this.releaseType(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -890,6 +890,7 @@ class ApplicationServiceTest {
       val persistedApplication = validatableActionResult.entity as ApprovedPremisesApplicationEntity
       assertThat(persistedApplication.isPipeApplication).isTrue
       assertThat(persistedApplication.isWomensApplication).isFalse
+      assertThat(persistedApplication.releaseType).isEqualTo(submitApplication.releaseType.toString())
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) { mockAssessmentService.createAssessment(application) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
+
+class PlacementRequestTransformerTest {
+  private val personTransformer = PersonTransformer()
+  private val risksTransformer = RisksTransformer()
+
+  private val placementRequestTransformer = PlacementRequestTransformer(personTransformer, risksTransformer)
+
+  @Test
+  fun `transformJpaToApi transforms a basic placement request entity`() {
+    val offenderDetailSummary = OffenderDetailsSummaryFactory().produce()
+    val inmateDetail = InmateDetailFactory().produce()
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withReleaseType("licence")
+      .withCreatedByUser(user)
+      .produce()
+
+    val assessment = AssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val placementRequestEntity = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withEssentialCriteria(
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("isSemiSpecialistMentalHealth").produce(),
+          CharacteristicEntityFactory().withPropertyName("isRecoveryFocussed").produce(),
+          CharacteristicEntityFactory().withPropertyName("someOtherPropertyName").produce(),
+        ),
+      )
+      .withDesirableCriteria(
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("hasWideStepFreeAccess").produce(),
+          CharacteristicEntityFactory().withPropertyName("hasLift").produce(),
+          CharacteristicEntityFactory().withPropertyName("hasBrailleSignage").produce(),
+          CharacteristicEntityFactory().withPropertyName("somethingElse").produce(),
+        ),
+      )
+      .withAllocatedToUser(user)
+      .produce()
+
+    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, offenderDetailSummary, inmateDetail)
+
+    assertThat(result).isEqualTo(
+      PlacementRequest(
+        id = placementRequestEntity.id,
+        gender = placementRequestEntity.gender,
+        type = placementRequestEntity.apType,
+        expectedArrival = placementRequestEntity.expectedArrival,
+        duration = placementRequestEntity.duration,
+        location = placementRequestEntity.postcodeDistrict.outcode,
+        radius = placementRequestEntity.radius,
+        essentialCriteria = listOf(PlacementCriteria.isSemiSpecialistMentalHealth, PlacementCriteria.isRecoveryFocussed),
+        desirableCriteria = listOf(PlacementCriteria.hasWideStepFreeAccess, PlacementCriteria.hasLift, PlacementCriteria.hasBrailleSignage),
+        mentalHealthSupport = placementRequestEntity.mentalHealthSupport,
+        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        risks = risksTransformer.transformDomainToApi(placementRequestEntity.application.riskRatings!!, placementRequestEntity.application.crn),
+        applicationId = application.id,
+        assessmentId = assessment.id,
+        releaseType = ReleaseTypeOption.licence,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
We need to return the release type when listing placement requests. This is something we already send when an application is submitted, but this is only used for the Domain Event. We then need to add a new database column, so we can persist it in the database too, and return it when listing / showing placement requests.