### PR TITLE
(1472) Set an application as inapplicable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -145,6 +145,7 @@ class ApplicationsController(
         isPipeApplication = body.isPipeApplication,
         releaseType = body.releaseType?.name,
         arrivalDate = body.arrivalDate?.atOffset(ZoneOffset.UTC),
+        isInapplicable = body.isInapplicable,
         username = username
       )
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -168,6 +168,7 @@ class ApprovedPremisesApplicationEntity(
   assessments: MutableList<AssessmentEntity>,
   var isWomensApplication: Boolean?,
   var isPipeApplication: Boolean?,
+  var isInapplicable: Boolean?,
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -61,7 +61,8 @@ SELECT
     CAST(apa.risk_ratings AS TEXT) as riskRatings
 FROM approved_premises_applications apa
 LEFT JOIN applications a ON a.id = apa.id
-LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL;
+LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL
+WHERE apa.is_inapplicable IS NOT TRUE;
 """,
     nativeQuery = true
   )
@@ -88,6 +89,7 @@ FROM approved_premises_applications apa
 LEFT JOIN applications a ON a.id = apa.id
 LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL 
 WHERE (SELECT COUNT(1) FROM approved_premises_application_team_codes apatc WHERE apatc.application_id = apa.id AND apatc.team_code IN :teamCodes) > 0
+AND apa.is_inapplicable IS NOT TRUE;
 """,
     nativeQuery = true
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -240,6 +240,7 @@ class ApplicationService(
     releaseType: String?,
     arrivalDate: OffsetDateTime?,
     data: String,
+    isInapplicable: Boolean?,
     username: String
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
@@ -270,6 +271,7 @@ class ApplicationService(
     }
 
     application.apply {
+      this.isInapplicable = isInapplicable
       this.isWomensApplication = isWomensApplication
       this.isPipeApplication = isPipeApplication
       this.releaseType = releaseType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -215,7 +215,8 @@ class ApplicationService(
         teamCodes = mutableListOf(),
         placementRequests = mutableListOf(),
         releaseType = null,
-        arrivalDate = null
+        arrivalDate = null,
+        isInapplicable = null
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -109,6 +109,7 @@ class ApplicationsTransformer(
 
     if (entity is ApprovedPremisesApplicationEntity) {
       return when {
+        entity.isInapplicable == true -> ApplicationStatus.inapplicable
         latestAssessment?.submittedAt != null && latestAssessment.decision == AssessmentDecision.REJECTED -> ApplicationStatus.rejected
         latestAssessment?.submittedAt != null && latestAssessment.decision == AssessmentDecision.ACCEPTED && entity.getLatestPlacementRequest() == null -> ApplicationStatus.pending
         latestAssessment?.submittedAt != null && latestAssessment.decision == AssessmentDecision.ACCEPTED && entity.getLatestBooking() == null -> ApplicationStatus.awaitingPlacement

--- a/src/main/resources/db/migration/all/20230424115206__add_is_inapplicable_to_approved_premises_applications.sql
+++ b/src/main/resources/db/migration/all/20230424115206__add_is_inapplicable_to_approved_premises_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN is_inapplicable BOOLEAN;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3963,6 +3963,8 @@ components:
         - $ref: '#/components/schemas/UpdateApplication'
         - type: object
           properties:
+            isInapplicable:
+              type: boolean
             isWomensApplication:
               type: boolean
             isPipeApplication:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3925,6 +3925,7 @@ components:
         - rejected
         - awaitingPlacement
         - placed
+        - inapplicable
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
     NewApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -37,6 +37,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var placementRequests: Yielded<MutableList<PlacementRequestEntity>> = { mutableListOf() }
   private var releaseType: Yielded<String?> = { null }
   private var arrivalDate: Yielded<OffsetDateTime?> = { null }
+  private var isInapplicable: Yielded<Boolean?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -118,6 +119,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.arrivalDate = { arrivalDate }
   }
 
+  fun withIsInapplicable(isInapplicable: Boolean) = apply {
+    this.isInapplicable = { isInapplicable }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -138,6 +143,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     teamCodes = this.teamCodes(),
     placementRequests = this.placementRequests(),
     releaseType = this.releaseType(),
-    arrivalDate = this.arrivalDate()
+    arrivalDate = this.arrivalDate(),
+    isInapplicable = this.isInapplicable()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -51,6 +51,14 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withIsWomensApplication(false)
           withReleaseType("rotl")
           withSubmittedAt(null)
+          withIsInapplicable(false)
+        }
+
+        val inapplicableApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsInapplicable(true)
         }
 
         val submittedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -94,6 +102,8 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
 
         val results = realApplicationRepository.findAllApprovedPremisesSummaries()
 
+        assertThat(results.size).isEqualTo(2)
+
         results.first { it.getId() == nonSubmittedApplication.id }.let {
           assertThat(it.getCrn()).isEqualTo(nonSubmittedApplication.crn)
           assertThat(it.getCreatedByUserId()).isEqualTo(nonSubmittedApplication.createdByUser.id)
@@ -116,6 +126,10 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(true)
           assertThat(it.getHasPlacementRequest()).isEqualTo(true)
           assertThat(it.getHasBooking()).isEqualTo(true)
+        }
+
+        assertThat(results).noneMatch {
+          it.getId() == inapplicableApplication.id
         }
       }
     }
@@ -175,6 +189,14 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withIsWomensApplication(false)
           withReleaseType("rotl")
           withSubmittedAt(null)
+          withIsInapplicable(false)
+        }
+
+        val inapplicableApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withIsInapplicable(true)
         }
 
         val teamCodeForNonSubmittedApplication = applicationTeamCodeFactory.produceAndPersist {
@@ -228,6 +250,8 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
 
         val results = realApplicationRepository.findApprovedPremisesSummariesForManagingTeams(listOf("TEAM1"))
 
+        assertThat(results.size).isEqualTo(2)
+
         results.first { it.getId() == nonSubmittedApplication.id }.let {
           assertThat(it.getCrn()).isEqualTo(nonSubmittedApplication.crn)
           assertThat(it.getCreatedByUserId()).isEqualTo(nonSubmittedApplication.createdByUser.id)
@@ -254,6 +278,10 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
 
         assertThat(results).noneMatch {
           it.getId() == applicationForDifferentTeam.id
+        }
+
+        assertThat(results).noneMatch {
+          it.getId() == inapplicableApplication.id
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -550,7 +550,8 @@ class ApplicationServiceTest {
         releaseType = null,
         arrivalDate = null,
         data = "{}",
-        username = username
+        username = username,
+        isInapplicable = null
       ) is AuthorisableActionResult.NotFound
     ).isTrue
   }
@@ -592,7 +593,8 @@ class ApplicationServiceTest {
         releaseType = null,
         arrivalDate = null,
         data = "{}",
-        username = username
+        username = username,
+        isInapplicable = null
       ) is AuthorisableActionResult.Unauthorised
     ).isTrue
   }
@@ -631,7 +633,8 @@ class ApplicationServiceTest {
       releaseType = null,
       arrivalDate = null,
       data = "{}",
-      username = username
+      username = username,
+      isInapplicable = null
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -680,7 +683,8 @@ class ApplicationServiceTest {
       releaseType = null,
       arrivalDate = null,
       data = "{}",
-      username = username
+      username = username,
+      isInapplicable = null
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -736,7 +740,8 @@ class ApplicationServiceTest {
       releaseType = "rotl",
       arrivalDate = OffsetDateTime.parse("2023-04-17T14:10:00+01:00"),
       data = updatedData,
-      username = username
+      username = username,
+      isInapplicable = false
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -751,6 +756,7 @@ class ApplicationServiceTest {
     assertThat(approvedPremisesApplication.isWomensApplication).isEqualTo(false)
     assertThat(approvedPremisesApplication.isPipeApplication).isEqualTo(true)
     assertThat(approvedPremisesApplication.releaseType).isEqualTo("rotl")
+    assertThat(approvedPremisesApplication.isInapplicable).isEqualTo(false)
     assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T14:10:00+01:00"))
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -113,6 +113,17 @@ class ApplicationsTransformerTest {
   }
 
   @Test
+  fun `transformJpaToApi transforms an inapplicable Approved Premises application correctly`() {
+    val application = approvedPremisesApplicationFactory.withIsInapplicable(true).produce()
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.id).isEqualTo(application.id)
+    assertThat(result.createdByUserId).isEqualTo(user.id)
+    assertThat(result.status).isEqualTo(ApplicationStatus.inapplicable)
+  }
+
+  @Test
   fun `transformJpaToApi transforms an in progress Temporary Accommodation application correctly`() {
     val application = temporaryAccommodationApplicationEntityFactory.withSubmittedAt(null).produce()
 


### PR DESCRIPTION
This adds a new `isInapplicable` property that can be sent when an application is updated. If it is set to true, then the status returned is `inapplicable` and the application is filtered out when requesting all applications.