### PR TITLE
Add user/pass delimiter to rediss urls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -68,7 +68,7 @@ class RedisConfiguration {
     @Value("\${spring.redis.ssl}") ssl: Boolean,
   ): RedLock {
     val scheme = if (ssl) "rediss" else "redis"
-    val passwordString = if (password.isNotEmpty()) "$password@" else ""
+    val passwordString = if (password.isNotEmpty()) ":$password@" else ""
     return RedLock(arrayOf("$scheme://$passwordString$host:$port/$database"))
   }
 


### PR DESCRIPTION
The format we were outputting originally (only a password) is valid but JedisURIHelper that's used by RedLock assumes username and password always appear together