### PR TITLE
(1536) Add endpoint to show bed details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -20,11 +20,12 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
 
   @Query(nativeQuery = true)
   fun findAllBedsForPremises(premisesId: UUID): List<DomainBedSummary>
+
+  @Query(nativeQuery = true)
+  fun getDetailById(id: UUID): DomainBedSummary?
 }
 
-@NamedNativeQuery(
-  name = "BedEntity.findAllBedsForPremises",
-  query =
+const val bedSummaryQuery =
   """
     select cast(b.id as text) as id,
       cast(b.name as text) as name,
@@ -44,9 +45,26 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
           and lost_bed.end_date >= CURRENT_DATE
       ) > 0 as bedOutOfService
       from beds b
-           join rooms r on b.room_id = r.id
-     where r.premises_id = cast(?1 as UUID)
-    """,
+           join rooms r on b.room_id = r.id 
+  """
+
+@NamedNativeQuery(
+  name = "BedEntity.findAllBedsForPremises",
+  query =
+  """
+    $bedSummaryQuery
+    where r.premises_id = cast(?1 as UUID)
+  """,
+  resultSetMapping = "DomainBedSummaryMapping"
+)
+
+@NamedNativeQuery(
+  name = "BedEntity.getDetailById",
+  query =
+  """
+    $bedSummaryQuery
+    where b.id = cast(?1 as UUID)
+  """,
   resultSetMapping = "DomainBedSummaryMapping"
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -30,6 +30,7 @@ const val bedSummaryQuery =
     select cast(b.id as text) as id,
       cast(b.name as text) as name,
       cast(r.name as text) as roomName,
+      r.id as roomId,
       (
         select count(booking.id)
         from bookings booking
@@ -76,6 +77,7 @@ const val bedSummaryQuery =
       columns = [
         ColumnResult(name = "id", type = UUID::class),
         ColumnResult(name = "name"),
+        ColumnResult(name = "roomId", type = UUID::class),
         ColumnResult(name = "roomName"),
         ColumnResult(name = "bedBooked"),
         ColumnResult(name = "bedOutOfService"),
@@ -102,6 +104,7 @@ data class BedEntity(
 open class DomainBedSummary(
   val id: UUID,
   val name: String,
+  val roomId: UUID,
   val roomName: String,
   val bedBooked: Boolean,
   val bedOutOfService: Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -36,6 +36,17 @@ interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
       "WHERE c.propertyName IN :names",
   )
   fun findAllWherePropertyNameIn(names: List<String>): List<CharacteristicEntity>
+
+  @Query(
+    """
+      SELECT c.*
+      FROM characteristics c
+      LEFT JOIN room_characteristics rc ON rc.characteristic_id = c.id
+      WHERE rc.room_id = :roomId
+    """,
+    nativeQuery = true,
+  )
+  fun findAllForRoomId(roomId: UUID): List<CharacteristicEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedService.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import java.util.UUID
+
+@Service
+class BedService(
+  private val bedRepository: BedRepository,
+  private val characteristicRepository: CharacteristicRepository
+) {
+
+  fun getBedAndRoomCharacteristics(id: UUID): AuthorisableActionResult<Pair<DomainBedSummary, List<CharacteristicEntity>>> {
+    val bedDetail = bedRepository.getDetailById(id) ?: return AuthorisableActionResult.NotFound()
+    val characteristics = characteristicRepository.findAllForRoomId(bedDetail.roomId)
+
+    return AuthorisableActionResult.Success(
+      Pair(bedDetail, characteristics),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedDetailTransformer.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CharacteristicPair
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+
+@Component
+class BedDetailTransformer(
+  private val bedSummaryTransformer: BedSummaryTransformer
+) {
+  fun transformToApi(summaryAndCharacteristics: Pair<DomainBedSummary, List<CharacteristicEntity>>): BedDetail {
+    val summary = summaryAndCharacteristics.first
+    val characteristics = summaryAndCharacteristics.second
+
+    var bedSummary = bedSummaryTransformer.transformToApi(summary)
+    var characteristicPairs = characteristics.map {
+      CharacteristicPair(
+        name = it.name,
+        propertyName = it.propertyName,
+      )
+    }
+
+    return BedDetail(
+      id = bedSummary.id,
+      name = bedSummary.name,
+      roomName = bedSummary.roomName,
+      status = bedSummary.status,
+      characteristics = characteristicPairs,
+    )
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -804,6 +804,39 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/beds/{bedId}:
+    get:
+      tags:
+        - Rooms
+      summary: Gets a given bed for a given premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises that the bed is in
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bedId
+          in: path
+          description: ID of the bed to return
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BedDetail'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/rooms:
     get:
       tags:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4704,6 +4704,18 @@ components:
         - name
         - roomName
         - status
+    BedDetail:
+      allOf:
+        - $ref: '#/components/schemas/BedSummary'
+        - type: object
+          properties:
+            characteristics:
+              type: array
+              items:
+                type: object
+                $ref: '#/components/schemas/CharacteristicPair'
+          required:
+            - characteristics
     BedStatus:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedSummaryFactory.kt
@@ -10,6 +10,7 @@ class BedSummaryFactory : Factory<DomainBedSummary> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringUpperCase(6) }
   private var roomName: Yielded<String> = { randomStringUpperCase(6) }
+  private var roomId: Yielded<UUID> = { UUID.randomUUID() }
   private var bedBooked: Boolean = false
   private var bedOutOfService: Boolean = false
 
@@ -32,6 +33,7 @@ class BedSummaryFactory : Factory<DomainBedSummary> {
   override fun produce(): DomainBedSummary = DomainBedSummary(
     id = this.id(),
     name = this.name(),
+    roomId = this.roomId(),
     roomName = this.roomName(),
     bedBooked = this.bedBooked,
     bedOutOfService = this.bedOutOfService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
@@ -36,6 +36,7 @@ class BedDetailQueryTest : IntegrationTestBase() {
 
     assertThat(result.id).isEqualTo(bed.id)
     assertThat(result.name).isEqualTo(bed.name)
+    assertThat(result.roomId).isEqualTo(room.id)
     assertThat(result.roomName).isEqualTo(room.name)
     assertThat(result.bedBooked).isEqualTo(false)
     assertThat(result.bedOutOfService).isEqualTo(false)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+
+class BedDetailQueryTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realBedRepository: BedRepository
+
+  @Test
+  fun `summary works as expected`() {
+    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea {
+        apAreaEntityFactory.produceAndPersist()
+      }
+    }
+
+    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    var premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+
+    var room = roomEntityFactory.produceAndPersist {
+      withPremises(premises)
+    }
+
+    var bed = bedEntityFactory.produceAndPersist {
+      withRoom(room)
+    }
+
+    var result = realBedRepository.getDetailById(bed.id)!!
+
+    assertThat(result.id).isEqualTo(bed.id)
+    assertThat(result.name).isEqualTo(bed.name)
+    assertThat(result.roomName).isEqualTo(room.name)
+    assertThat(result.bedBooked).isEqualTo(false)
+    assertThat(result.bedOutOfService).isEqualTo(false)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -81,6 +81,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
 
     results.first { it.id == bedWithoutBooking.id }.let {
       assertThat(it.name).isEqualTo(bedWithoutBooking.name)
+      assertThat(it.roomId).isEqualTo(bedWithoutBooking.room.id)
       assertThat(it.roomName).isEqualTo(bedWithoutBooking.room.name)
       assertThat(it.bedBooked).isEqualTo(false)
       assertThat(it.bedOutOfService).isEqualTo(false)
@@ -88,6 +89,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
 
     results.first { it.id == bedWithBooking.id }.let {
       assertThat(it.name).isEqualTo(bedWithBooking.name)
+      assertThat(it.roomId).isEqualTo(bedWithBooking.room.id)
       assertThat(it.roomName).isEqualTo(bedWithBooking.room.name)
       assertThat(it.bedBooked).isEqualTo(true)
       assertThat(it.bedOutOfService).isEqualTo(false)
@@ -95,6 +97,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
 
     results.first { it.id == bedWithLostBed.id }.let {
       assertThat(it.name).isEqualTo(bedWithLostBed.name)
+      assertThat(it.roomId).isEqualTo(bedWithLostBed.room.id)
       assertThat(it.roomName).isEqualTo(bedWithLostBed.room.name)
       assertThat(it.bedBooked).isEqualTo(false)
       assertThat(it.bedOutOfService).isEqualTo(true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CharacteristicQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CharacteristicQueryTest.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+
+class CharacteristicQueryTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realCharacteristicRepository: CharacteristicRepository
+
+  @Test
+  fun `findAllForRoomId returns all the characteristics for a roomId`() {
+    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea {
+        apAreaEntityFactory.produceAndPersist()
+      }
+    }
+
+    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    var premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+
+    var roomCharacteristics = mutableListOf(
+      characteristicEntityFactory.produceAndPersist(),
+      characteristicEntityFactory.produceAndPersist(),
+      characteristicEntityFactory.produceAndPersist(),
+    )
+
+    var otherCharacteristics = mutableListOf(
+      characteristicEntityFactory.produceAndPersist(),
+      characteristicEntityFactory.produceAndPersist(),
+    )
+
+    var room = roomEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withCharacteristics(roomCharacteristics)
+    }
+
+    assertThat(realCharacteristicRepository.findAllForRoomId(room.id)).isEqualTo(roomCharacteristics)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BedDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BedDetailTransformerTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CharacteristicPair
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedDetailTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
+
+class BedDetailTransformerTest {
+  private val bedSummaryTransformer = BedSummaryTransformer()
+  private val bedDetailTransformer = BedDetailTransformer(bedSummaryTransformer)
+
+  @Test
+  fun `it transforms the bed and characteristics`() {
+    val domainSummary = BedSummaryFactory()
+      .produce()
+
+    val characteristics = listOf(
+      CharacteristicEntityFactory().produce(),
+      CharacteristicEntityFactory().produce(),
+    )
+
+    val result = bedDetailTransformer.transformToApi(Pair(domainSummary, characteristics))
+
+    assertThat(result.id).isEqualTo(domainSummary.id)
+    assertThat(result.name).isEqualTo(domainSummary.name)
+    assertThat(result.roomName).isEqualTo(domainSummary.roomName)
+    assertThat(result.status).isEqualTo(BedStatus.available)
+
+    assertThat(result.characteristics.size).isEqualTo(2)
+
+    assertThat(result.characteristics[0]).isEqualTo(
+      CharacteristicPair(characteristics[0].name, characteristics[0].propertyName),
+    )
+    assertThat(result.characteristics[1]).isEqualTo(
+      CharacteristicPair(characteristics[1].name, characteristics[1].propertyName),
+    )
+  }
+}


### PR DESCRIPTION
This builds on #648 to add an endpoint to show all the details of a given bed, together with the characteristics that are tied to that bed's room. This will allow us to build out the bed view as shown in https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/manage/bed-information