### PR TITLE
Ensure requirements are copied when reallocated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -103,7 +103,9 @@ class PlacementRequestService(
         id = UUID.randomUUID(),
         reallocatedAt = null,
         allocatedToUser = assigneeUser,
-        createdAt = dateTimeNow
+        createdAt = dateTimeNow,
+        desirableCriteria = currentPlacementRequest.desirableCriteria.toList(),
+        essentialCriteria = currentPlacementRequest.essentialCriteria.toList(),
       )
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -330,10 +330,16 @@ class TasksTest : IntegrationTestBase() {
               )
 
             val placementRequests = placementRequestRepository.findAll()
+            val allocatedPlacementRequest = placementRequests.find { it.allocatedToUser.id == assigneeUser.id }
 
             Assertions.assertThat(placementRequests.first { it.id == existingPlacementRequest.id }.reallocatedAt).isNotNull
-            Assertions.assertThat(placementRequests)
-              .anyMatch { it.application.id == application.id && it.allocatedToUser.id == assigneeUser.id }
+            Assertions.assertThat(allocatedPlacementRequest).isNotNull
+
+            val desirableCriteria = allocatedPlacementRequest!!.desirableCriteria.map { it.propertyName }
+            val essentialCriteria = allocatedPlacementRequest!!.essentialCriteria.map { it.propertyName }
+
+            Assertions.assertThat(desirableCriteria).isEqualTo(existingPlacementRequest.desirableCriteria.map { it.propertyName })
+            Assertions.assertThat(essentialCriteria).isEqualTo(existingPlacementRequest.essentialCriteria.map { it.propertyName })
           }
         }
       }


### PR DESCRIPTION
Before, when a placement request was reallocated, the requirements were not copied over. To make this work properly, we need to load the relation by calling `toList` on each collection. We can’t eagerly load the relation as we get a `MultipleBagsException`. There are all manner of complex workarounds, but this seems to do the trick and only results in two additional queries, so not worth the additional stress and complexity.