### PR TITLE
Fix for Placement Request failure sequencing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
@@ -4,6 +4,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import java.util.UUID
 
 sealed interface ValidatableActionResult<EntityType> {
+  fun <T> translateError(): ValidatableActionResult<T> = when (this) {
+    is Success -> throw RuntimeException("Cannot translate Success")
+    is FieldValidationError -> FieldValidationError(this.validationMessages)
+    is GeneralValidationError -> GeneralValidationError(this.message)
+    is ConflictError -> ConflictError(this.conflictingEntityId, this.message)
+  }
+
   data class Success<EntityType>(val entity: EntityType) : ValidatableActionResult<EntityType>
   data class FieldValidationError<EntityType>(val validationMessages: ValidationErrors) :
     ValidatableActionResult<EntityType>


### PR DESCRIPTION
This fixes the issue where a failure to create a Placement Request after an `application.assessed` Domain Event has been emitted causes the Domain Event to be removed from the database when the transaction rolls back.