### PR TITLE
Fix/#1515 add missing fields to assessment summaries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -46,6 +46,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                    and acn.assessment_id = a.id
            ) as dateOfInfoRequest,
            a.decision is not null as completed,
+           a.decision as decision,
            ap.crn as crn
       from assessments a
            join applications ap on a.application_id = ap.id
@@ -70,6 +71,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
         ColumnResult(name = "arrivalDate", type = OffsetDateTime::class),
         ColumnResult(name = "dateOfInfoRequest", type = OffsetDateTime::class),
         ColumnResult(name = "completed"),
+        ColumnResult(name = "decision"),
         ColumnResult(name = "crn"),
       ]
     )
@@ -130,6 +132,7 @@ open class DomainAssessmentSummary(
   val arrivalDate: OffsetDateTime?,
   val dateOfInfoRequest: OffsetDateTime?,
   val completed: Boolean,
+  val decision: String?,
   val crn: String
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -77,6 +77,7 @@ class AssessmentTransformer(
       id = ase.id,
       applicationId = ase.applicationId,
       createdAt = ase.createdAt.toInstant(),
+      arrivalDate = ase.arrivalDate?.toInstant(),
       status = when {
         ase.completed -> AssessmentStatus.completed
         ase.dateOfInfoRequest != null -> AssessmentStatus.awaitingResponse
@@ -84,6 +85,7 @@ class AssessmentTransformer(
       },
       risks = ase.riskRatings?.let { risksTransformer.transformDomainToApi(objectMapper.readValue<PersonRisks>(it), ase.crn) },
       person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+
     )
 
   fun transformJpaDecisionToApi(decision: JpaAssessmentDecision?) = when (decision) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -83,9 +83,13 @@ class AssessmentTransformer(
         ase.dateOfInfoRequest != null -> AssessmentStatus.awaitingResponse
         else -> AssessmentStatus.active
       },
+      decision = when (ase.decision) {
+        "ACCEPTED" -> ApiAssessmentDecision.accepted
+        "REJECTED" -> ApiAssessmentDecision.rejected
+        else -> null
+      },
       risks = ase.riskRatings?.let { risksTransformer.transformDomainToApi(objectMapper.readValue<PersonRisks>(it), ase.crn) },
       person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
-
     )
 
   fun transformJpaDecisionToApi(decision: JpaAssessmentDecision?) = when (decision) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4367,6 +4367,8 @@ components:
           format: date-time
         status:
           $ref: '#/components/schemas/AssessmentStatus'
+        decision:
+          $ref: '#/components/schemas/AssessmentDecision'
         risks:
           $ref: '#/components/schemas/PersonRisks'
         person:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Temporary Accommodation`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
@@ -41,6 +42,7 @@ class AssessmentSummaryQueryTest : IntegrationTestBase() {
               withAllocatedToUser(user2)
               withAssessmentSchema(apAssessment.schemaVersion)
               withApplication(application)
+              withDecision(AssessmentDecision.ACCEPTED)
             }
 
             val results: List<DomainAssessmentSummary> = realAssessmentRepository.findAllAssessmentSummariesNotReallocated()
@@ -90,6 +92,7 @@ class AssessmentSummaryQueryTest : IntegrationTestBase() {
     assertThat(summary.createdAt).isEqualTo(assessment.createdAt)
     assertThat(summary.dateOfInfoRequest).isEqualTo(dateOfInfoRequest)
     assertThat(summary.completed).isEqualTo(assessment.decision != null)
+    assertThat(summary?.decision).isEqualTo(assessment.decision?.name)
     assertThat(summary.crn).isEqualTo(application.crn)
     when (application) {
       is ApprovedPremisesApplicationEntity -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -234,6 +234,7 @@ class AssessmentTransformerTest {
     assertThat(apiSummary.id).isEqualTo(domainSummary.id)
     assertThat(apiSummary.applicationId).isEqualTo(domainSummary.applicationId)
     assertThat(apiSummary.createdAt).isEqualTo(domainSummary.createdAt.toInstant())
+    assertThat(apiSummary.arrivalDate).isEqualTo(domainSummary.arrivalDate?.toInstant())
     assertThat(apiSummary.status).isEqualTo(AssessmentStatus.awaitingResponse)
     assertThat(apiSummary.risks).isEqualTo(risksTransformer.transformDomainToApi(personRisks, domainSummary.crn))
     assertThat(apiSummary.person).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -58,6 +58,15 @@ class AssessmentTransformerTest {
     registerKotlinModule()
   }
 
+  companion object {
+    @JvmStatic
+    fun assessmentDecisionPairs(): Stream<Arguments> = Stream.of(
+      of("ACCEPTED", ApiAssessmentDecision.accepted),
+      of("REJECTED", ApiAssessmentDecision.rejected),
+      of(null, null)
+    )
+  }
+
   private val assessmentTransformer = AssessmentTransformer(
     objectMapper,
     mockApplicationsTransformer,
@@ -247,14 +256,5 @@ class AssessmentTransformerTest {
     assertThat(apiSummary.status).isEqualTo(AssessmentStatus.awaitingResponse)
     assertThat(apiSummary.risks).isEqualTo(risksTransformer.transformDomainToApi(personRisks, domainSummary.crn))
     assertThat(apiSummary.person).isNotNull
-  }
-
-  companion object {
-    @JvmStatic
-    fun assessmentDecisionPairs(): Stream<Arguments> = Stream.of(
-      of("ACCEPTED", ApiAssessmentDecision.accepted),
-      of("REJECTED", ApiAssessmentDecision.rejected),
-      of(null, null)
-    )
   }
 }


### PR DESCRIPTION
Extra bits for card #1515 'assessments to only return necessary information to prevent OOM issues'
Added these fields to each returned assessment summary.
* `arrivalDate`, optional.
* `decision`, optional.  'accepted', 'rejected' or null.