### PR TITLE
Return confirmation object after making a booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NewPlacementRequestBookingConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NewPlacementRequestBookingConfirmationTransformer.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementRequestBookingConfirmation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+
+@Component
+class NewPlacementRequestBookingConfirmationTransformer {
+  fun transformJpaToApi(jpa: BookingEntity) = NewPlacementRequestBookingConfirmation(
+    arrivalDate = jpa.arrivalDate,
+    departureDate = jpa.departureDate,
+    premisesName = jpa.bed!!.room.premises.name,
+  )
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2198,7 +2198,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/Booking'
+                $ref: '#/components/schemas/NewPlacementRequestBookingConfirmation'
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -5053,6 +5053,19 @@ components:
       required:
         - id
         - name
+    NewPlacementRequestBookingConfirmation:
+      type: object
+      properties:
+        premisesName:
+          type: string
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
     NewBookingNotMade:
       type: object
       properties:


### PR DESCRIPTION
This simplifies the response made when making a booking request to return just the information we need, rather than the entire booking object.