### PR TITLE
Add in-progress and not-started statuses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -47,6 +47,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
            ) as dateOfInfoRequest,
            a.decision is not null as completed,
            a.decision as decision,
+           a.data is not null as isStarted,
            ap.crn as crn
       from assessments a
            join applications ap on a.application_id = ap.id
@@ -71,6 +72,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
         ColumnResult(name = "arrivalDate", type = OffsetDateTime::class),
         ColumnResult(name = "dateOfInfoRequest", type = OffsetDateTime::class),
         ColumnResult(name = "completed"),
+        ColumnResult(name = "isStarted"),
         ColumnResult(name = "decision"),
         ColumnResult(name = "crn"),
       ]
@@ -132,6 +134,7 @@ open class DomainAssessmentSummary(
   val arrivalDate: OffsetDateTime?,
   val dateOfInfoRequest: OffsetDateTime?,
   val completed: Boolean,
+  val isStarted: Boolean,
   val decision: String?,
   val crn: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -81,7 +81,8 @@ class AssessmentTransformer(
       status = when {
         ase.completed -> AssessmentStatus.completed
         ase.dateOfInfoRequest != null -> AssessmentStatus.awaitingResponse
-        else -> AssessmentStatus.active
+        ase.isStarted -> AssessmentStatus.inProgress
+        else -> AssessmentStatus.notStarted
       },
       decision = when (ase.decision) {
         "ACCEPTED" -> ApiAssessmentDecision.accepted
@@ -102,6 +103,7 @@ class AssessmentTransformer(
     entity.decision !== null -> AssessmentStatus.completed
     entity.clarificationNotes.any { it.response == null } -> AssessmentStatus.awaitingResponse
     entity.reallocatedAt != null -> AssessmentStatus.reallocated
-    else -> AssessmentStatus.active
+    entity.data != null -> AssessmentStatus.inProgress
+    else -> AssessmentStatus.notStarted
   }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4317,9 +4317,10 @@ components:
       type: string
       enum:
         - awaiting_response
-        - active
         - completed
         - reallocated
+        - in_progress
+        - not_started
     ApprovedPremisesAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
@@ -38,7 +38,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     this.id = { id }
   }
 
-  fun withData(data: String) = apply {
+  fun withData(data: String?) = apply {
     this.data = { data }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -138,7 +138,8 @@ class AssessmentTest : IntegrationTestBase() {
 
       completed = assessment.decision != null,
       decision = assessment.decision?.name,
-      crn = assessment.application.crn
+      crn = assessment.application.crn,
+      isStarted = assessment.data != null
     )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -13,6 +13,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
+  data: String? = "{ \"some\": \"data\"}",
   block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -34,6 +35,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withAllocatedToUser(allocatedToUser)
     withApplication(application)
     withAssessmentSchema(assessmentSchema)
+    withData(data)
     if (reallocated) {
       withReallocatedAt(OffsetDateTime.now())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -190,14 +190,27 @@ class AssessmentTransformerTest {
   }
 
   @Test
-  fun `transformJpaToApi sets an active status when there is no decision`() {
+  fun `transformJpaToApi sets an inProgress status when there is no decision and the assessment has data`() {
     val assessment = assessmentFactory
+      .withData("{\"data\": \"something\"}")
       .withDecision(null)
       .produce()
 
     val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
 
-    assertThat(result.status).isEqualTo(AssessmentStatus.active)
+    assertThat(result.status).isEqualTo(AssessmentStatus.inProgress)
+  }
+
+  @Test
+  fun `transformJpaToApi sets an notStarted status when there is no decision and the assessment has no data`() {
+    val assessment = assessmentFactory
+      .withData(null)
+      .withDecision(null)
+      .produce()
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+
+    assertThat(result.status).isEqualTo(AssessmentStatus.notStarted)
   }
 
   @ParameterizedTest
@@ -213,7 +226,8 @@ class AssessmentTransformerTest {
       dateOfInfoRequest = null,
       completed = false,
       decision = domainDecision,
-      crn = randomStringMultiCaseWithNumbers(6)
+      crn = randomStringMultiCaseWithNumbers(6),
+      isStarted = true
     )
 
     every { mockPersonTransformer.transformModelToApi(any(), any()) } returns mockk<Person>()
@@ -223,7 +237,7 @@ class AssessmentTransformerTest {
     assertThat(apiSummary.id).isEqualTo(domainSummary.id)
     assertThat(apiSummary.applicationId).isEqualTo(domainSummary.applicationId)
     assertThat(apiSummary.createdAt).isEqualTo(domainSummary.createdAt.toInstant())
-    assertThat(apiSummary.status).isEqualTo(AssessmentStatus.active)
+    assertThat(apiSummary.status).isEqualTo(AssessmentStatus.inProgress)
     assertThat(apiSummary.decision).isEqualTo(apiDecision)
     assertThat(apiSummary.risks).isNull()
     assertThat(apiSummary.person).isNotNull
@@ -242,7 +256,8 @@ class AssessmentTransformerTest {
       dateOfInfoRequest = OffsetDateTime.now().randomDateTimeBefore(),
       completed = false,
       decision = "ACCEPTED",
-      crn = randomStringMultiCaseWithNumbers(6)
+      crn = randomStringMultiCaseWithNumbers(6),
+      isStarted = true
     )
 
     every { mockPersonTransformer.transformModelToApi(any(), any()) } returns mockk<Person>()


### PR DESCRIPTION
This replaces the `active` status with an `in_progress` and `not_started` status based on if the assessment is started.