### PR TITLE
1451 - Applications Summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -137,7 +137,7 @@ class ApplicationsController(
 
     val serializedData = objectMapper.writeValueAsString(body.data)
 
-    val applicationResult = when(body) {
+    val applicationResult = when (body) {
       is UpdateApprovedPremisesApplication -> applicationService.updateApprovedPremisesApplication(
         applicationId = applicationId,
         data = serializedData,
@@ -347,10 +347,10 @@ class ApplicationsController(
     return applicationsTransformer.transformJpaToApi(application, offender, inmate)
   }
 
-  private fun getPersonDetailAndTransformToSummary(application: ApplicationEntity): ApplicationSummary {
-    val (offender, inmate) = getPersonDetail(application.crn)
+  private fun getPersonDetailAndTransformToSummary(application: uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary): ApplicationSummary {
+    val (offender, inmate) = getPersonDetail(application.getCrn())
 
-    return applicationsTransformer.transformJpaToApiSummary(application, offender, inmate)
+    return applicationsTransformer.transformDomainToApiSummary(application, offender, inmate)
   }
 
   private fun getPersonDetailAndTransform(offlineApplication: OfflineApplicationEntity): Application {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -106,6 +106,7 @@ class ApprovedPremisesApplicationEntity(
   @OneToMany(mappedBy = "application")
   var placementRequests: MutableList<PlacementRequestEntity>,
   var releaseType: String?,
+  var arrivalDate: OffsetDateTime?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import java.sql.Timestamp
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Convert
@@ -40,6 +41,78 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query("SELECT a FROM ApplicationEntity a WHERE a.id = :id")
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   fun findByIdOrNullWithWriteLock(id: UUID): ApplicationEntity?
+
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt,
+    ass.submitted_at as latestAssessmentSubmittedAt,
+    ass.decision as latestAssessmentDecision,
+    (SELECT COUNT(1) FROM assessment_clarification_notes acn WHERE acn.assessment_id = ass.id AND acn.response IS NULL) > 0 as latestAssessmentHasClarificationNotesWithoutResponse,
+    (SELECT COUNT(1) FROM placement_requests pr WHERE pr.application_id = apa.id) > 0 as hasPlacementRequest,
+    (SELECT COUNT(1) FROM bookings b WHERE b.application_id = apa.id) > 0 as hasBooking,
+    apa.is_womens_application as isWomensApplication,
+    apa.is_pipe_application as isPipeApplication,
+    apa.arrival_date as arrivalDate,
+    CAST(apa.risk_ratings AS TEXT) as riskRatings
+FROM approved_premises_applications apa
+LEFT JOIN applications a ON a.id = apa.id
+LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL;
+""",
+    nativeQuery = true
+  )
+  fun findAllApprovedPremisesSummaries(): List<ApprovedPremisesApplicationSummary>
+
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt,
+    ass.submitted_at as latestAssessmentSubmittedAt,
+    ass.decision as latestAssessmentDecision,
+    (SELECT COUNT(1) FROM assessment_clarification_notes acn WHERE acn.assessment_id = ass.id AND acn.response IS NULL) > 0 as latestAssessmentHasClarificationNotesWithoutResponse,
+    (SELECT COUNT(1) FROM placement_requests pr WHERE pr.application_id = apa.id) > 0 as hasPlacementRequest,
+    (SELECT COUNT(1) FROM bookings b WHERE b.application_id = apa.id) > 0 as hasBooking,
+    apa.is_womens_application as isWomensApplication,
+    apa.is_pipe_application as isPipeApplication,
+    apa.arrival_date as arrivalDate,
+    CAST(apa.risk_ratings AS TEXT) as riskRatings
+FROM approved_premises_applications apa
+LEFT JOIN applications a ON a.id = apa.id
+LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL 
+WHERE (SELECT COUNT(1) FROM approved_premises_application_team_codes apatc WHERE apatc.application_id = apa.id AND apatc.team_code IN :teamCodes) > 0
+""",
+    nativeQuery = true
+  )
+  fun findApprovedPremisesSummariesForManagingTeams(teamCodes: List<String>): List<ApprovedPremisesApplicationSummary>
+
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt,
+    ass.submitted_at as latestAssessmentSubmittedAt,
+    ass.decision as latestAssessmentDecision,
+    (SELECT COUNT(1) FROM assessment_clarification_notes acn WHERE acn.assessment_id = ass.id AND acn.response IS NULL) > 0 as latestAssessmentHasClarificationNotesWithoutResponse,
+    (SELECT COUNT(1) FROM bookings b WHERE b.application_id = taa.id) > 0 as hasBooking
+FROM temporary_accommodation_applications taa 
+LEFT JOIN applications a ON a.id = taa.id 
+LEFT JOIN assessments ass ON ass.application_id = taa.id AND ass.reallocated_at IS NULL 
+WHERE a.created_by_user_id = :userId
+""",
+    nativeQuery = true
+  )
+  fun findAllTemporaryAccommodationSummariesCreatedByUser(userId: UUID): List<TemporaryAccommodationApplicationSummary>
 }
 
 @Entity
@@ -182,3 +255,25 @@ class TemporaryAccommodationApplicationEntity(
 ) {
   override fun getRequiredQualifications(): List<UserQualification> = emptyList()
 }
+
+interface ApplicationSummary {
+  fun getId(): UUID
+  fun getCrn(): String
+  fun getCreatedByUserId(): UUID
+  fun getCreatedAt(): Timestamp
+  fun getSubmittedAt(): Timestamp?
+  fun getLatestAssessmentSubmittedAt(): Timestamp?
+  fun getLatestAssessmentDecision(): AssessmentDecision?
+  fun getLatestAssessmentHasClarificationNotesWithoutResponse(): Boolean
+  fun getHasBooking(): Boolean
+}
+
+interface ApprovedPremisesApplicationSummary : ApplicationSummary {
+  fun getHasPlacementRequest(): Boolean
+  fun getIsWomensApplication(): Boolean?
+  fun getIsPipeApplication(): Boolean?
+  fun getArrivalDate(): Timestamp?
+  fun getRiskRatings(): String?
+}
+
+interface TemporaryAccommodationApplicationSummary : ApplicationSummary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
@@ -42,6 +42,16 @@ class ApprovedPremisesApplicationJsonSchemaEntity(
 ) : JsonSchemaEntity(id, addedAt, schema)
 
 @Entity
+@DiscriminatorValue("TEMPORARY_ACCOMMODATION_APPLICATION")
+@Table(name = "temporary_accommodation_application_json_schemas")
+@PrimaryKeyJoinColumn(name = "json_schema_id")
+class TemporaryAccommodationApplicationJsonSchemaEntity(
+  id: UUID,
+  addedAt: OffsetDateTime,
+  schema: String,
+) : JsonSchemaEntity(id, addedAt, schema)
+
+@Entity
 @DiscriminatorValue("APPROVED_PREMISES_ASSESSMENT")
 @Table(name = "approved_premises_assessment_json_schemas")
 @PrimaryKeyJoinColumn(name = "json_schema_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -40,6 +40,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.ZoneOffset
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -220,6 +221,7 @@ class ApplicationService(
         teamCodes = mutableListOf(),
         placementRequests = mutableListOf(),
         releaseType = null,
+        arrivalDate = null
       ),
     )
 
@@ -322,6 +324,7 @@ class ApplicationService(
       submittedAt = OffsetDateTime.now()
       document = serializedTranslatedDocument
       releaseType = submitApplication.releaseType.toString()
+      arrivalDate = submitApplication.arrivalDate?.atOffset(ZoneOffset.UTC)
     }
 
     assessmentService.createAssessment(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -53,7 +57,38 @@ class ApplicationsTransformer(
     else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
   }
 
+  fun transformJpaToApiSummary(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): ApplicationSummary = when (jpa) {
+    is ApprovedPremisesApplicationEntity -> ApprovedPremisesApplicationSummary(
+      id = jpa.id,
+      person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+      createdByUserId = jpa.createdByUser.id,
+      createdAt = jpa.createdAt.toInstant(),
+      submittedAt = jpa.submittedAt?.toInstant(),
+      isWomensApplication = jpa.isWomensApplication,
+      isPipeApplication = jpa.isPipeApplication,
+      arrivalDate = jpa.arrivalDate?.toInstant(),
+      risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null,
+      status = getStatus(jpa)
+    )
+    is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplicationSummary(
+      id = jpa.id,
+      person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+      createdByUserId = jpa.createdByUser.id,
+      createdAt = jpa.createdAt.toInstant(),
+      submittedAt = jpa.submittedAt?.toInstant(),
+      status = getStatus(jpa)
+    )
+    else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
+  }
+
   fun transformJpaToApi(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplication(
+    id = jpa.id,
+    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+    createdAt = jpa.createdAt.toInstant(),
+    submittedAt = jpa.submittedAt.toInstant()
+  )
+
+  fun transformJpaToApiSummary(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplicationSummary(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -32,6 +32,7 @@ class ApplicationsTransformer(
       submittedAt = jpa.submittedAt?.toInstant(),
       isWomensApplication = jpa.isWomensApplication,
       isPipeApplication = jpa.isPipeApplication,
+      arrivalDate = jpa.arrivalDate?.toInstant(),
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -1,23 +1,28 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary as ApiApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary as ApiApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary as ApiTemporaryAccommodationApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary as DomainApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary as DomainApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity as DomainTemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationSummary as DomainTemporaryAccommodationApplicationSummary
 
 @Component
 class ApplicationsTransformer(
@@ -42,7 +47,7 @@ class ApplicationsTransformer(
       risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null,
       status = getStatus(jpa)
     )
-    is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
+    is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
       id = jpa.id,
       person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
       createdByUserId = jpa.createdByUser.id,
@@ -57,28 +62,32 @@ class ApplicationsTransformer(
     else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
   }
 
-  fun transformJpaToApiSummary(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): ApplicationSummary = when (jpa) {
-    is ApprovedPremisesApplicationEntity -> ApprovedPremisesApplicationSummary(
-      id = jpa.id,
+  fun transformDomainToApiSummary(domain: DomainApplicationSummary, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): ApiApplicationSummary = when (domain) {
+    is DomainApprovedPremisesApplicationSummary -> {
+      val riskRatings = if (domain.getRiskRatings() != null) objectMapper.readValue<PersonRisks>(domain.getRiskRatings()!!) else null
+
+      ApiApprovedPremisesApplicationSummary(
+        id = domain.getId(),
+        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        createdByUserId = domain.getCreatedByUserId(),
+        createdAt = domain.getCreatedAt().toInstant(),
+        submittedAt = domain.getSubmittedAt()?.toInstant(),
+        isWomensApplication = domain.getIsWomensApplication(),
+        isPipeApplication = domain.getIsPipeApplication(),
+        arrivalDate = domain.getArrivalDate()?.toInstant(),
+        risks = if (riskRatings != null) risksTransformer.transformDomainToApi(riskRatings, domain.getCrn()) else null,
+        status = getStatusFromSummary(domain)
+      )
+    }
+    is DomainTemporaryAccommodationApplicationSummary -> ApiTemporaryAccommodationApplicationSummary(
+      id = domain.getId(),
       person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
-      createdByUserId = jpa.createdByUser.id,
-      createdAt = jpa.createdAt.toInstant(),
-      submittedAt = jpa.submittedAt?.toInstant(),
-      isWomensApplication = jpa.isWomensApplication,
-      isPipeApplication = jpa.isPipeApplication,
-      arrivalDate = jpa.arrivalDate?.toInstant(),
-      risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null,
-      status = getStatus(jpa)
+      createdByUserId = domain.getCreatedByUserId(),
+      createdAt = domain.getCreatedAt().toInstant(),
+      submittedAt = domain.getSubmittedAt()?.toInstant(),
+      status = getStatusFromSummary(domain)
     )
-    is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplicationSummary(
-      id = jpa.id,
-      person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
-      createdByUserId = jpa.createdByUser.id,
-      createdAt = jpa.createdAt.toInstant(),
-      submittedAt = jpa.submittedAt?.toInstant(),
-      status = getStatus(jpa)
-    )
-    else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
+    else -> throw RuntimeException("Unrecognised application type when transforming: ${domain::class.qualifiedName}")
   }
 
   fun transformJpaToApi(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplication(
@@ -113,6 +122,26 @@ class ApplicationsTransformer(
     return when {
       latestAssessment?.clarificationNotes?.any { it.response == null } == true -> ApplicationStatus.requestedFurtherInformation
       entity.submittedAt !== null -> ApplicationStatus.submitted
+      else -> ApplicationStatus.inProgress
+    }
+  }
+
+  private fun getStatusFromSummary(entity: DomainApplicationSummary): ApplicationStatus {
+    if (entity is DomainApprovedPremisesApplicationSummary) {
+      return when {
+        entity.getSubmittedAt() != null && entity.getLatestAssessmentDecision() == AssessmentDecision.REJECTED -> ApplicationStatus.rejected
+        entity.getSubmittedAt() != null && entity.getLatestAssessmentDecision() == AssessmentDecision.ACCEPTED && !entity.getHasPlacementRequest() -> ApplicationStatus.pending
+        entity.getSubmittedAt() != null && entity.getLatestAssessmentDecision() == AssessmentDecision.ACCEPTED && !entity.getHasBooking() -> ApplicationStatus.awaitingPlacement
+        entity.getSubmittedAt() != null && entity.getLatestAssessmentDecision() == AssessmentDecision.ACCEPTED && entity.getHasBooking() -> ApplicationStatus.placed
+        entity.getLatestAssessmentHasClarificationNotesWithoutResponse() -> ApplicationStatus.requestedFurtherInformation
+        entity.getSubmittedAt() !== null -> ApplicationStatus.submitted
+        else -> ApplicationStatus.inProgress
+      }
+    }
+
+    return when {
+      entity.getLatestAssessmentHasClarificationNotesWithoutResponse() -> ApplicationStatus.requestedFurtherInformation
+      entity.getSubmittedAt() !== null -> ApplicationStatus.submitted
       else -> ApplicationStatus.inProgress
     }
   }

--- a/src/main/resources/db/migration/all/20230417115757__add_arrival_date_to_ap_applications.sql
+++ b/src/main/resources/db/migration/all/20230417115757__add_arrival_date_to_ap_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN arrival_date TIMESTAMP WITH TIME ZONE;

--- a/src/main/resources/db/migration/all/20230418103022__add_ta_application_schema.sql
+++ b/src/main/resources/db/migration/all/20230418103022__add_ta_application_schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE temporary_accommodation_application_json_schemas (
+    json_schema_id UUID NOT NULL,
+    PRIMARY KEY (json_schema_id),
+    FOREIGN KEY (json_schema_id) REFERENCES json_schemas(id)
+);
+
+INSERT INTO json_schemas (id, added_at, "schema") VALUES  ('18499823-422e-4813-be61-ef24d2534a18', NOW(), '{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "title": "Application Placeholder Schema",
+ "description": "An application schema that requires no properties",
+ "type": "object",
+ "properties": {},
+ "required": []
+}');
+
+INSERT INTO temporary_accommodation_application_json_schemas (json_schema_id) VALUES
+    ('18499823-422e-4813-be61-ef24d2534a18');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1433,7 +1433,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Application'
+                  $ref: '#/components/schemas/ApplicationSummary'
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -3849,6 +3849,71 @@ components:
             - createdByUserId
             - schemaVersion
             - outdatedSchema
+            - status
+    ApplicationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: type
+        mapping:
+          Offline: '#/components/schemas/OfflineApplicationSummary'
+          CAS1: '#/components/schemas/ApprovedPremisesApplicationSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationApplicationSummary'
+      required:
+        - id
+        - person
+        - createdAt
+        - type
+    OfflineApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties: { }
+    ApprovedPremisesApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+            arrivalDate:
+              type: string
+              format: date-time
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+          required:
+            - createdByUserId
+            - status
+    TemporaryAccommodationApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+          required:
+            - createdByUserId
             - status
     ApplicationStatus:
       type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3802,6 +3802,9 @@ components:
               type: boolean
             isPipeApplication:
               type: boolean
+            arrivalDate:
+              type: string
+              format: date-time
             risks:
               $ref: '#/components/schemas/PersonRisks'
             createdByUserId:
@@ -3902,6 +3905,9 @@ components:
           type: string
         releaseType:
           $ref: '#/components/schemas/ReleaseTypeOption'
+        arrivalDate:
+          type: string
+          format: date-time
       required:
         - translatedDocument
         - isPipeApplication

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3886,12 +3886,32 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/AnyValue'
-        isWomensApplication:
-          type: boolean
-        isPipeApplication:
-          type: boolean
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/UpdateApprovedPremisesApplication'
+          CAS3: '#/components/schemas/UpdateTemporaryAccommodationApplication'
       required:
         - data
+    UpdateApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+            targetLocation:
+              type: string
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            arrivalDate:
+              type: string
+              format: date-time
+    UpdateTemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
     SubmitApplication:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTeamCodeEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTeamCodeEntityFactory.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+class ApplicationTeamCodeEntityFactory : Factory<ApplicationTeamCodeEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var application: Yielded<ApprovedPremisesApplicationEntity>? = null
+  private var teamCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+  fun withApplication(application: ApprovedPremisesApplicationEntity) = apply {
+    this.application = { application }
+  }
+  fun withTeamCode(teamCode: String) = apply {
+    this.teamCode = { teamCode }
+  }
+
+  override fun produce() = ApplicationTeamCodeEntity(
+    id = this.id(),
+    application = this.application?.invoke() ?: throw RuntimeException("Must provide an Application"),
+    teamCode = this.teamCode()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -36,6 +36,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var teamCodes: Yielded<MutableList<ApplicationTeamCodeEntity>> = { mutableListOf() }
   private var placementRequests: Yielded<MutableList<PlacementRequestEntity>> = { mutableListOf() }
   private var releaseType: Yielded<String?> = { null }
+  private var arrivalDate: Yielded<OffsetDateTime?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -113,6 +114,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.releaseType = { releaseType }
   }
 
+  fun withArrivalDate(arrivalDate: OffsetDateTime?) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -133,5 +138,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     teamCodes = this.teamCodes(),
     placementRequests = this.placementRequests(),
     releaseType = this.releaseType(),
+    arrivalDate = this.arrivalDate()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -40,7 +40,7 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     this.query = { query }
   }
 
-  fun withResponse(response: String) = apply {
+  fun withResponse(response: String?) = apply {
     this.response = { response }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationJsonSchemaEntityFactory.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class TemporaryAccommodationApplicationJsonSchemaEntityFactory : Factory<TemporaryAccommodationApplicationJsonSchemaEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var addedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var schema: Yielded<String> = { "{}" }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAddedAt(addedAt: OffsetDateTime) = apply {
+    this.addedAt = { addedAt }
+  }
+
+  fun withSchema(schema: String) = apply {
+    this.schema = { schema }
+  }
+
+  fun withPermissiveSchema() = apply {
+    withSchema(
+      """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """
+    )
+  }
+
+  override fun produce() = TemporaryAccommodationApplicationJsonSchemaEntity(
+    id = this.id(),
+    addedAt = this.addedAt(),
+    schema = this.schema(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -1,0 +1,352 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import java.time.OffsetDateTime
+
+class ApplicationSummaryQueryTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realApplicationRepository: ApplicationRepository
+
+  @Test
+  fun `findAllApprovedPremisesSummaries query works as described`() {
+    `Given a User` { user, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val postcodeDistrict = postCodeDistrictFactory.produceAndPersist()
+
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(
+            probationRegionEntityFactory.produceAndPersist {
+              withApArea(apAreaEntityFactory.produceAndPersist())
+            }
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val room = roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withRoom(room)
+        }
+
+        val nonSubmittedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsPipeApplication(true)
+          withIsWomensApplication(false)
+          withReleaseType("rotl")
+          withSubmittedAt(null)
+        }
+
+        val submittedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsPipeApplication(true)
+          withIsWomensApplication(false)
+          withReleaseType("rotl")
+          withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))
+        }
+
+        val assessmentForSubmittedApplication = assessmentEntityFactory.produceAndPersist {
+          withApplication(submittedApplication)
+          withAllocatedToUser(user)
+          withAssessmentSchema(assessmentSchema)
+          withSubmittedAt(OffsetDateTime.parse("2023-04-19T10:15:00+01:00"))
+        }
+
+        val unansweredClarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
+          withAssessment(assessmentForSubmittedApplication)
+          withCreatedBy(user)
+          withResponse(null)
+        }
+
+        val booking = bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBed(bed)
+          withApplication(submittedApplication)
+        }
+
+        val placementRequest = placementRequestFactory.produceAndPersist {
+          withApplication(submittedApplication)
+          withAssessment(assessmentForSubmittedApplication)
+          withAllocatedToUser(user)
+          withPostcodeDistrict(postcodeDistrict)
+          withEssentialCriteria(emptyList())
+          withDesirableCriteria(emptyList())
+          withBooking(booking)
+        }
+
+        val results = realApplicationRepository.findAllApprovedPremisesSummaries()
+
+        results.first { it.getId() == nonSubmittedApplication.id }.let {
+          assertThat(it.getCrn()).isEqualTo(nonSubmittedApplication.crn)
+          assertThat(it.getCreatedByUserId()).isEqualTo(nonSubmittedApplication.createdByUser.id)
+          assertThat(it.getCreatedAt().toInstant()).isEqualTo(nonSubmittedApplication.createdAt.toInstant())
+          assertThat(it.getSubmittedAt()?.toInstant()).isEqualTo(nonSubmittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentSubmittedAt()).isNull()
+          assertThat(it.getLatestAssessmentDecision()).isNull()
+          assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(false)
+          assertThat(it.getHasPlacementRequest()).isEqualTo(false)
+          assertThat(it.getHasBooking()).isEqualTo(false)
+        }
+
+        results.first { it.getId() == submittedApplication.id }.let {
+          assertThat(it.getCrn()).isEqualTo(submittedApplication.crn)
+          assertThat(it.getCreatedByUserId()).isEqualTo(submittedApplication.createdByUser.id)
+          assertThat(it.getCreatedAt().toInstant()).isEqualTo(submittedApplication.createdAt.toInstant())
+          assertThat(it.getSubmittedAt()?.toInstant()).isEqualTo(submittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentSubmittedAt()?.toInstant()).isEqualTo(assessmentForSubmittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentDecision()).isEqualTo(assessmentForSubmittedApplication.decision)
+          assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(true)
+          assertThat(it.getHasPlacementRequest()).isEqualTo(true)
+          assertThat(it.getHasBooking()).isEqualTo(true)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `findApprovedPremisesSummariesForManagingTeams query works as described`() {
+    `Given a User` { user, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val postcodeDistrict = postCodeDistrictFactory.produceAndPersist()
+
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(
+            probationRegionEntityFactory.produceAndPersist {
+              withApArea(apAreaEntityFactory.produceAndPersist())
+            }
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val room = roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withRoom(room)
+        }
+
+        val applicationForDifferentTeam = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsPipeApplication(true)
+          withIsWomensApplication(false)
+          withReleaseType("rotl")
+          withSubmittedAt(null)
+        }
+
+        val teamCodeForApplicationForDifferentTeam = applicationTeamCodeFactory.produceAndPersist {
+          withApplication(applicationForDifferentTeam)
+          withTeamCode("TEAM2")
+        }
+
+        val nonSubmittedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsPipeApplication(true)
+          withIsWomensApplication(false)
+          withReleaseType("rotl")
+          withSubmittedAt(null)
+        }
+
+        val teamCodeForNonSubmittedApplication = applicationTeamCodeFactory.produceAndPersist {
+          withApplication(nonSubmittedApplication)
+          withTeamCode("TEAM1")
+        }
+
+        val submittedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsPipeApplication(true)
+          withIsWomensApplication(false)
+          withReleaseType("rotl")
+          withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))
+        }
+
+        val teamCodeForSubmittedApplication = applicationTeamCodeFactory.produceAndPersist {
+          withApplication(submittedApplication)
+          withTeamCode("TEAM1")
+        }
+
+        val assessmentForSubmittedApplication = assessmentEntityFactory.produceAndPersist {
+          withApplication(submittedApplication)
+          withAllocatedToUser(user)
+          withAssessmentSchema(assessmentSchema)
+          withSubmittedAt(OffsetDateTime.parse("2023-04-19T10:15:00+01:00"))
+        }
+
+        val unansweredClarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
+          withAssessment(assessmentForSubmittedApplication)
+          withCreatedBy(user)
+          withResponse(null)
+        }
+
+        val booking = bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBed(bed)
+          withApplication(submittedApplication)
+        }
+
+        val placementRequest = placementRequestFactory.produceAndPersist {
+          withApplication(submittedApplication)
+          withAssessment(assessmentForSubmittedApplication)
+          withAllocatedToUser(user)
+          withPostcodeDistrict(postcodeDistrict)
+          withEssentialCriteria(emptyList())
+          withDesirableCriteria(emptyList())
+          withBooking(booking)
+        }
+
+        val results = realApplicationRepository.findApprovedPremisesSummariesForManagingTeams(listOf("TEAM1"))
+
+        results.first { it.getId() == nonSubmittedApplication.id }.let {
+          assertThat(it.getCrn()).isEqualTo(nonSubmittedApplication.crn)
+          assertThat(it.getCreatedByUserId()).isEqualTo(nonSubmittedApplication.createdByUser.id)
+          assertThat(it.getCreatedAt().toInstant()).isEqualTo(nonSubmittedApplication.createdAt.toInstant())
+          assertThat(it.getSubmittedAt()?.toInstant()).isEqualTo(nonSubmittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentSubmittedAt()).isNull()
+          assertThat(it.getLatestAssessmentDecision()).isNull()
+          assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(false)
+          assertThat(it.getHasPlacementRequest()).isEqualTo(false)
+          assertThat(it.getHasBooking()).isEqualTo(false)
+        }
+
+        results.first { it.getId() == submittedApplication.id }.let {
+          assertThat(it.getCrn()).isEqualTo(submittedApplication.crn)
+          assertThat(it.getCreatedByUserId()).isEqualTo(submittedApplication.createdByUser.id)
+          assertThat(it.getCreatedAt().toInstant()).isEqualTo(submittedApplication.createdAt.toInstant())
+          assertThat(it.getSubmittedAt()?.toInstant()).isEqualTo(submittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentSubmittedAt()?.toInstant()).isEqualTo(assessmentForSubmittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentDecision()).isEqualTo(assessmentForSubmittedApplication.decision)
+          assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(true)
+          assertThat(it.getHasPlacementRequest()).isEqualTo(true)
+          assertThat(it.getHasBooking()).isEqualTo(true)
+        }
+
+        assertThat(results).noneMatch {
+          it.getId() == applicationForDifferentTeam.id
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `findAllTemporaryAccommodationSummariesCreatedByUser query works as described`() {
+    `Given a User` { user, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val postcodeDistrict = postCodeDistrictFactory.produceAndPersist()
+
+        val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(
+            probationRegionEntityFactory.produceAndPersist {
+              withApArea(apAreaEntityFactory.produceAndPersist())
+            }
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val room = roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withRoom(room)
+        }
+
+        val nonSubmittedApplication = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withSubmittedAt(null)
+        }
+
+        val submittedApplication = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))
+        }
+
+        val assessmentForSubmittedApplication = assessmentEntityFactory.produceAndPersist {
+          withApplication(submittedApplication)
+          withAllocatedToUser(user)
+          withAssessmentSchema(assessmentSchema)
+          withSubmittedAt(OffsetDateTime.parse("2023-04-19T10:15:00+01:00"))
+        }
+
+        val unansweredClarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
+          withAssessment(assessmentForSubmittedApplication)
+          withCreatedBy(user)
+          withResponse(null)
+        }
+
+        val booking = bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBed(bed)
+          withApplication(submittedApplication)
+        }
+
+        val results = realApplicationRepository.findAllTemporaryAccommodationSummariesCreatedByUser(user.id)
+
+        results.first { it.getId() == nonSubmittedApplication.id }.let {
+          assertThat(it.getCrn()).isEqualTo(nonSubmittedApplication.crn)
+          assertThat(it.getCreatedByUserId()).isEqualTo(nonSubmittedApplication.createdByUser.id)
+          assertThat(it.getCreatedAt().toInstant()).isEqualTo(nonSubmittedApplication.createdAt.toInstant())
+          assertThat(it.getSubmittedAt()?.toInstant()).isEqualTo(nonSubmittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentSubmittedAt()).isNull()
+          assertThat(it.getLatestAssessmentDecision()).isNull()
+          assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(false)
+          assertThat(it.getHasBooking()).isEqualTo(false)
+        }
+
+        results.first { it.getId() == submittedApplication.id }.let {
+          assertThat(it.getCrn()).isEqualTo(submittedApplication.crn)
+          assertThat(it.getCreatedByUserId()).isEqualTo(submittedApplication.createdByUser.id)
+          assertThat(it.getCreatedAt().toInstant()).isEqualTo(submittedApplication.createdAt.toInstant())
+          assertThat(it.getSubmittedAt()?.toInstant()).isEqualTo(submittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentSubmittedAt()?.toInstant()).isEqualTo(assessmentForSubmittedApplication.submittedAt?.toInstant())
+          assertThat(it.getLatestAssessmentDecision()).isEqualTo(assessmentForSubmittedApplication.decision)
+          assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(true)
+          assertThat(it.getHasBooking()).isEqualTo(true)
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -21,11 +21,11 @@ import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
@@ -190,16 +190,14 @@ class ApplicationTest : IntegrationTestBase() {
               .responseBody
               .blockFirst()
 
-            val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplication>>() {})
+            val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {})
 
             assertThat(responseBody).anyMatch {
               outdatedApplicationEntityManagedByTeam.id == it.id &&
                 outdatedApplicationEntityManagedByTeam.crn == it.person?.crn &&
                 outdatedApplicationEntityManagedByTeam.createdAt.toInstant() == it.createdAt &&
                 outdatedApplicationEntityManagedByTeam.createdByUser.id == it.createdByUserId &&
-                outdatedApplicationEntityManagedByTeam.submittedAt?.toInstant() == it.submittedAt &&
-                serializableToJsonNode(outdatedApplicationEntityManagedByTeam.data) == serializableToJsonNode(it.data) &&
-                olderJsonSchema.id == it.schemaVersion && it.outdatedSchema
+                outdatedApplicationEntityManagedByTeam.submittedAt?.toInstant() == it.submittedAt
             }
 
             assertThat(responseBody).anyMatch {
@@ -207,9 +205,7 @@ class ApplicationTest : IntegrationTestBase() {
                 upToDateApplicationEntityManagedByTeam.crn == it.person?.crn &&
                 upToDateApplicationEntityManagedByTeam.createdAt.toInstant() == it.createdAt &&
                 upToDateApplicationEntityManagedByTeam.createdByUser.id == it.createdByUserId &&
-                upToDateApplicationEntityManagedByTeam.submittedAt?.toInstant() == it.submittedAt &&
-                serializableToJsonNode(upToDateApplicationEntityManagedByTeam.data) == serializableToJsonNode(it.data) &&
-                newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
+                upToDateApplicationEntityManagedByTeam.submittedAt?.toInstant() == it.submittedAt
             }
 
             assertThat(responseBody).noneMatch {
@@ -328,16 +324,14 @@ class ApplicationTest : IntegrationTestBase() {
               .responseBody
               .blockFirst()
 
-            val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplication>>() {})
+            val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {})
 
             assertThat(responseBody).anyMatch {
               outdatedApplicationEntityCreatedByUser.id == it.id &&
                 outdatedApplicationEntityCreatedByUser.crn == it.person?.crn &&
                 outdatedApplicationEntityCreatedByUser.createdAt.toInstant() == it.createdAt &&
                 outdatedApplicationEntityCreatedByUser.createdByUser.id == it.createdByUserId &&
-                outdatedApplicationEntityCreatedByUser.submittedAt?.toInstant() == it.submittedAt &&
-                serializableToJsonNode(outdatedApplicationEntityCreatedByUser.data) == serializableToJsonNode(it.data) &&
-                olderJsonSchema.id == it.schemaVersion && it.outdatedSchema
+                outdatedApplicationEntityCreatedByUser.submittedAt?.toInstant() == it.submittedAt
             }
 
             assertThat(responseBody).anyMatch {
@@ -345,9 +339,7 @@ class ApplicationTest : IntegrationTestBase() {
                 upToDateApplicationEntityCreatedByUser.crn == it.person?.crn &&
                 upToDateApplicationEntityCreatedByUser.createdAt.toInstant() == it.createdAt &&
                 upToDateApplicationEntityCreatedByUser.createdByUser.id == it.createdByUserId &&
-                upToDateApplicationEntityCreatedByUser.submittedAt?.toInstant() == it.submittedAt &&
-                serializableToJsonNode(upToDateApplicationEntityCreatedByUser.data) == serializableToJsonNode(it.data) &&
-                newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
+                upToDateApplicationEntityCreatedByUser.submittedAt?.toInstant() == it.submittedAt
             }
 
             assertThat(responseBody).anyMatch {
@@ -355,9 +347,7 @@ class ApplicationTest : IntegrationTestBase() {
                 outdatedApplicationEntityNotCreatedByUser.crn == it.person?.crn &&
                 outdatedApplicationEntityNotCreatedByUser.createdAt.toInstant() == it.createdAt &&
                 outdatedApplicationEntityNotCreatedByUser.createdByUser.id == it.createdByUserId &&
-                outdatedApplicationEntityNotCreatedByUser.submittedAt?.toInstant() == it.submittedAt &&
-                serializableToJsonNode(outdatedApplicationEntityNotCreatedByUser.data) == serializableToJsonNode(it.data) &&
-                olderJsonSchema.id == it.schemaVersion && it.outdatedSchema
+                outdatedApplicationEntityNotCreatedByUser.submittedAt?.toInstant() == it.submittedAt
             }
 
             assertThat(responseBody).anyMatch {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
@@ -987,7 +988,7 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Update existing application returns 200 with correct body`() {
+  fun `Update existing AP application returns 200 with correct body`() {
     `Given a User` { submittingUser, jwt ->
       `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE)) { assessorUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
@@ -1027,7 +1028,7 @@ class ApplicationTest : IntegrationTestBase() {
             .uri("/applications/$applicationId")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
-              UpdateApplication(
+              UpdateApprovedPremisesApplication(
                 data = mapOf("thingId" to 123),
                 isWomensApplication = false,
                 isPipeApplication = true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -21,6 +21,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTeamCodeEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentJsonSchemaEntityFactory
@@ -55,11 +56,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliver
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
@@ -97,6 +100,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
@@ -138,6 +142,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.OfflineApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PostCodeDistrictTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationDeliveryUnitTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationApplicationJsonSchemaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssignmentTestRepository
@@ -244,13 +250,16 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesApplicationRepository: ApprovedPremisesApplicationTestRepository
 
   @Autowired
-  lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationPremisesTestRepository
+  lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationApplicationTestRepository
 
   @Autowired
   lateinit var offlineApplicationRepository: OfflineApplicationTestRepository
 
   @Autowired
   lateinit var approvedPremisesApplicationJsonSchemaRepository: ApprovedPremisesApplicationJsonSchemaTestRepository
+
+  @Autowired
+  lateinit var temporaryAccommodationApplicationJsonSchemaRepository: TemporaryAccommodationApplicationJsonSchemaTestRepository
 
   @Autowired
   lateinit var approvedPremisesAssessmentJsonSchemaRepository: ApprovedPremisesAssessmentJsonSchemaTestRepository
@@ -321,6 +330,7 @@ abstract class IntegrationTestBase {
   lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
   lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
+  lateinit var temporaryAccommodationApplicationJsonSchemaEntityFactory: PersistedFactory<TemporaryAccommodationApplicationJsonSchemaEntity, UUID, TemporaryAccommodationApplicationJsonSchemaEntityFactory>
   lateinit var approvedPremisesAssessmentJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesAssessmentJsonSchemaEntity, UUID, ApprovedPremisesAssessmentJsonSchemaEntityFactory>
   lateinit var userEntityFactory: PersistedFactory<UserEntity, UUID, UserEntityFactory>
   lateinit var userRoleAssignmentEntityFactory: PersistedFactory<UserRoleAssignmentEntity, UUID, UserRoleAssignmentEntityFactory>
@@ -335,6 +345,7 @@ abstract class IntegrationTestBase {
   lateinit var placementRequestFactory: PersistedFactory<PlacementRequestEntity, UUID, PlacementRequestEntityFactory>
   lateinit var bookingNotMadeFactory: PersistedFactory<BookingNotMadeEntity, UUID, BookingNotMadeEntityFactory>
   lateinit var probationDeliveryUnitFactory: PersistedFactory<ProbationDeliveryUnitEntity, UUID, ProbationDeliveryUnitEntityFactory>
+  lateinit var applicationTeamCodeFactory: PersistedFactory<ApplicationTeamCodeEntity, UUID, ApplicationTeamCodeEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -384,8 +395,10 @@ abstract class IntegrationTestBase {
     extensionEntityFactory = PersistedFactory({ ExtensionEntityFactory() }, extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory({ NonArrivalReasonEntityFactory() }, nonArrivalReasonRepository)
     approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)
+    temporaryAccommodationApplicationEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationEntityFactory() }, temporaryAccommodationApplicationRepository)
     offlineApplicationEntityFactory = PersistedFactory({ OfflineApplicationEntityFactory() }, offlineApplicationRepository)
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesApplicationJsonSchemaEntityFactory() }, approvedPremisesApplicationJsonSchemaRepository)
+    temporaryAccommodationApplicationJsonSchemaEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationJsonSchemaEntityFactory() }, temporaryAccommodationApplicationJsonSchemaRepository)
     approvedPremisesAssessmentJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesAssessmentJsonSchemaEntityFactory() }, approvedPremisesAssessmentJsonSchemaRepository)
     userEntityFactory = PersistedFactory({ UserEntityFactory() }, userRepository)
     userRoleAssignmentEntityFactory = PersistedFactory({ UserRoleAssignmentEntityFactory() }, userRoleAssignmentRepository)
@@ -400,6 +413,7 @@ abstract class IntegrationTestBase {
     placementRequestFactory = PersistedFactory({ PlacementRequestEntityFactory() }, placementRequestRepository)
     bookingNotMadeFactory = PersistedFactory({ BookingNotMadeEntityFactory() }, bookingNotMadeRepository)
     probationDeliveryUnitFactory = PersistedFactory({ ProbationDeliveryUnitEntityFactory() }, probationDeliveryUnitRepository)
+    applicationTeamCodeFactory = PersistedFactory({ ApplicationTeamCodeEntityFactory() }, applicationTeamCodeRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/JsonSchemaTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/JsonSchemaTestRepository.kt
@@ -4,10 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import java.util.UUID
 
 @Repository
 interface ApprovedPremisesApplicationJsonSchemaTestRepository : JpaRepository<ApprovedPremisesApplicationJsonSchemaEntity, UUID>
+
+@Repository
+interface TemporaryAccommodationApplicationJsonSchemaTestRepository : JpaRepository<TemporaryAccommodationApplicationJsonSchemaEntity, UUID>
 
 @Repository
 interface ApprovedPremisesAssessmentJsonSchemaTestRepository : JpaRepository<ApprovedPremisesAssessmentJsonSchemaEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -534,15 +534,17 @@ class ApplicationServiceTest {
 
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns null
 
-    assertThat(applicationService.updateApprovedPremisesApplication(
-      applicationId = applicationId,
-      isWomensApplication = false,
-      isPipeApplication = null,
-      releaseType = null,
-      arrivalDate = null,
-      data = "{}",
-      username = username
-    ) is AuthorisableActionResult.NotFound).isTrue
+    assertThat(
+      applicationService.updateApprovedPremisesApplication(
+        applicationId = applicationId,
+        isWomensApplication = false,
+        isPipeApplication = null,
+        releaseType = null,
+        arrivalDate = null,
+        data = "{}",
+        username = username
+      ) is AuthorisableActionResult.NotFound
+    ).isTrue
   }
 
   @Test
@@ -574,15 +576,17 @@ class ApplicationServiceTest {
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-    assertThat(applicationService.updateApprovedPremisesApplication(
-      applicationId = applicationId,
-      isWomensApplication = false,
-      isPipeApplication = null,
-      releaseType = null,
-      arrivalDate = null,
-      data = "{}",
-      username = username
-    ) is AuthorisableActionResult.Unauthorised).isTrue
+    assertThat(
+      applicationService.updateApprovedPremisesApplication(
+        applicationId = applicationId,
+        isWomensApplication = false,
+        isPipeApplication = null,
+        releaseType = null,
+        arrivalDate = null,
+        data = "{}",
+        username = username
+      ) is AuthorisableActionResult.Unauthorised
+    ).isTrue
   }
 
   @Test
@@ -742,7 +746,6 @@ class ApplicationServiceTest {
     assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T14:10:00+01:00"))
   }
 
-  //here
   @Test
   fun `updateTemporaryAccommodationApplication returns NotFound when application doesn't exist`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
@@ -750,11 +753,13 @@ class ApplicationServiceTest {
 
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns null
 
-    assertThat(applicationService.updateTemporaryAccommodationApplication(
-      applicationId = applicationId,
-      data = "{}",
-      username = username
-    ) is AuthorisableActionResult.NotFound).isTrue
+    assertThat(
+      applicationService.updateTemporaryAccommodationApplication(
+        applicationId = applicationId,
+        data = "{}",
+        username = username
+      ) is AuthorisableActionResult.NotFound
+    ).isTrue
   }
 
   @Test
@@ -786,11 +791,13 @@ class ApplicationServiceTest {
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-    assertThat(applicationService.updateTemporaryAccommodationApplication(
-      applicationId = applicationId,
-      data = "{}",
-      username = username
-    ) is AuthorisableActionResult.Unauthorised).isTrue
+    assertThat(
+      applicationService.updateTemporaryAccommodationApplication(
+        applicationId = applicationId,
+        data = "{}",
+        username = username
+      ) is AuthorisableActionResult.Unauthorised
+    ).isTrue
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -39,6 +39,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -48,6 +50,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
@@ -525,17 +528,25 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `updateApplication returns NotFound when application doesn't exist`() {
+  fun `updateApprovedPremisesApplication returns NotFound when application doesn't exist`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
 
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns null
 
-    assertThat(applicationService.updateApplication(applicationId, "{}", username) is AuthorisableActionResult.NotFound).isTrue
+    assertThat(applicationService.updateApprovedPremisesApplication(
+      applicationId = applicationId,
+      isWomensApplication = false,
+      isPipeApplication = null,
+      releaseType = null,
+      arrivalDate = null,
+      data = "{}",
+      username = username
+    ) is AuthorisableActionResult.NotFound).isTrue
   }
 
   @Test
-  fun `updateApplication returns Unauthorised when application doesn't belong to request user`() {
+  fun `updateApprovedPremisesApplication returns Unauthorised when application doesn't belong to request user`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
 
@@ -563,11 +574,19 @@ class ApplicationServiceTest {
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-    assertThat(applicationService.updateApplication(applicationId, "{}", username) is AuthorisableActionResult.Unauthorised).isTrue
+    assertThat(applicationService.updateApprovedPremisesApplication(
+      applicationId = applicationId,
+      isWomensApplication = false,
+      isPipeApplication = null,
+      releaseType = null,
+      arrivalDate = null,
+      data = "{}",
+      username = username
+    ) is AuthorisableActionResult.Unauthorised).isTrue
   }
 
   @Test
-  fun `updateApplication returns GeneralValidationError when application schema is outdated`() {
+  fun `updateApprovedPremisesApplication returns GeneralValidationError when application schema is outdated`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
 
@@ -593,7 +612,15 @@ class ApplicationServiceTest {
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-    val result = applicationService.updateApplication(applicationId, "{}", username)
+    val result = applicationService.updateApprovedPremisesApplication(
+      applicationId = applicationId,
+      isWomensApplication = false,
+      isPipeApplication = null,
+      releaseType = null,
+      arrivalDate = null,
+      data = "{}",
+      username = username
+    )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     result as AuthorisableActionResult.Success
@@ -605,7 +632,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `updateApplication returns GeneralValidationError when application has already been submitted`() {
+  fun `updateApprovedPremisesApplication returns GeneralValidationError when application has already been submitted`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
 
@@ -634,7 +661,15 @@ class ApplicationServiceTest {
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
     every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-    val result = applicationService.updateApplication(applicationId, "{}", username)
+    val result = applicationService.updateApprovedPremisesApplication(
+      applicationId = applicationId,
+      isWomensApplication = false,
+      isPipeApplication = null,
+      releaseType = null,
+      arrivalDate = null,
+      data = "{}",
+      username = username
+    )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     result as AuthorisableActionResult.Success
@@ -646,7 +681,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `updateApplication returns Success with updated Application`() {
+  fun `updateApprovedPremisesApplication returns Success with updated Application`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
 
@@ -682,7 +717,15 @@ class ApplicationServiceTest {
     every { mockJsonSchemaService.validate(newestSchema, updatedData) } returns true
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
-    val result = applicationService.updateApplication(applicationId, updatedData, username)
+    val result = applicationService.updateApprovedPremisesApplication(
+      applicationId = applicationId,
+      isWomensApplication = false,
+      isPipeApplication = true,
+      releaseType = "rotl",
+      arrivalDate = OffsetDateTime.parse("2023-04-17T14:10:00+01:00"),
+      data = updatedData,
+      username = username
+    )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     result as AuthorisableActionResult.Success
@@ -690,7 +733,205 @@ class ApplicationServiceTest {
     assertThat(result.entity is ValidatableActionResult.Success).isTrue
     val validatableActionResult = result.entity as ValidatableActionResult.Success
 
-    assertThat(validatableActionResult.entity.data).isEqualTo(updatedData)
+    val approvedPremisesApplication = validatableActionResult.entity as ApprovedPremisesApplicationEntity
+
+    assertThat(approvedPremisesApplication.data).isEqualTo(updatedData)
+    assertThat(approvedPremisesApplication.isWomensApplication).isEqualTo(false)
+    assertThat(approvedPremisesApplication.isPipeApplication).isEqualTo(true)
+    assertThat(approvedPremisesApplication.releaseType).isEqualTo("rotl")
+    assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T14:10:00+01:00"))
+  }
+
+  //here
+  @Test
+  fun `updateTemporaryAccommodationApplication returns NotFound when application doesn't exist`() {
+    val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
+    val username = "SOMEPERSON"
+
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns null
+
+    assertThat(applicationService.updateTemporaryAccommodationApplication(
+      applicationId = applicationId,
+      data = "{}",
+      username = username
+    ) is AuthorisableActionResult.NotFound).isTrue
+  }
+
+  @Test
+  fun `updateTemporaryAccommodationApplication returns Unauthorised when application doesn't belong to request user`() {
+    val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
+    val username = "SOMEPERSON"
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withId(applicationId)
+      .withYieldedCreatedByUser {
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
+    every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
+
+    assertThat(applicationService.updateTemporaryAccommodationApplication(
+      applicationId = applicationId,
+      data = "{}",
+      username = username
+    ) is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `updateTemporaryAccommodationApplication returns GeneralValidationError when application schema is outdated`() {
+    val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
+    val username = "SOMEPERSON"
+
+    val user = UserEntityFactory()
+      .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withId(applicationId)
+      .withCreatedByUser(user)
+      .withSubmittedAt(null)
+      .produce()
+      .apply {
+        schemaUpToDate = false
+      }
+
+    every { mockUserService.getUserForRequest() } returns user
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
+    every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
+
+    val result = applicationService.updateTemporaryAccommodationApplication(
+      applicationId = applicationId,
+      data = "{}",
+      username = username
+    )
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+
+    assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
+    val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+
+    assertThat(validatableActionResult.message).isEqualTo("The schema version is outdated")
+  }
+
+  @Test
+  fun `updateTemporaryAccommodationApplication returns GeneralValidationError when application has already been submitted`() {
+    val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
+    val username = "SOMEPERSON"
+
+    val newestSchema = TemporaryAccommodationApplicationJsonSchemaEntityFactory().produce()
+
+    val user = UserEntityFactory()
+      .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withApplicationSchema(newestSchema)
+      .withId(applicationId)
+      .withCreatedByUser(user)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+      .apply {
+        schemaUpToDate = true
+      }
+
+    every { mockUserService.getUserForRequest() } returns user
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
+    every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
+
+    val result = applicationService.updateTemporaryAccommodationApplication(
+      applicationId = applicationId,
+      data = "{}",
+      username = username
+    )
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+
+    assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
+    val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+
+    assertThat(validatableActionResult.message).isEqualTo("This application has already been submitted")
+  }
+
+  @Test
+  fun `updateTemporaryAccommodationApplication returns Success with updated Application`() {
+    val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
+    val username = "SOMEPERSON"
+
+    val user = UserEntityFactory()
+      .withDeliusUsername(username)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val newestSchema = TemporaryAccommodationApplicationJsonSchemaEntityFactory().produce()
+    val updatedData = """
+      {
+        "aProperty": "value"
+      }
+    """
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withApplicationSchema(newestSchema)
+      .withId(applicationId)
+      .withCreatedByUser(user)
+      .produce()
+      .apply {
+        schemaUpToDate = true
+      }
+
+    every { mockUserService.getUserForRequest() } returns user
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
+    every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
+    every { mockJsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns newestSchema
+    every { mockJsonSchemaService.validate(newestSchema, updatedData) } returns true
+    every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+
+    val result = applicationService.updateTemporaryAccommodationApplication(
+      applicationId = applicationId,
+      data = updatedData,
+      username = username
+    )
+
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+
+    assertThat(result.entity is ValidatableActionResult.Success).isTrue
+    val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+    val approvedPremisesApplication = validatableActionResult.entity as TemporaryAccommodationApplicationEntity
+
+    assertThat(approvedPremisesApplication.data).isEqualTo(updatedData)
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -325,5 +326,16 @@ class ApplicationsTransformerTest {
     val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms an in progress Approved Premises application correctly`() {
+    val application = approvedPremisesApplicationFactory.withSubmittedAt(null).produce()
+
+    val result = applicationsTransformer.transformJpaToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.id)
+    assertThat(result.createdByUserId).isEqualTo(user.id)
+    assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -17,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
@@ -27,14 +31,25 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Offender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.sql.Timestamp
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary as DomainApprovedPremisesApplicationSummary
 
 class ApplicationsTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockRisksTransformer = mockk<RisksTransformer>()
 
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
   private val applicationsTransformer = ApplicationsTransformer(
-    jacksonObjectMapper(),
+    objectMapper,
     mockPersonTransformer,
     mockRisksTransformer
   )
@@ -330,12 +345,183 @@ class ApplicationsTransformerTest {
 
   @Test
   fun `transformJpaToApiSummary transforms an in progress Approved Premises application correctly`() {
-    val application = approvedPremisesApplicationFactory.withSubmittedAt(null).produce()
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = true
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = null
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = null
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = false
+      override fun getHasBooking() = false
+    }
 
-    val result = applicationsTransformer.transformJpaToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
 
-    assertThat(result.id).isEqualTo(application.id)
-    assertThat(result.createdByUserId).isEqualTo(user.id)
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
     assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms a submitted Approved Premises application correctly`() {
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = true
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = null
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = false
+      override fun getHasBooking() = false
+    }
+
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
+    assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms a requested information Approved Premises application correctly`() {
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = true
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = null
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = true
+      override fun getHasBooking() = false
+    }
+
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
+    assertThat(result.status).isEqualTo(ApplicationStatus.requestedFurtherInformation)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms a placed Approved Premises application correctly`() {
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = true
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = AssessmentDecision.ACCEPTED
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = false
+      override fun getHasBooking() = true
+    }
+
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
+    assertThat(result.status).isEqualTo(ApplicationStatus.placed)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms an awaitingPlacement Approved Premises application correctly`() {
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = true
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = AssessmentDecision.ACCEPTED
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = false
+      override fun getHasBooking() = false
+    }
+
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
+    assertThat(result.status).isEqualTo(ApplicationStatus.awaitingPlacement)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms a pending Approved Premises application correctly`() {
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = false
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = AssessmentDecision.ACCEPTED
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = false
+      override fun getHasBooking() = false
+    }
+
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
+    assertThat(result.status).isEqualTo(ApplicationStatus.pending)
+  }
+
+  @Test
+  fun `transformJpaToApiSummary transforms a rejected Approved Premises application correctly`() {
+    val application = object : DomainApprovedPremisesApplicationSummary {
+      override fun getHasPlacementRequest() = false
+      override fun getIsWomensApplication() = false
+      override fun getIsPipeApplication() = true
+      override fun getArrivalDate() = Timestamp(Instant.parse("2023-04-19T14:25:00+01:00").toEpochMilli())
+      override fun getRiskRatings() = objectMapper.writeValueAsString(PersonRisksFactory().produce())
+      override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+      override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+      override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+      override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      override fun getLatestAssessmentSubmittedAt() = null
+      override fun getLatestAssessmentDecision() = AssessmentDecision.REJECTED
+      override fun getLatestAssessmentHasClarificationNotesWithoutResponse() = false
+      override fun getHasBooking() = false
+    }
+
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+
+    assertThat(result.id).isEqualTo(application.getId())
+    assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
+    assertThat(result.status).isEqualTo(ApplicationStatus.rejected)
   }
 }


### PR DESCRIPTION
The `GET /applications` endpoint in dev has been taking a long time to respond and often hitting out of memory exceptions.  This is because:
- the `data` and `document` fields on Applications are huge
- we don't have pagination on this endpoint
- we do upstream requests to Community API for offender info to construct the `person` part of the response - when these are a cache miss this takes a toll
- we do upstream requests to Community API for each user-offender pair to establish whether they're a limited access offender and if the user can view their records if so

To try and alleviate:
- changed `PUT /applications/{id}` to allow sending the first class properties for AP Applications
- made release date a first class property (this is the only piece of data needed for the table in the frontend that's only in `data` at the moment)
- removed `data` and `document` from the responses (to reduce response size)
- changed to a bespoke query to fetch these Application "Summaries" which avoids JPA loading the `data` and `document` fields into API memory

Improvements to response size:
![image](https://user-images.githubusercontent.com/110207532/233115567-a54ec93a-95f6-46aa-bc06-a2c2a660859a.png)

Improvements to response times:
![image](https://user-images.githubusercontent.com/110207532/233128725-153f37c6-7171-4228-b29e-fa3743822f61.png)

Both users have the `WORKFLOW_MANAGER` role meaning they can see all Applications.
- The first call from user 1 has to make upstream requests to Community API and Prison API (which are then cached in Redis) AND calls to Community API to check if the user is allowed to access each CRN (as the Offender may be an LAO offender)
- The second call from user 1 has cache hits for all upstream calls
- The first call from user 1 has cache hits for the Offender and Inmate detail upstream requests but cache misses for the LAO calls

Whilst this change will alleviate OOM problems, we're still not where we could be for response times.  Further optimisations might be:
- Preemptive caching for Offender and Inmate details requests, so cache misses for these calls will be rare
- Make LAO check calls concurrently
- or: A bulk endpoint from PI team for LAO checks, e.g. we post them a Delius username and an array of CRNs and they respond with whether that user is allowed to view each CRN
- Refactor such that we're looking at the `currentRestriction`, `currentExclusion` entries from the Community API Offender Details response.  If these are both `false` which will be the case for the majority of CRNs there is no need to make the User Access call for that CRN at all.  The difficulty here is that the Controller makes those calls after the user access call is made by the service layer.