### PR TITLE
Automatically create a turnaround when creating a new Temporary Accommodation booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -15,6 +15,7 @@ import org.springframework.data.redis.serializer.RedisSerializer
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
@@ -37,6 +38,7 @@ class RedisConfiguration {
     @Value("\${caches.inmateDetails.expiry-seconds}") inmateDetailsExpirySeconds: Long,
     @Value("\${caches.staffDetails.expiry-seconds}") staffDetailsExpirySeconds: Long,
     @Value("\${caches.teamManagingCases.expiry-seconds}") teamManagingCasesExpirySeconds: Long,
+    @Value("\${caches.ukBankHolidays.expiry-seconds}") ukBankHolidaysExpirySeconds: Long,
   ): RedisCacheManagerBuilderCustomizer? {
     val time = buildProperties.time.epochSecond.toString()
 
@@ -47,6 +49,7 @@ class RedisConfiguration {
         .clientCacheFor<InmateDetail>("inmateDetailsCache", Duration.ofSeconds(inmateDetailsExpirySeconds), time, objectMapper)
         .clientCacheFor<StaffUserDetails>("staffDetailsCache", Duration.ofSeconds(staffDetailsExpirySeconds), time, objectMapper)
         .clientCacheFor<ManagingTeamsResponse>("teamsManagingCaseCache", Duration.ofSeconds(teamManagingCasesExpirySeconds), time, objectMapper)
+        .clientCacheFor<UKBankHolidays>("ukBankHolidaysCache", Duration.ofSeconds(ukBankHolidaysExpirySeconds), time, objectMapper)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -357,7 +357,8 @@ class PremisesController(
           crn = body.crn,
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
-          bedId = body.bedId
+          bedId = body.bedId,
+          enableTurnarounds = body.enableTurnarounds ?: false,
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -28,6 +28,15 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
 
   @Query("SELECT b FROM BookingEntity b WHERE b.bed.id = :bedId AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate AND SIZE(b.cancellations) = 0 AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)")
   fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<BookingEntity>
+
+  @Query(
+    "SELECT b FROM BookingEntity b " +
+      "WHERE b.bed.id = :bedId " +
+      "AND b.arrivalDate <= :date " +
+      "AND SIZE(b.cancellations) = 0 " +
+      "AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)"
+  )
+  fun findByBedIdAndArrivingBeforeDate(bedId: UUID, date: LocalDate, thisEntityId: UUID?): List<BookingEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.GovUKBankHolidaysApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNextWorkingDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWorkingDay
 import java.time.LocalDate
 
@@ -18,5 +19,19 @@ class WorkingDayCountService(
       is ClientResult.Failure -> govUKBankHolidaysResponse.throwException()
     }
     return from.getDaysUntilInclusive(to).filter { it.isWorkingDay(bankHolidays) }.size
+  }
+
+  fun addWorkingDays(date: LocalDate, count: Int): LocalDate {
+    val bankHolidays = when (val govUKBankHolidaysResponse = govUKBankHolidaysApiClient.getUKBankHolidays()) {
+      is ClientResult.Success -> govUKBankHolidaysResponse.body.englandAndWales.events.map { it.date }
+      is ClientResult.Failure -> govUKBankHolidaysResponse.throwException()
+    }
+
+    var result = date
+    for (i in 0 until count) {
+      result = result.getNextWorkingDay(bankHolidays)
+    }
+
+    return result
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -22,6 +22,7 @@ class BookingTransformer(
   private val confirmationTransformer: ConfirmationTransformer,
   private val extensionTransformer: ExtensionTransformer,
   private val bedTransformer: BedTransformer,
+  private val turnaroundTransformer: TurnaroundTransformer,
   private val enumConverterFactory: EnumConverterFactory,
 ) {
   fun transformJpaToApi(jpa: BookingEntity, offender: OffenderDetailSummary, inmateDetail: InmateDetail, staffMember: StaffMember?) = Booking(
@@ -44,6 +45,8 @@ class BookingTransformer(
     originalArrivalDate = jpa.originalArrivalDate,
     originalDepartureDate = jpa.originalDepartureDate,
     createdAt = jpa.createdAt.toInstant(),
+    turnaround = jpa.turnaround?.let(turnaroundTransformer::transformJpaToApi),
+    turnarounds = jpa.turnarounds.map(turnaroundTransformer::transformJpaToApi),
   )
 
   private fun determineStatus(jpa: BookingEntity) = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TurnaroundTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TurnaroundTransformer.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+
+@Component
+class TurnaroundTransformer {
+  fun transformJpaToApi(jpa: TurnaroundEntity) = Turnaround(
+    id = jpa.id,
+    bookingId = jpa.booking.id,
+    workingDays = jpa.workingDayCount,
+    createdAt = jpa.createdAt.toInstant(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -63,3 +63,12 @@ fun LocalDate.isWorkingDay(bankHolidays: List<LocalDate>) =
   this.dayOfWeek != DayOfWeek.SATURDAY &&
     this.dayOfWeek != DayOfWeek.SUNDAY &&
     !bankHolidays.contains(this)
+
+fun LocalDate.getNextWorkingDay(bankHolidays: List<LocalDate>): LocalDate {
+  var result = this.plusDays(1)
+  while (!result.isWorkingDay(bankHolidays)) {
+    result = result.plusDays(1)
+  }
+
+  return result
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,6 +165,8 @@ caches:
     expiry-seconds: 1200
   teamManagingCases:
     expiry-seconds: 21600
+  ukBankHolidays:
+    expiry-seconds: 86400
 
 seed:
   file-prefix: "/tmp/seed"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TurnaroundEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TurnaroundEntityFactory.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import java.time.OffsetDateTime
+import java.util.UUID
+
+public class TurnaroundEntityFactory : Factory<TurnaroundEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var workingDayCount: Yielded<Int> = { randomInt(0, 14) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var booking: Yielded<BookingEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withWorkingDayCount(workingDayCount: Int) = apply {
+    this.workingDayCount = { workingDayCount }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withBooking(booking: BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withYieldedBooking(booking: Yielded<BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  override fun produce() = TurnaroundEntity(
+    id = this.id(),
+    workingDayCount = this.workingDayCount(),
+    createdAt = this.createdAt(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Must provide a Booking"),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
@@ -102,6 +103,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepositor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
@@ -145,6 +147,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationPremisesTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TurnaroundTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserTestRepository
@@ -344,6 +347,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var probationDeliveryUnitRepository: ProbationDeliveryUnitTestRepository
 
+  @Autowired
+  lateinit var turnaroundRepository: TurnaroundTestRepository
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
@@ -384,6 +390,7 @@ abstract class IntegrationTestBase {
   lateinit var bookingNotMadeFactory: PersistedFactory<BookingNotMadeEntity, UUID, BookingNotMadeEntityFactory>
   lateinit var probationDeliveryUnitFactory: PersistedFactory<ProbationDeliveryUnitEntity, UUID, ProbationDeliveryUnitEntityFactory>
   lateinit var applicationTeamCodeFactory: PersistedFactory<ApplicationTeamCodeEntity, UUID, ApplicationTeamCodeEntityFactory>
+  lateinit var turnaroundFactory: PersistedFactory<TurnaroundEntity, UUID, TurnaroundEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -450,6 +457,7 @@ abstract class IntegrationTestBase {
     bookingNotMadeFactory = PersistedFactory({ BookingNotMadeEntityFactory() }, bookingNotMadeRepository)
     probationDeliveryUnitFactory = PersistedFactory({ ProbationDeliveryUnitEntityFactory() }, probationDeliveryUnitRepository)
     applicationTeamCodeFactory = PersistedFactory({ ApplicationTeamCodeEntityFactory() }, applicationTeamCodeRepository)
+    turnaroundFactory = PersistedFactory({ TurnaroundEntityFactory() }, turnaroundRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
@@ -1166,6 +1167,8 @@ class LostBedsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.parse("2022-08-15"))
         }
 
+        GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
         webTestClient.post()
           .uri("/premises/${premises.id}/lost-beds")
           .header("Authorization", "Bearer $jwt")
@@ -1425,6 +1428,8 @@ class LostBedsTest : IntegrationTestBase() {
         withArrivalDate(LocalDate.parse("2022-07-15"))
         withDepartureDate(LocalDate.parse("2022-08-15"))
       }
+
+      GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
       webTestClient.put()
         .uri("/premises/${premises.id}/lost-beds/${lostBeds.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/GovUKBankHolidaysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/GovUKBankHolidaysAPI.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.CountryBankHolidays
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
+
+fun IntegrationTestBase.GovUKBankHolidaysAPI_mockSuccessfulCall(bankHolidays: UKBankHolidays) =
+  mockSuccessfulGetCallWithJsonResponse(
+    url = "/bank-holidays.json",
+    responseBody = bankHolidays
+  )
+
+fun IntegrationTestBase.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse() =
+  GovUKBankHolidaysAPI_mockSuccessfulCall(
+    UKBankHolidays(
+      englandAndWales = CountryBankHolidays("england-and-wales", listOf()),
+      scotland = CountryBankHolidays("scotland", listOf()),
+      northernIreland = CountryBankHolidays("northern-ireland", listOf()),
+    )
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TurnaroundTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TurnaroundTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import java.util.UUID
+
+@Repository
+interface TurnaroundTestRepository : JpaRepository<TurnaroundEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
@@ -37,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMemberName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
@@ -49,6 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -64,6 +67,7 @@ class BookingTransformerTest {
   private val mockDepartureTransformer = mockk<DepartureTransformer>()
   private val mockExtensionTransformer = mockk<ExtensionTransformer>()
   private val mockBedTransformer = mockk<BedTransformer>()
+  private val mockTurnaroundTransformer = mockk<TurnaroundTransformer>()
   private val enumConverterFactory = EnumConverterFactory()
 
   private val bookingTransformer = BookingTransformer(
@@ -76,6 +80,7 @@ class BookingTransformerTest {
     mockConfirmationTransformer,
     mockExtensionTransformer,
     mockBedTransformer,
+    mockTurnaroundTransformer,
     enumConverterFactory,
   )
 
@@ -219,6 +224,7 @@ class BookingTransformerTest {
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         departures = listOf(),
         cancellations = listOf(),
+        turnarounds = listOf(),
       )
     )
   }
@@ -257,6 +263,7 @@ class BookingTransformerTest {
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         departures = listOf(),
         cancellations = listOf(),
+        turnarounds = listOf(),
       )
     )
   }
@@ -319,6 +326,7 @@ class BookingTransformerTest {
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         departures = listOf(),
         cancellations = listOf(),
+        turnarounds = listOf(),
       )
     )
   }
@@ -383,6 +391,7 @@ class BookingTransformerTest {
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         departures = listOf(),
         cancellations = listOf(),
+        turnarounds = listOf(),
       )
     )
   }
@@ -453,6 +462,7 @@ class BookingTransformerTest {
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
           )
         ),
+        turnarounds = listOf(),
       )
     )
   }
@@ -553,6 +563,7 @@ class BookingTransformerTest {
             createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
           )
         ),
+        turnarounds = listOf(),
       )
     )
   }
@@ -720,6 +731,7 @@ class BookingTransformerTest {
           )
         ),
         cancellations = listOf(),
+        turnarounds = listOf(),
       )
     )
   }
@@ -970,6 +982,7 @@ class BookingTransformerTest {
           )
         ),
         cancellations = listOf(),
+        turnarounds = listOf(),
       )
     )
   }
@@ -1033,6 +1046,114 @@ class BookingTransformerTest {
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         departures = listOf(),
         cancellations = listOf(),
+        turnarounds = listOf(),
+      )
+    )
+  }
+
+  @Test
+  fun `Turnarounds on a booking are correctly transformed`() {
+    val awaitingArrivalBooking = baseBookingEntity.copy(
+      id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+      service = ServiceName.temporaryAccommodation.value,
+      turnarounds = mutableListOf()
+    )
+
+    val turnaround1 = TurnaroundEntity(
+      id = UUID.fromString("34ae3124-cf7a-47d5-86c1-ef9ab4255e30"),
+      workingDayCount = 2,
+      createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
+      booking = awaitingArrivalBooking,
+    )
+    val turnaround2 = TurnaroundEntity(
+      id = UUID.fromString("b2af671a-997d-443e-906d-3a1a28c71416"),
+      workingDayCount = 3,
+      createdAt = OffsetDateTime.parse("2022-07-02T10:11:12.345Z"),
+      booking = awaitingArrivalBooking,
+    )
+    val turnaround3 = TurnaroundEntity(
+      id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
+      workingDayCount = 4,
+      createdAt = OffsetDateTime.parse("2022-07-03T09:08:07.654Z"),
+      booking = awaitingArrivalBooking,
+    )
+
+    awaitingArrivalBooking.turnarounds += listOf(turnaround1, turnaround2, turnaround3)
+
+    every { mockTurnaroundTransformer.transformJpaToApi(turnaround1) } returns Turnaround(
+      id = UUID.fromString("34ae3124-cf7a-47d5-86c1-ef9ab4255e30"),
+      bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+      workingDays = 2,
+      createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+    )
+
+    every { mockTurnaroundTransformer.transformJpaToApi(turnaround2) } returns Turnaround(
+      id = UUID.fromString("b2af671a-997d-443e-906d-3a1a28c71416"),
+      bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+      workingDays = 3,
+      createdAt = Instant.parse("2022-07-02T10:11:12.345Z"),
+    )
+
+    every { mockTurnaroundTransformer.transformJpaToApi(turnaround3) } returns Turnaround(
+      id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
+      bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+      workingDays = 4,
+      createdAt = Instant.parse("2022-07-03T09:08:07.654Z"),
+    )
+
+    val transformedBooking = bookingTransformer.transformJpaToApi(awaitingArrivalBooking, offenderDetails, inmateDetail, null)
+
+    assertThat(transformedBooking).isEqualTo(
+      Booking(
+        id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+        person = Person(
+          crn = "crn",
+          name = "first last",
+          dateOfBirth = LocalDate.parse("2022-09-08"),
+          sex = "Male",
+          status = Person.Status.inCommunity,
+          nomsNumber = "NOMS321",
+          nationality = "English",
+          religionOrBelief = null,
+          genderIdentity = null,
+          prisonName = null
+        ),
+        arrivalDate = LocalDate.parse("2022-08-10"),
+        departureDate = LocalDate.parse("2022-08-30"),
+        status = BookingStatus.provisional,
+        extensions = listOf(),
+        serviceName = ServiceName.temporaryAccommodation,
+        originalArrivalDate = LocalDate.parse("2022-08-10"),
+        originalDepartureDate = LocalDate.parse("2022-08-30"),
+        createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+        departures = listOf(),
+        cancellations = listOf(),
+        turnaround = Turnaround(
+          id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
+          bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+          workingDays = 4,
+          createdAt = Instant.parse("2022-07-03T09:08:07.654Z"),
+        ),
+        turnarounds = listOf(
+          Turnaround(
+            id = UUID.fromString("34ae3124-cf7a-47d5-86c1-ef9ab4255e30"),
+            bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+            workingDays = 2,
+            createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+          ),
+          Turnaround(
+            id = UUID.fromString("b2af671a-997d-443e-906d-3a1a28c71416"),
+            bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+            workingDays = 3,
+            createdAt = Instant.parse("2022-07-02T10:11:12.345Z"),
+          ),
+          Turnaround(
+            id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
+            bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
+            workingDays = 4,
+            createdAt = Instant.parse("2022-07-03T09:08:07.654Z"),
+          ),
+        ),
       )
     )
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -71,6 +71,8 @@ services:
     base-url: http://localhost:#WIREMOCK_PORT
   ap-oasys-context-api:
     base-url: http://localhost:#WIREMOCK_PORT
+  gov-uk-bank-holidays-api:
+    base-url: http://localhost:#WIREMOCK_PORT
 
 prison-case-notes:
   lookback-days: 365


### PR DESCRIPTION
> See ticket #1027 on the CAS3 Trello board](https://trello.com/c/k0gQjnra/1027-new-bookings-automatically-create-a-new-turnaround-record).

This PR is the second part of the work to introduce and automatically create turnarounds for bookings. It follows on from #607, which created the `turnarounds` table in the database and introduced the associated `TurnaroundEntity`.

This PR contains the following changes:
- A turnaround is automatically created for a booking when the booking itself is created. The working day count is set to the value as specified on the premises that the booking is within.
- The Redis configuration has been updated to support the GOV.UK Bank Holidays API, which was introduced as a dependency in #606, and configured with a cache expiry of 1 day.
- The booking conflict check has been updated to incorporate the turnaround time, which requires the calculation of a given number of working days (i.e. Monday-Friday and not a bank holiday) from a given date.