### PR TITLE
Fix for gradle build task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,3 +182,5 @@ tasks {
     jvmArgs!!.plus("java.base/java.lang=ALL-UNNAMED")
   }
 }
+
+tasks.getByName("runKtlintCheckOverMainSourceSet").dependsOn("openApiGenerate", "openApiGenerateDomainEvents")


### PR DESCRIPTION
This fixes an issue around `runKtlintCheckOverMainSourceSet` not explitly declaring dependency on `openApiGenerate` and `openApiGenerateDomainEvents`