### PR TITLE
Add turnaroundWorkingDayCount to TemporaryAccommodationPremises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -134,6 +134,7 @@ class PremisesController(
         body.notes,
         body.status,
         Ior.fromNullables(body.pdu, body.probationDeliveryUnitId)?.toEither(),
+        body.turnaroundWorkingDayCount
       )
 
     val validationResult = when (updatePremisesResult) {
@@ -200,6 +201,7 @@ class PremisesController(
         characteristicIds = body.characteristicIds,
         status = body.status,
         probationDeliveryUnitIdentifier = Ior.fromNullables(body.pdu, body.probationDeliveryUnitId)?.toEither(),
+        turnaroundWorkingDayCount = body.turnaroundWorkingDayCount
       )
     )
     return ResponseEntity(premisesTransformer.transformJpaToApi(premises, premises.totalBeds), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -171,6 +171,7 @@ class TemporaryAccommodationPremisesEntity(
   @ManyToOne
   @JoinColumn(name = "probation_delivery_unit_id")
   var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
+  var turnaroundWorkingDayCount: Int
 ) : PremisesEntity(
   id,
   name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationPremisesSeedJob.kt
@@ -111,6 +111,7 @@ class TemporaryAccommodationPremisesSeedJob(
         characteristics = mutableListOf(),
         probationDeliveryUnit = probationDeliveryUnit,
         status = PropertyStatus.active,
+        turnaroundWorkingDayCount = 2
       )
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -53,7 +53,8 @@ class PremisesTransformer(
       characteristics = jpa.characteristics.map(characteristicTransformer::transformJpaToApi),
       status = jpa.status,
       pdu = jpa.probationDeliveryUnit?.name ?: "Not specified",
-      probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) }
+      probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
+      turnaroundWorkingDayCount = jpa.turnaroundWorkingDayCount
     )
     else -> throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/resources/db/migration/all/20230426110622__add_turnaround_working_day_count_to_temporary_accommodation.sql
+++ b/src/main/resources/db/migration/all/20230426110622__add_turnaround_working_day_count_to_temporary_accommodation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE temporary_accommodation_premises ADD COLUMN turnaround_working_day_count INTEGER NOT NULL DEFAULT 2;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2808,6 +2808,8 @@ components:
         probationDeliveryUnitId:
           type: string
           format: uuid
+        turnaroundWorkingDayCount:
+          type: integer
       required:
         - name
         - addressLine1
@@ -4185,6 +4187,8 @@ components:
         probationDeliveryUnitId:
           type: string
           format: uuid
+        turnaroundWorkingDayCount:
+          type: integer
       required:
         - addressLine1
         - postcode

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -95,8 +95,8 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     this.probationDeliveryUnit = probationDeliveryUnit
   }
 
-  fun withTurnaroundWorkingDayCount(turnaroundWorkingDayCount: Yielded<Int>) = apply {
-    this.turnaroundWorkingDayCount = turnaroundWorkingDayCount
+  fun withTurnaroundWorkingDayCount(turnaroundWorkingDayCount: Int) = apply {
+    this.turnaroundWorkingDayCount = { turnaroundWorkingDayCount }
   }
 
   fun withUnitTestControlTestProbationAreaAndLocalAuthority() = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -29,6 +29,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   private var service: Yielded<String> = { ServiceName.temporaryAccommodation.value }
   private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.values().asList()) }
   private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
+  private var turnaroundWorkingDayCount: Yielded<Int>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -94,6 +95,10 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     this.probationDeliveryUnit = probationDeliveryUnit
   }
 
+  fun withTurnaroundWorkingDayCount(turnaroundWorkingDayCount: Yielded<Int>) = apply {
+    this.turnaroundWorkingDayCount = turnaroundWorkingDayCount
+  }
+
   fun withUnitTestControlTestProbationAreaAndLocalAuthority() = apply {
     this.withLocalAuthorityArea(
       LocalAuthorityEntityFactory()
@@ -132,5 +137,6 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     characteristics = mutableListOf(),
     status = this.status(),
     probationDeliveryUnit = this.probationDeliveryUnit?.invoke(),
+    turnaroundWorkingDayCount = this.turnaroundWorkingDayCount?.invoke() ?: 2
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -114,6 +114,7 @@ class BookingTransformerTest {
     characteristics = mutableListOf(),
     status = PropertyStatus.active,
     probationDeliveryUnit = null,
+    turnaroundWorkingDayCount = 2
   )
 
   private val baseBookingEntity = BookingEntity(


### PR DESCRIPTION
### Task
https://trello.com/c/iWShWKBw/1016-premises-can-record-the-turnaround-day-count

### Changes
This PR builds on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/597 and includes changes to:

- Add `turnaround_working_day_count` field to `temporary_accommodation_premises` table
- Expose/handle the new field when using CRUD operations on TemporaryAccommodationPremises entities