### PR TITLE
Clear applications and premises in dev on deploy

### DIFF
--- a/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
+++ b/src/main/resources/db/migration/local+dev/R__2_create_premises.sql
@@ -1,5 +1,7 @@
 -- ${flyway:timestamp}
 
+TRUNCATE TABLE premises CASCADE;
+
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 1', 'd33006b7-55d9-4a8e-b722-5e18093dbcdf', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'Something House', NULL, 'LA9 1DS', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active', 30) ON CONFLICT (id) DO NOTHING;
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 2', 'ada106c7-e1fb-409a-a38e-0002ea8e7e45', '89faa462-7ea6-45ba-b169-93d947d20cae', 'Something Court', NULL, 'EC1 3XZ', '6b4a1308-17af-4c1a-a330-6005bec9e27b', 'temporary-accommodation', 'active', 10) ON CONFLICT (id) DO NOTHING;
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status", "total_beds") values ('Address 3', '36c7b1f2-5a4b-467b-838c-2970c9c253cf', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'Something Place', NULL, 'SA1 1AF', 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'temporary-accommodation', 'active', 25) ON CONFLICT (id) DO NOTHING;

--- a/src/main/resources/db/migration/local+dev/R__5_clear_applications.sql
+++ b/src/main/resources/db/migration/local+dev/R__5_clear_applications.sql
@@ -1,0 +1,4 @@
+-- ${flyway:timestamp}
+
+TRUNCATE TABLE applications CASCADE;
+TRUNCATE table assessments CASCADE;


### PR DESCRIPTION
This ensures a clean database when we deploy, and stops the DB getting clogged with test data. A drawback is that we don’t have realistic premises data in dev/test, but we don’t have seeded data in test anyway, so this is not a concern.