### PR TITLE
Fix for auto seeding when running from JAR

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/SeedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/SeedServiceTest.kt
@@ -81,7 +81,8 @@ class SeedServiceTest {
 
     assertThat(logEntries).anyMatch {
       it.level == "warn" &&
-        it.message.contains("/db/seed/unknown-job-type/unknown_seed_file.csv does not have a known job type; skipping.")
+        it.message.contains("/db/seed/unknown-job-type/unknown_seed_file.csv does not have a known job type; skipping.") ||
+        it.message.contains("\\db\\seed\\unknown-job-type\\unknown_seed_file.csv does not have a known job type; skipping.")
     }
   }
 


### PR DESCRIPTION
When running tests & locally through IntelliJ seed files can be loaded because they physically exist on the Filesystem.  When running from a JAR they are embedded within the JAR so first need to be copied to a real file before the rest of the seeding process can read them.