### PR TITLE
Change capitalisation of Pipe and Esap criteria

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5113,8 +5113,8 @@ components:
     PlacementCriteria:
       type: string
       enum:
-        - isPipe
-        - isEsap
+        - isPIPE
+        - isESAP
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - hasBrailleSignage

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -403,7 +403,7 @@ class AssessmentTest : IntegrationTestBase() {
 
             assessment.schemaUpToDate = true
 
-            val essentialCriteria = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.isEsap)
+            val essentialCriteria = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.isESAP)
             val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
             val placementRequirements = PlacementRequirements(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -83,12 +83,12 @@ class BedSearchServiceTest {
     val premisesCharacteristicPropertyName = "isRecoveryFocussed"
 
     val roomCharacteristic = CharacteristicEntityFactory()
-      .withPropertyName("isEsap")
+      .withPropertyName("isESAP")
       .withModelScope("room")
       .withServiceScope("approved-premises")
       .produce()
 
-    every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf("isEsap", premisesCharacteristicPropertyName)) } returns listOf(roomCharacteristic)
+    every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf("isESAP", premisesCharacteristicPropertyName)) } returns listOf(roomCharacteristic)
 
     val authorisableResult = bedSearchService.findApprovedPremisesBeds(
       user = user,
@@ -96,7 +96,7 @@ class BedSearchServiceTest {
       maxDistanceMiles = 20,
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
-      requiredCharacteristics = listOf(PlacementCriteria.isEsap, PlacementCriteria.isRecoveryFocussed),
+      requiredCharacteristics = listOf(PlacementCriteria.isESAP, PlacementCriteria.isRecoveryFocussed),
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
These are stored in the database as `isPIPE` and `isESAP`, so they need to match.