### PR TITLE
Update placement criteria

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostcodeDistrictRepository
@@ -29,7 +30,7 @@ class BedSearchService(
     maxDistanceMiles: Int,
     startDate: LocalDate,
     durationInDays: Int,
-    requiredCharacteristics: List<String>,
+    requiredCharacteristics: List<PlacementCriteria>,
   ): AuthorisableActionResult<ValidatableActionResult<List<ApprovedPremisesBedSearchResult>>> {
     if (!user.hasRole(UserRole.MATCHER)) {
       return AuthorisableActionResult.Unauthorised()
@@ -40,10 +41,11 @@ class BedSearchService(
         val characteristicErrors = mutableListOf<String>()
         val premisesCharacteristicIds = mutableListOf<UUID>()
         val roomCharacteristicIds = mutableListOf<UUID>()
+        val requiredPropertyNames = requiredCharacteristics.map { it.toString() }
 
-        val characteristics = characteristicService.getCharacteristicsByPropertyNames(requiredCharacteristics)
+        val characteristics = characteristicService.getCharacteristicsByPropertyNames(requiredPropertyNames)
 
-        requiredCharacteristics.forEach { propertyName ->
+        requiredPropertyNames.forEach { propertyName ->
           val characteristic = characteristics.firstOrNull { it.propertyName == propertyName }
           when {
             characteristic == null -> characteristicErrors += "$propertyName doesNotExist"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -55,24 +55,12 @@ class PlacementRequestTransformer(
     return PlacementRequestStatus.matched
   }
 
-  private fun characteristicToCriteria(characteristic: CharacteristicEntity): PlacementCriteria? = when (characteristic.propertyName) {
-    "isSemiSpecialistMentalHealth" -> PlacementCriteria.isSemiSpecialistMentalHealth
-    "isRecoveryFocussed" -> PlacementCriteria.isRecoveryFocussed
-    "isSuitableForVulnerable" -> PlacementCriteria.isSuitableForVulnerable
-    "acceptsSexOffenders" -> PlacementCriteria.acceptsSexOffenders
-    "acceptsChildSexOffenders" -> PlacementCriteria.acceptsChildSexOffenders
-    "acceptsNonSexualChildOffenders" -> PlacementCriteria.acceptsNonSexualChildOffenders
-    "acceptsHateCrimeOffenders" -> PlacementCriteria.acceptsHateCrimeOffenders
-    "isCatered" -> PlacementCriteria.isCatered
-    "hasWideStepFreeAccess" -> PlacementCriteria.hasWideStepFreeAccess
-    "hasWideAccessToCommunalAreas" -> PlacementCriteria.hasWideAccessToCommunalAreas
-    "hasStepFreeAccessToCommunalAreas" -> PlacementCriteria.hasStepFreeAccessToCommunalAreas
-    "hasWheelChairAccessibleBathrooms" -> PlacementCriteria.hasWheelChairAccessibleBathrooms
-    "hasLift" -> PlacementCriteria.hasLift
-    "hasTactileFlooring" -> PlacementCriteria.hasTactileFlooring
-    "hasBrailleSignage" -> PlacementCriteria.hasBrailleSignage
-    "hasHearingLoop" -> PlacementCriteria.hasHearingLoop
-    else -> { null }
+  private fun characteristicToCriteria(characteristic: CharacteristicEntity): PlacementCriteria? {
+    return try {
+      PlacementCriteria.valueOf(characteristic.propertyName!!)
+    } catch (exception: Exception) {
+      null
+    }
   }
 
   private fun getReleaseType(releaseType: String?): ReleaseTypeOption? = when (releaseType) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5083,7 +5083,7 @@ components:
             requiredCharacteristics:
               type: array
               items:
-                type: string
+                $ref: '#/components/schemas/PlacementCriteria'
           required:
             - postcodeDistrict
             - maxDistanceMiles

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5019,6 +5019,9 @@ components:
     PlacementCriteria:
       type: string
       enum:
+        - isPipe
+        - isEsap
+        - isRecoveryFocused
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - isSuitableForVulnerable
@@ -5026,15 +5029,14 @@ components:
         - acceptsChildSexOffenders
         - acceptsNonSexualChildOffenders
         - acceptsHateCrimeOffenders
+        - isWheelchairDesignated
+        - isSingleRoom
+        - isStepFreeDesignated
         - isCatered
-        - hasWideStepFreeAccess
-        - hasWideAccessToCommunalAreas
-        - hasStepFreeAccessToCommunalAreas
-        - hasWheelChairAccessibleBathrooms
-        - hasLift
-        - hasTactileFlooring
-        - hasBrailleSignage
-        - hasHearingLoop
+        - isGroundFloor
+        - hasEnSuite
+        - isSuitedForSexOffenders
+        - isArsonSuitable
     Gender:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -158,8 +158,8 @@ class AssessmentTest : IntegrationTestBase() {
       duration = 12,
       location = "B74",
       radius = 50,
-      essentialCriteria = listOf(PlacementCriteria.hasHearingLoop, PlacementCriteria.hasLift),
-      desirableCriteria = listOf(PlacementCriteria.hasBrailleSignage, PlacementCriteria.acceptsSexOffenders),
+      essentialCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.hasEnSuite),
+      desirableCriteria = listOf(PlacementCriteria.isCatered, PlacementCriteria.acceptsSexOffenders),
       mentalHealthSupport = false
     )
 
@@ -204,8 +204,8 @@ class AssessmentTest : IntegrationTestBase() {
 
             assessment.schemaUpToDate = true
 
-            val essentialCriteria = listOf(PlacementCriteria.hasHearingLoop, PlacementCriteria.hasLift)
-            val desirableCriteria = listOf(PlacementCriteria.hasBrailleSignage, PlacementCriteria.acceptsSexOffenders)
+            val essentialCriteria = listOf(PlacementCriteria.hasEnSuite, PlacementCriteria.isRecoveryFocussed)
+            val desirableCriteria = listOf(PlacementCriteria.acceptsNonSexualChildOffenders, PlacementCriteria.acceptsSexOffenders)
 
             val placementRequirements = PlacementRequirements(
               gender = Gender.male,
@@ -358,8 +358,8 @@ class AssessmentTest : IntegrationTestBase() {
 
             assessment.schemaUpToDate = true
 
-            val essentialCriteria = listOf(PlacementCriteria.hasHearingLoop, PlacementCriteria.hasLift)
-            val desirableCriteria = listOf(PlacementCriteria.hasBrailleSignage, PlacementCriteria.acceptsSexOffenders)
+            val essentialCriteria = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.isEsap)
+            val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
             val placementRequirements = PlacementRequirements(
               gender = Gender.male,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
@@ -79,14 +80,15 @@ class BedSearchServiceTest {
 
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
-    val premisesCharacteristicPropertyName = "unknownPropertyName"
+    val premisesCharacteristicPropertyName = "isRecoveryFocussed"
 
     val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isEsap")
       .withModelScope("room")
       .withServiceScope("approved-premises")
       .produce()
 
-    every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf(premisesCharacteristicPropertyName, roomCharacteristic.propertyName!!)) } returns listOf(roomCharacteristic)
+    every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf("isEsap", premisesCharacteristicPropertyName)) } returns listOf(roomCharacteristic)
 
     val authorisableResult = bedSearchService.findApprovedPremisesBeds(
       user = user,
@@ -94,7 +96,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristicPropertyName, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.isEsap, PlacementCriteria.isRecoveryFocussed),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -123,11 +125,13 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
     val premisesCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("hasEnSuite")
       .withServiceScope("temporary-accommodation")
       .withModelScope("premises")
       .produce()
 
     val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isArsonSuitable")
       .withModelScope("room")
       .withServiceScope("approved-premises")
       .produce()
@@ -140,7 +144,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.hasEnSuite, PlacementCriteria.isArsonSuitable),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -169,11 +173,12 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
     val premisesCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("hasEnSuite")
       .withServiceScope("approved-premises")
       .withModelScope("premises")
       .produce()
 
-    val roomCharacteristicPropertyName = "unknownPropertyName"
+    val roomCharacteristicPropertyName = "isArsonSuitable"
 
     every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf(premisesCharacteristic.propertyName!!, roomCharacteristicPropertyName)) } returns listOf(premisesCharacteristic)
 
@@ -183,7 +188,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristicPropertyName),
+      requiredCharacteristics = listOf(PlacementCriteria.hasEnSuite, PlacementCriteria.isArsonSuitable),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -212,11 +217,13 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
     val premisesCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isArsonSuitable")
       .withServiceScope("approved-premises")
       .withModelScope("premises")
       .produce()
 
     val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("hasEnSuite")
       .withServiceScope("temporary-accommodation")
       .withModelScope("room")
       .produce()
@@ -229,7 +236,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.hasEnSuite),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -258,11 +265,13 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns null
 
     val premisesCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isArsonSuitable")
       .withServiceScope("approved-premises")
       .withModelScope("premises")
       .produce()
 
     val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("hasEnSuite")
       .withServiceScope("approved-premises")
       .withModelScope("room")
       .produce()
@@ -277,7 +286,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.hasEnSuite),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -306,11 +315,13 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
     val premisesCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("hasEnSuite")
       .withServiceScope("approved-premises")
       .withModelScope("premises")
       .produce()
 
     val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isArsonSuitable")
       .withServiceScope("approved-premises")
       .withModelScope("room")
       .produce()
@@ -323,7 +334,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 0,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.hasEnSuite, PlacementCriteria.isArsonSuitable),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -352,11 +363,13 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
     val premisesCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("hasEnSuite")
       .withServiceScope("approved-premises")
       .withModelScope("premises")
       .produce()
 
     val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isArsonSuitable")
       .withServiceScope("approved-premises")
       .withModelScope("room")
       .produce()
@@ -369,7 +382,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 0,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.hasEnSuite, PlacementCriteria.isArsonSuitable),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -398,13 +411,15 @@ class BedSearchServiceTest {
     every { mockPostcodeDistrictRepository.findByOutcode(postcodeDistrict.outcode) } returns postcodeDistrict
 
     val premisesCharacteristic = CharacteristicEntityFactory()
-      .withModelScope("premises")
+      .withPropertyName("hasEnSuite")
       .withServiceScope("approved-premises")
+      .withModelScope("premises")
       .produce()
 
     val roomCharacteristic = CharacteristicEntityFactory()
-      .withModelScope("room")
+      .withPropertyName("isArsonSuitable")
       .withServiceScope("approved-premises")
+      .withModelScope("room")
       .produce()
 
     every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!)) } returns listOf(premisesCharacteristic, roomCharacteristic)
@@ -455,7 +470,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!),
+      requiredCharacteristics = listOf(PlacementCriteria.hasEnSuite, PlacementCriteria.isArsonSuitable),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -79,9 +79,9 @@ class PlacementRequestTransformerTest {
     )
     .withDesirableCriteria(
       listOf(
-        CharacteristicEntityFactory().withPropertyName("hasWideStepFreeAccess").produce(),
-        CharacteristicEntityFactory().withPropertyName("hasLift").produce(),
-        CharacteristicEntityFactory().withPropertyName("hasBrailleSignage").produce(),
+        CharacteristicEntityFactory().withPropertyName("isWheelchairDesignated").produce(),
+        CharacteristicEntityFactory().withPropertyName("isSingleRoom").produce(),
+        CharacteristicEntityFactory().withPropertyName("hasEnSuite").produce(),
         CharacteristicEntityFactory().withPropertyName("somethingElse").produce(),
       ),
     )
@@ -103,7 +103,23 @@ class PlacementRequestTransformerTest {
 
   @Test
   fun `transformJpaToApi transforms a basic placement request entity`() {
-    val placementRequestEntity = placementRequestFactory.produce()
+    val placementRequestEntity = placementRequestFactory
+      .withEssentialCriteria(
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("isSemiSpecialistMentalHealth").produce(),
+          CharacteristicEntityFactory().withPropertyName("isRecoveryFocussed").produce(),
+          CharacteristicEntityFactory().withPropertyName("someOtherPropertyName").produce(),
+        ),
+      )
+      .withDesirableCriteria(
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("isWheelchairDesignated").produce(),
+          CharacteristicEntityFactory().withPropertyName("isSingleRoom").produce(),
+          CharacteristicEntityFactory().withPropertyName("hasEnSuite").produce(),
+          CharacteristicEntityFactory().withPropertyName("somethingElse").produce(),
+        ),
+      )
+      .produce()
 
     val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, offenderDetailSummary, inmateDetail)
 
@@ -117,7 +133,7 @@ class PlacementRequestTransformerTest {
         location = placementRequestEntity.postcodeDistrict.outcode,
         radius = placementRequestEntity.radius,
         essentialCriteria = listOf(PlacementCriteria.isSemiSpecialistMentalHealth, PlacementCriteria.isRecoveryFocussed),
-        desirableCriteria = listOf(PlacementCriteria.hasWideStepFreeAccess, PlacementCriteria.hasLift, PlacementCriteria.hasBrailleSignage),
+        desirableCriteria = listOf(PlacementCriteria.isWheelchairDesignated, PlacementCriteria.isSingleRoom, PlacementCriteria.hasEnSuite),
         mentalHealthSupport = placementRequestEntity.mentalHealthSupport,
         person = mockPerson,
         risks = mockRisks,


### PR DESCRIPTION
This updates the list of placement criteria, so it can be mapped more easily to the Matching Information  (see the Miro board here https://miro.com/app/board/uXjVOJdopVM=/?moveToWidget=3458764554027871863&cot=14). I've also updated the search endpoint to only accept an array of PlacementCriteria, so we can strongly type this in the UI.