### PR TITLE
1443 - Gov Notify integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
   testImplementation("com.ninja-squad:springmockk:4.0.2")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.2.0")
+
+  implementation("uk.gov.service.notify:notifications-java-client:4.0.0-RELEASE") {
+    exclude(group = "org.json", module = "json")
+  }
 }
 
 java {

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,6 +31,7 @@ generic-service:
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -45,6 +45,9 @@ generic-service:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ACCESS_KEY_ID: "access_key_id"
       HMPPS_SQS_TOPICS_DOMAINEVENTS_SECRET_ACCESS_KEY: "secret_access_key"
+    hmpps-approved-premises-api:
+      NOTIFY_APIKEY: "NOTIFY_APIKEY"
+      NOTIFY_GUESTLISTAPIKEY: "NOTIFY_GUESTLISTAPIKEY"
 
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,19 +24,20 @@ generic-service:
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: dev
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    APPLICATION-URL-TEMPLATE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
-    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    APPLICATION-ASSESSED-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    BOOKING-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    PERSON-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    PERSON-NOT-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    PERSON-DEPARTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    BOOKING-NOT-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: true
     PREEMPTIVE-CACHE-LOGGING-ENABLED: true
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev
+
+    URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,15 +22,17 @@ generic-service:
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    APPLICATION-URL-TEMPLATE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
-    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    APPLICATION-ASSESSED-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    BOOKING-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    PERSON-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    PERSON-NOT-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    PERSON-DEPARTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    BOOKING-NOT-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: true
+
+    URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
+
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,7 @@ generic-service:
     DOMAIN-EVENTS_EMIT-ENABLED: true
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,15 +22,17 @@ generic-service:
     LOG-CLIENT-CREDENTIALS-JWT-INFO: false
     SENTRY_ENVIRONMENT: prod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
-    APPLICATION-URL-TEMPLATE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
-    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    APPLICATION-ASSESSED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    BOOKING-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    PERSON-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    PERSON-NOT-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    PERSON-DEPARTED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    BOOKING-NOT-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: true
+
+    URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
+
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -25,6 +25,7 @@ generic-service:
     DOMAIN-EVENTS_EMIT-ENABLED: true
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -24,15 +24,16 @@ generic-service:
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    APPLICATION-URL-TEMPLATE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
-    APPLICATION-SUBMITTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    APPLICATION-ASSESSED-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    BOOKING-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    PERSON-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    PERSON-NOT-ARRIVED-DETAIL-URL-TEMPLATE: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    PERSON-DEPARTED-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    BOOKING-NOT-MADE-DETAIL-URL-TEMPLATE: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     DOMAIN-EVENTS_EMIT-ENABLED: false
+
+    URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
 
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -27,6 +27,7 @@ generic-service:
     DOMAIN-EVENTS_EMIT-ENABLED: false
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -16,7 +16,7 @@ class NotifyConfig {
 }
 
 class NotifyTemplates {
-
+  var assessmentAllocated = "f3d78814-383f-4b5f-a681-9bd3ab912888"
 }
 
 enum class NotifyMode {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
+import uk.gov.service.notify.NotificationClient
 
 @Component
 @ConfigurationProperties(prefix = "notify")
@@ -18,4 +21,17 @@ class NotifyTemplates {
 
 enum class NotifyMode {
   DISABLED, TEST_AND_GUEST_LIST, ENABLED
+}
+
+@Configuration
+class NotifyClientConfig {
+  @Bean("normalNotificationClient")
+  fun normalNotificationClient(notifyConfig: NotifyConfig) = if (notifyConfig.mode != NotifyMode.DISABLED) {
+    NotificationClient(notifyConfig.apiKey)
+  } else null
+
+  @Bean("guestListNotificationClient")
+  fun guestListNotificationClient(notifyConfig: NotifyConfig) = if (notifyConfig.mode == NotifyMode.TEST_AND_GUEST_LIST) {
+    NotificationClient(notifyConfig.guestListApiKey)
+  } else null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "notify")
+class NotifyConfig {
+  var mode: NotifyMode = NotifyMode.DISABLED
+  var apiKey: String? = null
+  var guestListApiKey: String? = null
+  var templates: NotifyTemplates = NotifyTemplates()
+}
+
+class NotifyTemplates {
+
+}
+
+enum class NotifyMode {
+  DISABLED, TEST_AND_GUEST_LIST, ENABLED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NotifyGuestListUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NotifyGuestListUserEntity.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface NotifyGuestListUserRepository : JpaRepository<NotifyGuestListUserEntity, UUID>
+
+@Entity
+@Table(name = "notify_guest_list_users")
+data class NotifyGuestListUserEntity(
+  @Id
+  val userId: UUID
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -62,7 +62,7 @@ class ApplicationService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val applicationTeamCodeRepository: ApplicationTeamCodeRepository,
   private val objectMapper: ObjectMapper,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationSummary> {
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -45,7 +45,7 @@ class AssessmentService(
   private val communityApiClient: CommunityApiClient,
   private val cruService: CruService,
   private val placementRequestService: PlacementRequestService,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
 ) {
   fun getVisibleAssessmentSummariesForUser(user: UserEntity): List<DomainAssessmentSummary> =
     assessmentRepository.findAllAssessmentSummariesNotReallocated(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -87,7 +87,7 @@ class BookingService(
   private val placementRequestRepository: PlacementRequestRepository,
   private val lostBedsRepository: LostBedsRepository,
   private val turnaroundRepository: TurnaroundRepository,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
 ) {
   fun updateBooking(bookingEntity: BookingEntity): BookingEntity = bookingRepository.save(bookingEntity)
   fun getBooking(id: UUID) = bookingRepository.findByIdOrNull(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -35,13 +35,13 @@ class DomainEventService(
   private val domainEventRepository: DomainEventRepository,
   private val hmppsQueueService: HmppsQueueService,
   @Value("\${domain-events.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
-  @Value("\${application-submitted-detail-url-template}") private val applicationSubmittedDetailUrlTemplate: String,
-  @Value("\${application-assessed-detail-url-template}") private val applicationAssessedDetailUrlTemplate: String,
-  @Value("\${booking-made-detail-url-template}") private val bookingMadeDetailUrlTemplate: String,
-  @Value("\${person-arrived-detail-url-template}") private val personArrivedDetailUrlTemplate: String,
-  @Value("\${person-not-arrived-detail-url-template}") private val personNotArrivedDetailUrlTemplate: String,
-  @Value("\${person-departed-detail-url-template}") private val personDepartedDetailUrlTemplate: String,
-  @Value("\${booking-not-made-detail-url-template}") private val bookingNotMadeDetailUrlTemplate: String,
+  @Value("\${url-templates.api.application-submitted-event-detail}") private val applicationSubmittedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.application-assessed-event-detail}") private val applicationAssessedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.booking-made-event-detail}") private val bookingMadeDetailUrlTemplate: String,
+  @Value("\${url-templates.api.person-arrived-event-detail}") private val personArrivedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.person-not-arrived-event-detail}") private val personNotArrivedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.person-departed-event-detail}") private val personDepartedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.booking-not-made-event-detail}") private val bookingNotMadeDetailUrlTemplate: String,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyMode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NotifyGuestListUserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.service.notify.NotificationClient
+import uk.gov.service.notify.NotificationClientException
+
+@Service
+class EmailNotificationService(
+  private val notifyConfig: NotifyConfig,
+  @Qualifier("normalNotificationClient") private val normalNotificationClient: NotificationClient?,
+  @Qualifier("guestListNotificationClient") private val guestListNotificationClient: NotificationClient?,
+  private val guestListUserRepository: NotifyGuestListUserRepository
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun sendEmail(user: UserEntity, templateId: String, personalisation: Map<String, *>) {
+    try {
+      if (notifyConfig.mode == NotifyMode.DISABLED) {
+        log.info("Email sending is disabled - would have sent template $templateId to user ${user.id}")
+        return
+      }
+
+      if (notifyConfig.mode == NotifyMode.TEST_AND_GUEST_LIST && guestListUserRepository.findByIdOrNull(user.id) != null) {
+        guestListNotificationClient!!.sendEmail(templateId, user.email, personalisation, null)
+      } else {
+        normalNotificationClient!!.sendEmail(templateId, user.email, personalisation, null)
+      }
+    } catch (notificationClientException: NotificationClientException) {
+      log.error("Unable to send email", notificationClientException)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -43,7 +43,7 @@ class PlacementRequestService(
   private val offenderService: OffenderService,
   private val communityApiClient: CommunityApiClient,
   private val cruService: CruService,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
 ) {
 
   fun getVisiblePlacementRequestsForUser(user: UserEntity): List<PlacementRequestEntity> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -169,14 +169,18 @@ seed:
   file-prefix: "/tmp/seed"
 
 assign-default-region-to-users-with-unknown-region: false
-application-url-template: http://localhost:3000/applications/#id
-application-submitted-detail-url-template: http://localhost:3000/events/application-submitted/#eventId
-application-assessed-detail-url-template: http://localhost:3000/events/application-assessed/#eventId
-booking-made-detail-url-template: http://localhost:3000/events/booking-made/#eventId
-person-arrived-detail-url-template: http://localhost:3000/events/person-arrived/#eventId
-person-not-arrived-detail-url-template: http://localhost:3000/events/person-not-arrived/#eventId
-person-departed-detail-url-template: http://localhost:3000/events/person-departed/#eventId
-booking-not-made-detail-url-template: http://localhost:3000/events/booking-not-made/#eventId
+
+url-templates:
+  api:
+    application-submitted-event-detail: http://localhost:3000/events/application-submitted/#eventId
+    application-assessed-event-detail: http://localhost:3000/events/application-assessed/#eventId
+    booking-made-event-detail: http://localhost:3000/events/booking-made/#eventId
+    person-arrived-event-detail: http://localhost:3000/events/person-arrived/#eventId
+    person-not-arrived-event-detail: http://localhost:3000/events/person-not-arrived/#eventId
+    person-departed-event-detail: http://localhost:3000/events/person-departed/#eventId
+    booking-not-made-event-detail: http://localhost:3000/events/booking-not-made/#eventId
+  frontend:
+    application: http://localhost:3000/applications/#id
 
 preemptive-cache-key-prefix: ""
 preemptive-cache-logging-enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -181,6 +181,7 @@ url-templates:
     booking-not-made-event-detail: http://localhost:3000/events/booking-not-made/#eventId
   frontend:
     application: http://localhost:3000/applications/#id
+    assessment: http://localhost:3000/assessments/#id
 
 preemptive-cache-key-prefix: ""
 preemptive-cache-logging-enabled: false

--- a/src/main/resources/db/migration/all/20230512113922__add_notify_guest_list.sql
+++ b/src/main/resources/db/migration/all/20230512113922__add_notify_guest_list.sql
@@ -1,0 +1,5 @@
+CREATE TABLE notify_guest_list_users (
+    user_id UUID NOT NULL,
+    PRIMARY KEY (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1207,7 +1207,7 @@ class ApplicationTest : IntegrationTestBase() {
 
           assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.submitted")
           assertThat(emittedMessage.description).isEqualTo("An application has been submitted for an Approved Premises placement")
-          assertThat(emittedMessage.detailUrl).matches("http://frontend/events/application-submitted/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+          assertThat(emittedMessage.detailUrl).matches("http://api/events/application-submitted/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
           assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(applicationId)
           assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
             SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -281,7 +281,7 @@ class AssessmentTest : IntegrationTestBase() {
 
             assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.assessed")
             assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")
-            assertThat(emittedMessage.detailUrl).matches("http://frontend/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+            assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
             assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
               SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
@@ -358,7 +358,7 @@ class AssessmentTest : IntegrationTestBase() {
 
             assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.assessed")
             assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")
-            assertThat(emittedMessage.detailUrl).matches("http://frontend/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+            assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
             assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
               SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
@@ -490,7 +490,7 @@ class AssessmentTest : IntegrationTestBase() {
 
         assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.assessed")
         assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")
-        assertThat(emittedMessage.detailUrl).matches("http://frontend/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+        assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
         assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
         assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
           SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -461,7 +461,7 @@ class BookingTest : IntegrationTestBase() {
 
         assertThat(emittedMessage.eventType).isEqualTo("approved-premises.booking.made")
         assertThat(emittedMessage.description).isEqualTo("An Approved Premises booking has been made")
-        assertThat(emittedMessage.detailUrl).matches("http://frontend/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+        assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
         assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
         assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
           SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/EmailNotificationServiceTest.kt
@@ -1,0 +1,185 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyMode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NotifyGuestListUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NotifyGuestListUserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+import uk.gov.service.notify.NotificationClient
+
+class EmailNotificationServiceTest {
+  private val mockNormalNotificationClient = mockk<NotificationClient>()
+  private val mockGuestListNotificationClient = mockk<NotificationClient>()
+  private val mockNotifyGuestListUserRepository = mockk<NotifyGuestListUserRepository>()
+
+  @Test
+  fun `sendEmail does not send an email if feature flag is set to DISABLED`() {
+    val emailNotificationService = createServiceWithConfig {
+      mode = NotifyMode.DISABLED
+    }
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    emailNotificationService.sendEmail(
+      user = user,
+      templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888",
+      personalisation = mapOf(
+        "name" to "Jim",
+        "assessmentUrl" to "https://frontend/assessment/73eff3e8-d2f0-434f-a776-4f975b891444"
+      )
+    )
+
+    verify(exactly = 0) { mockGuestListNotificationClient.sendEmail(any(), any(), any(), any()) }
+    verify(exactly = 0) { mockNormalNotificationClient.sendEmail(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun `sendEmail sends email using the guest list client if feature flag is set to TEST_AND_GUEST_LIST and user is in guest list`() {
+    val emailNotificationService = createServiceWithConfig {
+      mode = NotifyMode.TEST_AND_GUEST_LIST
+    }
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    every { mockNotifyGuestListUserRepository.findByIdOrNull(user.id) } returns NotifyGuestListUserEntity(user.id)
+
+    val templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888"
+    val personalisation = mapOf(
+      "name" to "Jim",
+      "assessmentUrl" to "https://frontend/assessment/73eff3e8-d2f0-434f-a776-4f975b891444"
+    )
+
+    every {
+      mockGuestListNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null
+      )
+    } returns mockk()
+
+    emailNotificationService.sendEmail(
+      user = user,
+      templateId = templateId,
+      personalisation = personalisation
+    )
+
+    verify(exactly = 1) {
+      mockGuestListNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null
+      )
+    }
+
+    verify(exactly = 0) { mockNormalNotificationClient.sendEmail(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun `sendEmail sends email using the normal client if feature flag is set to TEST_AND_GUEST_LIST and user is not in guest list`() {
+    val emailNotificationService = createServiceWithConfig {
+      mode = NotifyMode.TEST_AND_GUEST_LIST
+    }
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    every { mockNotifyGuestListUserRepository.findByIdOrNull(user.id) } returns null
+
+    val templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888"
+    val personalisation = mapOf(
+      "name" to "Jim",
+      "assessmentUrl" to "https://frontend/assessment/73eff3e8-d2f0-434f-a776-4f975b891444"
+    )
+
+    every {
+      mockNormalNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null
+      )
+    } returns mockk()
+
+    emailNotificationService.sendEmail(
+      user = user,
+      templateId = templateId,
+      personalisation = personalisation
+    )
+
+    verify(exactly = 1) {
+      mockNormalNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null
+      )
+    }
+
+    verify(exactly = 0) { mockGuestListNotificationClient.sendEmail(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun `sendEmail sends email using the normal client if feature flag is set to ENABLED, does not check if Guest List User`() {
+    val emailNotificationService = createServiceWithConfig {
+      mode = NotifyMode.ENABLED
+    }
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888"
+    val personalisation = mapOf(
+      "name" to "Jim",
+      "assessmentUrl" to "https://frontend/assessment/73eff3e8-d2f0-434f-a776-4f975b891444"
+    )
+
+    every {
+      mockNormalNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null
+      )
+    } returns mockk()
+
+    emailNotificationService.sendEmail(
+      user = user,
+      templateId = templateId,
+      personalisation = personalisation
+    )
+
+    verify(exactly = 1) {
+      mockNormalNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null
+      )
+    }
+
+    verify(exactly = 0) { mockGuestListNotificationClient.sendEmail(any(), any(), any(), any()) }
+
+    verify(exactly = 0) { mockNotifyGuestListUserRepository.findByIdOrNull(user.id) }
+  }
+
+  private fun createServiceWithConfig(configBlock: NotifyConfig.() -> Unit) = EmailNotificationService(
+    notifyConfig = NotifyConfig().apply(configBlock),
+    normalNotificationClient = mockNormalNotificationClient,
+    guestListNotificationClient = mockGuestListNotificationClient,
+    guestListUserRepository = mockNotifyGuestListUserRepository
+  )
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -105,13 +105,16 @@ caches:
 seed:
   file-prefix: "./test-seed-csvs"
 
-application-url-template: http://frontend/applications/#id
-application-submitted-detail-url-template: http://frontend/events/application-submitted/#eventId
-application-assessed-detail-url-template: http://frontend/events/application-assessed/#eventId
-booking-made-detail-url-template: http://frontend/events/booking-made/#eventId
-person-arrived-detail-url-template: http://frontend/events/events/person-arrived/#eventId
-person-not-arrived-detail-url-template: http://frontend/events/events/person-not-arrived/#eventId
-person-departed-detail-url-template: http://frontend/events/events/person-departed/#eventId
-booking-not-made-detail-url-template: http://frontend/events/events/booking-not-made/#eventId
+url-templates:
+  api:
+    application-submitted-event-detail: http://api/events/application-submitted/#eventId
+    application-assessed-event-detail: http://api/events/application-assessed/#eventId
+    booking-made-event-detail: http://api/events/booking-made/#eventId
+    person-arrived-event-detail: http://api/events/person-arrived/#eventId
+    person-not-arrived-event-detail: http://api/events/person-not-arrived/#eventId
+    person-departed-event-detail: http://api/events/person-departed/#eventId
+    booking-not-made-event-detail: http://api/events/booking-not-made/#eventId
+  frontend:
+    application: http://frontend/applications/#id
 
 preemptive-cache-delay-ms: 250

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -116,5 +116,6 @@ url-templates:
     booking-not-made-event-detail: http://api/events/booking-not-made/#eventId
   frontend:
     application: http://frontend/applications/#id
+    assessment: http://frontend/assessments/#id
 
 preemptive-cache-delay-ms: 250


### PR DESCRIPTION
This adds a Gov Notify integration and uses it to send an email when an Assessment for an Application is allocated or reallocated.

The `notify.mode` property has 3 options:
- DISABLED: no interaction with the Notify service actually takes place
- TEST_AND_GUEST_LIST: use a Notify Guest List key for certain users, use a different key for other users
- ENABLED: use a single Notify key for all users

There are 3 types of Notify key:
- Test: Doesn't actually send emails but the API responds as though it has
- Guest List: Does send emails to verified email addresses but responds with an error for other email addresses
- Live: Sends emails to any email address

In dev we can combine the guest list and test modes by having a list on our side (which is the new table `notify_guest_list_users`) which we first check to see which key to use.  This allows us to actually send emails to the product team and not error for other emails.

The email templates are setup on the Notify web app - we are awaiting copy for these so I have improvised for now but since the feature isn't enabled in any environment as part of this PR no emails will actually be sent yet.

Also refactored the existing URL templates into a more structured form e.g. `url-templates.api.application-submitted-event-detail` instead of `application-submitted-detail-url-template`.