### PR TITLE
Change base image to no longer require JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM openjdk:17-slim AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jre-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
@@ -7,7 +7,7 @@ WORKDIR /app
 ADD . .
 RUN ./gradlew --no-daemon assemble
 
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jre-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER


### PR DESCRIPTION
This new image[1] has no critical or high vulnerabilities whereas the one we were on[2] has 6 critical and 8 high.

When looking at the Kotlin template that we were originally based off we can see that it has made the change from openjdk to eclipse-temurin on the basis that "Kotlin doesn't require JDK to build" [3]. We stop short of jumping to Java 18 as that pull request does to try and make the smallest step.

[1] https://hub.docker.com/layers/library/eclipse-temurin/17-jre-jammy/images/sha256-ddf36656dc8920621fddf4928bdcb4b98c0d0e7bc9672f0cea8115c10ad5cbc6?context=explore
[2] https://hub.docker.com/layers/library/openjdk/17-slim/images/sha256-779635c0c3d23cc8dbab2d8c1ee4cf2a9202e198dfc8f4c0b279824d9b8e0f22?context=explore
[3] https://github.com/ministryofjustice/hmpps-template-kotlin/commit/25457f47e8bd9b03d70408b6c038728f6afcf24e

You can test this with Trivy locally by checking the branch out and running the following:

```
$ docker build . -t test-17jammy
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-17jammy
```