### PR TITLE
(1536) Add an endpoint to list a summary of all beds in a premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -1,18 +1,70 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
+import javax.persistence.ColumnResult
+import javax.persistence.ConstructorResult
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.NamedNativeQuery
+import javax.persistence.SqlResultSetMapping
 import javax.persistence.Table
 
 @Repository
 interface BedRepository : JpaRepository<BedEntity, UUID> {
   fun findByCode(bedCode: String): BedEntity?
+
+  @Query(nativeQuery = true)
+  fun findAllBedsForPremises(premisesId: UUID): List<DomainBedSummary>
 }
+
+@NamedNativeQuery(
+  name = "BedEntity.findAllBedsForPremises",
+  query =
+  """
+    select cast(b.id as text) as id,
+      cast(b.name as text) as name,
+      cast(r.name as text) as roomName,
+      (
+        select count(booking.id)
+        from bookings booking
+        where booking.bed_id = b.id
+          and booking.arrival_date <= CURRENT_DATE
+          and booking.departure_date >= CURRENT_DATE
+      ) > 0 as bedBooked,
+      (
+        select count(lost_bed.id)
+        from lost_beds lost_bed
+        where lost_bed.bed_id = b.id
+          and lost_bed.start_date <= CURRENT_DATE
+          and lost_bed.end_date >= CURRENT_DATE
+      ) > 0 as bedOutOfService
+      from beds b
+           join rooms r on b.room_id = r.id
+     where r.premises_id = cast(?1 as UUID)
+    """,
+  resultSetMapping = "DomainBedSummaryMapping"
+)
+
+@SqlResultSetMapping(
+  name = "DomainBedSummaryMapping",
+  classes = [
+    ConstructorResult(
+      targetClass = DomainBedSummary::class,
+      columns = [
+        ColumnResult(name = "id", type = UUID::class),
+        ColumnResult(name = "name"),
+        ColumnResult(name = "roomName"),
+        ColumnResult(name = "bedBooked"),
+        ColumnResult(name = "bedOutOfService"),
+      ]
+    )
+  ]
+)
 
 @Entity
 @Table(name = "beds")
@@ -28,3 +80,11 @@ data class BedEntity(
 
   override fun toString() = "BedEntity: $id"
 }
+
+open class DomainBedSummary(
+  val id: UUID,
+  val name: String,
+  val roomName: String,
+  val bedBooked: Boolean,
+  val bedOutOfService: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedCancellationEntity
@@ -41,7 +42,8 @@ class PremisesService(
   private val probationRegionRepository: ProbationRegionRepository,
   private val lostBedCancellationRepository: LostBedCancellationRepository,
   private val probationDeliveryUnitRepository: ProbationDeliveryUnitRepository,
-  private val characteristicService: CharacteristicService
+  private val characteristicService: CharacteristicService,
+  private val bedRepository: BedRepository
 ) {
   private val serviceNameToEntityType = mapOf(
     ServiceName.approvedPremises to ApprovedPremisesEntity::class.java,
@@ -429,6 +431,8 @@ class PremisesService(
       ValidatableActionResult.Success(savedPremises)
     )
   }
+
+  fun getBeds(premisesId: UUID) = bedRepository.findAllBedsForPremises(premisesId)
 
   private fun serviceScopeMatches(scope: String, premises: PremisesEntity) = when (scope) {
     "*" -> true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSummaryTransformer.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+
+@Component
+class BedSummaryTransformer {
+  fun transformToApi(summary: DomainBedSummary) = BedSummary(
+    id = summary.id,
+    name = summary.name,
+    roomName = summary.roomName,
+    status = getStatus(summary),
+  )
+
+  private fun getStatus(summary: DomainBedSummary): BedStatus {
+    if (summary.bedBooked) {
+      return BedStatus.occupied
+    } else if (summary.bedOutOfService) {
+      return BedStatus.outOfService
+    } else {
+      return BedStatus.available
+    }
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4655,6 +4655,29 @@ components:
       required:
         - id
         - name
+    BedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        roomName:
+          type: string
+        status:
+          $ref: '#/components/schemas/BedStatus'
+      required:
+        - id
+        - name
+        - roomName
+        - status
+    BedStatus:
+      type: string
+      enum:
+        - occupied
+        - available
+        - out_of_service
     PropertyStatus:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -776,6 +776,34 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /premises/{premisesId}/beds:
+    get:
+      tags:
+        - Rooms
+      summary: Lists all beds for the given premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to list the beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BedSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/rooms:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedSummaryFactory.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class BedSummaryFactory : Factory<DomainBedSummary> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringUpperCase(6) }
+  private var roomName: Yielded<String> = { randomStringUpperCase(6) }
+  private var bedBooked: Boolean = false
+  private var bedOutOfService: Boolean = false
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withRoomName(roomName: String) = apply {
+    this.roomName = { roomName }
+  }
+
+  fun withBedBooked(bedBooked: Boolean) = apply {
+    this.bedBooked = bedBooked
+  }
+
+  fun withBedOutOfService(bedOutOfService: Boolean) = apply {
+    this.bedOutOfService = bedOutOfService
+  }
+
+  override fun produce(): DomainBedSummary = DomainBedSummary(
+    id = this.id(),
+    name = this.name(),
+    roomName = this.roomName(),
+    bedBooked = this.bedBooked,
+    bedOutOfService = this.bedOutOfService
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import java.time.LocalDate
+
+class BedSummaryQueryTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realBedRepository: BedRepository
+
+  lateinit var bed: BedEntity
+  lateinit var premises: PremisesEntity
+
+  @BeforeEach
+  fun setup() {
+    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea {
+        apAreaEntityFactory.produceAndPersist()
+      }
+    }
+
+    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    this.premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+  }
+
+  @Test
+  fun `summary works shows basic bed details and status`() {
+    val bedWithoutBooking = bedEntityFactory.produceAndPersist {
+      withRoom(
+        roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        },
+      )
+    }
+
+    val bedWithBooking = bedEntityFactory.produceAndPersist {
+      withRoom(
+        roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        },
+      )
+    }
+
+    val bedWithLostBed = bedEntityFactory.produceAndPersist {
+      withRoom(
+        roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        },
+      )
+    }
+
+    bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(bedWithBooking)
+      withArrivalDate(LocalDate.now().minusDays((7).toLong()))
+      withDepartureDate(LocalDate.now().plusDays((20).toLong()))
+    }
+
+    lostBedsEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(bedWithLostBed)
+      withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+      withStartDate(LocalDate.now().minusDays((7).toLong()))
+      withEndDate(LocalDate.now().plusDays((20).toLong()))
+    }
+
+    val results: List<DomainBedSummary> =
+      realBedRepository.findAllBedsForPremises(premises.id)
+
+    assertThat(results.size).isEqualTo(3)
+
+    results.first { it.id == bedWithoutBooking.id }.let {
+      assertThat(it.name).isEqualTo(bedWithoutBooking.name)
+      assertThat(it.roomName).isEqualTo(bedWithoutBooking.room.name)
+      assertThat(it.bedBooked).isEqualTo(false)
+      assertThat(it.bedOutOfService).isEqualTo(false)
+    }
+
+    results.first { it.id == bedWithBooking.id }.let {
+      assertThat(it.name).isEqualTo(bedWithBooking.name)
+      assertThat(it.roomName).isEqualTo(bedWithBooking.room.name)
+      assertThat(it.bedBooked).isEqualTo(true)
+      assertThat(it.bedOutOfService).isEqualTo(false)
+    }
+
+    results.first { it.id == bedWithLostBed.id }.let {
+      assertThat(it.name).isEqualTo(bedWithLostBed.name)
+      assertThat(it.roomName).isEqualTo(bedWithLostBed.room.name)
+      assertThat(it.bedBooked).isEqualTo(false)
+      assertThat(it.bedOutOfService).isEqualTo(true)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
@@ -1,0 +1,112 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import java.time.LocalDate
+import java.util.UUID
+
+class BedSummaryTest : IntegrationTestBase() {
+  lateinit var premises: PremisesEntity
+
+  @BeforeEach
+  fun setup() {
+    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea {
+        apAreaEntityFactory.produceAndPersist()
+      }
+    }
+
+    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    this.premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+  }
+
+  @Test
+  fun `Getting beds for a premises without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/premises/${premises.id}/beds")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting beds for a premises that does not exist returns 404`() {
+    `Given a User` { _, jwt ->
+      webTestClient.get()
+        .uri("/premises/${UUID.randomUUID()}/beds")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "approved-premises")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting beds for a premises returns a list of beds`() {
+    `Given a User` { _, jwt ->
+      val bedWithoutBooking = bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          },
+        )
+      }
+
+      val bedWithBooking = bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          },
+        )
+      }
+
+      val bedWithLostBed = bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          },
+        )
+      }
+
+      bookingEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withBed(bedWithBooking)
+        withArrivalDate(LocalDate.now().minusDays((7).toLong()))
+        withDepartureDate(LocalDate.now().plusDays((20).toLong()))
+      }
+
+      lostBedsEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withBed(bedWithLostBed)
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withStartDate(LocalDate.now().minusDays((7).toLong()))
+        withEndDate(LocalDate.now().plusDays((20).toLong()))
+      }
+
+      val expectedResponse = listOf(
+        BedSummary(bedWithoutBooking.id, bedWithoutBooking.name, bedWithoutBooking.room.name, BedStatus.available),
+        BedSummary(bedWithBooking.id, bedWithBooking.name, bedWithBooking.room.name, BedStatus.occupied),
+        BedSummary(bedWithLostBed.id, bedWithLostBed.name, bedWithLostBed.room.name, BedStatus.outOfService),
+      )
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/beds")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "approved-premises")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse))
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedCancellationRepository
@@ -50,6 +51,7 @@ class PremisesServiceTest {
   private val lostBedCancellationRepositoryMock = mockk<LostBedCancellationRepository>()
   private val probationDeliveryUnitRepositoryMock = mockk<ProbationDeliveryUnitRepository>()
   private val characteristicServiceMock = mockk<CharacteristicService>()
+  private val bedRepositoryMock = mockk<BedRepository>()
 
   private val premisesService = PremisesService(
     premisesRepositoryMock,
@@ -60,7 +62,8 @@ class PremisesServiceTest {
     probationRegionRepositoryMock,
     lostBedCancellationRepositoryMock,
     probationDeliveryUnitRepositoryMock,
-    characteristicServiceMock
+    characteristicServiceMock,
+    bedRepositoryMock,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BedSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BedSummaryTransformerTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
+
+class BedSummaryTransformerTest {
+  private val bedSummaryTransformer = BedSummaryTransformer()
+
+  @Test
+  fun `it transforms an available bed correctly`() {
+    val domainSummary = BedSummaryFactory()
+      .withBedBooked(false)
+      .withBedOutOfService(false)
+      .produce()
+
+    val summary = bedSummaryTransformer.transformToApi(domainSummary)
+
+    assertThat(summary.id).isEqualTo(domainSummary.id)
+    assertThat(summary.name).isEqualTo(domainSummary.name)
+    assertThat(summary.roomName).isEqualTo(domainSummary.roomName)
+    assertThat(summary.status).isEqualTo(BedStatus.available)
+  }
+
+  @Test
+  fun `it transforms a booked bed correctly`() {
+    val domainSummary = BedSummaryFactory()
+      .withBedBooked(true)
+      .withBedOutOfService(false)
+      .produce()
+
+    val summary = bedSummaryTransformer.transformToApi(domainSummary)
+
+    assertThat(summary.id).isEqualTo(domainSummary.id)
+    assertThat(summary.name).isEqualTo(domainSummary.name)
+    assertThat(summary.roomName).isEqualTo(domainSummary.roomName)
+    assertThat(summary.status).isEqualTo(BedStatus.occupied)
+  }
+
+  @Test
+  fun `it transforms an unavailable bed correctly`() {
+    val domainSummary = BedSummaryFactory()
+      .withBedBooked(false)
+      .withBedOutOfService(true)
+      .produce()
+
+    val summary = bedSummaryTransformer.transformToApi(domainSummary)
+
+    assertThat(summary.id).isEqualTo(domainSummary.id)
+    assertThat(summary.name).isEqualTo(domainSummary.name)
+    assertThat(summary.roomName).isEqualTo(domainSummary.roomName)
+    assertThat(summary.status).isEqualTo(BedStatus.outOfService)
+  }
+}


### PR DESCRIPTION
This add a `/premises/$premises.id/beds` endpoint to return a summary of all the beds in a premises. I borrow heavily from @bell-pa's work on Assessment summaries to carry out a JPQL query that returns booleans for if a room is booked or out of service, and then transform that into a status response.