### PR TITLE
Add support for creating Temporary Accommodation applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -117,7 +117,7 @@ class ApplicationsController(
 
     val applicationResult = when (xServiceName ?: ServiceName.approvedPremises) {
       ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
-      ServiceName.temporaryAccommodation -> applicationService.createTemporaryAccommodationApplication()
+      ServiceName.temporaryAccommodation -> applicationService.createTemporaryAccommodationApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
     }
 
     val application = when (applicationResult) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -110,14 +110,17 @@ class ApplicationsController(
 
   @Transactional
   override fun applicationsPost(body: NewApplication, xServiceName: ServiceName?, createWithRisks: Boolean?): ResponseEntity<Application> {
-    val serviceName = xServiceName?.value ?: ServiceName.approvedPremises.value
-
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val user = userService.getUserForRequest()
 
     val (offender, inmate) = getPersonDetail(body.crn)
 
-    val application = when (val applicationResult = applicationService.createApplication(body.crn, user, deliusPrincipal.token.tokenValue, serviceName, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)) {
+    val applicationResult = when (xServiceName ?: ServiceName.approvedPremises) {
+      ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
+      ServiceName.temporaryAccommodation -> applicationService.createTemporaryAccommodationApplication()
+    }
+
+    val application = when (applicationResult) {
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = applicationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = applicationResult.validationMessages)
       is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = applicationResult.conflictingEntityId, conflictReason = applicationResult.message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -244,6 +244,15 @@ class TemporaryAccommodationApplicationEntity(
   submittedAt: OffsetDateTime?,
   schemaUpToDate: Boolean,
   assessments: MutableList<AssessmentEntity>,
+  val convictionId: Long,
+  val eventNumber: String,
+  val offenceId: String,
+  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
+  @Convert(disableConversion = true)
+  val riskRatings: PersonRisks?,
+  @ManyToOne
+  @JoinColumn(name = "probation_region_id")
+  val probationRegion: ProbationRegionEntity,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -144,12 +144,15 @@ class ApplicationService(
     return AuthorisableActionResult.Unauthorised()
   }
 
-  fun createApplication(crn: String, user: UserEntity, jwt: String, service: String, convictionId: Long?, deliusEventNumber: String?, offenceId: String?, createWithRisks: Boolean? = true) = validated<ApplicationEntity> {
-    if (service != ServiceName.approvedPremises.value) {
-      "$.service" hasValidationError "onlyCas1Supported"
-      return fieldValidationError
-    }
-
+  fun createApprovedPremisesApplication(
+    crn: String,
+    user: UserEntity,
+    jwt: String,
+    convictionId: Long?,
+    deliusEventNumber: String?,
+    offenceId: String?,
+    createWithRisks: Boolean? = true,
+  ) = validated<ApplicationEntity> {
     when (offenderService.getOffenderByCrn(crn, user.deliusUsername)) {
       is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
       is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "userPermission"
@@ -232,6 +235,10 @@ class ApplicationService(
     }
 
     return success(createdApplication.apply { schemaUpToDate = true })
+  }
+
+  fun createTemporaryAccommodationApplication() = validated<ApplicationEntity> {
+    "$.service" hasSingleValidationError "onlyCas1Supported"
   }
 
   fun updateApprovedPremisesApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -237,8 +238,70 @@ class ApplicationService(
     return success(createdApplication.apply { schemaUpToDate = true })
   }
 
-  fun createTemporaryAccommodationApplication() = validated<ApplicationEntity> {
-    "$.service" hasSingleValidationError "onlyCas1Supported"
+  fun createTemporaryAccommodationApplication(
+    crn: String,
+    user: UserEntity,
+    jwt: String,
+    convictionId: Long?,
+    deliusEventNumber: String?,
+    offenceId: String?,
+    createWithRisks: Boolean? = true,
+  ) = validated<ApplicationEntity> {
+    when (offenderService.getOffenderByCrn(crn, user.deliusUsername)) {
+      is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
+      is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "userPermission"
+      is AuthorisableActionResult.Success -> Unit
+    }
+
+    if (convictionId == null) {
+      "$.convictionId" hasValidationError "empty"
+    }
+
+    if (deliusEventNumber == null) {
+      "$.deliusEventNumber" hasValidationError "empty"
+    }
+
+    if (offenceId == null) {
+      "$.offenceId" hasValidationError "empty"
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    var riskRatings: PersonRisks? = null
+
+    if (createWithRisks == true) {
+      val riskRatingsResult = offenderService.getRiskByCrn(crn, jwt, user.deliusUsername)
+
+      riskRatings = when (riskRatingsResult) {
+        is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
+        is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "userPermission"
+        is AuthorisableActionResult.Success -> riskRatingsResult.entity
+      }
+    }
+
+    val createdApplication = applicationRepository.save(
+      TemporaryAccommodationApplicationEntity(
+        id = UUID.randomUUID(),
+        crn = crn,
+        createdByUser = user,
+        data = null,
+        document = null,
+        schemaVersion = jsonSchemaService.getNewestSchema(TemporaryAccommodationApplicationJsonSchemaEntity::class.java),
+        createdAt = OffsetDateTime.now(),
+        submittedAt = null,
+        convictionId = convictionId!!,
+        eventNumber = deliusEventNumber!!,
+        offenceId = offenceId!!,
+        schemaUpToDate = true,
+        riskRatings = riskRatings,
+        assessments = mutableListOf(),
+        probationRegion = user.probationRegion,
+      ),
+    )
+
+    return success(createdApplication.apply { schemaUpToDate = true })
   }
 
   fun updateApprovedPremisesApplication(

--- a/src/main/resources/db/migration/all/20230517152824__add_offence_conviction_risk_information_to_temporary_accommodation_applications_table.sql
+++ b/src/main/resources/db/migration/all/20230517152824__add_offence_conviction_risk_information_to_temporary_accommodation_applications_table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE temporary_accommodation_applications ADD COLUMN conviction_id BIGINT NOT NULL;
+ALTER TABLE temporary_accommodation_applications ADD COLUMN event_number TEXT NOT NULL;
+ALTER TABLE temporary_accommodation_applications ADD COLUMN offence_id TEXT NOT NULL;
+ALTER TABLE temporary_accommodation_applications ADD COLUMN probation_region_id UUID NOT NULL;
+ALTER TABLE temporary_accommodation_applications ADD COLUMN risk_ratings JSON;
+
+ALTER TABLE temporary_accommodation_applications ADD FOREIGN KEY (probation_region_id) REFERENCES probation_regions(id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -4,9 +4,12 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -22,9 +25,12 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
-  private var isWomensApplication: Yielded<Boolean?> = { null }
-  private var isPipeApplication: Yielded<Boolean?> = { null }
   private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf<AssessmentEntity>() }
+  private var convictionId: Yielded<Long> = { randomInt(0, 1000).toLong() }
+  private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
+  private var offenceId: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
+  private var riskRatings: Yielded<PersonRisks> = { PersonRisksFactory().produce() }
+  private var probationRegion: Yielded<ProbationRegionEntity>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -70,6 +76,26 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.assessments = { assessments }
   }
 
+  fun withConvictionId(convictionId: Long) = apply {
+    this.convictionId = { convictionId }
+  }
+
+  fun withEventNumber(eventNumber: String) = apply {
+    this.eventNumber = { eventNumber }
+  }
+
+  fun withOffenceId(offenceId: String) = apply {
+    this.offenceId = { offenceId }
+  }
+
+  fun withProbationRegion(probationRegion: ProbationRegionEntity) = apply {
+    this.probationRegion = { probationRegion }
+  }
+
+  fun withYieldedProbationRegion(probationRegion: Yielded<ProbationRegionEntity>) = apply {
+    this.probationRegion = probationRegion
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -81,5 +107,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     submittedAt = this.submittedAt(),
     schemaUpToDate = false,
     assessments = this.assessments(),
+    convictionId = this.convictionId(),
+    eventNumber = this.eventNumber(),
+    offenceId = this.offenceId(),
+    riskRatings = this.riskRatings(),
+    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided")
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -301,12 +301,12 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
 
         val postcodeDistrict = postCodeDistrictFactory.produceAndPersist()
 
+        val probationRegion = probationRegionEntityFactory.produceAndPersist {
+          withApArea(apAreaEntityFactory.produceAndPersist())
+        }
+
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-          withProbationRegion(
-            probationRegionEntityFactory.produceAndPersist {
-              withApArea(apAreaEntityFactory.produceAndPersist())
-            }
-          )
+          withProbationRegion(probationRegion)
           withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
         }
 
@@ -323,6 +323,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withCreatedByUser(user)
           withApplicationSchema(applicationSchema)
           withSubmittedAt(null)
+          withProbationRegion(probationRegion)
         }
 
         val submittedApplication = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
@@ -330,6 +331,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withCreatedByUser(user)
           withApplicationSchema(applicationSchema)
           withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))
+          withProbationRegion(probationRegion)
         }
 
         val assessmentForSubmittedApplication = assessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -67,6 +67,7 @@ fun IntegrationTestBase.`Given an Assessment for Temporary Accommodation`(
     withCrn(crn)
     withCreatedByUser(createdByUser)
     withApplicationSchema(applicationSchema)
+    withProbationRegion(createdByUser.probationRegion)
   }
 
   val assessment = assessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -53,6 +53,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
@@ -536,6 +537,117 @@ class ApplicationServiceTest {
   }
 
   @Test
+  fun `createTemporaryAccommodationApplication returns FieldValidationError when CRN does not exist`() {
+    val crn = "CRN345"
+    val username = "SOMEPERSON"
+
+    every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.NotFound()
+
+    val user = userWithUsername(username)
+
+    val result = applicationService.createTemporaryAccommodationApplication(crn, user, "jwt", 123, "1", "A12HI")
+
+    assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
+    result as ValidatableActionResult.FieldValidationError
+    assertThat(result.validationMessages).containsEntry("$.crn", "doesNotExist")
+  }
+
+  @Test
+  fun `createTemporaryAccommodationApplication returns FieldValidationError when CRN is LAO restricted`() {
+    val crn = "CRN345"
+    val username = "SOMEPERSON"
+
+    every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Unauthorised()
+
+    val user = userWithUsername(username)
+
+    val result = applicationService.createTemporaryAccommodationApplication(crn, user, "jwt", 123, "1", "A12HI")
+
+    assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
+    result as ValidatableActionResult.FieldValidationError
+    assertThat(result.validationMessages).containsEntry("$.crn", "userPermission")
+  }
+
+  @Test
+  fun `createTemporaryAccommodationApplication returns FieldValidationError when convictionId, eventNumber or offenceId are null`() {
+    val crn = "CRN345"
+    val username = "SOMEPERSON"
+
+    every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
+      OffenderDetailsSummaryFactory().produce()
+    )
+
+    val user = userWithUsername(username)
+
+    val result = applicationService.createTemporaryAccommodationApplication(crn, user, "jwt", null, null, null)
+
+    assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
+    result as ValidatableActionResult.FieldValidationError
+    assertThat(result.validationMessages).containsEntry("$.convictionId", "empty")
+    assertThat(result.validationMessages).containsEntry("$.deliusEventNumber", "empty")
+    assertThat(result.validationMessages).containsEntry("$.offenceId", "empty")
+  }
+
+  @Test
+  fun `createTemporaryAccommodationApplication returns Success with created Application + persisted Risk data`() {
+    val crn = "CRN345"
+    val username = "SOMEPERSON"
+
+    val schema = ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
+
+    val user = userWithUsername(username)
+
+    every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
+      OffenderDetailsSummaryFactory().produce()
+    )
+    every { mockUserService.getUserForRequest() } returns user
+    every { mockJsonSchemaService.getNewestSchema(TemporaryAccommodationApplicationJsonSchemaEntity::class.java) } returns schema
+    every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+
+    val riskRatings = PersonRisksFactory()
+      .withRoshRisks(
+        RiskWithStatus(
+          value = RoshRisks(
+            overallRisk = "High",
+            riskToChildren = "Medium",
+            riskToPublic = "Low",
+            riskToKnownAdult = "High",
+            riskToStaff = "High",
+            lastUpdated = null
+          )
+        )
+      )
+      .withMappa(
+        RiskWithStatus(
+          value = Mappa(
+            level = "",
+            lastUpdated = LocalDate.parse("2022-12-12")
+          )
+        )
+      )
+      .withFlags(
+        RiskWithStatus(
+          value = listOf(
+            "flag1",
+            "flag2"
+          )
+        )
+      )
+      .produce()
+
+    every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(riskRatings)
+
+    val result = applicationService.createTemporaryAccommodationApplication(crn, user, "jwt", 123, "1", "A12HI")
+
+    assertThat(result is ValidatableActionResult.Success).isTrue
+    result as ValidatableActionResult.Success
+    assertThat(result.entity.crn).isEqualTo(crn)
+    assertThat(result.entity.createdByUser).isEqualTo(user)
+    val temporaryAccommodationApplication = result.entity as TemporaryAccommodationApplicationEntity
+    assertThat(temporaryAccommodationApplication.riskRatings).isEqualTo(riskRatings)
+  }
+
+  @Test
   fun `updateApprovedPremisesApplication returns NotFound when application doesn't exist`() {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
@@ -781,17 +893,17 @@ class ApplicationServiceTest {
     val applicationId = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
 
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
     val application = TemporaryAccommodationApplicationEntityFactory()
       .withId(applicationId)
       .withYieldedCreatedByUser {
         UserEntityFactory()
-          .withYieldedProbationRegion {
-            ProbationRegionEntityFactory()
-              .withYieldedApArea { ApAreaEntityFactory().produce() }
-              .produce()
-          }
+          .withProbationRegion(probationRegion)
           .produce()
       }
+      .withProbationRegion(probationRegion)
       .produce()
 
     every { mockUserService.getUserForRequest() } returns UserEntityFactory()
@@ -832,6 +944,7 @@ class ApplicationServiceTest {
       .withId(applicationId)
       .withCreatedByUser(user)
       .withSubmittedAt(null)
+      .withProbationRegion(user.probationRegion)
       .produce()
       .apply {
         schemaUpToDate = false
@@ -877,6 +990,7 @@ class ApplicationServiceTest {
       .withId(applicationId)
       .withCreatedByUser(user)
       .withSubmittedAt(OffsetDateTime.now())
+      .withProbationRegion(user.probationRegion)
       .produce()
       .apply {
         schemaUpToDate = true
@@ -926,6 +1040,7 @@ class ApplicationServiceTest {
       .withApplicationSchema(newestSchema)
       .withId(applicationId)
       .withCreatedByUser(user)
+      .withProbationRegion(user.probationRegion)
       .produce()
       .apply {
         schemaUpToDate = true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -385,7 +385,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `createApplication returns FieldValidationError when CRN does not exist`() {
+  fun `createApprovedPremisesApplication returns FieldValidationError when CRN does not exist`() {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
@@ -393,7 +393,7 @@ class ApplicationServiceTest {
 
     val user = userWithUsername(username)
 
-    val result = applicationService.createApplication(crn, user, "jwt", "approved-premises", 123, "1", "A12HI")
+    val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
@@ -401,7 +401,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `createApplication returns FieldValidationError when CRN is LAO restricted`() {
+  fun `createApprovedPremisesApplication returns FieldValidationError when CRN is LAO restricted`() {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
@@ -409,7 +409,7 @@ class ApplicationServiceTest {
 
     val user = userWithUsername(username)
 
-    val result = applicationService.createApplication(crn, user, "jwt", "approved-premises", 123, "1", "A12HI")
+    val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
@@ -417,7 +417,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `createApplication returns FieldValidationError when CRN is not managed by any teams the user is part of`() {
+  fun `createApprovedPremisesApplication returns FieldValidationError when CRN is not managed by any teams the user is part of`() {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
@@ -434,7 +434,7 @@ class ApplicationServiceTest {
       )
     )
 
-    val result = applicationService.createApplication(crn, user, "jwt", "approved-premises", null, null, null)
+    val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", null, null, null)
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
@@ -442,7 +442,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `createApplication returns FieldValidationError when convictionId, eventNumber or offenceId are null`() {
+  fun `createApprovedPremisesApplication returns FieldValidationError when convictionId, eventNumber or offenceId are null`() {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
@@ -459,7 +459,7 @@ class ApplicationServiceTest {
       )
     )
 
-    val result = applicationService.createApplication(crn, user, "jwt", "approved-premises", null, null, null)
+    val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", null, null, null)
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
@@ -469,7 +469,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `createApplication returns Success with created Application + persisted Risk data`() {
+  fun `createApprovedPremisesApplication returns Success with created Application + persisted Risk data`() {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
@@ -525,7 +525,7 @@ class ApplicationServiceTest {
 
     every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(riskRatings)
 
-    val result = applicationService.createApplication(crn, user, "jwt", "approved-premises", 123, "1", "A12HI")
+    val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.Success).isTrue
     result as ValidatableActionResult.Success

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -125,7 +125,17 @@ class ApplicationsTransformerTest {
 
   @Test
   fun `transformJpaToApi transforms an in progress Temporary Accommodation application correctly`() {
-    val application = temporaryAccommodationApplicationEntityFactory.withSubmittedAt(null).produce()
+    val application = temporaryAccommodationApplicationEntityFactory
+      .withSubmittedAt(null)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory()
+              .produce()
+          )
+          .produce()
+      }
+      .produce()
 
     val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
 
@@ -145,7 +155,16 @@ class ApplicationsTransformerTest {
 
   @Test
   fun `transformJpaToApi transforms a submitted Temporary Accommodation application correctly`() {
-    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val application = submittedTemporaryAccommodationApplicationFactory
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory()
+              .produce()
+          )
+          .produce()
+      }
+      .produce()
 
     val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
 
@@ -174,7 +193,16 @@ class ApplicationsTransformerTest {
 
   @Test
   fun `transformJpaToApi sets status as 'requested further information' when transforming a Temporary Accommodation application with requested clarification notes`() {
-    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val application = submittedTemporaryAccommodationApplicationFactory
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory()
+              .produce()
+          )
+          .produce()
+      }
+      .produce()
     val assessment = assessmentFactory.withApplication(application).produce()
 
     application.assessments = mutableListOf(assessment)
@@ -309,7 +337,16 @@ class ApplicationsTransformerTest {
 
   @Test
   fun `transformJpaToApi sets status as 'submitted' when transforming a Temporary Accommodation application with a completed clarification note`() {
-    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val application = submittedTemporaryAccommodationApplicationFactory
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory()
+              .produce()
+          )
+          .produce()
+      }
+      .produce()
     val assessment = assessmentFactory.withApplication(application).produce()
 
     assessment.clarificationNotes = mutableListOf(
@@ -327,7 +364,16 @@ class ApplicationsTransformerTest {
 
   @Test
   fun `transformJpaToApi uses the latest assessment`() {
-    val application = submittedTemporaryAccommodationApplicationFactory.produce()
+    val application = submittedTemporaryAccommodationApplicationFactory
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory()
+              .produce()
+          )
+          .produce()
+      }
+      .produce()
     val oldAssessment = assessmentFactory.withApplication(application)
       .withCreatedAt(OffsetDateTime.parse("2022-09-01T12:34:56.789Z"))
       .produce()


### PR DESCRIPTION
> See [ticket #1104 on the CAS3 Trello board](https://trello.com/c/nonHg12u/1104-a-user-can-create-a-temporary-accommodation-application).

This PR allows clients to create an application for the Temporary Accommodation service. The process is similar to creating an Approved Premises application, but no checks are made using the `apDeliusContextApiClient.getTeamsManagingCase` function. Temporary Accommodation will be using probation regions to determine access to applications at this stage.