### PR TITLE
Resolve vulnerabilities reported by Trivy as High or Critical

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@7.3.1
+  mem: circleci/rememborb@0.0.2
 
 parameters:
   alerts-slack-channel:
@@ -10,6 +11,9 @@ parameters:
   releases-slack-channel:
     type: string
     default: approved-premises-team-events
+  run-security-workflow-on-branch:
+    type: boolean
+    default: false
 
 jobs:
   trigger-ui-tests:
@@ -33,6 +37,84 @@ jobs:
                 --header "Circle-Token: $CIRCLECI_PIPELINE_TOKEN" \
                 --header "content-type: application/json" \
                 --data '{"branch":"main"}'
+  generate_trivyignore:
+    # Needed to get Trivy to respect the .trivyignore file, as it doesn't use the one that's inside the Docker image.
+    docker:
+      - image: cimg/openjdk:17.0
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: "Initialise Gradle"
+          # Any Gradle command will cause .trivyignore to be generated.
+          command: |
+            ./gradlew init
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .trivyignore
+  build_multiplatform_docker_without_publish:
+    # Hybrid of the hmpps/build_docker and hmpps/build_multiplatform_docker jobs.
+    # Needed for the 'security_branch' workflow as:
+    # - the hmpps/build_multiplatform_docker job does not allow for building Docker images without also
+    #   publishing to quay.io, which would both clutter the repo with ephemeral builds and set the 'latest' tag to an
+    #   image built from a non-main branch.
+    # - the hmpps/build_docker job does allow for building Docker images and persisting them locally, but uses the
+    #   legacy build system instead of buildx, which would necessitate changes to the Dockerfile, and possibly break
+    #   local builds.
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    parameters:
+      image_name:
+        type: string
+        default: "quay.io/hmpps/${CIRCLE_PROJECT_REPONAME}"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - hmpps/create_app_version
+      - run:
+          name: Create IMAGE_NAME env var
+          command: |
+            IMAGE_NAME="<< parameters.image_name >>"
+            echo "export IMAGE_NAME=$IMAGE_NAME" >> $BASH_ENV
+      - mem/remember:
+          env_var: IMAGE_NAME
+          value: "${IMAGE_NAME}"
+      - run:
+          name: Setup buildx
+          command: |
+            docker context create multi-arch-build
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker run --rm --privileged tonistiigi/binfmt --install all
+            docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64
+      - run:
+          name: Build container image
+          command: |
+            docker buildx build \
+              --platform linux/amd64 --pull \
+              --progress plain \
+              --rm=false . \
+              --build-arg BUILD_NUMBER=$APP_VERSION \
+              --build-arg GIT_REF=$CIRCLE_SHA1 \
+              --tag "${IMAGE_NAME}:${APP_VERSION}" \
+              --label "maintainer=dps-hmpps@digital.justice.gov.uk" \
+              --label "app.version=${APP_VERSION}" \
+              --label "build.version=${APP_VERSION}" \
+              --label "build.number=${CIRCLE_BUILD_NUM}" \
+              --label "build.url=${CIRCLE_BUILD_URL}" \
+              --label "build.gitref=${CIRCLE_SHA1}" \
+              --output=type=docker
+      - run:
+          name: Persist container image to workspace
+          command: |
+            mkdir -p docker_cache
+            docker save ${IMAGE_NAME}:${APP_VERSION} -o docker_cache/build_image.tar
+      - persist_to_workspace:
+          root: .
+          paths:
+            - docker_cache
 
 workflows:
   version: 2
@@ -108,6 +190,8 @@ workflows:
               only:
                 - main
     jobs:
+      - generate_trivyignore:
+          name: generate_trivyignore
       - hmpps/gradle_owasp_dependency_check:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
@@ -116,11 +200,34 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
+          requires:
+            - generate_trivyignore
       - hmpps/veracode_pipeline_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - veracode-credentials
             - hmpps-common-vars
+  security-branch:
+    # Mimics the 'security' workflow, but can be manually triggered on any branch.
+    when: << pipeline.parameters.run-security-workflow-on-branch >>
+    jobs:
+      - generate_trivyignore:
+          name: generate_trivyignore
+      - build_multiplatform_docker_without_publish:
+          name: build_docker
+          image_name: hmpps-approved-premises-api
+      - hmpps/gradle_owasp_dependency_check:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          context:
+            - hmpps-common-vars
+          requires:
+            - build_docker
+      - hmpps/trivy_pipeline_scan:
+          context:
+            - hmpps-common-vars
+          requires:
+            - build_docker
+            - generate_trivyignore
   security-weekly:
     triggers:
       - schedule:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.6.0"
-  kotlin("plugin.spring") version "1.7.22"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.7"
+  kotlin("plugin.spring") version "1.8.21"
   id("org.openapi.generator") version "5.4.0"
-  id("org.jetbrains.kotlin.plugin.jpa") version "1.7.22"
+  id("org.jetbrains.kotlin.plugin.jpa") version "1.8.21"
 }
 
 configurations {

--- a/doc/how-to/check-vulnerabilities.md
+++ b/doc/how-to/check-vulnerabilities.md
@@ -1,0 +1,27 @@
+# How to check vulnerabilities in the API
+
+There are two dependency analysis tools used in the API: [Trivy](https://trivy.dev/) and
+[Dependency-Check-Gradle](https://github.com/dependency-check/dependency-check-gradle).
+
+These are automatically run on the `main` branch in CircleCI once every weekday, at 05:11.
+However, these can also be run locally or manually triggered on any branch in CircleCI.
+
+## Check locally
+To run a Trivy scan locally, run:
+```shell
+script/trivy_scan
+```
+
+To run the Gradle dependency check locally, run:
+```shell
+./gradlew dependencyCheckAnalyze
+```
+
+## Triggered check on CircleCI
+To trigger a check on CircleCI:
+- Select your branch on the dropdown on the
+[CircleCI dashboard](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-api).
+- Press the `Trigger Pipeline` button.
+- Expand the `Add Parameters (optional)` section.
+- Set the parameter type to `boolean`, the name to `run-security-workflow-on-branch`, and the value to `true`.
+- Press the `Trigger Pipeline` button.

--- a/script/trivy_scan
+++ b/script/trivy_scan
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cd "$(dirname "$0")/.."
+
+GIT_VERSION="$(git rev-parse --short HEAD)"
+IMAGE_NAME="hmpps-approved-premises-api-$GIT_VERSION"
+
+docker build . -t $IMAGE_NAME
+
+TRIVY_CONTAINER="$(docker create -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar $IMAGE_NAME)"
+
+if [ ! -f ./.trivyignore ]; then
+  ./gradlew init
+fi
+
+docker cp ./.trivyignore $TRIVY_CONTAINER:.
+
+docker start --attach $TRIVY_CONTAINER


### PR DESCRIPTION
> See [ticket #1157 on the CAS3 Trello board](https://trello.com/c/0IlKERvZ/1157-patch-4-critical-vulnerabilities-identified-by-trivy).

This PR updates the following plugins to ensure that the API is using fixed versions of the Spring dependencies where possible:
- `uk.gov.justice.hmpps.gradle-spring-boot:4.8.7` pins Spring to 2.7.12 and updates `.trivyignore` to resolve vulnerabilities that cannot be patched without a major version change
- `org.jetbrains.kotlin.plugin.spring:1.8.21`
- `org.jetbrains.kotlin.plugin.jpa:1.8.21`

It also provides fixes/improvements to the Trivy integration with the project:
- The Trivy scan in the `security` CircleCI workflow has been fixed to respect the contents of the `.trivyignore` file
- A new `security-branch`  workflow has been introduced that can be manually triggered at any time on a branch.
- A `trivy_scan` script has been added to the `script/` folder which runs the Trivy scan locally. It uses the Dockerised version of Trivy to mimic the CI pipeline's behaviour as closely as possible, as running `trivy` directly in the project folder obscures the fact that Trivy doesn't pick up the `.trivyignore` file inside the image it's scanning and can cause misleading reports.