### PR TITLE
Add `all-except-integration` migration set to local profile

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,7 +5,7 @@ spring:
     driverClassName: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5431/approved_premises_localdev
   flyway:
-    locations: classpath:db/migration/all,classpath:db/migration/local+dev
+    locations: classpath:db/migration/all,classpath:db/migration/local+dev,classpath:db/migration/all-except-integration
   jpa:
     database: postgresql
   redis:


### PR DESCRIPTION
This should have been added when the `all-except-integation` and `integration` migration sets were split out but I missed it!