### PR TITLE
#1515 :zap: Change/Assessments to return necessary information only to prevent OOM problems.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -2,29 +2,79 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import javax.persistence.ColumnResult
+import javax.persistence.ConstructorResult
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.NamedNativeQuery
 import javax.persistence.OneToMany
-import javax.persistence.OneToOne
+import javax.persistence.SqlResultSetMapping
 import javax.persistence.Table
 
 @Repository
 interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
-  fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<AssessmentEntity>
-
-  fun findAllByReallocatedAtNull(): List<AssessmentEntity>
+  @Query(nativeQuery = true)
+  fun findAllAssessmentSummariesNotReallocated(userIdString: String? = null): List<DomainAssessmentSummary>
 
   fun findAllByReallocatedAtNullAndSubmittedAtNull(): List<AssessmentEntity>
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 }
+
+@NamedNativeQuery(
+  name = "AssessmentEntity.findAllAssessmentSummariesNotReallocated",
+  query =
+  """
+    select service as type,
+           cast(a.id as text) as id,
+           cast(a.application_id as text) as applicationId,
+           a.created_at as createdAt,
+           CAST(apa.risk_ratings AS TEXT) as riskRatings,
+           apa.arrival_date as arrivalDate,
+           (
+            select min(acn.created_at)
+             from  assessment_clarification_notes acn
+             where acn.response is null
+                   and acn.assessment_id = a.id
+           ) as dateOfInfoRequest,
+           a.decision is not null as completed,
+           ap.crn as crn
+      from assessments a
+           join applications ap on a.application_id = ap.id
+           left outer join approved_premises_applications apa on ap.id = apa.id
+     where a.reallocated_at is null
+           and (?1 is null or a.allocated_to_user_id = cast(?1 as UUID))
+    """,
+  resultSetMapping = "DomainAssessmentSummaryMapping"
+)
+
+@SqlResultSetMapping(
+  name = "DomainAssessmentSummaryMapping",
+  classes = [
+    ConstructorResult(
+      targetClass = DomainAssessmentSummary::class,
+      columns = [
+        ColumnResult(name = "type"),
+        ColumnResult(name = "id", type = UUID::class),
+        ColumnResult(name = "applicationId", type = UUID::class),
+        ColumnResult(name = "createdAt", type = OffsetDateTime::class),
+        ColumnResult(name = "riskRatings"),
+        ColumnResult(name = "arrivalDate", type = OffsetDateTime::class),
+        ColumnResult(name = "dateOfInfoRequest", type = OffsetDateTime::class),
+        ColumnResult(name = "completed"),
+        ColumnResult(name = "crn"),
+      ]
+    )
+  ]
+)
 
 @Entity
 @Table(name = "assessments")
@@ -32,7 +82,7 @@ data class AssessmentEntity(
   @Id
   val id: UUID,
 
-  @OneToOne
+  @ManyToOne
   @JoinColumn(name = "application_id")
   val application: ApplicationEntity,
 
@@ -65,6 +115,22 @@ data class AssessmentEntity(
 
   @Transient
   var schemaUpToDate: Boolean
+)
+
+/**
+ * Summary data for an assessment - read-only, to be used when retrieving large numbers of Assessments.
+ * Hibernate compatible equals, hash code and toString aren't needed.
+ */
+open class DomainAssessmentSummary(
+  val type: String,
+  val id: UUID,
+  val applicationId: UUID,
+  val createdAt: OffsetDateTime,
+  val riskRatings: String?,
+  val arrivalDate: OffsetDateTime?,
+  val dateOfInfoRequest: OffsetDateTime?,
+  val completed: Boolean,
+  val crn: String
 )
 
 enum class AssessmentDecision {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import org.slf4j.Logger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -28,8 +29,33 @@ fun <T> transformAssessment(
   offenderService: OffenderService,
   transformer: (AssessmentEntity, OffenderDetailSummary, InmateDetail) -> T
 ): T {
-  val personDetail = getPersonDetailsForCrn(log, assessment.application.crn, deliusUsername, offenderService)
+  val (offenderDetailSummary, inmateDetail) = getPersonDetailsForCrn(log, assessment.application.crn, deliusUsername, offenderService)
     ?: throw NotFoundProblem(assessment.application.crn, "Offender")
 
-  return transformer(assessment, personDetail.first, personDetail.second)
+  return transformer(assessment, offenderDetailSummary, inmateDetail)
+}
+
+fun <T> mapAndTransformAssessmentSummaries(
+  log: Logger,
+  assessments: List<DomainAssessmentSummary>,
+  deliusUsername: String,
+  offenderService: OffenderService,
+  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T
+): List<T> {
+  return assessments.mapNotNull {
+    transformAssessmentSummary(log, it, deliusUsername, offenderService, transformer) ?: return@mapNotNull null
+  }
+}
+
+fun <T> transformAssessmentSummary(
+  log: Logger,
+  assessment: DomainAssessmentSummary,
+  deliusUsername: String,
+  offenderService: OffenderService,
+  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T
+): T {
+  val (offenderDetailSummary, inmateDetail) = getPersonDetailsForCrn(log, assessment.crn, deliusUsername, offenderService)
+    ?: throw NotFoundProblem(assessment.crn, "Offender")
+
+  return transformer(assessment, offenderDetailSummary, inmateDetail)
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2316,7 +2316,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Assessment'
+                  $ref: '#/components/schemas/AssessmentSummary'
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -4342,6 +4342,43 @@ components:
               $ref: '#/components/schemas/TemporaryAccommodationUser'
           required:
             - application
+    AssessmentSummary:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - CAS1
+            - CAS3
+        id:
+          type: string
+          format: uuid
+        applicationId:
+          type: string
+          format: uuid
+        arrivalDate:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        dateOfInfoRequest:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/AssessmentStatus'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        person:
+          $ref: '#/components/schemas/Person'
+      required:
+        - type
+        - id
+        - applicationId
+        - createdAt
+        - status
+        - person
+
     AssessmentDecision:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Temporary Accommodation`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+
+class AssessmentSummaryQueryTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realAssessmentRepository: AssessmentRepository
+
+  @Test
+  fun `assessment summary query works as described when not restricted to user`() {
+    `Given a User` { user, _ ->
+      `Given an Assessment for Approved Premises`(user, user, reallocated = true) { _, _ -> }
+      `Given an Assessment for Approved Premises`(user, user) { apAssessment, _ ->
+        val expectedApAssessmentNote = earliestUnansweredClarificationNote(apAssessment, user)
+        `Given an Assessment for Temporary Accommodation`(user, user) { taAssessment, _ ->
+          val expectedTaAssessmentNote = earliestUnansweredClarificationNote(taAssessment, user)
+
+          val results: List<DomainAssessmentSummary> = realAssessmentRepository.findAllAssessmentSummariesNotReallocated()
+
+          assertThat(results.size).isEqualTo(2)
+
+          results.forEach {
+            when (it.id) {
+              apAssessment.id -> assertForAssessmentSummary(it, apAssessment, expectedApAssessmentNote.createdAt)
+              taAssessment.id -> assertForAssessmentSummary(it, taAssessment, expectedTaAssessmentNote.createdAt)
+              else -> fail()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `assessment summary query works as described when restricted to one user`() {
+    `Given a User` { user1, _ ->
+      `Given a User` { user2, _ ->
+        `Given an Assessment for Approved Premises`(user2, user2) { _, _ -> }
+        `Given an Assessment for Approved Premises`(user1, user1, reallocated = true) { _, _ -> }
+        `Given an Assessment for Approved Premises`(user1, user1) { apAssessment, _ ->
+          val expectedApAssessmentNote = earliestUnansweredClarificationNote(apAssessment, user1)
+
+          `Given an Assessment for Temporary Accommodation`(user2, user2) { taAssessment, _ ->
+            earliestUnansweredClarificationNote(taAssessment, user2)
+
+            val results: List<DomainAssessmentSummary> = realAssessmentRepository.findAllAssessmentSummariesNotReallocated(user1.id.toString())
+
+            assertThat(results.size).isEqualTo(1)
+            assertForAssessmentSummary(results[0], apAssessment, expectedApAssessmentNote.createdAt)
+          }
+        }
+      }
+    }
+  }
+
+  private fun assertForAssessmentSummary(summary: DomainAssessmentSummary, assessment: AssessmentEntity, dateOfInfoRequest: OffsetDateTime) {
+    assertThat(summary.id).isEqualTo(assessment.id)
+    val application = assessment.application
+    assertThat(summary.applicationId).isEqualTo(application.id)
+    assertThat(summary.createdAt.toInstant()).isEqualTo(assessment.createdAt.toInstant())
+    assertThat(summary.dateOfInfoRequest?.toInstant()).isEqualTo(dateOfInfoRequest.toInstant())
+    assertThat(summary.completed).isEqualTo(assessment.decision != null)
+    assertThat(summary.crn).isEqualTo(application.crn)
+    when (application) {
+      is ApprovedPremisesApplicationEntity -> {
+        assertThat(summary.type).isEqualTo("approved-premises")
+        assertThat(summary.arrivalDate?.toInstant()).isEqualTo(application.arrivalDate?.toInstant())
+        assertThat(summary.riskRatings).isEqualTo("""{"roshRisks":{"status":"NotFound","value":null},"mappa":{"status":"NotFound","value":null},"tier":{"status":"NotFound","value":null},"flags":{"status":"NotFound","value":null}}""")
+      }
+
+      is TemporaryAccommodationApplicationEntity -> {
+        assertThat(summary.type).isEqualTo("temporary-accommodation")
+        assertThat(summary.riskRatings).isNull()
+      }
+    }
+  }
+
+  private fun earliestUnansweredClarificationNote(assessment: AssessmentEntity, user: UserEntity): AssessmentClarificationNoteEntity {
+    assessmentClarificationNoteEntityFactory.produceAndPersistMultiple(2) {
+      withAssessment(assessment)
+      withCreatedBy(user)
+      withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(maxDays = 7))
+      withResponse("Response")
+    }
+
+    assessmentClarificationNoteEntityFactory.produceAndPersist {
+      withAssessment(assessment)
+      withCreatedBy(user)
+      withCreatedAt(OffsetDateTime.now().minusDays(3))
+    }
+
+    val earliestUnansweredClarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
+      withAssessment(assessment)
+      withCreatedBy(user)
+      withCreatedAt(OffsetDateTime.now().minusDays(4).randomDateTimeBefore(maxDays = 2))
+    }
+    return earliestUnansweredClarificationNote
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskWrapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
@@ -53,12 +53,12 @@ class TasksTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
       `Given a User` { otherUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Assessment`(
+          `Given an Assessment for Approved Premises`(
             allocatedToUser = otherUser,
             createdByUser = otherUser,
             crn = offenderDetails.otherIds.crn
           ) { assessment, _ ->
-            `Given an Assessment`(
+            `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
@@ -110,7 +110,7 @@ class TasksTest : IntegrationTestBase() {
   fun `Get an unknown task type for an application returns 404`() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
       `Given an Offender` { offenderDetails, _ ->
-        `Given an Assessment`(
+        `Given an Assessment for Approved Premises`(
           allocatedToUser = user,
           createdByUser = user,
           crn = offenderDetails.otherIds.crn
@@ -134,7 +134,7 @@ class TasksTest : IntegrationTestBase() {
           roles = listOf(UserRole.ASSESSOR)
         ) { allocatableUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
-            `Given an Assessment`(
+            `Given an Assessment for Approved Premises`(
               allocatedToUser = user,
               createdByUser = user,
               crn = offenderDetails.otherIds.crn
@@ -201,7 +201,7 @@ class TasksTest : IntegrationTestBase() {
   fun `Get an non-implemented task type for an application returns 405`() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
       `Given an Offender` { offenderDetails, _ ->
-        `Given an Assessment`(
+        `Given an Assessment for Approved Premises`(
           allocatedToUser = user,
           createdByUser = user,
           crn = offenderDetails.otherIds.crn
@@ -256,7 +256,7 @@ class TasksTest : IntegrationTestBase() {
           roles = listOf(UserRole.ASSESSOR)
         ) { assigneeUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
-            `Given an Assessment`(
+            `Given an Assessment for Approved Premises`(
               allocatedToUser = user,
               createdByUser = user,
               crn = offenderDetails.otherIds.crn

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -1,18 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
-fun IntegrationTestBase.`Given an Assessment`(
+fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   allocatedToUser: UserEntity,
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
-  block: (assessment: AssessmentEntity, application: ApplicationEntity) -> Unit
+  block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -24,6 +25,43 @@ fun IntegrationTestBase.`Given an Assessment`(
   }
 
   val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+    withCrn(crn)
+    withCreatedByUser(createdByUser)
+    withApplicationSchema(applicationSchema)
+  }
+
+  val assessment = assessmentEntityFactory.produceAndPersist {
+    withAllocatedToUser(allocatedToUser)
+    withApplication(application)
+    withAssessmentSchema(assessmentSchema)
+    if (reallocated) {
+      withReallocatedAt(OffsetDateTime.now())
+    }
+  }
+
+  assessment.schemaUpToDate = true
+
+  block(assessment, application)
+}
+
+fun IntegrationTestBase.`Given an Assessment for Temporary Accommodation`(
+  allocatedToUser: UserEntity,
+  createdByUser: UserEntity,
+  crn: String = randomStringMultiCaseWithNumbers(8),
+  reallocated: Boolean = false,
+  block: (assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit
+) {
+  val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
+    withPermissiveSchema()
+    withAddedAt(OffsetDateTime.now())
+  }
+
+  val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+    withPermissiveSchema()
+    withAddedAt(OffsetDateTime.now())
+  }
+
+  val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
     withCrn(crn)
     withCreatedByUser(createdByUser)
     withApplicationSchema(applicationSchema)


### PR DESCRIPTION
Implementation of this Trello card: https://trello.com/c/ldChlHiW/1515-change-assessments-to-only-return-necessary-information-to-prevent-oom-issues

**This is a breaking change**

Changes the `GET /assessments` end-point to return summary information for each assessment as described in the card.
Maps each row of a SQL query to a 'domain' object (dto?) using `@Query`, `@NamedNativeQuery` and `@SqlResultSetMapping` annotations in the `AssessmentRepository` interface.

In outline the implementation follows the approach used to modify the `GET /applications` end-point to return application summaries.