### PR TITLE
Truncate characteristics before create

### DIFF
--- a/src/main/resources/db/migration/local+dev/R__3_create_characteristics.sql
+++ b/src/main/resources/db/migration/local+dev/R__3_create_characteristics.sql
@@ -1,4 +1,7 @@
 -- ${flyway:timestamp}
+
+TRUNCATE TABLE characteristics CASCADE;
+
 insert into
   "characteristics" (
     "id",


### PR DESCRIPTION
The new seeds in #616 broke the build as there were existing characteristics with the same names. As CAS3 don’t use these in the seeds, and premises get truncated on every deploy, I think this is safe to do.