### PR TITLE
Set up an integration to gov uk bank holidays

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://api-dev.prison.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://dev.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
+    SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL: https://www.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://api-preprod.prison.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://preprod.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-preprod.hmpps.service.justice.gov.uk
+    SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL: https://www.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     SENTRY_ENVIRONMENT: preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://api.prison.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys.hmpps.service.justice.gov.uk
+    SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL: https://www.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: false
     SENTRY_ENVIRONMENT: prod

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -18,6 +18,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://community-accommodation-wiremock.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://community-accommodation-wiremock.hmpps.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://community-accommodation-wiremock.hmpps.service.justice.gov.uk
+    SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL: https://www.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev,classpath:db/migration/test,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component
+class GovUKBankHolidaysApiClient(@Qualifier("govUKBankHolidaysApiClient") webClient: WebClient,
+                                 objectMapper: ObjectMapper
+) : BaseHMPPSClient(webClient, objectMapper) {
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
@@ -14,7 +14,7 @@ class GovUKBankHolidaysApiClient(
   objectMapper: ObjectMapper
 ) : BaseHMPPSClient(webClient, objectMapper) {
 
-  @Cacheable(value = ["uKBankHolidaysCache"], unless = IS_NOT_SUCCESSFUL)
+  @Cacheable(value = ["ukBankHolidaysCache"], unless = IS_NOT_SUCCESSFUL)
   fun getUKBankHolidays() = getRequest<UKBankHolidays> {
     path = "/bank-holidays.json"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
@@ -2,12 +2,20 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
 
 @Component
-class GovUKBankHolidaysApiClient(@Qualifier("govUKBankHolidaysApiClient") webClient: WebClient,
-                                 objectMapper: ObjectMapper
+class GovUKBankHolidaysApiClient(
+  @Qualifier("govUKBankHolidaysApiWebClient") webClient: WebClient,
+  objectMapper: ObjectMapper
 ) : BaseHMPPSClient(webClient, objectMapper) {
 
+  @Cacheable(value = ["uKBankHolidaysCache"], unless = IS_NOT_SUCCESSFUL)
+  fun getUKBankHolidays() = getRequest<UKBankHolidays> {
+    path = "/bank-holidays.json"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -123,7 +123,7 @@ class WebClientConfiguration {
       .build()
   }
 
-  @Bean(name = ["govUKBankHolidaysApiClient"])
+  @Bean(name = ["govUKBankHolidaysApiWebClient"])
   fun govUKBankHolidaysApiClient(
     @Value("\${services.gov-uk-bank-holidays-api.base-url}") govUKBankHolidaysApiBaseUrl: String
   ): WebClient {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -122,4 +122,13 @@ class WebClientConfiguration {
       .filter(oauth2Client)
       .build()
   }
+
+  @Bean(name = ["govUKBankHolidaysApiClient"])
+  fun govUKBankHolidaysApiClient(
+    @Value("\${services.gov-uk-bank-holidays-api.base-url}") govUKBankHolidaysApiBaseUrl: String
+  ): WebClient {
+    return WebClient.builder()
+      .baseUrl(govUKBankHolidaysApiBaseUrl)
+      .build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/bankholidaysapi/UKBankHolidays.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/bankholidaysapi/UKBankHolidays.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+
+data class UKBankHolidays(
+  @JsonProperty("england-and-wales")
+  val englandAndWales: CountryBankHolidays,
+  @JsonProperty("scotland")
+  val scotland: CountryBankHolidays,
+  @JsonProperty("northern-ireland")
+  val northernIreland: CountryBankHolidays
+)
+
+data class CountryBankHolidays(
+  val division: String,
+  val events: List<BankHolidayEvent>
+)
+
+data class BankHolidayEvent(
+  val title: String,
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val date: LocalDate,
+  val notes: String,
+  val bunting: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.GovUKBankHolidaysApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWorkingDay
+import java.time.LocalDate
+
+@Service
+class WorkingDayCountService(
+  private val govUKBankHolidaysApiClient: GovUKBankHolidaysApiClient
+) {
+
+  fun getWorkingDaysCount(from: LocalDate, to: LocalDate): Int {
+    val bankHolidays = when (val govUKBankHolidaysResponse = govUKBankHolidaysApiClient.getUKBankHolidays()) {
+      is ClientResult.Success -> govUKBankHolidaysResponse.body.englandAndWales.events.map { it.date }
+      is ClientResult.Failure -> govUKBankHolidaysResponse.throwException()
+    }
+    return from.getDaysUntilInclusive(to).filter { it.isWorkingDay(bankHolidays) }.size
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
@@ -57,3 +58,8 @@ infix fun ClosedRange<LocalDate>.overlaps(other: ClosedRange<LocalDate>): Boolea
 
   return !(thisFullyBefore || thisFullyAfter)
 }
+
+fun LocalDate.isWorkingDay(bankHolidays: List<LocalDate>) =
+  this.dayOfWeek != DayOfWeek.SATURDAY &&
+    this.dayOfWeek != DayOfWeek.SUNDAY &&
+    !bankHolidays.contains(this)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,6 +125,8 @@ services:
     base-url: http://localhost:9004
   ap-oasys-context-api:
     base-url: http://localhost:9004
+  gov-uk-bank-holidays-api:
+    base-url: https://www.gov.uk
 
 hmpps:
   auth:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WorkingDayCountServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WorkingDayCountServiceTest.kt
@@ -1,0 +1,162 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.GovUKBankHolidaysApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.BankHolidayEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.CountryBankHolidays
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import java.util.stream.Stream
+
+class WorkingDayCountServiceTest {
+
+  private val mockGovUKBankHolidaysApiClient = mockk<GovUKBankHolidaysApiClient>()
+
+  private val workingDayCountService = WorkingDayCountService(mockGovUKBankHolidaysApiClient)
+
+  private val emptyBankHolidays = ClientResult.Success(
+    HttpStatus.OK,
+    UKBankHolidays(
+      englandAndWales = CountryBankHolidays(
+        division = "england-and-wales",
+        events = listOf()
+      ),
+      scotland = CountryBankHolidays(
+        division = "scotland",
+        events = listOf()
+      ),
+      northernIreland = CountryBankHolidays(
+        division = "northern-ireland",
+        events = listOf()
+      )
+    )
+  )
+
+  @ParameterizedTest(name = "getWorkingDaysCount returns 0 if from and to are the same date = {0} and it is a weekend day")
+  @MethodSource("weekendDayProvider")
+  fun `getWorkingDaysCount returns 0 if from and to are the same date and it is a weekend day`(
+    from: LocalDate
+  ) {
+    every {
+      mockGovUKBankHolidaysApiClient.getUKBankHolidays()
+    } returns emptyBankHolidays
+
+    assertThat(workingDayCountService.getWorkingDaysCount(from, from)).isEqualTo(0)
+  }
+
+  @Test
+  fun `getWorkingDaysCount returns 0 if from and to are the same date and it is a week day bank holiday`() {
+
+    val weekDayBankHoliday = LocalDate.of(2023, 4, 27).with(TemporalAdjusters.next(DayOfWeek.TUESDAY))
+
+    val bankHolidays = ClientResult.Success(
+      HttpStatus.OK,
+      UKBankHolidays(
+        englandAndWales = CountryBankHolidays(
+          division = "england-and-wales",
+          events = listOf(
+            BankHolidayEvent(
+              title = "sunny bank holiday",
+              date = weekDayBankHoliday,
+              notes = "",
+              bunting = true
+            )
+          )
+        ),
+        scotland = CountryBankHolidays(
+          division = "scotland",
+          events = listOf()
+        ),
+        northernIreland = CountryBankHolidays(
+          division = "northern-ireland",
+          events = listOf()
+        )
+      )
+    )
+
+    every {
+      mockGovUKBankHolidaysApiClient.getUKBankHolidays()
+    } returns bankHolidays
+
+    assertThat(workingDayCountService.getWorkingDaysCount(weekDayBankHoliday, weekDayBankHoliday)).isEqualTo(0)
+  }
+
+  @Test
+  fun `getWorkingDaysCount returns 1 if from and to are the same date and it is not a weekend day and it is not a bank holiday`() {
+
+    every {
+      mockGovUKBankHolidaysApiClient.getUKBankHolidays()
+    } returns emptyBankHolidays
+
+    val weekDay = LocalDate.of(2023, 4, 27).with(TemporalAdjusters.next(DayOfWeek.TUESDAY))
+
+    assertThat(workingDayCountService.getWorkingDaysCount(weekDay, weekDay)).isEqualTo(1)
+  }
+
+  private companion object {
+    @JvmStatic
+    fun weekendDayProvider(): Stream<Arguments> {
+      val from = LocalDate.of(2023, 4, 27)
+      return Stream.of(
+        Arguments.of(from.with(TemporalAdjusters.next(DayOfWeek.SATURDAY))),
+        Arguments.of(from.with(TemporalAdjusters.next(DayOfWeek.SUNDAY))),
+      )
+    }
+  }
+
+  @Test
+  fun `getWorkingDaysCount returns 3 for a week period that includes 2 bank holidays`() {
+    val aMonday = LocalDate.of(2023, 4, 27).with(TemporalAdjusters.next(DayOfWeek.MONDAY))
+    val aSunday = aMonday.plusDays(6)
+    val aTuesdayBankHoliday = aMonday.plusDays(1)
+    val aThursdayBankHoliday = aMonday.plusDays(3)
+
+    val bankHolidays = ClientResult.Success(
+      HttpStatus.OK,
+      UKBankHolidays(
+        englandAndWales = CountryBankHolidays(
+          division = "england-and-wales",
+          events = listOf(
+            BankHolidayEvent(
+              title = "sunny tuesday bank holiday",
+              date = aTuesdayBankHoliday,
+              notes = "",
+              bunting = true
+            ),
+            BankHolidayEvent(
+              title = "sunny thursday bank holiday",
+              date = aThursdayBankHoliday,
+              notes = "",
+              bunting = true
+            )
+          )
+        ),
+        scotland = CountryBankHolidays(
+          division = "scotland",
+          events = listOf()
+        ),
+        northernIreland = CountryBankHolidays(
+          division = "northern-ireland",
+          events = listOf()
+        )
+      )
+    )
+
+    every {
+      mockGovUKBankHolidaysApiClient.getUKBankHolidays()
+    } returns bankHolidays
+
+    assertThat(workingDayCountService.getWorkingDaysCount(aMonday, aSunday)).isEqualTo(3)
+  }
+}


### PR DESCRIPTION
### Task
https://trello.com/c/LNcyCgA9/1057-set-up-an-integration-to-govuk-bank-holidays
### Changes
This PR include changes to add:
-   An integration for gov uk bank holidays endpoint
-  A working day count service to return working day count between two dates (both inclusive)
