### PR TITLE
Use duration in weeks for placement requests and bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
@@ -29,7 +29,7 @@ class BedSearchController(
         user = user,
         maxDistanceMiles = bedSearchParameters.maxDistanceMiles,
         startDate = bedSearchParameters.startDate,
-        durationInDays = bedSearchParameters.durationDays,
+        durationInWeeks = bedSearchParameters.durationWeeks,
         requiredCharacteristics = bedSearchParameters.requiredCharacteristics,
         postcodeDistrictOutcode = bedSearchParameters.postcodeDistrict,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -84,7 +84,7 @@ class PlacementRequestsController(
       placementRequestId = id,
       bedId = newPlacementRequestBooking.bedId,
       arrivalDate = newPlacementRequestBooking.arrivalDate,
-      departureDate = newPlacementRequestBooking.departureDate
+      durationWeeks = newPlacementRequestBooking.durationWeeks
     )
 
     val validatableResult = when (authorisableResult) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -70,7 +70,7 @@ ORDER BY distance_miles;
     postcodeDistrictOutcode: String,
     maxDistanceMiles: Int,
     startDate: LocalDate,
-    durationInDays: Int,
+    durationInWeeks: Int,
     requiredPremisesCharacteristics: List<UUID>,
     requiredRoomCharacteristics: List<UUID>,
   ): List<ApprovedPremisesBedSearchResult> {
@@ -82,7 +82,7 @@ ORDER BY distance_miles;
       addValue("room_characteristic_ids", requiredRoomCharacteristics)
       addValue("room_characteristic_ids_count", requiredRoomCharacteristics.size)
       addValue("start_date", startDate)
-      addValue("end_date", startDate.plusDays(durationInDays.toLong()))
+      addValue("end_date", startDate.plusWeeks(durationInWeeks.toLong()))
     }
 
     var optionalFilters = ""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -25,7 +25,7 @@ class BedSearchService(
     postcodeDistrictOutcode: String,
     maxDistanceMiles: Int,
     startDate: LocalDate,
-    durationInDays: Int,
+    durationInWeeks: Int,
     requiredCharacteristics: List<String>,
   ): AuthorisableActionResult<ValidatableActionResult<List<ApprovedPremisesBedSearchResult>>> {
     if (!user.hasRole(UserRole.MATCHER)) {
@@ -57,8 +57,8 @@ class BedSearchService(
         postcodeDistrictRepository.findByOutcode(postcodeDistrictOutcode)
           ?: ("$.postcodeDistrictOutcode" hasValidationError "doesNotExist")
 
-        if (durationInDays < 1) {
-          "$.durationDays" hasValidationError "mustBeAtLeast1"
+        if (durationInWeeks < 1) {
+          "$.durationInWeeks" hasValidationError "mustBeAtLeast1"
         }
 
         if (maxDistanceMiles < 1) {
@@ -74,7 +74,7 @@ class BedSearchService(
             postcodeDistrictOutcode = postcodeDistrictOutcode,
             maxDistanceMiles = maxDistanceMiles,
             startDate = startDate,
-            durationInDays = durationInDays,
+            durationInWeeks = durationInWeeks,
             requiredPremisesCharacteristics = premisesCharacteristicIds,
             requiredRoomCharacteristics = roomCharacteristicIds,
           ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -94,7 +94,7 @@ class BookingService(
     placementRequestId: UUID,
     bedId: UUID,
     arrivalDate: LocalDate,
-    departureDate: LocalDate
+    durationWeeks: Int
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
@@ -103,11 +103,9 @@ class BookingService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    val validationResult = validated {
-      if (departureDate.isBefore(arrivalDate)) {
-        "$.departureDate" hasValidationError "beforeBookingArrivalDate"
-      }
+    val departureDate = arrivalDate.plusWeeks(durationWeeks.toLong())
 
+    val validationResult = validated {
       getBookingWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
         return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates"
       }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4748,12 +4748,8 @@ components:
           type: string
           format: date
           description: The date the Bed will need to be free from
-        durationDays:
-          type: integer
-          description: The number of days the Bed will need to be free from the start_date until
       required:
         - startDate
-        - durationDays
       discriminator:
         propertyName: serviceName
         mapping:
@@ -4774,10 +4770,14 @@ components:
               type: array
               items:
                 type: string
+            durationWeeks:
+              type: integer
+              description: The number of weeks the Bed will need to be free from the start_date until
           required:
             - postcodeDistrict
             - maxDistanceMiles
             - requiredCharacteristics
+            - durationWeeks
     TemporaryAccommodationBedSearchParameters:
       allOf:
         - $ref: '#/components/schemas/BedSearchParameters'
@@ -4786,8 +4786,12 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            durationDays:
+              type: integer
+              description: The number of days the Bed will need to be free from the start_date until
           required:
             - probationDeliveryUnit
+            - durationDays
     BedSearchResults:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2996,16 +2996,15 @@ components:
           type: string
           format: date
           example: 2022-07-28
-        departureDate:
-          type: string
-          format: date
-          example: 2022-09-30
+        durationWeeks:
+          type: integer
+          description: The number of weeks the booking will need to last for
         bedId:
           type: string
           format: uuid
       required:
         - arrivalDate
-        - departureDate
+        - durationWeeks
         - bedId
     Booking:
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
@@ -387,7 +387,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 50,
       startDate = LocalDate.parse("2023-03-09"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredPremisesCharacteristics = requiredPremisesCharacteristics.map(CharacteristicEntity::id),
       requiredRoomCharacteristics = requiredRoomCharacteristics.map(CharacteristicEntity::id),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -27,7 +27,7 @@ class BedSearchTest : IntegrationTestBase() {
           maxDistanceMiles = 20,
           requiredCharacteristics = listOf(),
           startDate = LocalDate.parse("2023-03-23"),
-          durationDays = 7,
+          durationWeeks = 1,
           serviceName = "approved-premises",
         ),
       )
@@ -48,7 +48,7 @@ class BedSearchTest : IntegrationTestBase() {
             maxDistanceMiles = 20,
             requiredCharacteristics = listOf(),
             startDate = LocalDate.parse("2023-03-23"),
-            durationDays = 7,
+            durationWeeks = 1,
             serviceName = "approved-premises",
           ),
         )
@@ -106,7 +106,7 @@ class BedSearchTest : IntegrationTestBase() {
             maxDistanceMiles = 20,
             requiredCharacteristics = listOf(),
             startDate = LocalDate.parse("2023-03-23"),
-            durationDays = 7,
+            durationWeeks = 1,
             serviceName = "approved-premises",
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -199,7 +199,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
       .bodyValue(
         NewPlacementRequestBooking(
           arrivalDate = LocalDate.parse("2023-03-29"),
-          departureDate = LocalDate.parse("2023-04-01"),
+          durationWeeks = 12,
           bedId = UUID.fromString("d5dfd808-b8f4-4cc0-a0ac-fdce7144126e"),
         ),
       )
@@ -226,7 +226,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 .bodyValue(
                   NewPlacementRequestBooking(
                     arrivalDate = LocalDate.parse("2023-03-29"),
-                    departureDate = LocalDate.parse("2023-04-01"),
+                    durationWeeks = 12,
                     bedId = UUID.fromString("d5dfd808-b8f4-4cc0-a0ac-fdce7144126e"),
                   ),
                 )
@@ -273,7 +273,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 .bodyValue(
                   NewPlacementRequestBooking(
                     arrivalDate = LocalDate.parse("2023-03-29"),
-                    departureDate = LocalDate.parse("2023-04-01"),
+                    durationWeeks = 12,
                     bedId = bed.id,
                   ),
                 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -43,7 +43,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = "AA11",
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 7,
       requiredCharacteristics = listOf(),
     )
 
@@ -81,7 +81,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristicPropertyName, roomCharacteristic.propertyName!!),
     )
 
@@ -127,7 +127,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
     )
 
@@ -170,7 +170,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristicPropertyName),
     )
 
@@ -216,7 +216,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
     )
 
@@ -264,7 +264,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
     )
 
@@ -310,7 +310,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 0,
+      durationInWeeks = 0,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
     )
 
@@ -319,7 +319,7 @@ class BedSearchServiceTest {
     assertThat(authorisableResult.entity is ValidatableActionResult.FieldValidationError).isTrue
     val fieldValidationError = authorisableResult.entity as ValidatableActionResult.FieldValidationError
 
-    assertThat(fieldValidationError.validationMessages["$.durationDays"]).isEqualTo("mustBeAtLeast1")
+    assertThat(fieldValidationError.validationMessages["$.durationInWeeks"]).isEqualTo("mustBeAtLeast1")
   }
 
   @Test
@@ -356,7 +356,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 0,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
     )
 
@@ -431,7 +431,7 @@ class BedSearchServiceTest {
         postcodeDistrictOutcode = postcodeDistrict.outcode,
         maxDistanceMiles = 20,
         startDate = LocalDate.parse("2023-03-22"),
-        durationInDays = 7,
+        durationInWeeks = 1,
         requiredPremisesCharacteristics = listOf(premisesCharacteristic.id),
         requiredRoomCharacteristics = listOf(roomCharacteristic.id),
       )
@@ -442,7 +442,7 @@ class BedSearchServiceTest {
       postcodeDistrictOutcode = postcodeDistrict.outcode,
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
+      durationInWeeks = 1,
       requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2101,7 +2101,7 @@ class BookingServiceTest {
       placementRequestId = placementRequestId,
       bedId = bedId,
       arrivalDate = LocalDate.parse("2023-03-28"),
-      departureDate = LocalDate.parse("2023-03-30")
+      durationWeeks = 7
     )
 
     assertThat(result is AuthorisableActionResult.NotFound).isTrue
@@ -2141,7 +2141,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bedId,
       arrivalDate = LocalDate.parse("2023-03-28"),
-      departureDate = LocalDate.parse("2023-03-30")
+      durationWeeks = 7
     )
 
     assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
@@ -2150,7 +2150,8 @@ class BookingServiceTest {
   @Test
   fun `createApprovedPremisesBookingFromPlacementRequest returns GeneralValidationError if Bed does not belong to an Approved Premises`() {
     val arrivalDate = LocalDate.parse("2023-03-28")
-    val departureDate = LocalDate.parse("2023-03-30")
+    val durationWeeks = 12
+    val departureDate = arrivalDate.plusWeeks(durationWeeks.toLong())
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -2198,7 +2199,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      durationWeeks = durationWeeks
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -2212,7 +2213,8 @@ class BookingServiceTest {
   @Test
   fun `createApprovedPremisesBookingFromPlacementRequest returns ConflictError if Bed has a conflicting Booking`() {
     val arrivalDate = LocalDate.parse("2023-03-28")
-    val departureDate = LocalDate.parse("2023-03-30")
+    val durationWeeks = 12
+    val departureDate = arrivalDate.plusWeeks(durationWeeks.toLong())
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -2267,7 +2269,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      durationWeeks = durationWeeks
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -2281,7 +2283,8 @@ class BookingServiceTest {
   @Test
   fun `createApprovedPremisesBookingFromPlacementRequest returns ConflictError if Bed has a conflicting Lost Bed`() {
     val arrivalDate = LocalDate.parse("2023-03-28")
-    val departureDate = LocalDate.parse("2023-03-30")
+    val durationWeeks = 12
+    val departureDate = arrivalDate.plusWeeks(durationWeeks.toLong())
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -2337,7 +2340,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      durationWeeks = durationWeeks
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -2352,7 +2355,8 @@ class BookingServiceTest {
   fun `createApprovedPremisesBookingFromPlacementRequest saves Booking and creates Domain Event`() {
     val crn = "CRN123"
     val arrivalDate = LocalDate.parse("2023-02-22")
-    val departureDate = LocalDate.parse("2023-02-23")
+    val durationWeeks = 12
+    val departureDate = arrivalDate.plusWeeks(durationWeeks.toLong())
 
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
@@ -2417,7 +2421,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      durationWeeks = durationWeeks
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
For Approved Premises bookings, we talk in terms of weeks, rather than days for bookings. This tweaks the endpoint to accepts a duration in weeks when searching for a bed for Approved Premises, as well as changing the `NewPlacementRequestBooking` to have a duration, rather than an end date.