### PR TITLE
1446 - Store noms number on Bookings & Applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -356,6 +356,7 @@ class PremisesController(
         bookingService.createApprovedPremisesAdHocBooking(
           user = user,
           crn = body.crn,
+          nomsNumber = inmate.offenderNo,
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
           bedId = body.bedId
@@ -367,6 +368,7 @@ class PremisesController(
           user = user,
           premises = premises,
           crn = body.crn,
+          nomsNumber = inmate.offenderNo,
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
           bedId = body.bedId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -149,6 +149,8 @@ abstract class ApplicationEntity(
 
   @OneToMany(mappedBy = "application")
   var assessments: MutableList<AssessmentEntity>,
+
+  var nomsNumber: String?
 ) {
   fun getLatestAssessment(): AssessmentEntity? = this.assessments.maxByOrNull { it.createdAt }
   abstract fun getRequiredQualifications(): List<UserQualification>
@@ -175,6 +177,7 @@ class ApprovedPremisesApplicationEntity(
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,
+  nomsNumber: String?,
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   @Convert(disableConversion = true)
   val riskRatings: PersonRisks?,
@@ -195,6 +198,7 @@ class ApprovedPremisesApplicationEntity(
   submittedAt,
   schemaUpToDate,
   assessments,
+  nomsNumber
 ) {
   fun hasTeamCode(code: String) = teamCodes.any { it.teamCode == code }
   fun hasAnyTeamCode(codes: List<String>) = codes.any(::hasTeamCode)
@@ -245,6 +249,7 @@ class TemporaryAccommodationApplicationEntity(
   submittedAt: OffsetDateTime?,
   schemaUpToDate: Boolean,
   assessments: MutableList<AssessmentEntity>,
+  nomsNumber: String?,
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,
@@ -264,7 +269,8 @@ class TemporaryAccommodationApplicationEntity(
   createdAt,
   submittedAt,
   schemaUpToDate,
-  assessments
+  assessments,
+  nomsNumber
 ) {
   override fun getRequiredQualifications(): List<UserQualification> = emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -93,6 +93,7 @@ data class BookingEntity(
   val createdAt: OffsetDateTime,
   @OneToMany(mappedBy = "booking")
   var turnarounds: MutableList<TurnaroundEntity>,
+  var nomsNumber: String?
 ) {
   val departure: DepartureEntity?
     get() = departures.maxByOrNull { it.createdAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/PopulateNomsNumbersOnApplicationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/PopulateNomsNumbersOnApplicationsJob.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+
+class PopulateNomsNumbersOnApplicationsJob(
+  private val applicationsRepository: ApplicationRepository,
+  private val communityApiClient: CommunityApiClient
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun process() {
+    applicationsRepository.findAll().forEach {
+      if (it.nomsNumber != null) {
+        log.info("Application ${it.id} already has nomsNumber")
+        return@forEach
+      }
+
+      log.info("Updating Noms Number on Application ${it.id}")
+
+      try {
+        val offenderDetailsResult = communityApiClient.getOffenderDetailSummary(it.crn)
+        if (offenderDetailsResult is ClientResult.Failure) {
+          offenderDetailsResult.throwException()
+        }
+
+        val offenderDetails = (offenderDetailsResult as ClientResult.Success).body
+
+        if (offenderDetails.otherIds.nomsNumber != null) {
+          log.error("No nomsNumber present for ${it.crn}")
+        }
+
+        it.nomsNumber = offenderDetails.otherIds.nomsNumber
+        applicationsRepository.save(it)
+      } catch (exception: Exception) {
+        log.error("Unable to update nomsNumber on Application ${it.id}", exception)
+      }
+
+      Thread.sleep(500)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/PopulateNomsNumbersOnBookingsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/PopulateNomsNumbersOnBookingsJob.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+
+class PopulateNomsNumbersOnBookingsJob(
+  private val bookingRepository: BookingRepository,
+  private val communityApiClient: CommunityApiClient
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun process() {
+    bookingRepository.findAll().forEach {
+      if (it.nomsNumber != null) {
+        log.info("Booking ${it.id} already has nomsNumber")
+        return@forEach
+      }
+
+      log.info("Updating Noms Number on Booking ${it.id}")
+
+      try {
+        val offenderDetailsResult = communityApiClient.getOffenderDetailSummary(it.crn)
+        if (offenderDetailsResult is ClientResult.Failure) {
+          offenderDetailsResult.throwException()
+        }
+
+        val offenderDetails = (offenderDetailsResult as ClientResult.Success).body
+
+        if (offenderDetails.otherIds.nomsNumber != null) {
+          log.error("No nomsNumber present for ${it.crn}")
+        }
+
+        it.nomsNumber = offenderDetails.otherIds.nomsNumber
+        bookingRepository.save(it)
+      } catch (exception: Exception) {
+        log.error("Unable to update nomsNumber on Booking ${it.id}", exception)
+      }
+
+      Thread.sleep(500)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -156,6 +156,7 @@ class BookingService(
           application = placementRequest.application,
           offlineApplication = null,
           turnarounds = mutableListOf(),
+          nomsNumber = placementRequest.application.nomsNumber
         )
       )
 
@@ -178,6 +179,7 @@ class BookingService(
   fun createApprovedPremisesAdHocBooking(
     user: UserEntity,
     crn: String,
+    nomsNumber: String,
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     bedId: UUID
@@ -250,6 +252,7 @@ class BookingService(
           application = if (associateWithOnlineApplication) newestSubmittedOnlineApplication else null,
           offlineApplication = if (associateWithOfflineApplication) newestOfflineApplication else null,
           turnarounds = mutableListOf(),
+          nomsNumber = nomsNumber
         )
       )
 
@@ -341,6 +344,7 @@ class BookingService(
     user: UserEntity,
     premises: TemporaryAccommodationPremisesEntity,
     crn: String,
+    nomsNumber: String,
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     bedId: UUID,
@@ -378,6 +382,7 @@ class BookingService(
         BookingEntity(
           id = UUID.randomUUID(),
           crn = crn,
+          nomsNumber = nomsNumber,
           arrivalDate = arrivalDate,
           departureDate = departureDate,
           keyWorkerStaffCode = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.PopulateNomsNumbersOnApplicationsJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.PopulateNomsNumbersOnBookingsJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
 
@@ -33,6 +35,10 @@ class MigrationJobService(
         )
         MigrationJobType.populateNomsNumbersBookings -> PopulateNomsNumbersOnBookingsJob(
           applicationContext.getBean(BookingRepository::class.java),
+          applicationContext.getBean(CommunityApiClient::class.java)
+        )
+        MigrationJobType.populateNomsNumberApplications -> PopulateNomsNumbersOnApplicationsJob(
+          applicationContext.getBean(ApplicationRepository::class.java),
           applicationContext.getBean(CommunityApiClient::class.java)
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -5,9 +5,12 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.PopulateNomsNumbersOnBookingsJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
 
 @Service
@@ -27,6 +30,10 @@ class MigrationJobService(
         MigrationJobType.updateAllUsersFromCommunityApi -> UpdateAllUsersFromCommunityApiJob(
           applicationContext.getBean(UserRepository::class.java),
           applicationContext.getBean(UserService::class.java)
+        )
+        MigrationJobType.populateNomsNumbersBookings -> PopulateNomsNumbersOnBookingsJob(
+          applicationContext.getBean(BookingRepository::class.java),
+          applicationContext.getBean(CommunityApiClient::class.java)
         )
       }
 

--- a/src/main/resources/db/migration/all/20230523183735__add_noms_number_applications.sql
+++ b/src/main/resources/db/migration/all/20230523183735__add_noms_number_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE applications ADD COLUMN noms_number TEXT;

--- a/src/main/resources/db/migration/all/20230524084116__add_noms_number_bookings.sql
+++ b/src/main/resources/db/migration/all/20230524084116__add_noms_number_bookings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookings ADD COLUMN noms_number TEXT;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5073,6 +5073,7 @@ components:
       type: string
       enum:
         - update_all_users_from_community_api
+        - populate_noms_numbers_bookings
     PlacementRequirements:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5074,6 +5074,7 @@ components:
       enum:
         - update_all_users_from_community_api
         - populate_noms_numbers_bookings
+        - populate_noms_number_applications
     PlacementRequirements:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -38,6 +39,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var releaseType: Yielded<String?> = { null }
   private var arrivalDate: Yielded<OffsetDateTime?> = { null }
   private var isInapplicable: Yielded<Boolean?> = { null }
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -123,6 +125,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isInapplicable = { isInapplicable }
   }
 
+  fun withNomsNumber(nomsNumber: String?) = apply {
+    this.nomsNumber = { nomsNumber }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -144,6 +150,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     placementRequests = this.placementRequests(),
     releaseType = this.releaseType(),
     arrivalDate = this.arrivalDate(),
-    isInapplicable = this.isInapplicable()
+    isInapplicable = this.isInapplicable(),
+    nomsNumber = this.nomsNumber()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -45,6 +45,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var application: Yielded<ApplicationEntity?> = { null }
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
   private var turnarounds: Yielded<MutableList<TurnaroundEntity>>? = null
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -162,6 +163,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.turnarounds = { turnarounds }
   }
 
+  fun withNomsNumber(nomsNumber: String?) = apply {
+    this.nomsNumber = { nomsNumber }
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),
@@ -183,5 +188,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     application = this.application(),
     offlineApplication = this.offlineApplication(),
     turnarounds = this.turnarounds?.invoke() ?: mutableListOf(),
+    nomsNumber = this.nomsNumber()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -31,6 +32,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var offenceId: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
   private var riskRatings: Yielded<PersonRisks> = { PersonRisksFactory().produce() }
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -96,6 +98,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.probationRegion = probationRegion
   }
 
+  fun withNomsNumber(nomsNumber: String?) = apply {
+    this.nomsNumber = { nomsNumber }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -111,6 +117,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     eventNumber = this.eventNumber(),
     offenceId = this.offenceId(),
     riskRatings = this.riskRatings(),
-    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided")
+    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided"),
+    nomsNumber = this.nomsNumber()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PopulateNomsNumbersOnApplicationsMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PopulateNomsNumbersOnApplicationsMigrationTest.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
+
+class PopulateNomsNumbersOnApplicationsMigrationTest : MigrationJobTestBase() {
+  @Test
+  fun `All Applications without Noms Number have Noms Number populated from Community API with a 500ms artificial delay`() {
+    `Given a User` { createdByUser, _ ->
+      val applicationJsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+
+      val applicationOne = approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withCreatedByUser(createdByUser)
+        withApplicationSchema(applicationJsonSchema)
+        withCrn("CRNAPPLICATION1")
+        withNomsNumber(null)
+      }
+
+      val applicationTwo = approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withCreatedByUser(createdByUser)
+        withApplicationSchema(applicationJsonSchema)
+        withCrn("CRNAPPLICATION2")
+        withNomsNumber(null)
+      }
+
+      CommunityAPI_mockSuccessfulOffenderDetailsCall(
+        OffenderDetailsSummaryFactory()
+          .withCrn(applicationOne.crn)
+          .withNomsNumber("NOMSAPPLICATION1")
+          .produce()
+      )
+
+      CommunityAPI_mockSuccessfulOffenderDetailsCall(
+        OffenderDetailsSummaryFactory()
+          .withCrn(applicationTwo.crn)
+          .withNomsNumber("NOMSAPPLICATION2")
+          .produce()
+      )
+
+      val startTime = System.currentTimeMillis()
+      migrationJobService.runMigrationJob(MigrationJobType.populateNomsNumberApplications)
+      val endTime = System.currentTimeMillis()
+
+      assertThat(endTime - startTime).isGreaterThan(500 * 2)
+
+      val applicationOneAfterUpdate = approvedPremisesApplicationRepository.findByIdOrNull(applicationOne.id)!!
+      val applicationTwoAfterUpdate = approvedPremisesApplicationRepository.findByIdOrNull(applicationTwo.id)!!
+
+      assertThat(applicationOneAfterUpdate.nomsNumber).isEqualTo("NOMSAPPLICATION1")
+      assertThat(applicationTwoAfterUpdate.nomsNumber).isEqualTo("NOMSAPPLICATION2")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PopulateNomsNumbersOnBookingsMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PopulateNomsNumbersOnBookingsMigrationTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
+
+class PopulateNomsNumbersOnBookingsMigrationTest : MigrationJobTestBase() {
+  @Test
+  fun `All Bookings without Noms Number have Noms Number populated from Community API with a 500ms artificial delay`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(
+        probationRegionEntityFactory.produceAndPersist {
+          withApArea(apAreaEntityFactory.produceAndPersist())
+        }
+      )
+      withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+    }
+
+    val room = roomEntityFactory.produceAndPersist {
+      withPremises(premises)
+    }
+
+    val bed = bedEntityFactory.produceAndPersist {
+      withRoom(room)
+    }
+
+    val bookingOne = bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(bed)
+      withCrn("CRNBOOKING1")
+      withNomsNumber(null)
+    }
+
+    val bookingTwo = bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(bed)
+      withCrn("CRNBOOKING2")
+      withNomsNumber(null)
+    }
+
+    CommunityAPI_mockSuccessfulOffenderDetailsCall(
+      OffenderDetailsSummaryFactory()
+        .withCrn(bookingOne.crn)
+        .withNomsNumber("NOMSBOOKING1")
+        .produce()
+    )
+
+    CommunityAPI_mockSuccessfulOffenderDetailsCall(
+      OffenderDetailsSummaryFactory()
+        .withCrn(bookingTwo.crn)
+        .withNomsNumber("NOMSBOOKING2")
+        .produce()
+    )
+
+    val startTime = System.currentTimeMillis()
+    migrationJobService.runMigrationJob(MigrationJobType.populateNomsNumbersBookings)
+    val endTime = System.currentTimeMillis()
+
+    assertThat(endTime - startTime).isGreaterThan(500 * 2)
+
+    val bookingOneAfterUpdate = bookingRepository.findByIdOrNull(bookingOne.id)!!
+    val bookingTwoAfterUpdate = bookingRepository.findByIdOrNull(bookingTwo.id)!!
+
+    assertThat(bookingOneAfterUpdate.nomsNumber).isEqualTo("NOMSBOOKING1")
+    assertThat(bookingTwoAfterUpdate.nomsNumber).isEqualTo("NOMSBOOKING2")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1654,7 +1654,7 @@ class BookingServiceTest {
       .withUnitTestControlTestProbationAreaAndLocalAuthority()
       .produce()
 
-    val result = bookingService.createApprovedPremisesAdHocBooking(user, "CRN", LocalDate.parse("2023-02-22"), LocalDate.parse("2023-02-24"), UUID.randomUUID())
+    val result = bookingService.createApprovedPremisesAdHocBooking(user, "CRN", "NOMS123", LocalDate.parse("2023-02-22"), LocalDate.parse("2023-02-24"), UUID.randomUUID())
 
     assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -1695,7 +1695,7 @@ class BookingServiceTest {
     every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(existingApplication)
     every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
 
-    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -1731,7 +1731,7 @@ class BookingServiceTest {
     every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(existingApplication)
     every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
 
-    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bedId)
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bedId)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -1774,7 +1774,7 @@ class BookingServiceTest {
     every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
     every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
 
-    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -1826,7 +1826,7 @@ class BookingServiceTest {
     every { mockOffenderService.getOffenderByCrn(crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()
 
     val runtimeException = assertThrows<RuntimeException> {
-      bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
+      bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
     }
 
     assertThat(runtimeException.message).isEqualTo("Unable to get Offender Details when creating Booking Made Domain Event: Unauthorised")
@@ -1877,7 +1877,7 @@ class BookingServiceTest {
     every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/staff-details/${user.deliusUsername}", HttpStatus.NOT_FOUND, null)
 
     val runtimeException = assertThrows<RuntimeException> {
-      bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
+      bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
     }
 
     assertThat(runtimeException.message).isEqualTo("Unable to complete GET request to /staff-details/${user.deliusUsername}: 404 NOT_FOUND")
@@ -1934,7 +1934,7 @@ class BookingServiceTest {
     every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
     every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
 
-    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
     assertThat(authorisableResult is AuthorisableActionResult.Success)
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
     assertThat(validatableResult is ValidatableActionResult.Success)
@@ -2016,7 +2016,7 @@ class BookingServiceTest {
     every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
     every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
-    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, arrivalDate, departureDate, bed.id)
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
     assertThat(validatableResult is ValidatableActionResult.Success).isTrue
@@ -2059,7 +2059,7 @@ class BookingServiceTest {
       .withUnitTestControlTestProbationAreaAndLocalAuthority()
       .produce()
 
-    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, LocalDate.parse("2023-02-23"), LocalDate.parse("2023-02-22"), bedId, false)
+    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", LocalDate.parse("2023-02-23"), LocalDate.parse("2023-02-22"), bedId, false)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -2091,7 +2091,7 @@ class BookingServiceTest {
       .withUnitTestControlTestProbationAreaAndLocalAuthority()
       .produce()
 
-    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, arrivalDate, departureDate, bedId, false)
+    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bedId, false)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -2134,7 +2134,7 @@ class BookingServiceTest {
 
     every { mockWorkingDayCountService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
-    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, arrivalDate, departureDate, bed.id, false)
+    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, false)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -2186,7 +2186,7 @@ class BookingServiceTest {
 
     every { mockWorkingDayCountService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
-    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, arrivalDate, departureDate, bed.id, false)
+    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, false)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
@@ -2247,7 +2247,7 @@ class BookingServiceTest {
 
     every { mockWorkingDayCountService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
-    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, arrivalDate, departureDate, bed.id, true)
+    val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, true)
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
 
     val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -149,6 +149,7 @@ class BookingTransformerTest {
     application = null,
     offlineApplication = null,
     turnarounds = mutableListOf(),
+    nomsNumber = "NOMS123"
   )
 
   private val staffMember = StaffMember(


### PR DESCRIPTION
So that we can preemptively cache Prison API Inmate Details responses we need to know the Noms Number of any Offenders we want to do this for.  By storing the Noms Number on Applications/Bookings alongside the CRN we can avoid having to call Community API every time (or getting the full cached response from Redis) to get the Noms Number - this will help us reduce the amount of data transfer needed for preemptive caching.