### PR TITLE
Upgrade to Redis 7.0.11 in dev

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
       - "5433:5432"
 
   integration_test_redis:
-    image: "bitnami/redis:5.0"
+    image: "bitnami/redis:7.0.11"
     container_name: approved-premises-redis-test
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - ./nomis-db:/nomis-db
 
   redis:
-    image: "bitnami/redis:5.0"
+    image: "bitnami/redis:7.0.11"
     container_name: approved-premises-redis-dev
     environment:
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
- The API appears to still work when we create a CAS1 application we can see redis keys added for the offenderDetailsCache
- Our environments are currently running version 4.x.x
- We've been asked to upgrade due to EOL
- I can't find out why we are using bitnami rather than the official redis image, to avoid potential problems with the upgrade I'm going to keep the surface area of problems smaller by staying with the same maintainer - one for later
- apparently redis supports backwards compatibility even between major changes[1] so we should be able to attempt the otherwise big jump in one go

[1] https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/upgrade.html#upgrade-paths