### PR TITLE
1037 - Cache clear mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.nonprod.js
 COPY --from=builder --chown=appuser:appgroup /app/script/run_seed_job /app
 COPY --from=builder --chown=appuser:appgroup /app/script/run_migration_job /app
 COPY --from=builder --chown=appuser:appgroup /app/script/delete_booking /app
-RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job && chmod +x /app/run_migration_job && chmod +x /app/delete_booking
+COPY --from=builder --chown=appuser:appgroup /app/script/clear_cache /app
+RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job && chmod +x /app/run_migration_job && chmod +x /app/delete_booking && chmod +x /app/clear_cache
 
 USER 2000
 

--- a/doc/how-to/clear_a_cache_remotely.md
+++ b/doc/how-to/clear_a_cache_remotely.md
@@ -1,0 +1,29 @@
+# How to clear a cache remotely
+
+## Run book
+
+To clear a cache on a non-local environment:
+
+- Ensure nobody is deploying a change (or is going to deploy a change shortly.)
+
+- Run `kubectl get pod` against the namespace for the environment you wish to run the seed job in. 
+
+- Copy the name of one of the running `hmpps-approved-premises-api` pods.
+
+- Log in to the pod in order to run the script, e.g. 
+  ```
+  kubectl exec --stdin --tty {pod name} -- /bin/bash
+  ```
+
+- Run the helper script from within the container to trigger the cache clear:
+  ```
+  /app/clear_cache {cache name}
+  ```
+
+  Where `cache name` is a value from the `CacheType` enum in the OpenAPI spec.  e.g.
+  ```
+  kubectl exec --stdin --tty {pod name} -- /bin/bash
+  /app/clear_cache qCodeStaffMembers
+  ```
+
+- Check the logs via `kubectl logs {pod name}` to confirm the cache was cleared.

--- a/script/clear_cache
+++ b/script/clear_cache
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/clear_cache:  Clear given type of cache e.g.
+#                      script/clear_cache qCodeStaffMembers
+#                      Would clear the qCodeStaffMembers cache
+
+set -e
+
+curl --location --request DELETE 'http://127.0.0.1:8080/cache/'$1'/clear'
+
+echo "Requested cache clear - check the application logs for status"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -44,6 +44,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
         authorize(HttpMethod.POST, "/seed", permitAll)
+        authorize(HttpMethod.DELETE, "/cache/*", permitAll)
         authorize(HttpMethod.POST, "/migration-job", permitAll)
         authorize(HttpMethod.DELETE, "/internal/booking/*", permitAll)
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/CacheController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/CacheController.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.CacheApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CacheType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CacheService
+
+@Service
+class CacheController(private val cacheService: CacheService) : CacheApiDelegate {
+  override fun cacheCacheNameDelete(cacheName: CacheType): ResponseEntity<Unit> {
+    throwIfNotLoopbackRequest()
+
+    cacheService.clearCache(cacheName)
+
+    return ResponseEntity(HttpStatus.OK)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CacheService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CacheService.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CacheType
+
+@Service
+class CacheService(
+  private val cacheManager: CacheManager,
+  private val redisTemplate: RedisTemplate<String, String>,
+  @Value("\${preemptive-cache-key-prefix}") private val preemptiveCacheKeyPrefix: String
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun clearCache(cacheName: CacheType) {
+    when (cacheName) {
+      CacheType.offenderDetails -> clearPreemptiveCache("offenderDetails")
+      CacheType.inmateDetails -> clearPreemptiveCache("inmateDetails")
+      CacheType.qCodeStaffMembers -> clearRegularCache("qCodeStaffMembersCache")
+      CacheType.userAccess -> clearRegularCache("userAccessCache")
+      CacheType.staffDetails -> clearRegularCache("staffDetailsCache")
+      CacheType.teamsManagingCase -> clearRegularCache("teamsManagingCaseCache")
+      CacheType.ukBankHolidays -> clearRegularCache("ukBankHolidaysCache")
+    }
+  }
+
+  private fun clearRegularCache(cacheName: String) {
+    cacheManager.getCache(cacheName)!!.invalidate()
+
+    log.info("Cleared regular cache $cacheName")
+  }
+
+  private fun clearPreemptiveCache(cacheName: String) {
+    var total: Int
+    redisTemplate.keys("$preemptiveCacheKeyPrefix-$cacheName-**")
+      .apply { total = size }
+      .forEach(redisTemplate::delete)
+
+    log.info("Cleared $total entries from preemptive cache $cacheName")
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2628,6 +2628,24 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /cache/{cacheName}:
+    delete:
+      summary: Clears the given cache, can only be called from a local connection
+      parameters:
+        - in: path
+          name: cacheName
+          required: true
+          schema:
+            $ref: '#/components/schemas/CacheType'
+      responses:
+        200:
+          description: successfully cleared cache
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /migration-job:
     post:
       summary: Starts a migration job (process for data migrations that can't be achieved solely via SQL migrations), can only be called from a local connection
@@ -5404,3 +5422,13 @@ components:
       required:
         - id
         - name
+    CacheType:
+      type: string
+      enum:
+        - qCodeStaffMembers
+        - userAccess
+        - staffDetails
+        - teamsManagingCase
+        - ukBankHolidays
+        - offenderDetails
+        - inmateDetails

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
@@ -1,0 +1,139 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import java.util.UUID
+
+class CacheClearTest : IntegrationTestBase() {
+  @Test
+  fun `Clearing a regular cache results in upstream calls being made again`() {
+    `Given a User`(roles = listOf(UserRole.MANAGER)) { _, jwt ->
+      val premisesId = UUID.fromString("d687f947-ff80-431e-9c72-75f704730978")
+      val qCode = "FOUND"
+
+      setupQCodeUpstreamResponse(premisesId, qCode)
+
+      // Given I call the qCode endpoint twice
+      repeat(2) {
+        webTestClient.get()
+          .uri("/premises/$premisesId/staff")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+      }
+
+      // Then the upstream request should only have been made once
+      validateUpstreamQCodeRequestMade(qCode, times = 1)
+
+      // When I clear the qCode cache
+      webTestClient.delete()
+        .uri("/cache/qCodeStaffMembers")
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // And I call the endpoint again
+      webTestClient.get()
+        .uri("/premises/$premisesId/staff")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // Then the upstream request should be made again
+      validateUpstreamQCodeRequestMade(qCode, times = 2)
+    }
+  }
+
+  @Test
+  fun `Clearing a preemptive cache results in upstream calls being made again`() {
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .produce()
+
+    // Given a Booking for an Offender
+    CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails)
+    setupBookingForOffender(offenderDetails)
+
+    // Then OffenderDetailsCacheRefreshWorker should pick up the CRN and preemptively load it
+    validateUpstreamOffenderDetailsRequestEventuallyMade(offenderDetails.otherIds.crn, times = 1)
+
+    // When I clear the offenderDetails cache
+    webTestClient.delete()
+      .uri("/cache/offenderDetails")
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    // Then OffenderDetailsCacheRefreshWorker should pick up the CRN and preemptively load it again
+    validateUpstreamOffenderDetailsRequestEventuallyMade(offenderDetails.otherIds.crn, times = 2)
+  }
+
+  private fun setupBookingForOffender(offenderDetails: OffenderDetailSummary) {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(
+        probationRegionEntityFactory.produceAndPersist {
+          withApArea(apAreaEntityFactory.produceAndPersist())
+        }
+      )
+      withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+    }
+
+    val room = roomEntityFactory.produceAndPersist {
+      withPremises(premises)
+    }
+
+    val bed = bedEntityFactory.produceAndPersist {
+      withRoom(room)
+    }
+
+    bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(bed)
+      withCrn(offenderDetails.otherIds.crn)
+    }
+  }
+
+  private fun validateUpstreamOffenderDetailsRequestEventuallyMade(crn: String, times: Int) {
+    var attempts = 1
+    while (attempts <= 100) {
+      try {
+        validateUpstreamOffenderDetailsRequestMade(crn, times)
+        break
+      } catch (throwable: Throwable) {
+        if (attempts == 100) {
+          throw RuntimeException("Upstream endpoint was never called by OffenderDetailsCacheRefreshWorker", throwable)
+        }
+      }
+
+      attempts += 1
+      Thread.sleep(500)
+    }
+  }
+
+  private fun validateUpstreamQCodeRequestMade(qCode: String, times: Int) =
+    wiremockServer.verify(WireMock.exactly(times), WireMock.getRequestedFor(WireMock.urlEqualTo("/approved-premises/$qCode/staff")))
+
+  private fun setupQCodeUpstreamResponse(premisesId: UUID, qCode: String) {
+    approvedPremisesEntityFactory.produceAndPersist {
+      withId(premisesId)
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+      withQCode(qCode)
+    }
+
+    APDeliusContext_mockSuccessfulStaffMembersCall(ContextStaffMemberFactory().produce(), qCode)
+  }
+
+  private fun validateUpstreamOffenderDetailsRequestMade(crn: String, times: Int) =
+    wiremockServer.verify(WireMock.exactly(times), WireMock.getRequestedFor(WireMock.urlEqualTo("/secure/offenders/crn/$crn")))
+}


### PR DESCRIPTION
This adds a `DELETE /cache/{cache name}/clear` endpoint that can only be accessed locally which clears the named cache.