### PR TITLE
Add/update cancellation reasons for Temporary Accommodation

### DIFF
--- a/src/main/resources/db/migration/all/20230414145914__update_cancellation_reasons_for_temporary_accommodation.sql
+++ b/src/main/resources/db/migration/all/20230414145914__update_cancellation_reasons_for_temporary_accommodation.sql
@@ -1,0 +1,22 @@
+UPDATE cancellation_reasons
+SET name = 'Alternative suitable accommodation provided by Local Authority'
+WHERE name = 'Alternative suitable accommodation provided by LHA'
+AND service_scope = 'temporary-accommodation';
+
+UPDATE cancellation_reasons
+SET name = 'Alternative suitable accommodation provided - Other (inc. AP, CAS2, friends/family etc.)'
+WHERE name = 'Alternative suitable accommodation provided (Other)'
+AND service_scope = 'temporary-accommodation';
+
+UPDATE cancellation_reasons
+SET name = 'Person on probation rejected placement'
+WHERE name = 'Person on probation rejected placement (Out of area)'
+AND service_scope = 'temporary-accommodation';
+
+UPDATE cancellation_reasons
+SET name = 'Withdrawn by referrer (e.g. recalled, further custody, placement related risk concern)'
+WHERE name = 'Withdrawn by referrer'
+AND service_scope = 'temporary-accommodation';
+
+INSERT INTO cancellation_reasons(id, name, is_active, service_scope)
+VALUES ('2a7fc443-2f31-4501-90c4-435a6e8e59d3', 'Supplier unable to accommodate (Please explain in notes)', TRUE, 'temporary-accommodation');


### PR DESCRIPTION
> See [ticket #1005 on the CAS3 Trello board](https://trello.com/c/KgbBdrru/1005-update-new-cancellation-reasons-provided-by-the-central-team).

The CAS3 team has been provided with an updated list of cancellation reasons to be used within the Temporary Accommodation service.

Unlike in #569, all of the changes to existing reasons are on reasons with a `service_scope` of `'temporary-accommodation'`, so have been updated in place.