### PR TITLE
Add turnaroundWorkingDayCount to TemporaryAccommodationPremises schema

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2744,6 +2744,9 @@ components:
               type: string
             probationDeliveryUnit:
               $ref: '#/components/schemas/ProbationDeliveryUnit'
+            turnaroundWorkingDayCount:
+              type: integer
+              example: 2
       required:
         - pdu
     ApprovedPremisesSummary:


### PR DESCRIPTION
### Task
https://trello.com/c/iWShWKBw/1016-premises-can-record-the-turnaround-day-count
### Changes
This PR include changes to add the `turnaroundWorkingDayCount` field to the `TemporaryAccommodationPremises` schema in the openApi spec