### PR TITLE
1059 - Support specifying year and month for Bookings report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReportsApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ReportService
@@ -22,6 +23,14 @@ class ReportsController(
     when {
       probationRegionId == null && !userAccessService.currentUserHasAllRegionsAccess() -> throw ForbiddenProblem()
       probationRegionId != null && !userAccessService.currentUserCanAccessRegion(probationRegionId) -> throw ForbiddenProblem()
+    }
+
+    if (month != null && (month < 1 || month > 12)) {
+      throw BadRequestProblem(errorDetail = "month must be between 1 and 12")
+    }
+
+    if ((month != null && year == null) || (year != null && month == null)) {
+      throw BadRequestProblem(errorDetail = "month and year must be provided together")
     }
 
     val properties = BookingsReportProperties(xServiceName, probationRegionId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
@@ -33,7 +33,7 @@ class ReportsController(
       throw BadRequestProblem(errorDetail = "month and year must be provided together")
     }
 
-    val properties = BookingsReportProperties(xServiceName, probationRegionId)
+    val properties = BookingsReportProperties(xServiceName, probationRegionId, year, month)
     val outputStream = ByteArrayOutputStream()
 
     reportService.createBookingsReport(properties, outputStream)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -20,6 +20,9 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   @Query("SELECT b FROM BookingEntity b WHERE b.premises.id = :premisesId AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate")
   fun findAllByPremisesIdAndOverlappingDate(premisesId: UUID, startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
 
+  @Query("SELECT b FROM BookingEntity b WHERE b.arrivalDate <= :endDate AND b.departureDate >= :startDate")
+  fun findAllByOverlappingDate(startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
+
   @Query("SELECT MAX(b.departureDate) FROM BookingEntity b WHERE b.premises.id = :premisesId")
   fun getHighestBookingDate(premisesId: UUID): LocalDate?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BookingsReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BookingsReportProperties.kt
@@ -6,4 +6,6 @@ import java.util.UUID
 data class BookingsReportProperties(
   val serviceName: ServiceName,
   val probationRegionId: UUID?,
+  val year: Int?,
+  val month: Int?
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -11,9 +11,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemb
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import java.time.LocalDate
 import java.util.UUID
 
 class ReportsTest : IntegrationTestBase() {
@@ -134,10 +136,108 @@ class ReportsTest : IntegrationTestBase() {
         }
 
         val expectedDataFrame = BookingsReportGenerator()
-          .createReport(bookings, BookingsReportProperties(ServiceName.approvedPremises, null))
+          .createReport(bookings, BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
 
         webTestClient.get()
           .uri("/reports/bookings")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BookingsReportRow>(ExcessiveColumns.Remove)
+            Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bookings report returns OK with only Bookings with at least one day in month when year and month are specified`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        val keyWorker = ContextStaffMemberFactory().produce()
+        APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
+
+        val shouldNotBeIncludedBookings = mutableListOf<BookingEntity>()
+        val shouldBeIncludedBookings = mutableListOf<BookingEntity>()
+
+        // Straddling start of month
+        shouldBeIncludedBookings += bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withServiceName(ServiceName.approvedPremises)
+          withStaffKeyWorkerCode(keyWorker.code)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.of(2023, 3, 29))
+          withDepartureDate(LocalDate.of(2023, 4, 1))
+        }
+
+        // Straddling end of month
+        shouldBeIncludedBookings += bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withServiceName(ServiceName.approvedPremises)
+          withStaffKeyWorkerCode(keyWorker.code)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.of(2023, 4, 2))
+          withDepartureDate(LocalDate.of(2023, 4, 3))
+        }
+
+        // Entirely within month
+        shouldBeIncludedBookings += bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withServiceName(ServiceName.approvedPremises)
+          withStaffKeyWorkerCode(keyWorker.code)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.of(2023, 4, 30))
+          withDepartureDate(LocalDate.of(2023, 5, 15))
+        }
+
+        // Encompassing month
+        shouldBeIncludedBookings += bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withServiceName(ServiceName.approvedPremises)
+          withStaffKeyWorkerCode(keyWorker.code)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.of(2023, 3, 28))
+          withDepartureDate(LocalDate.of(2023, 5, 28))
+        }
+
+        // Before month
+        shouldNotBeIncludedBookings += bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withServiceName(ServiceName.approvedPremises)
+          withStaffKeyWorkerCode(keyWorker.code)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.of(2023, 3, 28))
+          withDepartureDate(LocalDate.of(2023, 3, 30))
+        }
+
+        // After month
+        shouldNotBeIncludedBookings += bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withServiceName(ServiceName.approvedPremises)
+          withStaffKeyWorkerCode(keyWorker.code)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.of(2023, 5, 1))
+          withDepartureDate(LocalDate.of(2023, 5, 3))
+        }
+
+        val expectedDataFrame = BookingsReportGenerator()
+          .createReport(shouldBeIncludedBookings, BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
+
+        webTestClient.get()
+          .uri("/reports/bookings?year=2023&month=4")
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -44,6 +44,51 @@ class ReportsTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get bookings report returns 400 if month is provided and not within 1-12`() {
+    `Given a User` { user, jwt ->
+      webTestClient.get()
+        .uri("/reports/bookings?probationRegionId=${user.probationRegion.id}&year=2023&month=-1")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("month must be between 1 and 12")
+    }
+  }
+
+  @Test
+  fun `Get bookings report returns 400 if month is provided without year`() {
+    `Given a User` { user, jwt ->
+      webTestClient.get()
+        .uri("/reports/bookings?probationRegionId=${user.probationRegion.id}&month=1")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("month and year must be provided together")
+    }
+  }
+
+  @Test
+  fun `Get bookings report returns 400 if year is provided without month`() {
+    `Given a User` { user, jwt ->
+      webTestClient.get()
+        .uri("/reports/bookings?probationRegionId=${user.probationRegion.id}&year=2023")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("month and year must be provided together")
+    }
+  }
+
+  @Test
   fun `Get bookings report returns OK with correct body`() {
     `Given a User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -64,10 +64,10 @@ class BookingsReportGeneratorTest {
 
     val allBookings = approvedPremisesBookings + temporaryAccommodationBookings
 
-    val actual1 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual1 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual1.count()).isEqualTo(5)
 
-    val actual2 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual2 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual2.count()).isEqualTo(4)
   }
 
@@ -110,7 +110,7 @@ class BookingsReportGeneratorTest {
 
     val allBookings = expectedBookings + unexpectedBookings
 
-    val actual = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, probationRegionId))
+    val actual = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, probationRegionId, null, null))
     assertThat(actual.count()).isEqualTo(5)
   }
 
@@ -132,7 +132,7 @@ class BookingsReportGeneratorTest {
       .take(5)
       .toList()
 
-    val actual = reportGenerator.createReport(expectedBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(expectedBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(5)
   }
 
@@ -153,7 +153,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::probationRegion]).isEqualTo("East of England")
   }
@@ -175,7 +175,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::crn]).isEqualTo("X123456")
   }
@@ -200,7 +200,7 @@ class BookingsReportGeneratorTest {
       .withBooking(booking)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::offerAccepted]).isTrue
   }
@@ -221,7 +221,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::offerAccepted]).isFalse
   }
@@ -253,7 +253,7 @@ class BookingsReportGeneratorTest {
         .produce()
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::isCancelled]).isTrue
     assertThat(actual.count()).isEqualTo(1)
@@ -276,7 +276,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::isCancelled]).isFalse
     assertThat(actual.count()).isEqualTo(1)
@@ -306,7 +306,7 @@ class BookingsReportGeneratorTest {
       .withBooking(booking)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::startDate]).isEqualTo(today)
     assertThat(actual.count()).isEqualTo(1)
@@ -329,7 +329,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::startDate]).isNull()
     assertThat(actual.count()).isEqualTo(1)
@@ -374,7 +374,7 @@ class BookingsReportGeneratorTest {
         .produce()
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualEndDate]).isEqualTo(today)
   }
@@ -395,7 +395,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualEndDate]).isNull()
   }
@@ -425,7 +425,7 @@ class BookingsReportGeneratorTest {
       .withBooking(booking)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isEqualTo(37)
   }
@@ -446,7 +446,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isNull()
   }
@@ -497,7 +497,7 @@ class BookingsReportGeneratorTest {
         .produce()
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isNull()
   }
@@ -548,7 +548,7 @@ class BookingsReportGeneratorTest {
         .produce()
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isEqualTo(87L)
   }
@@ -569,7 +569,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isNull()
   }
@@ -609,7 +609,7 @@ class BookingsReportGeneratorTest {
         .produce()
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::accommodationOutcome]).isEqualTo("Joined the Space Force")
   }
@@ -630,7 +630,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null))
+    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, null, null))
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::accommodationOutcome]).isNull()
   }


### PR DESCRIPTION
https://trello.com/c/p1Jey0Qq/1059-change-booking-report-endpoint-to-require-a-month-and-year