### PR TITLE
Update bed search endpoint to filter out beds with an active turnaround

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -40,6 +40,18 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       "AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)"
   )
   fun findByBedIdAndArrivingBeforeDate(bedId: UUID, date: LocalDate, thisEntityId: UUID?): List<BookingEntity>
+
+  @Query(
+    "SELECT b FROM BookingEntity b WHERE (b.bed, b.departureDate) IN (" +
+      "  SELECT b2.bed, MAX(b2.departureDate)" +
+      "  FROM BookingEntity b2 " +
+      "  WHERE b2.departureDate < :date " +
+      "  AND b2.bed.id IN :bedIds " +
+      "  AND SIZE(b2.cancellations) = 0 " +
+      "  GROUP BY b2.bed " +
+      ")"
+  )
+  fun findClosestBookingBeforeDateForBeds(date: LocalDate, bedIds: List<UUID>): List<BookingEntity>
 }
 
 @Entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -230,6 +231,84 @@ class BedSearchTest : IntegrationTestBase() {
                   serviceName = ServiceName.approvedPremises,
                 ),
               ),
+            ),
+          ),
+        )
+    }
+  }
+
+  @Test
+  fun `Searching for a Temporary Accommodation Bed returns results that do not include beds with current turnarounds`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea {
+        apAreaEntityFactory.produceAndPersist()
+      }
+    }
+
+    val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+    }
+
+    `Given a User`(
+      probationRegion = probationRegion
+    ) { _, jwt ->
+      val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+      val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+        withLocalAuthorityArea(localAuthorityArea)
+        withProbationDeliveryUnit(searchPdu)
+        withProbationRegion(probationRegion)
+        withStatus(PropertyStatus.active)
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premises)
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withName("Matching Bed")
+        withRoom(room)
+      }
+
+      val booking = bookingEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withBed(bed)
+        withArrivalDate(LocalDate.parse("2022-12-21"))
+        withDepartureDate(LocalDate.parse("2023-03-21"))
+      }
+
+      val turnaround = turnaroundFactory.produceAndPersist {
+        withBooking(booking)
+        withWorkingDayCount(2)
+      }
+
+      booking.turnarounds = mutableListOf(turnaround)
+
+      GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+      webTestClient.post()
+        .uri("/beds/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          TemporaryAccommodationBedSearchParameters(
+            startDate = LocalDate.parse("2023-03-23"),
+            durationDays = 7,
+            serviceName = "temporary-accommodation",
+            probationDeliveryUnit = searchPdu.name,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            BedSearchResults(
+              resultsRoomCount = 0,
+              resultsPremisesCount = 0,
+              resultsBedCount = 0,
+              results = listOf(),
             ),
           ),
         )


### PR DESCRIPTION
> See [ticket #1056 on the CAS3 Trello board](https://trello.com/c/QRj1kCPr/1056-find-a-bedspace-journey-should-take-turnarounds-into-account-before-returning-them-as-available-options).

This PR updates the bed search logic to filter out beds with a booking that will be in a turnaround state at some point during the desired date range.

Due to the dependency on external services for calculating the duration of a turnaround, the existing SQL query has not been modified, and the filtering logic has been implemented at the service level. To do this, the following simplifying assumptions have been made:
- A booking that overlaps at all with the desired range of dates is already filtered out by the existing SQL query.
- Only the booking with the closest departure date for each candidate bed can possibly have a turnaround that would encroach on the desired dates.