### PR TITLE
Implement support for either PDU name or ID when creating or updating a Temporary Accommodation premises

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 
   implementation("org.jetbrains.kotlinx:dataframe:0.10.0")
 
+  implementation("io.arrow-kt:arrow-core:1.1.5")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.5")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
+import arrow.core.Ior
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -132,7 +133,7 @@ class PremisesController(
         body.characteristicIds,
         body.notes,
         body.status,
-        body.pdu,
+        Ior.fromNullables(body.pdu, body.probationDeliveryUnitId)?.toEither(),
       )
 
     val validationResult = when (updatePremisesResult) {
@@ -198,7 +199,7 @@ class PremisesController(
         notes = body.notes,
         characteristicIds = body.characteristicIds,
         status = body.status,
-        pdu = body.pdu,
+        probationDeliveryUnitIdentifier = Ior.fromNullables(body.pdu, body.probationDeliveryUnitId)?.toEither(),
       )
     )
     return ResponseEntity(premisesTransformer.transformJpaToApi(premises, premises.totalBeds), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
@@ -12,6 +12,10 @@ import javax.persistence.Table
 @Repository
 interface ProbationDeliveryUnitRepository : JpaRepository<ProbationDeliveryUnitEntity, UUID> {
   fun findAllByProbationRegion_Id(probationRegionId: UUID): List<ProbationDeliveryUnitEntity>
+
+  fun findByIdAndProbationRegion_Id(id: UUID, probationRegionId: UUID): ProbationDeliveryUnitEntity?
+
+  fun findByNameAndProbationRegion_Id(name: String, probationRegionId: UUID): ProbationDeliveryUnitEntity?
 }
 
 @Entity

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2794,6 +2794,9 @@ components:
           $ref: '#/components/schemas/PropertyStatus'
         pdu:
           type: string
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
       required:
         - name
         - addressLine1
@@ -4074,6 +4077,9 @@ components:
           $ref: '#/components/schemas/PropertyStatus'
         pdu:
           type: string
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
       required:
         - addressLine1
         - postcode

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -47,6 +48,7 @@ class PremisesServiceTest {
   private val localAuthorityAreaRepositoryMock = mockk<LocalAuthorityAreaRepository>()
   private val probationRegionRepositoryMock = mockk<ProbationRegionRepository>()
   private val lostBedCancellationRepositoryMock = mockk<LostBedCancellationRepository>()
+  private val probationDeliveryUnitRepositoryMock = mockk<ProbationDeliveryUnitRepository>()
   private val characteristicServiceMock = mockk<CharacteristicService>()
 
   private val premisesService = PremisesService(
@@ -57,6 +59,7 @@ class PremisesServiceTest {
     localAuthorityAreaRepositoryMock,
     probationRegionRepositoryMock,
     lostBedCancellationRepositoryMock,
+    probationDeliveryUnitRepositoryMock,
     characteristicServiceMock
   )
 


### PR DESCRIPTION
> See [ticket #1015 on the CAS3 Trello board](https://trello.com/c/5Jhi2OZF/1015-re-associate-existing-premises-to-the-new-pdu-records).

This PR is the second part of the work to migrate Temporary Accommodation premises away from using opaque strings for probation delivery units (PDUs). It follows on from #550, which introduced a reference data endpoint for PDUs to the API and provided the infrastructure to perform this migration.

This PR updates the `POST /premises` and `PUT /premises/{premisesId}` endpoints to allow an ID representing a PDU in the database to be provided.

To maintain backwards compatibility while transitioning to modelling premises PDUs in a structured way, when creating or updating a premises, the `PremisesService` now accepts an `Either<String, UUID>` that represents both the legacy PDU name as well as the ID of a PDU that exists in the database. The `PremisesService.tryGetProbationDeliveryUnit` method is used to perform the validation for the legacy `pdu` name field or the `probationDeliveryUnitId` UUID (as appropriate) and uses the relevant repository method to obtain a `ProbationDeliveryUnitEntity` instance.

From this point, the use of `probationDeliveryUnitId` is preferred, which is reflected in the use of `UUID` as the second type argument of `Either` (which is right-biased) and the validation error `"empty"` being reported on that property instead of `pdu` when neither has a value.

The PDU is still stored in the premises as a string name rather than as an ID to a foreign key table, but performing the work to resolve the name or ID now will reduce the work needed to migrate premises away from string PDU names.