### PR TITLE
Fix NonUniqueResultException when checking for conflicts with bookings/lost beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -24,7 +24,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   fun getHighestBookingDate(premisesId: UUID): LocalDate?
 
   @Query("SELECT b FROM BookingEntity b WHERE b.bed.id = :bedId AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate AND SIZE(b.cancellations) = 0 AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)")
-  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): BookingEntity?
+  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<BookingEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedsEntity.kt
@@ -33,7 +33,7 @@ interface LostBedsRepository : JpaRepository<LostBedsEntity, UUID> {
           c is NULL
   """,
   )
-  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): LostBedsEntity?
+  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<LostBedsEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -904,7 +904,7 @@ class BookingService(
     arrivalDate,
     departureDate,
     thisEntityId
-  )
+  ).firstOrNull()
 
   fun getLostBedWithConflictingDates(
     startDate: LocalDate,
@@ -916,7 +916,7 @@ class BookingService(
     startDate,
     endDate,
     thisEntityId
-  )
+  ).firstOrNull()
 }
 
 sealed interface GetBookingForPremisesResult {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1624,8 +1624,8 @@ class BookingServiceTest {
       .produce()
 
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val existingApplication = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(user)
@@ -1655,8 +1655,8 @@ class BookingServiceTest {
     val departureDate = LocalDate.parse("2023-02-23")
 
     every { mockBedRepository.findByIdOrNull(bedId) } returns null
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -1708,8 +1708,8 @@ class BookingServiceTest {
 
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
     every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
@@ -1751,8 +1751,8 @@ class BookingServiceTest {
       .produce()
 
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val existingApplication = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(user)
@@ -1797,8 +1797,8 @@ class BookingServiceTest {
       .produce()
 
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val existingApplication = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(user)
@@ -1848,8 +1848,8 @@ class BookingServiceTest {
       .produce()
 
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val existingApplication = ApprovedPremisesApplicationEntityFactory()
       .withCrn(crn)
@@ -1953,8 +1953,8 @@ class BookingServiceTest {
 
     every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -1986,8 +1986,8 @@ class BookingServiceTest {
 
     every { mockBedRepository.findByIdOrNull(bedId) } returns null
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -2016,8 +2016,8 @@ class BookingServiceTest {
     val departureDate = LocalDate.parse("2023-02-22")
 
     every { mockBedRepository.findByIdOrNull(bedId) } returns null
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -2064,8 +2064,8 @@ class BookingServiceTest {
 
     every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, arrivalDate, departureDate, bed.id)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -2190,8 +2190,8 @@ class BookingServiceTest {
     every { mockPlacementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
       user = user,
@@ -2252,13 +2252,15 @@ class BookingServiceTest {
     every { mockPlacementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns BookingEntityFactory()
-      .withArrivalDate(arrivalDate)
-      .withDepartureDate(departureDate)
-      .withPremises(premises)
-      .withBed(bed)
-      .produce()
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf(
+      BookingEntityFactory()
+        .withArrivalDate(arrivalDate)
+        .withDepartureDate(departureDate)
+        .withPremises(premises)
+        .withBed(bed)
+        .produce()
+    )
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
       user = user,
@@ -2319,14 +2321,16 @@ class BookingServiceTest {
     every { mockPlacementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns LostBedsEntityFactory()
-      .withStartDate(arrivalDate)
-      .withEndDate(departureDate)
-      .withPremises(premises)
-      .withBed(bed)
-      .withYieldedReason { LostBedReasonEntityFactory().produce() }
-      .produce()
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf(
+      LostBedsEntityFactory()
+        .withStartDate(arrivalDate)
+        .withEndDate(departureDate)
+        .withPremises(premises)
+        .withBed(bed)
+        .withYieldedReason { LostBedReasonEntityFactory().produce() }
+        .produce()
+    )
 
     val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
       user = user,
@@ -2388,8 +2392,8 @@ class BookingServiceTest {
       .withRoom(room)
       .produce()
 
-    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
-    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns null
+    every { mockBookingRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
     every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 


### PR DESCRIPTION
The original logic (written in Kotlin) used `.firstOrNull()` to get a single booking or lost bed that conflicts (if any existed). The logic was later converted into JPQL queries which returned a nullable single result, which works as long as the query returns 0 or 1 results, but more than one results in a NonUniqueResultException. Unfortunately, JPQL doesn't have any `LIMIT 1`/`FETCH FIRST ROW ONLY` construct, so the repository methods that execute the JPQL queries have been updated to return a list. The service methods then call `.firstOrNull()` on the list returned by the repository to achieve the same result as the original logic.