### PR TITLE
Add CAS2 pipeline trigger for UI updates

### DIFF
--- a/.github/workflows/generate-ui-types.yml
+++ b/.github/workflows/generate-ui-types.yml
@@ -30,6 +30,19 @@ jobs:
               workflow_id: 'generate-types.yml',
               ref: 'main'
             })
+      - name: Trigger Supported Accommodation UI Type Generation Workflow
+        if: ${{ github.ref == 'refs/heads/main' }}
+        id: sa-trigger-ui-workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'hmpps-supported-accommodation-ui',
+              workflow_id: 'generate-types.yml',
+              ref: 'main'
+            })
       - name: Trigger TA UI Type Generation Workflow
         if: ${{ github.ref == 'refs/heads/main' }}
         id: ta-trigger-ui-workflow


### PR DESCRIPTION
This will trigger the `generate-types` workflow on the CAS2 repo whenever the api.yml file changes on the `main` branch.