### PR TITLE
(Fix) Update and submit applications accepts date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -53,7 +53,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsFor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.kebabCaseToPascalCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.transformAssessment
 import java.net.URI
-import java.time.ZoneOffset
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -144,7 +143,7 @@ class ApplicationsController(
         isWomensApplication = body.isWomensApplication,
         isPipeApplication = body.isPipeApplication,
         releaseType = body.releaseType?.name,
-        arrivalDate = body.arrivalDate?.atOffset(ZoneOffset.UTC),
+        arrivalDate = body.arrivalDate,
         isInapplicable = body.isInapplicable,
         username = username
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
 import java.time.ZoneOffset
@@ -238,7 +239,7 @@ class ApplicationService(
     isWomensApplication: Boolean?,
     isPipeApplication: Boolean?,
     releaseType: String?,
-    arrivalDate: OffsetDateTime?,
+    arrivalDate: LocalDate?,
     data: String,
     isInapplicable: Boolean?,
     username: String
@@ -275,7 +276,7 @@ class ApplicationService(
       this.isWomensApplication = isWomensApplication
       this.isPipeApplication = isPipeApplication
       this.releaseType = releaseType
-      this.arrivalDate = arrivalDate
+      this.arrivalDate = if (arrivalDate !== null) OffsetDateTime.of(arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC) else null
       this.data = data
     }
 
@@ -384,7 +385,7 @@ class ApplicationService(
       submittedAt = OffsetDateTime.now()
       document = serializedTranslatedDocument
       releaseType = submitApplication.releaseType.toString()
-      arrivalDate = submitApplication.arrivalDate?.atOffset(ZoneOffset.UTC)
+      arrivalDate = if (submitApplication.arrivalDate !== null) OffsetDateTime.of(submitApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC) else null
     }
 
     assessmentService.createAssessment(application)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3976,7 +3976,7 @@ components:
               $ref: '#/components/schemas/ReleaseTypeOption'
             arrivalDate:
               type: string
-              format: date-time
+              format: date
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'
@@ -3995,7 +3995,7 @@ components:
           $ref: '#/components/schemas/ReleaseTypeOption'
         arrivalDate:
           type: string
-          format: date-time
+          format: date
       required:
         - translatedDocument
         - isPipeApplication

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -738,7 +738,7 @@ class ApplicationServiceTest {
       isWomensApplication = false,
       isPipeApplication = true,
       releaseType = "rotl",
-      arrivalDate = OffsetDateTime.parse("2023-04-17T14:10:00+01:00"),
+      arrivalDate = LocalDate.parse("2023-04-17"),
       data = updatedData,
       username = username,
       isInapplicable = false
@@ -757,7 +757,7 @@ class ApplicationServiceTest {
     assertThat(approvedPremisesApplication.isPipeApplication).isEqualTo(true)
     assertThat(approvedPremisesApplication.releaseType).isEqualTo("rotl")
     assertThat(approvedPremisesApplication.isInapplicable).isEqualTo(false)
-    assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T14:10:00+01:00"))
+    assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T00:00:00Z"))
   }
 
   @Test


### PR DESCRIPTION
We’re passing the arrival dates from the frontend as dates, not datetimes, so we need to update the service to accept dates. The underlying data model stores the `arrivalDate` as a datetime, but I think it’s OK to keep them like this to give us flexibility.