### PR TITLE
Remove erroneously added PlacementCriteria

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5021,7 +5021,6 @@ components:
       enum:
         - isPipe
         - isEsap
-        - isRecoveryFocused
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - isSuitableForVulnerable


### PR DESCRIPTION
This was doubled up. I think `isRecoveryFocused` is the correct spelling but as the misspelled one is in the database, I think we should stick with that one for now (as it’s only used as a key)