### PR TITLE
Include risk data in API responses returning a Temporary Accommodation application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -106,7 +106,8 @@ SELECT
     ass.submitted_at as latestAssessmentSubmittedAt,
     ass.decision as latestAssessmentDecision,
     (SELECT COUNT(1) FROM assessment_clarification_notes acn WHERE acn.assessment_id = ass.id AND acn.response IS NULL) > 0 as latestAssessmentHasClarificationNotesWithoutResponse,
-    (SELECT COUNT(1) FROM bookings b WHERE b.application_id = taa.id) > 0 as hasBooking
+    (SELECT COUNT(1) FROM bookings b WHERE b.application_id = taa.id) > 0 as hasBooking,
+    CAST(taa.risk_ratings AS TEXT) as riskRatings
 FROM temporary_accommodation_applications taa 
 LEFT JOIN applications a ON a.id = taa.id 
 LEFT JOIN assessments ass ON ass.application_id = taa.id AND ass.reallocated_at IS NULL 
@@ -288,4 +289,6 @@ interface ApprovedPremisesApplicationSummary : ApplicationSummary {
   fun getRiskRatings(): String?
 }
 
-interface TemporaryAccommodationApplicationSummary : ApplicationSummary
+interface TemporaryAccommodationApplicationSummary : ApplicationSummary {
+  fun getRiskRatings(): String?
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4077,6 +4077,8 @@ components:
               $ref: '#/components/schemas/AnyValue'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
           required:
             - createdByUserId
             - schemaVersion
@@ -4144,6 +4146,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
           required:
             - createdByUserId
             - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -364,6 +364,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           assertThat(it.getLatestAssessmentDecision()).isNull()
           assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(false)
           assertThat(it.getHasBooking()).isEqualTo(false)
+          assertThat(it.getRiskRatings()).isNotBlank()
         }
 
         results.first { it.getId() == submittedApplication.id }.let {
@@ -375,6 +376,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           assertThat(it.getLatestAssessmentDecision()).isEqualTo(assessmentForSubmittedApplication.decision)
           assertThat(it.getLatestAssessmentHasClarificationNotesWithoutResponse()).isEqualTo(true)
           assertThat(it.getHasBooking()).isEqualTo(true)
+          assertThat(it.getRiskRatings()).isNotBlank()
         }
       }
     }


### PR DESCRIPTION
> See [ticket #1120 on the CAS3 Trello board](https://trello.com/c/5FEf051U/1120-include-risk-information-in-the-api-responses-for-application-endpoints).

The frontend logic that was copied across from AP includes the RoSH/MAPPA risks widget. This information is stored in the database for a Temporary Accommodation application but is not returned by the API.

This should be returned for now as although we don’t know if we need it in the future, it’s fairly trivial to implement, compared to the effort involved in removing it from the frontend.