### PR TITLE
Return PDU information in endpoints returning a Temporary Accommodation premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -14,7 +14,8 @@ class PremisesTransformer(
   private val probationRegionTransformer: ProbationRegionTransformer,
   private val apAreaTransformer: ApAreaTransformer,
   private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer,
-  private val characteristicTransformer: CharacteristicTransformer
+  private val characteristicTransformer: CharacteristicTransformer,
+  private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
 ) {
   fun transformJpaToApi(jpa: PremisesEntity, availableBedsForToday: Int): Premises = when (jpa) {
     is ApprovedPremisesEntity -> ApprovedPremises(
@@ -52,6 +53,7 @@ class PremisesTransformer(
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
       status = jpa.status,
       pdu = jpa.probationDeliveryUnit?.name ?: "Not specified",
+      probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) }
     )
     else -> throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2742,6 +2742,8 @@ components:
           properties:
             pdu:
               type: string
+            probationDeliveryUnit:
+              $ref: '#/components/schemas/ProbationDeliveryUnit'
       required:
         - pdu
     ApprovedPremisesSummary:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -108,6 +108,8 @@ class PremisesTest : IntegrationTestBase() {
         .jsonPath("probationRegion.id").isEqualTo(user.probationRegion.id.toString())
         .jsonPath("status").isEqualTo("pending")
         .jsonPath("pdu").isEqualTo(probationDeliveryUnit.name)
+        .jsonPath("probationDeliveryUnit.id").isEqualTo(probationDeliveryUnit.id.toString())
+        .jsonPath("probationDeliveryUnit.name").isEqualTo(probationDeliveryUnit.name)
     }
   }
 
@@ -152,6 +154,8 @@ class PremisesTest : IntegrationTestBase() {
         .jsonPath("probationRegion.id").isEqualTo(user.probationRegion.id.toString())
         .jsonPath("status").isEqualTo("pending")
         .jsonPath("pdu").isEqualTo(probationDeliveryUnit.name)
+        .jsonPath("probationDeliveryUnit.id").isEqualTo(probationDeliveryUnit.id.toString())
+        .jsonPath("probationDeliveryUnit.name").isEqualTo(probationDeliveryUnit.name)
     }
   }
 
@@ -253,6 +257,8 @@ class PremisesTest : IntegrationTestBase() {
         .jsonPath("probationRegion.name").isEqualTo(user.probationRegion.name)
         .jsonPath("status").isEqualTo("archived")
         .jsonPath("pdu").isEqualTo(probationDeliveryUnit.name)
+        .jsonPath("probationDeliveryUnit.id").isEqualTo(probationDeliveryUnit.id.toString())
+        .jsonPath("probationDeliveryUnit.name").isEqualTo(probationDeliveryUnit.name)
     }
   }
 
@@ -308,6 +314,8 @@ class PremisesTest : IntegrationTestBase() {
         .jsonPath("probationRegion.name").isEqualTo(user.probationRegion.name)
         .jsonPath("status").isEqualTo("archived")
         .jsonPath("pdu").isEqualTo(probationDeliveryUnit.name)
+        .jsonPath("probationDeliveryUnit.id").isEqualTo(probationDeliveryUnit.id.toString())
+        .jsonPath("probationDeliveryUnit.name").isEqualTo(probationDeliveryUnit.name)
     }
   }
 


### PR DESCRIPTION
> See [ticket #1015 on the CAS3 Trello board](https://trello.com/c/5Jhi2OZF/1015-re-associate-existing-premises-to-the-new-pdu-records).

This PR is the fourth and final part of the work to migrate Temporary Accommodation premises away from using opaque strings for probation delivery units (PDUs). It follows on from #550, which introduced a reference data endpoint for PDUs to the API and provided the infrastructure to perform this migration; #577, which allowed clients of the API to use PDU IDs when creating or updating premises; and #589, which performed the migration on the database and refactored the API to support that change.

This PR changes the `TemporaryAccommodationPremises` schema in the API to provide the `probationDeliveryUnit` field. This field is an object with the schema `ProbationDeliveryUnit`, enabling the API to return information about the PDU. The existing `pdu` field has not been removed for backwards compatibility, but is now deprecated and will return the same value as `probationDeliveryUnit.name`.