### PR TITLE
Set selfDiagnosis level to DEBUG on AppInsights in dev to ascertain available JMX metrics

### DIFF
--- a/applicationinsights.nonprod.json
+++ b/applicationinsights.nonprod.json
@@ -11,7 +11,8 @@
     }
   },
   "selfDiagnostics": {
-    "destination": "console"
+    "destination": "console",
+    "level": "DEBUG"
   },
   "preview": {
     "sampling": {


### PR DESCRIPTION
Ideally we will collect and ship to AppInsights:
- Max Heap
- Heap Committed
- Heap Used
- GCs

This property causes AppInsights to log available JMX metrics so we can progress this.