### PR TITLE
Format project with incoming ktlint rules

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
@@ -13,7 +13,7 @@ class InmateDetailsCacheRefreshWorker(
   private val prisonsApiClient: PrisonsApiClient,
   private val loggingEnabled: Boolean,
   private val delayMs: Long,
-  redLock: RedLock
+  redLock: RedLock,
 ) : CacheRefreshWorker(redLock, "inmateDetails") {
   override fun work(checkShouldStop: () -> Boolean) {
     val distinctNomsNumbers = (applicationRepository.getDistinctNomsNumbers() + bookingRepository.getDistinctNomsNumbers()).distinct()
@@ -37,7 +37,7 @@ class InmateDetailsCacheRefreshWorker(
 
       val prisonsApiResult = prisonsApiClient.getInmateDetailsWithCall(it)
       if (prisonsApiResult is ClientResult.Failure.StatusCode) {
-        if (! prisonsApiResult.isPreemptivelyCachedResponse) {
+        if (!prisonsApiResult.isPreemptivelyCachedResponse) {
           log.error("Unable to refresh Inmate Details for $it, response status: ${prisonsApiResult.status}")
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
@@ -13,7 +13,7 @@ class OffenderDetailsCacheRefreshWorker(
   private val communityApiClient: CommunityApiClient,
   private val loggingEnabled: Boolean,
   private val delayMs: Long,
-  redLock: RedLock
+  redLock: RedLock,
 ) : CacheRefreshWorker(redLock, "offenderDetails") {
   override fun work(checkShouldStop: () -> Boolean) {
     val distinctCrns = (applicationRepository.getDistinctCrns() + bookingRepository.getDistinctCrns()).distinct()
@@ -37,7 +37,7 @@ class OffenderDetailsCacheRefreshWorker(
 
       val communityApiResult = communityApiClient.getOffenderDetailSummaryWithCall(it)
       if (communityApiResult is ClientResult.Failure.StatusCode) {
-        if (! communityApiResult.isPreemptivelyCachedResponse) {
+        if (!communityApiResult.isPreemptivelyCachedResponse) {
           log.error("Unable to refresh Offender Details for $it, response status: ${communityApiResult.status}")
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
@@ -22,7 +22,7 @@ class PreemptiveCacheRefresher(
   private val prisonsApiClient: PrisonsApiClient,
   @Value("\${preemptive-cache-logging-enabled}") private val loggingEnabled: Boolean,
   @Value("\${preemptive-cache-delay-ms}") private val delayMs: Long,
-  redLock: RedLock
+  redLock: RedLock,
 ) : DisposableBean {
   protected val log = LoggerFactory.getLogger(this::class.java)
   private val preemptiveCacheThreads = mutableListOf<CacheRefreshWorker>()
@@ -43,7 +43,7 @@ class PreemptiveCacheRefresher(
         communityApiClient,
         loggingEnabled,
         delayMs,
-        redLock
+        redLock,
       )
 
       preemptiveCacheThreads += InmateDetailsCacheRefreshWorker(
@@ -52,7 +52,7 @@ class PreemptiveCacheRefresher(
         prisonsApiClient,
         loggingEnabled,
         delayMs,
-        redLock
+        redLock,
       )
 
       log.info("Starting preemptive cache refresh threads")
@@ -91,7 +91,7 @@ fun interruptableSleep(millis: Long) {
 
 abstract class CacheRefreshWorker(
   private val redLock: RedLock,
-  private val cacheName: String
+  private val cacheName: String,
 ) : Thread() {
   protected val log = LoggerFactory.getLogger(this::class.java)
 
@@ -101,7 +101,7 @@ abstract class CacheRefreshWorker(
   var shuttingDown = false
 
   override fun run() {
-    while (! shuttingDown) {
+    while (!shuttingDown) {
       var lock: LockResult? = null
       try {
         lock = redLock.lock(cacheName, twoMinutesInMilliseconds) ?: continue

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -34,7 +34,7 @@ class CommunityApiClient(
     cacheName = "offenderDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
     failureSoftTtlSeconds = Duration.ofMinutes(30).toSeconds().toInt(),
-    hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt()
+    hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 
   fun getOffenderDetailSummaryWithWait(crn: String) = getRequest<OffenderDetailSummary> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
@@ -22,7 +22,7 @@ class PrisonsApiClient(
     cacheName = "inmateDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
     failureSoftTtlSeconds = Duration.ofMinutes(30).toSeconds().toInt(),
-    hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt()
+    hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 
   fun getInmateDetailsWithWait(nomsNumber: String) = getRequest<InmateDetail> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ContentCachingFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ContentCachingFilter.kt
@@ -14,7 +14,7 @@ class ContentCachingFilter : OncePerRequestFilter() {
   override fun doFilterInternal(
     httpServletRequest: HttpServletRequest,
     httpServletResponse: HttpServletResponse,
-    filterChain: FilterChain
+    filterChain: FilterChain,
   ) {
     filterChain.doFilter(ContentCachingRequestWrapper(httpServletRequest), httpServletResponse)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/LoggingHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/LoggingHandlerInterceptor.kt
@@ -16,7 +16,7 @@ class InterceptorConfig {
   fun mappedInterceptor(loggingHandlerInterceptor: HandlerInterceptor) = MappedInterceptor(
     null,
     arrayOf("/health/**"),
-    loggingHandlerInterceptor
+    loggingHandlerInterceptor,
   )
 }
 
@@ -28,7 +28,7 @@ class LoggingHandlerInterceptor : HandlerInterceptor {
     request: HttpServletRequest,
     response: HttpServletResponse,
     handler: Any,
-    ex: Exception?
+    ex: Exception?,
   ) {
     log.info("${request.method} ${request.requestURI} - ${response.status}")
     super.afterCompletion(request, response, handler, ex)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -69,8 +69,8 @@ class OAuth2ResourceServerSecurityConfiguration {
                   val status = 401
                   val detail =
                     "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint"
-                }
-              )
+                },
+              ),
             )
           }
         }
@@ -127,7 +127,7 @@ class AuthAwareTokenConverter() : Converter<Jwt, AbstractAuthenticationToken> {
 class AuthAwareAuthenticationToken(
   jwt: Jwt,
   private val aPrincipal: String,
-  authorities: Collection<GrantedAuthority>
+  authorities: Collection<GrantedAuthority>,
 ) : JwtAuthenticationToken(jwt, authorities) {
   override fun getPrincipal(): String {
     return aPrincipal
@@ -138,7 +138,7 @@ class AuthAwareAuthenticationToken(
 class AuthorizedClientServiceConfiguration(
   @Value("\${log-client-credentials-jwt-info}") private val logClintCredentialsJwtInfo: Boolean,
   private val clientRegistrationRepository: ClientRegistrationRepository,
-  private val objectMapper: ObjectMapper
+  private val objectMapper: ObjectMapper,
 ) {
   @Bean
   fun inMemoryOAuth2AuthorizedClientService(): OAuth2AuthorizedClientService {
@@ -154,7 +154,7 @@ class LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository:
 
   override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
     clientRegistrationId: String?,
-    principalName: String?
+    principalName: String?,
   ): T = backingImplementation.loadAuthorizedClient<T>(clientRegistrationId, principalName)
 
   override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient?, principal: Authentication?) {
@@ -181,5 +181,5 @@ class LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository:
 data class JwtLogInfo(
   val authorities: List<String>,
   val scope: List<String>,
-  val exp: Long
+  val exp: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/PrisonAdjudicationsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/PrisonAdjudicationsConfig.kt
@@ -10,5 +10,5 @@ class PrisonAdjudicationsConfigBindingModel {
 }
 
 data class PrisonAdjudicationsConfig(
-  val prisonApiPageSize: Int
+  val prisonApiPageSize: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/PrisonCaseNotesConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/PrisonCaseNotesConfig.kt
@@ -14,7 +14,7 @@ class PrisonCaseNotesConfigBindingModel {
 data class PrisonCaseNotesConfig(
   val lookbackDays: Int,
   val prisonApiPageSize: Int,
-  val excludedCategories: List<ExcludedCategory>
+  val excludedCategories: List<ExcludedCategory>,
 )
 
 class ExcludedCategoryBindingModel {
@@ -27,7 +27,7 @@ class ExcludedCategoryBindingModel {
 
 data class ExcludedCategory(
   val category: String,
-  val subcategory: String?
+  val subcategory: String?,
 ) {
   fun excluded(otherCategory: String, otherSubcategory: String) = (otherCategory == category && subcategory == null) || (otherCategory == category && otherSubcategory == subcategory)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -78,13 +78,13 @@ class RedisConfiguration {
       RedisCacheConfiguration.defaultCacheConfig()
         .entryTtl(duration)
         .serializeValuesWith(SerializationPair.fromSerializer(ClientResultRedisSerializer(objectMapper, object : TypeReference<T>() {})))
-        .prefixCacheNameWith(version)
+        .prefixCacheNameWith(version),
     )
 }
 
 class ClientResultRedisSerializer(
   private val objectMapper: ObjectMapper,
-  private val typeReference: TypeReference<*>
+  private val typeReference: TypeReference<*>,
 ) : RedisSerializer<ClientResult<*>> {
   override fun serialize(clientResult: ClientResult<*>?): ByteArray {
     val toSerialize = when (clientResult) {
@@ -96,7 +96,7 @@ class ClientResultRedisSerializer(
           exceptionMessage = null,
           type = null,
           method = clientResult.method,
-          path = clientResult.path
+          path = clientResult.path,
         )
       }
       is ClientResult.Failure.Other -> {
@@ -107,7 +107,7 @@ class ClientResultRedisSerializer(
           exceptionMessage = clientResult.exception.message,
           type = null,
           method = clientResult.method,
-          path = clientResult.path
+          path = clientResult.path,
         )
       }
       is ClientResult.Failure.PreemptiveCacheTimeout ->
@@ -120,7 +120,7 @@ class ClientResultRedisSerializer(
           exceptionMessage = null,
           type = clientResult.body!!::class.java.typeName,
           method = null,
-          path = null
+          path = null,
         )
       }
       else -> null
@@ -135,7 +135,7 @@ class ClientResultRedisSerializer(
     if (deserializedWrapper.discriminator == ClientResultDiscriminator.SUCCESS) {
       return ClientResult.Success(
         status = deserializedWrapper.status!!,
-        body = objectMapper.readValue(deserializedWrapper.body, typeReference)
+        body = objectMapper.readValue(deserializedWrapper.body, typeReference),
       )
     }
 
@@ -144,7 +144,7 @@ class ClientResultRedisSerializer(
         method = deserializedWrapper.method!!,
         path = deserializedWrapper.path!!,
         status = deserializedWrapper.status!!,
-        body = deserializedWrapper.body
+        body = deserializedWrapper.body,
       )
     }
 
@@ -152,7 +152,7 @@ class ClientResultRedisSerializer(
       return ClientResult.Failure.Other(
         method = deserializedWrapper.method!!,
         path = deserializedWrapper.path!!,
-        exception = RuntimeException(deserializedWrapper.exceptionMessage)
+        exception = RuntimeException(deserializedWrapper.exceptionMessage),
       )
     }
 
@@ -167,13 +167,13 @@ data class SerializableClientResult(
   val body: String?,
   val exceptionMessage: String?,
   val method: HttpMethod?,
-  val path: String?
+  val path: String?,
 )
 
 enum class ClientResultDiscriminator {
   SUCCESS,
   STATUS_CODE_FAILURE,
-  OTHER_FAILURE
+  OTHER_FAILURE,
 }
 
 const val IS_NOT_SUCCESSFUL = "!(#result instanceof T(uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult\$Success))"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -31,7 +31,7 @@ class WebClientConfiguration {
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
-    @Value("\${services.community-api.base-url}") communityApiBaseUrl: String
+    @Value("\${services.community-api.base-url}") communityApiBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
@@ -47,7 +47,7 @@ class WebClientConfiguration {
   fun apDeliusContextApiWebClient(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
-    @Value("\${services.ap-delius-context-api.base-url}") communityApiBaseUrl: String
+    @Value("\${services.ap-delius-context-api.base-url}") communityApiBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
@@ -63,7 +63,7 @@ class WebClientConfiguration {
   fun hmppsTierApiWebClient(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
-    @Value("\${services.hmpps-tier.base-url}") hmppsTierApiBaseUrl: String
+    @Value("\${services.hmpps-tier.base-url}") hmppsTierApiBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
@@ -80,7 +80,7 @@ class WebClientConfiguration {
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
-    @Value("\${services.prisons-api.base-url}") prisonsApiBaseUrl: String
+    @Value("\${services.prisons-api.base-url}") prisonsApiBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
@@ -96,7 +96,7 @@ class WebClientConfiguration {
   fun caseNotesWebClient(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
-    @Value("\${services.case-notes.base-url}") caseNotesBaseUrl: String
+    @Value("\${services.case-notes.base-url}") caseNotesBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
@@ -112,7 +112,7 @@ class WebClientConfiguration {
   fun apOASysContextApiWebClient(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
-    @Value("\${services.ap-oasys-context-api.base-url}") apOASysContextApiBaseUrl: String
+    @Value("\${services.ap-oasys-context-api.base-url}") apOASysContextApiBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
@@ -126,7 +126,7 @@ class WebClientConfiguration {
 
   @Bean(name = ["govUKBankHolidaysApiWebClient"])
   fun govUKBankHolidaysApiClient(
-    @Value("\${services.gov-uk-bank-holidays-api.base-url}") govUKBankHolidaysApiBaseUrl: String
+    @Value("\${services.gov-uk-bank-holidays-api.base-url}") govUKBankHolidaysApiBaseUrl: String,
   ): WebClient {
     return WebClient.builder()
       .baseUrl(govUKBankHolidaysApiBaseUrl)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -74,7 +74,7 @@ class ApplicationsController(
   private val taskTransformer: TaskTransformer,
   private val enumConverterFactory: EnumConverterFactory,
   private val placementRequestService: PlacementRequestService,
-  private val taskService: TaskService
+  private val taskService: TaskService,
 ) : ApplicationsApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -151,12 +151,12 @@ class ApplicationsController(
         releaseType = body.releaseType?.name,
         arrivalDate = body.arrivalDate,
         isInapplicable = body.isInapplicable,
-        username = username
+        username = username,
       )
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = serializedData,
-        username = username
+        username = username,
       )
       else -> throw RuntimeException("Unsupported UpdateApplication type: ${body::class.qualifiedName}")
     }
@@ -179,7 +179,7 @@ class ApplicationsController(
 
   override fun applicationsApplicationIdSubmissionPost(
     applicationId: UUID,
-    submitApplication: SubmitApplication
+    submitApplication: SubmitApplication,
   ): ResponseEntity<Unit> {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
@@ -246,11 +246,11 @@ class ApplicationsController(
 
   override fun applicationsApplicationIdTasksTaskTypeGet(
     applicationId: UUID,
-    taskName: String
+    taskName: String,
   ): ResponseEntity<TaskWrapper> {
     val user = userService.getUserForRequest()
     val taskType = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      taskName.kebabCaseToPascalCase()
+      taskName.kebabCaseToPascalCase(),
     ) ?: throw NotFoundProblem(taskName, "TaskType")
 
     val transformedTask: Task
@@ -270,7 +270,7 @@ class ApplicationsController(
           assessment,
           user.deliusUsername,
           offenderService,
-          taskTransformer::transformAssessmentToTask
+          taskTransformer::transformAssessmentToTask,
         )
 
         transformedAllocatableUsers = userService.getUsersWithQualificationsAndRoles(assessment.application.getRequiredQualifications(), listOf(UserRole.ASSESSOR))
@@ -301,8 +301,8 @@ class ApplicationsController(
     return ResponseEntity.ok(
       TaskWrapper(
         task = transformedTask,
-        users = transformedAllocatableUsers
-      )
+        users = transformedAllocatableUsers,
+      ),
     )
   }
 
@@ -311,7 +311,7 @@ class ApplicationsController(
     val user = userService.getUserForRequest()
 
     val taskType = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      taskName.kebabCaseToPascalCase()
+      taskName.kebabCaseToPascalCase(),
     ) ?: throw NotFoundProblem(taskName, "TaskType")
 
     val validationResult = when (val authorisationResult = taskService.reallocateTask(user, taskType, body.userId, applicationId)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -52,8 +52,8 @@ class AssessmentController(
         summaries,
         user.deliusUsername,
         offenderService,
-        assessmentTransformer::transformDomainToApiSummary
-      )
+        assessmentTransformer::transformDomainToApiSummary,
+      ),
     )
   }
 
@@ -86,7 +86,7 @@ class AssessmentController(
     }
 
     return ResponseEntity.ok(
-      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
+      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
     )
   }
 
@@ -129,7 +129,7 @@ class AssessmentController(
     }
 
     return ResponseEntity.ok(
-      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
+      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
     )
   }
 
@@ -143,7 +143,7 @@ class AssessmentController(
       user = user,
       assessmentId = assessmentId,
       document = serializedData,
-      placementRequirements = assessmentAcceptance.requirements
+      placementRequirements = assessmentAcceptance.requirements,
     )
 
     val assessmentValidationResult = when (assessmentAuthResult) {
@@ -188,7 +188,7 @@ class AssessmentController(
 
   override fun assessmentsAssessmentIdNotesPost(
     assessmentId: UUID,
-    newClarificationNote: NewClarificationNote
+    newClarificationNote: NewClarificationNote,
   ): ResponseEntity<ClarificationNote> {
     val user = userService.getUserForRequest()
 
@@ -200,14 +200,14 @@ class AssessmentController(
     }
 
     return ResponseEntity.ok(
-      assessmentClarificationNoteTransformer.transformJpaToApi(clarificationNote)
+      assessmentClarificationNoteTransformer.transformJpaToApi(clarificationNote),
     )
   }
 
   override fun assessmentsAssessmentIdNotesNoteIdPut(
     assessmentId: UUID,
     noteId: UUID,
-    updatedClarificationNote: UpdatedClarificationNote
+    updatedClarificationNote: UpdatedClarificationNote,
   ): ResponseEntity<ClarificationNote> {
     val user = userService.getUserForRequest()
     val clarificationNoteResult = assessmentService.updateAssessmentClarificationNote(
@@ -215,7 +215,7 @@ class AssessmentController(
       assessmentId,
       noteId,
       updatedClarificationNote.response,
-      updatedClarificationNote.responseReceivedOn
+      updatedClarificationNote.responseReceivedOn,
     )
 
     val clarificationNoteEntityResult = when (clarificationNoteResult) {
@@ -230,7 +230,7 @@ class AssessmentController(
     }
 
     return ResponseEntity.ok(
-      assessmentClarificationNoteTransformer.transformJpaToApi(clarificationNoteForResponse)
+      assessmentClarificationNoteTransformer.transformJpaToApi(clarificationNoteForResponse),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingSearchController.kt
@@ -25,7 +25,7 @@ class BookingSearchController(
     xServiceName: ServiceName,
     status: BookingStatus?,
     sortOrder: SortOrder?,
-    sortField: BookingSearchSortField?
+    sortField: BookingSearchSortField?,
   ): ResponseEntity<BookingSearchResults> {
     val sortOrder = sortOrder ?: SortOrder.ascending
     val sortField = sortField ?: BookingSearchSortField.bookingCreatedAt

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DocumentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DocumentsController.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 @Controller
 class DocumentsController(
   private val httpAuthService: HttpAuthService,
-  private val offenderService: OffenderService
+  private val offenderService: OffenderService,
 ) {
   @RequestMapping(method = [RequestMethod.GET], value = ["/documents/{crn}/{documentId}"], produces = ["application/octet-stream"])
   fun documentsCrnDocumentIdGet(@PathVariable("crn") crn: String, @PathVariable("documentId") documentId: String): ResponseEntity<StreamingResponseBody> {
@@ -49,7 +49,7 @@ class DocumentsController(
       HttpHeaders().apply {
         put("Content-Disposition", listOf("attachment; filename=\"${documentMetaData.documentName}\""))
       },
-      HttpStatus.OK
+      HttpStatus.OK,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 
 @Service
 class DomainEventsController(
-  private val domainEventService: DomainEventService
+  private val domainEventService: DomainEventService,
 ) : EventsApiDelegate {
   override fun eventsApplicationSubmittedEventIdGet(eventId: UUID): ResponseEntity<ApplicationSubmittedEnvelope> {
     val event = domainEventService.getApplicationSubmittedDomainEvent(eventId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/LoopbackUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/LoopbackUtils.kt
@@ -8,7 +8,7 @@ fun throwIfNotLoopbackRequest() {
   val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
   val remoteAddress = request.remoteAddr
 
-  if (! listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
+  if (!listOf("127.0.0.1", "localhost").contains(remoteAddress)) {
     throw UnauthenticatedProblem("This endpoint can only be called locally, was requested from: $remoteAddress")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -59,7 +59,7 @@ class PeopleController(
     }
 
     return ResponseEntity.ok(
-      personTransformer.transformModelToApi(offenderDetails, inmateDetail)
+      personTransformer.transformModelToApi(offenderDetails, inmateDetail),
     )
   }
 
@@ -171,8 +171,8 @@ class PeopleController(
         riskToTheIndividual,
         riskManagementPlan,
         needs,
-        selectedSections ?: emptyList()
-      )
+        selectedSections ?: emptyList(),
+      ),
     )
   }
 
@@ -183,7 +183,7 @@ class PeopleController(
     val activeConvictions = getSuccessEntityOrThrow(crn, convictionsResult).filter { it.active }
 
     return ResponseEntity.ok(
-      activeConvictions.flatMap(convictionTransformer::transformToApi)
+      activeConvictions.flatMap(convictionTransformer::transformToApi),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -146,7 +146,7 @@ class PremisesController(
         body.notes,
         body.status,
         Ior.fromNullables(body.pdu, body.probationDeliveryUnitId)?.toEither(),
-        body.turnaroundWorkingDayCount
+        body.turnaroundWorkingDayCount,
       )
 
     val validationResult = when (updatePremisesResult) {
@@ -183,7 +183,7 @@ class PremisesController(
           .values.first().getFreeCapacity(it.totalBeds)
 
         premisesTransformer.transformJpaToApi(it, availableBedsForToday)
-      }
+      },
     )
   }
 
@@ -213,8 +213,8 @@ class PremisesController(
         characteristicIds = body.characteristicIds,
         status = body.status,
         probationDeliveryUnitIdentifier = Ior.fromNullables(body.pdu, body.probationDeliveryUnitId)?.toEither(),
-        turnaroundWorkingDayCount = body.turnaroundWorkingDayCount
-      )
+        turnaroundWorkingDayCount = body.turnaroundWorkingDayCount,
+      ),
     )
     return ResponseEntity(premisesTransformer.transformJpaToApi(premises, premises.totalBeds), HttpStatus.CREATED)
   }
@@ -275,7 +275,7 @@ class PremisesController(
         }
 
         bookingTransformer.transformJpaToApi(it, offenderResult.entity, inmateDetailResult.entity, staffMember)
-      }
+      },
     )
   }
 
@@ -359,7 +359,7 @@ class PremisesController(
           nomsNumber = inmate.offenderNo,
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
-          bedId = body.bedId
+          bedId = body.bedId,
         )
       }
 
@@ -398,7 +398,7 @@ class PremisesController(
   override fun premisesPremisesIdBookingsBookingIdArrivalsPost(
     premisesId: UUID,
     bookingId: UUID,
-    body: NewArrival
+    body: NewArrival,
   ): ResponseEntity<Arrival> {
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -420,7 +420,7 @@ class PremisesController(
       expectedDepartureDate = body.expectedDepartureDate,
       notes = body.notes,
       keyWorkerStaffCode = body.keyWorkerStaffCode,
-      user = user
+      user = user,
     )
 
     val arrival = extractResultEntityOrThrow(result)
@@ -431,7 +431,7 @@ class PremisesController(
   override fun premisesPremisesIdBookingsBookingIdNonArrivalsPost(
     premisesId: UUID,
     bookingId: UUID,
-    body: NewNonarrival
+    body: NewNonarrival,
   ): ResponseEntity<Nonarrival> {
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -446,7 +446,7 @@ class PremisesController(
       booking = booking,
       date = body.date,
       reasonId = body.reason,
-      notes = body.notes
+      notes = body.notes,
     )
 
     val nonArrivalEntity = extractResultEntityOrThrow(result)
@@ -457,7 +457,7 @@ class PremisesController(
   override fun premisesPremisesIdBookingsBookingIdCancellationsPost(
     premisesId: UUID,
     bookingId: UUID,
-    body: NewCancellation
+    body: NewCancellation,
   ): ResponseEntity<Cancellation> {
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -469,7 +469,7 @@ class PremisesController(
       booking = booking,
       date = body.date,
       reasonId = body.reason,
-      notes = body.notes
+      notes = body.notes,
     )
 
     val cancellation = extractResultEntityOrThrow(result)
@@ -502,7 +502,7 @@ class PremisesController(
   override fun premisesPremisesIdBookingsBookingIdDeparturesPost(
     premisesId: UUID,
     bookingId: UUID,
-    body: NewDeparture
+    body: NewDeparture,
   ): ResponseEntity<Departure> {
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -519,7 +519,7 @@ class PremisesController(
       reasonId = body.reasonId,
       moveOnCategoryId = body.moveOnCategoryId,
       destinationProviderId = body.destinationProviderId,
-      notes = body.notes
+      notes = body.notes,
     )
 
     val departure = extractResultEntityOrThrow(result)
@@ -530,7 +530,7 @@ class PremisesController(
   override fun premisesPremisesIdBookingsBookingIdExtensionsPost(
     premisesId: UUID,
     bookingId: UUID,
-    body: NewExtension
+    body: NewExtension,
   ): ResponseEntity<Extension> {
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -547,7 +547,7 @@ class PremisesController(
     val result = bookingService.createExtension(
       booking = booking,
       newDepartureDate = body.newDepartureDate,
-      notes = body.notes
+      notes = body.notes,
     )
 
     val extension = extractResultEntityOrThrow(result)
@@ -634,7 +634,7 @@ class PremisesController(
         body.endDate,
         body.reason,
         body.referenceNumber,
-        body.notes
+        body.notes,
       )
 
     val validationResult = when (updateLostBedResult) {
@@ -697,17 +697,17 @@ class PremisesController(
       maxOf(
         LocalDate.now(),
         lastBookingDate ?: LocalDate.now(),
-        lastLostBedsDate ?: LocalDate.now()
-      )
+        lastLostBedsDate ?: LocalDate.now(),
+      ),
     )
 
     return ResponseEntity.ok(
       capacityForPeriod.map {
         DateCapacity(
           date = it.key,
-          availableBeds = it.value.getFreeCapacity(premises.totalBeds)
+          availableBeds = it.value.getFreeCapacity(premises.totalBeds),
         )
-      }
+      },
     )
   }
 
@@ -752,7 +752,7 @@ class PremisesController(
     }
 
     val room = extractResultEntityOrThrow(
-      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristicIds)
+      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristicIds),
     )
 
     return ResponseEntity(roomTransformer.transformJpaToApi(room), HttpStatus.CREATED)
@@ -773,7 +773,7 @@ class PremisesController(
   override fun premisesPremisesIdRoomsRoomIdPut(
     premisesId: UUID,
     roomId: UUID,
-    updateRoom: UpdateRoom
+    updateRoom: UpdateRoom,
   ): ResponseEntity<Room> {
     val premises = premisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
 
@@ -856,7 +856,7 @@ class PremisesController(
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     thisEntityId: UUID?,
-    bedId: UUID
+    bedId: UUID,
   ) {
     bookingService.getBookingWithConflictingDates(arrivalDate, departureDate, thisEntityId, bedId)?.let {
       throw ConflictProblem(it.id, "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates")
@@ -867,7 +867,7 @@ class PremisesController(
     startDate: LocalDate,
     endDate: LocalDate,
     thisEntityId: UUID?,
-    bedId: UUID
+    bedId: UUID,
   ) {
     bookingService.getLostBedWithConflictingDates(startDate, endDate, thisEntityId, bedId)?.let {
       throw ConflictProblem(it.id, "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransfor
 @Service
 class ProfileController(
   private val userService: UserService,
-  private val userTransformer: UserTransformer
+  private val userTransformer: UserTransformer,
 ) : ProfileApiDelegate {
   override fun profileGet(xServiceName: ServiceName): ResponseEntity<User> {
     val userEntity = userService.getUserForRequest()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole as J
 @Service
 class UsersController(
   private val userService: UserService,
-  private val userTransformer: UserTransformer
+  private val userTransformer: UserTransformer,
 ) : UsersApiDelegate {
 
   override fun usersIdGet(id: UUID, xServiceName: ServiceName): ResponseEntity<User> {
@@ -43,7 +43,7 @@ class UsersController(
 
     return ResponseEntity.ok(
       userService.getUsersWithQualificationsAndRoles(qualifications, roles)
-        .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
+        .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
@@ -22,8 +22,8 @@ fun hasQualificationsAndRoles(qualifications: List<UserQualification>?, roles: L
 
       predicates.add(
         criteriaBuilder.and(
-          userQualifications.`in`(qualifications)
-        )
+          userQualifications.`in`(qualifications),
+        ),
       )
     }
 
@@ -34,8 +34,8 @@ fun hasQualificationsAndRoles(qualifications: List<UserQualification>?, roles: L
 
       predicates.add(
         criteriaBuilder.and(
-          userRoles.`in`(roles)
-        )
+          userRoles.`in`(roles),
+        ),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -14,5 +14,5 @@ data class ApAreaEntity(
   val name: String,
   val identifier: String,
   @OneToMany(mappedBy = "apArea")
-  val probationRegions: MutableList<ProbationRegionEntity>
+  val probationRegions: MutableList<ProbationRegionEntity>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -31,7 +31,7 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query(
     "SELECT a FROM ApplicationEntity a " +
       "LEFT JOIN ApplicationTeamCodeEntity atc ON a = atc.application " +
-      "WHERE TYPE(a) = :type AND atc.teamCode IN (:managingTeamCodes)"
+      "WHERE TYPE(a) = :type AND atc.teamCode IN (:managingTeamCodes)",
   )
   fun <T : ApplicationEntity> findAllByManagingTeam(managingTeamCodes: List<String>, type: Class<T>): List<ApplicationEntity>
 
@@ -64,7 +64,7 @@ LEFT JOIN applications a ON a.id = apa.id
 LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL
 WHERE apa.is_inapplicable IS NOT TRUE;
 """,
-    nativeQuery = true
+    nativeQuery = true,
   )
   fun findAllApprovedPremisesSummaries(): List<ApprovedPremisesApplicationSummary>
 
@@ -91,7 +91,7 @@ LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at 
 WHERE (SELECT COUNT(1) FROM approved_premises_application_team_codes apatc WHERE apatc.application_id = apa.id AND apatc.team_code IN :teamCodes) > 0
 AND apa.is_inapplicable IS NOT TRUE;
 """,
-    nativeQuery = true
+    nativeQuery = true,
   )
   fun findApprovedPremisesSummariesForManagingTeams(teamCodes: List<String>): List<ApprovedPremisesApplicationSummary>
 
@@ -113,7 +113,7 @@ LEFT JOIN applications a ON a.id = taa.id
 LEFT JOIN assessments ass ON ass.application_id = taa.id AND ass.reallocated_at IS NULL 
 WHERE a.created_by_user_id = :userId
 """,
-    nativeQuery = true
+    nativeQuery = true,
   )
   fun findAllTemporaryAccommodationSummariesCreatedByUser(userId: UUID): List<TemporaryAccommodationApplicationSummary>
 
@@ -156,7 +156,7 @@ abstract class ApplicationEntity(
   @OneToMany(mappedBy = "application")
   var assessments: MutableList<AssessmentEntity>,
 
-  var nomsNumber: String
+  var nomsNumber: String,
 ) {
   fun getLatestAssessment(): AssessmentEntity? = this.assessments.maxByOrNull { it.createdAt }
   abstract fun getRequiredQualifications(): List<UserQualification>
@@ -204,7 +204,7 @@ class ApprovedPremisesApplicationEntity(
   submittedAt,
   schemaUpToDate,
   assessments,
-  nomsNumber
+  nomsNumber,
 ) {
   fun hasTeamCode(code: String) = teamCodes.any { it.teamCode == code }
   fun hasAnyTeamCode(codes: List<String>) = codes.any(::hasTeamCode)
@@ -237,7 +237,7 @@ data class ApplicationTeamCodeEntity(
   @ManyToOne
   @JoinColumn(name = "application_id")
   val application: ApprovedPremisesApplicationEntity,
-  val teamCode: String
+  val teamCode: String,
 )
 
 @Entity
@@ -276,7 +276,7 @@ class TemporaryAccommodationApplicationEntity(
   submittedAt,
   schemaUpToDate,
   assessments,
-  nomsNumber
+  nomsNumber,
 ) {
   override fun getRequiredQualifications(): List<UserQualification> = emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
@@ -26,7 +26,7 @@ data class ArrivalEntity(
   val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
-  var booking: BookingEntity
+  var booking: BookingEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -55,9 +55,8 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
      where a.reallocated_at is null
            and (?1 is null or a.allocated_to_user_id = cast(?1 as UUID))
     """,
-  resultSetMapping = "DomainAssessmentSummaryMapping"
+  resultSetMapping = "DomainAssessmentSummaryMapping",
 )
-
 @SqlResultSetMapping(
   name = "DomainAssessmentSummaryMapping",
   classes = [
@@ -75,11 +74,10 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
         ColumnResult(name = "isStarted"),
         ColumnResult(name = "decision"),
         ColumnResult(name = "crn"),
-      ]
-    )
-  ]
+      ],
+    ),
+  ],
 )
-
 @Entity
 @Table(name = "assessments")
 data class AssessmentEntity(
@@ -118,7 +116,7 @@ data class AssessmentEntity(
   var clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
 
   @Transient
-  var schemaUpToDate: Boolean
+  var schemaUpToDate: Boolean,
 )
 
 /**
@@ -136,12 +134,12 @@ open class DomainAssessmentSummary(
   val completed: Boolean,
   val isStarted: Boolean,
   val decision: String?,
-  val crn: String
+  val crn: String,
 )
 
 enum class AssessmentDecision {
   ACCEPTED,
-  REJECTED
+  REJECTED,
 }
 
 @Repository
@@ -168,5 +166,5 @@ data class AssessmentClarificationNoteEntity(
 
   var response: String?,
 
-  var responseReceivedOn: LocalDate?
+  var responseReceivedOn: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -56,9 +56,8 @@ const val bedSummaryQuery =
     $bedSummaryQuery
     where r.premises_id = cast(?1 as UUID)
   """,
-  resultSetMapping = "DomainBedSummaryMapping"
+  resultSetMapping = "DomainBedSummaryMapping",
 )
-
 @NamedNativeQuery(
   name = "BedEntity.getDetailById",
   query =
@@ -66,9 +65,8 @@ const val bedSummaryQuery =
     $bedSummaryQuery
     where b.id = cast(?1 as UUID)
   """,
-  resultSetMapping = "DomainBedSummaryMapping"
+  resultSetMapping = "DomainBedSummaryMapping",
 )
-
 @SqlResultSetMapping(
   name = "DomainBedSummaryMapping",
   classes = [
@@ -81,11 +79,10 @@ const val bedSummaryQuery =
         ColumnResult(name = "roomName"),
         ColumnResult(name = "bedBooked"),
         ColumnResult(name = "bedOutOfService"),
-      ]
-    )
-  ]
+      ],
+    ),
+  ],
 )
-
 @Entity
 @Table(name = "beds")
 data class BedEntity(
@@ -107,5 +104,5 @@ open class DomainBedSummary(
   val roomId: UUID,
   val roomName: String,
   val bedBooked: Boolean,
-  val bedOutOfService: Boolean
+  val bedOutOfService: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -43,7 +43,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       "WHERE b.bed.id = :bedId " +
       "AND b.arrivalDate <= :date " +
       "AND SIZE(b.cancellations) = 0 " +
-      "AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)"
+      "AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)",
   )
   fun findByBedIdAndArrivingBeforeDate(bedId: UUID, date: LocalDate, thisEntityId: UUID?): List<BookingEntity>
 
@@ -55,7 +55,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       "  AND b2.bed.id IN :bedIds " +
       "  AND SIZE(b2.cancellations) = 0 " +
       "  GROUP BY b2.bed " +
-      ")"
+      ")",
   )
   fun findClosestBookingBeforeDateForBeds(date: LocalDate, bedIds: List<UUID>): List<BookingEntity>
 }
@@ -99,7 +99,7 @@ data class BookingEntity(
   val createdAt: OffsetDateTime,
   @OneToMany(mappedBy = "booking")
   var turnarounds: MutableList<TurnaroundEntity>,
-  var nomsNumber: String
+  var nomsNumber: String,
 ) {
   val departure: DepartureEntity?
     get() = departures.maxByOrNull { it.createdAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingNotMade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingNotMade.kt
@@ -22,7 +22,7 @@ data class BookingNotMadeEntity(
   @JoinColumn(name = "placement_request_id")
   val placementRequest: PlacementRequestEntity,
   val createdAt: OffsetDateTime,
-  val notes: String?
+  val notes: String?,
 ) {
 
   override fun toString() = "BookingNotMadeEntity: $id"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
@@ -28,7 +28,7 @@ data class CancellationEntity(
   val createdAt: OffsetDateTime,
   @ManyToOne
   @JoinColumn(name = "booking_id")
-  var booking: BookingEntity
+  var booking: BookingEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ConfirmationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ConfirmationEntity.kt
@@ -24,7 +24,7 @@ data class ConfirmationEntity(
   val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
-  var booking: BookingEntity
+  var booking: BookingEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
@@ -33,7 +33,7 @@ data class DepartureEntity(
   val createdAt: OffsetDateTime,
   @ManyToOne
   @JoinColumn(name = "booking_id")
-  var booking: BookingEntity
+  var booking: BookingEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
@@ -28,7 +28,7 @@ data class DepartureReasonEntity(
   val name: String,
   val isActive: Boolean,
   val serviceScope: String,
-  val legacyDeliusReasonCode: String?
+  val legacyDeliusReasonCode: String?,
 ) {
   override fun toString() = "DepartureReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
@@ -16,7 +16,7 @@ data class DestinationProviderEntity(
   @Id
   val id: UUID,
   val name: String,
-  val isActive: Boolean
+  val isActive: Boolean,
 ) {
   override fun toString() = "DestinationProviderEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -26,7 +26,7 @@ data class DomainEventEntity(
   val occurredAt: OffsetDateTime,
   val createdAt: OffsetDateTime,
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
-  val data: String
+  val data: String,
 )
 
 enum class DomainEventType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExtensionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExtensionEntity.kt
@@ -26,7 +26,7 @@ data class ExtensionEntity(
   val createdAt: OffsetDateTime,
   @ManyToOne
   @JoinColumn(name = "booking_id")
-  var booking: BookingEntity
+  var booking: BookingEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
@@ -28,7 +28,7 @@ abstract class JsonSchemaEntity(
   @Id
   val id: UUID,
   val addedAt: OffsetDateTime,
-  val schema: String
+  val schema: String,
 )
 
 @Entity
@@ -58,5 +58,5 @@ class TemporaryAccommodationApplicationJsonSchemaEntity(
 class ApprovedPremisesAssessmentJsonSchemaEntity(
   id: UUID,
   addedAt: OffsetDateTime,
-  schema: String
+  schema: String,
 ) : JsonSchemaEntity(id, addedAt, schema)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -20,5 +20,5 @@ data class LocalAuthorityAreaEntity(
   var identifier: String,
   var name: String,
   @OneToMany(mappedBy = "localAuthorityArea")
-  var premises: MutableList<PremisesEntity>
+  var premises: MutableList<PremisesEntity>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -28,7 +28,7 @@ data class MoveOnCategoryEntity(
   val name: String,
   val isActive: Boolean,
   val serviceScope: String,
-  val legacyDeliusCategoryCode: String?
+  val legacyDeliusCategoryCode: String?,
 ) {
   override fun toString() = "MoveOnCategoryEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalEntity.kt
@@ -29,7 +29,7 @@ data class NonArrivalEntity(
   val createdAt: OffsetDateTime,
   @OneToOne
   @JoinColumn(name = "booking_id")
-  var booking: BookingEntity
+  var booking: BookingEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
@@ -16,7 +16,7 @@ data class NonArrivalReasonEntity(
   @Id
   val id: UUID,
   val name: String,
-  val isActive: Boolean
+  val isActive: Boolean,
 ) {
   override fun toString() = "NonArrivalReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -22,5 +22,5 @@ data class OfflineApplicationEntity(
   val crn: String,
   val service: String,
   val submittedAt: OffsetDateTime,
-  val createdAt: OffsetDateTime
+  val createdAt: OffsetDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -82,5 +82,5 @@ data class PlacementRequestEntity(
   @OneToMany(mappedBy = "placementRequest")
   var bookingNotMades: MutableList<BookingNotMadeEntity>,
 
-  var reallocatedAt: OffsetDateTime?
+  var reallocatedAt: OffsetDateTime?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PostCodeDistrictEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PostCodeDistrictEntity.kt
@@ -22,5 +22,5 @@ data class PostCodeDistrictEntity(
   val outcode: String,
   val latitude: Double,
   val longitude: Double,
-  val point: Point
+  val point: Point,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -39,7 +39,7 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
         WHERE 
           pr.id = :regionId
         GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, pdu.name, p.status
-      """
+      """,
   )
   fun findAllTemporaryAccommodationSummary(regionId: UUID): List<TemporaryAccommodationPremisesSummary>
 
@@ -98,7 +98,7 @@ abstract class PremisesEntity(
   )
   var characteristics: MutableList<CharacteristicEntity>,
   @Enumerated(value = EnumType.STRING)
-  var status: PropertyStatus
+  var status: PropertyStatus,
 )
 
 @Entity
@@ -125,7 +125,7 @@ class ApprovedPremisesEntity(
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
   status: PropertyStatus,
-  val point: Point? // TODO: Make not-null once Premises have had point added in all environments
+  val point: Point?, // TODO: Make not-null once Premises have had point added in all environments
 ) : PremisesEntity(
   id,
   name,
@@ -143,7 +143,7 @@ class ApprovedPremisesEntity(
   lostBeds,
   rooms,
   characteristics,
-  status
+  status,
 )
 
 @Entity
@@ -171,7 +171,7 @@ class TemporaryAccommodationPremisesEntity(
   @ManyToOne
   @JoinColumn(name = "probation_delivery_unit_id")
   var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
-  var turnaroundWorkingDayCount: Int
+  var turnaroundWorkingDayCount: Int,
 ) : PremisesEntity(
   id,
   name,
@@ -189,7 +189,7 @@ class TemporaryAccommodationPremisesEntity(
   lostBeds,
   rooms,
   characteristics,
-  status
+  status,
 )
 
 data class ApprovedPremisesSummary(
@@ -200,7 +200,7 @@ data class ApprovedPremisesSummary(
   val postcode: String,
   val status: PropertyStatus,
   val bedCount: Int,
-  val apCode: String
+  val apCode: String,
 )
 
 data class TemporaryAccommodationPremisesSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -31,7 +31,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
       (SELECT COUNT(1) FROM assessments a WHERE a.allocated_to_user_id = u.id AND a.submitted_at IS NULL) ASC 
     LIMIT 1
     """,
-    nativeQuery = true
+    nativeQuery = true,
   )
   fun findQualifiedAssessorWithLeastPendingAllocations(requiredQualifications: List<String>, totalRequiredQualifications: Long): UserEntity?
 
@@ -59,7 +59,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
       LIMIT
         1
     """,
-    nativeQuery = true
+    nativeQuery = true,
   )
   fun findRandomMatcher(): UserEntity?
 }
@@ -104,7 +104,7 @@ data class UserRoleAssignmentEntity(
   @JoinColumn(name = "user_id")
   val user: UserEntity,
   @Enumerated(value = EnumType.STRING)
-  val role: UserRole
+  val role: UserRole,
 ) {
   override fun hashCode() = Objects.hash(id, role)
 }
@@ -115,7 +115,7 @@ enum class UserRole {
   MANAGER,
   WORKFLOW_MANAGER,
   APPLICANT,
-  ROLE_ADMIN
+  ROLE_ADMIN,
 }
 
 @Repository
@@ -130,10 +130,10 @@ data class UserQualificationAssignmentEntity(
   @JoinColumn(name = "user_id")
   val user: UserEntity,
   @Enumerated(value = EnumType.STRING)
-  val qualification: UserQualification
+  val qualification: UserQualification,
 )
 
 enum class UserQualification {
   WOMENS,
-  PIPE
+  PIPE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
 class UpdateAllUsersFromCommunityApiJob(
   private val userRepository: UserRepository,
-  private val userService: UserService
+  private val userService: UserService,
 ) : MigrationJob() {
   private val log = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/Availability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/Availability.kt
@@ -8,7 +8,7 @@ data class Availability(
   val arrivedBookings: Int,
   val nonArrivedBookings: Int,
   val cancelledBookings: Int,
-  val lostBeds: Int
+  val lostBeds: Int,
 ) {
   fun getFreeCapacity(totalBeds: Int) = ((totalBeds - pendingBookings) - arrivedBookings) - lostBeds
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 import java.time.Instant
 import java.util.UUID
 
-data class DomainEvent <T> (
+data class DomainEvent<T> (
   val id: UUID,
   val applicationId: UUID,
   val crn: String,
   val occurredAt: Instant,
-  val data: T
+  val data: T,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonRisks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonRisks.kt
@@ -12,14 +12,14 @@ data class RiskWithStatus<T>(val status: RiskStatus, val value: T? = null) {
 enum class RiskStatus {
   Retrieved,
   NotFound,
-  Error
+  Error,
 }
 
 data class PersonRisks(
   val roshRisks: RiskWithStatus<RoshRisks>,
   val mappa: RiskWithStatus<Mappa>,
   val tier: RiskWithStatus<RiskTier>,
-  val flags: RiskWithStatus<List<String>>
+  val flags: RiskWithStatus<List<String>>,
 )
 
 data class RoshRisks(
@@ -28,17 +28,17 @@ data class RoshRisks(
   val riskToPublic: String,
   val riskToKnownAdult: String,
   val riskToStaff: String,
-  val lastUpdated: LocalDate?
+  val lastUpdated: LocalDate?,
 )
 
 data class Mappa(
   val level: String,
-  val lastUpdated: LocalDate
+  val lastUpdated: LocalDate,
 )
 
 data class RiskTier(
   val level: String,
-  val lastUpdated: LocalDate
+  val lastUpdated: LocalDate,
 )
 
 @Converter(autoApply = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/bankholidaysapi/UKBankHolidays.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/bankholidaysapi/UKBankHolidays.kt
@@ -10,12 +10,12 @@ data class UKBankHolidays(
   @JsonProperty("scotland")
   val scotland: CountryBankHolidays,
   @JsonProperty("northern-ireland")
-  val northernIreland: CountryBankHolidays
+  val northernIreland: CountryBankHolidays,
 )
 
 data class CountryBankHolidays(
   val division: String,
-  val events: List<BankHolidayEvent>
+  val events: List<BankHolidayEvent>,
 )
 
 data class BankHolidayEvent(
@@ -23,5 +23,5 @@ data class BankHolidayEvent(
   @JsonFormat(pattern = "yyyy-MM-dd")
   val date: LocalDate,
   val notes: String,
-  val bunting: Boolean
+  val bunting: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Conviction.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Conviction.kt
@@ -13,7 +13,7 @@ data class Conviction(
   val awaitingPsr: Boolean,
   val convictionDate: LocalDate?,
   val referralDate: LocalDate,
-  val offences: List<Offence>?
+  val offences: List<Offence>?,
 )
 
 data class Offence(
@@ -41,5 +41,5 @@ data class OffenceDetail(
   val subCategoryDescription: String,
   val form20Code: String?,
   val subCategoryAbbreviation: String?,
-  val cjitCode: String?
+  val cjitCode: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class GroupedDocuments(
   val documents: List<Document>,
-  val convictions: List<ConvictionDocuments>
+  val convictions: List<ConvictionDocuments>,
 ) {
   fun findDocument(documentId: String) = documents.firstOrNull { it.id == documentId } ?: convictions.flatMap { it.documents }.firstOrNull { it.id == documentId }
 }
@@ -17,15 +17,15 @@ data class Document(
   val extendedDescription: String?,
   val createdAt: LocalDateTime,
   val lastModifiedAt: LocalDateTime?,
-  val parentPrimaryKeyId: Long?
+  val parentPrimaryKeyId: Long?,
 )
 
 data class ConvictionDocuments(
   val convictionId: String,
-  val documents: List<Document>
+  val documents: List<Document>,
 )
 
 data class DocumentType(
   val code: String,
-  val description: String
+  val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
@@ -19,7 +19,7 @@ data class OffenderDetailSummary(
   val partitionArea: String?,
   val currentRestriction: Boolean,
   val currentExclusion: Boolean,
-  val isActiveProbationManagedSentence: Boolean
+  val isActiveProbationManagedSentence: Boolean,
 )
 
 data class OffenderIds(
@@ -29,7 +29,7 @@ data class OffenderIds(
   val mostRecentPrisonNumber: String?,
   val niNumber: String?,
   val nomsNumber: String?,
-  val pncNumber: String?
+  val pncNumber: String?,
 )
 
 data class OffenderProfile(
@@ -46,14 +46,14 @@ data class OffenderProfile(
   val riskColour: String?,
   val disabilities: List<Disability>?,
   val genderIdentity: String?,
-  val selfDescribedGender: String?
+  val selfDescribedGender: String?,
 )
 
 data class OffenderLanguages(
   val primaryLanguage: String?,
   val otherLanguages: List<String>?,
   val languageConcerns: String?,
-  val requiresInterpreter: Boolean?
+  val requiresInterpreter: Boolean?,
 )
 
 data class Disability(
@@ -64,12 +64,12 @@ data class Disability(
   val notes: String?,
   val provisions: List<DisabilityProvision>?,
   val lastUpdatedDateTime: LocalDate?,
-  val isActive: Boolean
+  val isActive: Boolean,
 )
 
 data class DisabilityType(
   val code: String?,
-  val description: String?
+  val description: String?,
 )
 
 data class DisabilityProvision(
@@ -77,10 +77,10 @@ data class DisabilityProvision(
   val notes: String?,
   val startDate: LocalDate?,
   val endDate: LocalDate?,
-  val provisionType: ProvisionType?
+  val provisionType: ProvisionType?,
 )
 
 data class ProvisionType(
   val code: String?,
-  val description: String?
+  val description: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Registrations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Registrations.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
 import java.time.LocalDate
 
 data class Registrations(
-  val registrations: List<Registration>
+  val registrations: List<Registration>,
 )
 
 data class Registration(
@@ -28,18 +28,18 @@ data class Registration(
   val deregisteringProbationArea: RegistrationKeyValue?,
   val deregisteringNotes: String?,
   val numberOfPreviousDeregistrations: Int,
-  val registrationReviews: List<RegistrationReview>?
+  val registrationReviews: List<RegistrationReview>?,
 )
 
 data class RegistrationKeyValue(
   val code: String,
-  val description: String
+  val description: String,
 )
 
 data class RegistrationStaffHuman(
   val code: String,
   val forenames: String,
-  val surname: String
+  val surname: String,
 )
 
 data class RegistrationReview(
@@ -48,5 +48,5 @@ data class RegistrationReview(
   val notes: String?,
   val reviewingTeam: RegistrationKeyValue,
   val reviewingOfficer: RegistrationStaffHuman,
-  val completed: Boolean
+  val completed: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/StaffUserDetails.kt
@@ -10,7 +10,7 @@ data class StaffUserDetails(
   val staffIdentifier: Long,
   val staff: StaffNames,
   val teams: List<StaffUserTeamMembership>?,
-  val probationArea: StaffProbationArea
+  val probationArea: StaffProbationArea,
 )
 
 data class StaffWithoutUsernameUserDetails(
@@ -18,13 +18,13 @@ data class StaffWithoutUsernameUserDetails(
   val staffIdentifier: Long,
   val staff: StaffNames,
   val teams: List<StaffUserTeamMembership>?,
-  val probationArea: StaffProbationArea
+  val probationArea: StaffProbationArea,
 )
 
 data class StaffNames(
   val forenames: String,
   val surname: String,
-  val fullName: String = "$forenames $surname"
+  val fullName: String = "$forenames $surname",
 )
 
 data class StaffUserTeamMembership(
@@ -37,15 +37,15 @@ data class StaffUserTeamMembership(
   val district: KeyValue,
   val borough: KeyValue,
   val startDate: LocalDate,
-  val endDate: LocalDate?
+  val endDate: LocalDate?,
 )
 
 data class KeyValue(
   val code: String,
-  val description: String
+  val description: String,
 )
 
 data class StaffProbationArea(
   val code: String,
-  val description: String
+  val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/UserOffenderAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/UserOffenderAccess.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
 data class UserOffenderAccess(
   val userRestricted: Boolean,
   val userExcluded: Boolean,
-  val restrictionMessage: String?
+  val restrictionMessage: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/ManagingTeamsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/ManagingTeamsResponse.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext
 
 data class ManagingTeamsResponse(
-  val teamCodes: List<String>
+  val teamCodes: List<String>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffMembersPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffMembersPage.kt
@@ -1,17 +1,17 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext
 
 data class StaffMembersPage(
-  val content: List<StaffMember>
+  val content: List<StaffMember>,
 )
 
 data class StaffMember(
   val code: String,
   val keyWorker: Boolean,
-  val name: StaffMemberName
+  val name: StaffMemberName,
 )
 
 data class StaffMemberName(
   val forename: String,
   val middleName: String?,
-  val surname: String
+  val surname: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
@@ -10,18 +10,18 @@ data class SnsEvent(
   val detailUrl: String,
   val occurredAt: OffsetDateTime,
   val additionalInformation: SnsEventAdditionalInformation,
-  val personReference: SnsEventPersonReferenceCollection
+  val personReference: SnsEventPersonReferenceCollection,
 )
 
 data class SnsEventPersonReferenceCollection(
-  val identifiers: List<SnsEventPersonReference>
+  val identifiers: List<SnsEventPersonReference>,
 )
 
 data class SnsEventPersonReference(
   val type: String,
-  val value: String
+  val value: String,
 )
 
 data class SnsEventAdditionalInformation(
-  val applicationId: UUID
+  val applicationId: UUID,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppsauth/GetTokenResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppsauth/GetTokenResponse.kt
@@ -14,5 +14,5 @@ data class GetTokenResponse(
   @JsonProperty("auth_source")
   val authSource: String,
   val jti: String,
-  val iss: String
+  val iss: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppsauth/Jwt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppsauth/Jwt.kt
@@ -13,5 +13,5 @@ data class Jwt(
   val userId: String?,
   @JsonProperty("passed_mfa")
   val passedMfa: Boolean?,
-  val exp: Long
+  val exp: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppstier/Tier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppstier/Tier.kt
@@ -6,5 +6,5 @@ import java.util.UUID
 data class Tier(
   val tierScore: String,
   val calculationId: UUID,
-  val calculationDate: LocalDateTime
+  val calculationDate: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/AssessmentInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/AssessmentInfo.kt
@@ -10,5 +10,5 @@ abstract class AssessmentInfo(
   val initiationDate: OffsetDateTime,
   val assessmentStatus: String,
   val superStatus: String?,
-  val limitedAccessOffender: Boolean
+  val limitedAccessOffender: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/HealthDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/HealthDetails.kt
@@ -11,7 +11,7 @@ class HealthDetails(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val health: HealthDetailsInner
+  val health: HealthDetailsInner,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -20,7 +20,7 @@ class HealthDetails(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class HealthDetailsInner(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/NeedsDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/NeedsDetails.kt
@@ -13,7 +13,7 @@ class NeedsDetails(
   limitedAccessOffender: Boolean,
   val needs: NeedsDetailsInner?,
   val linksToHarm: LinksToHarm?,
-  val linksToReOffending: LinksToReOffending?
+  val linksToReOffending: LinksToReOffending?,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -22,7 +22,7 @@ class NeedsDetails(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class NeedsDetailsInner(
@@ -36,7 +36,7 @@ data class NeedsDetailsInner(
   val educationTrainingEmploymentIssuesDetails: String?,
   val accommodationIssuesDetails: String?,
   val attitudeIssuesDetails: String?,
-  val thinkingBehaviouralIssuesDetails: String?
+  val thinkingBehaviouralIssuesDetails: String?,
 )
 
 data class LinksToHarm(
@@ -49,7 +49,7 @@ data class LinksToHarm(
   val alcoholLinkedToHarm: Boolean?,
   val emotionalLinkedToHarm: Boolean?,
   val thinkingBehaviouralLinkedToHarm: Boolean?,
-  val attitudeLinkedToHarm: Boolean?
+  val attitudeLinkedToHarm: Boolean?,
 )
 
 data class LinksToReOffending(
@@ -62,5 +62,5 @@ data class LinksToReOffending(
   val alcoholLinkedToReOffending: Boolean?,
   val emotionalLinkedToReOffending: Boolean?,
   val thinkingBehaviouralLinkedToReOffending: Boolean?,
-  val attitudeLinkedToReOffending: Boolean?
+  val attitudeLinkedToReOffending: Boolean?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/OffenceDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/OffenceDetails.kt
@@ -11,7 +11,7 @@ class OffenceDetails(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val offence: OffenceDetailsInner?
+  val offence: OffenceDetailsInner?,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -20,7 +20,7 @@ class OffenceDetails(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class OffenceDetailsInner(
@@ -32,5 +32,5 @@ data class OffenceDetailsInner(
   val victimPerpetratorRel: String?,
   val victimInfo: String?,
   val patternOffending: String?,
-  val acceptsResponsibility: String?
+  val acceptsResponsibility: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RiskManagementPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RiskManagementPlan.kt
@@ -11,7 +11,7 @@ class RiskManagementPlan(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val riskManagementPlan: RiskManagementPlanInner?
+  val riskManagementPlan: RiskManagementPlanInner?,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -20,7 +20,7 @@ class RiskManagementPlan(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class RiskManagementPlanInner(
@@ -31,5 +31,5 @@ data class RiskManagementPlanInner(
   val interventionsAndTreatment: String?,
   val monitoringAndControl: String?,
   val supervision: String?,
-  val keyInformationAboutCurrentSituation: String?
+  val keyInformationAboutCurrentSituation: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RiskToTheIndividual.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RiskToTheIndividual.kt
@@ -11,7 +11,7 @@ class RisksToTheIndividual(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val riskToTheIndividual: RiskToTheIndividualInner?
+  val riskToTheIndividual: RiskToTheIndividualInner?,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -20,7 +20,7 @@ class RisksToTheIndividual(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class RiskToTheIndividualInner(
@@ -31,5 +31,5 @@ data class RiskToTheIndividualInner(
   val currentVulnerability: String?,
   val previousVulnerability: String?,
   val riskOfSeriousHarm: String?,
-  val currentConcernsBreachOfTrustText: String?
+  val currentConcernsBreachOfTrustText: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RoshRatings.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RoshRatings.kt
@@ -11,7 +11,7 @@ class RoshRatings(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val rosh: RoshRatingsInner
+  val rosh: RoshRatingsInner,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -20,7 +20,7 @@ class RoshRatings(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class RoshRatingsInner(
@@ -52,5 +52,5 @@ enum class RiskLevel(val text: String) {
   VERY_HIGH("Very High"),
   HIGH("High"),
   MEDIUM("Medium"),
-  LOW("Low")
+  LOW("Low"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RoshSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/oasyscontext/RoshSummary.kt
@@ -11,7 +11,7 @@ class RoshSummary(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val roshSummary: RoshSummaryInner?
+  val roshSummary: RoshSummaryInner?,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,
@@ -20,7 +20,7 @@ class RoshSummary(
   initiationDate,
   assessmentStatus,
   superStatus,
-  limitedAccessOffender
+  limitedAccessOffender,
 )
 
 data class RoshSummaryInner(
@@ -28,5 +28,5 @@ data class RoshSummaryInner(
   val natureOfRisk: String?,
   val riskGreatest: String?,
   val riskIncreaseLikelyTo: String?,
-  val riskReductionLikelyTo: String?
+  val riskReductionLikelyTo: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/AdjudicationsPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/AdjudicationsPage.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class AdjudicationsPage(
   val results: List<Adjudication>,
-  val agencies: List<Agency>
+  val agencies: List<Agency>,
 )
 
 data class Adjudication(
@@ -13,18 +13,18 @@ data class Adjudication(
   val agencyIncidentId: Long,
   val agencyId: String,
   val partySeq: Long,
-  val adjudicationCharges: List<AdjudicationCharge>
+  val adjudicationCharges: List<AdjudicationCharge>,
 )
 
 data class AdjudicationCharge(
   val oicChargeId: String,
   val offenceCode: String,
   val offenceDescription: String,
-  val findingCode: String?
+  val findingCode: String?,
 )
 
 data class Agency(
   val agencyId: String,
   val description: String,
-  val agencyType: String
+  val agencyType: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/Alert.kt
@@ -14,5 +14,5 @@ data class Alert(
   val dateCreated: LocalDate,
   val dateExpires: LocalDate?,
   val expired: Boolean,
-  val active: Boolean
+  val active: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/CaseNotes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/CaseNotes.kt
@@ -6,7 +6,7 @@ data class CaseNotesPage(
   val totalElements: Int,
   val totalPages: Int,
   val number: Int,
-  val content: List<CaseNote>
+  val content: List<CaseNote>,
 )
 
 data class CaseNote(
@@ -25,11 +25,11 @@ data class CaseNote(
   val locationId: String?,
   val eventId: Int,
   val sensitive: Boolean,
-  val amendments: List<CaseNoteAmendment>
+  val amendments: List<CaseNoteAmendment>,
 )
 
 data class CaseNoteAmendment(
   val creationDateTime: LocalDateTime,
   val authorName: String,
-  val additionalNoteText: String
+  val additionalNoteText: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/InmateDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/InmateDetail.kt
@@ -3,18 +3,18 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi
 data class InmateDetail(
   val offenderNo: String,
   val inOutStatus: InOutStatus,
-  val assignedLivingUnit: AssignedLivingUnit?
+  val assignedLivingUnit: AssignedLivingUnit?,
 )
 
 data class AssignedLivingUnit(
   val agencyId: String,
   val locationId: Long,
   val description: String?,
-  val agencyName: String
+  val agencyName: String,
 )
 
 enum class InOutStatus {
   IN,
   OUT,
-  TRN
+  TRN,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
@@ -16,15 +16,15 @@ class BadRequestProblem(private val invalidParams: Map<String, String>? = null, 
         invalidParams?.map {
           ParamError(
             propertyName = it.key,
-            errorType = it.value
+            errorType = it.value,
           )
         } ?: emptyList()
-        )
+        ),
     )
   }
 }
 
 data class ParamError(
   val propertyName: String,
-  val errorType: String
+  val errorType: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeserializationV
 @ControllerAdvice
 class ExceptionHandling(
   private val objectMapper: ObjectMapper,
-  private val deserializationValidationService: DeserializationValidationService
+  private val deserializationValidationService: DeserializationValidationService,
 ) : ProblemHandling, MessageNotReadableAdviceTrait {
   override fun toProblem(throwable: Throwable, status: StatusType): ThrowableProblem? {
     Sentry.captureException(throwable)
@@ -41,18 +41,18 @@ class ExceptionHandling(
 
     if (throwable is MissingRequestHeaderException) {
       return BadRequestProblem(
-        errorDetail = "Missing required header ${throwable.headerName}"
+        errorDetail = "Missing required header ${throwable.headerName}",
       )
     }
 
     return InternalServerErrorProblem(
-      detail = "There was an unexpected problem"
+      detail = "There was an unexpected problem",
     )
   }
 
   override fun handleMessageNotReadableException(
     exception: HttpMessageNotReadableException,
-    request: NativeWebRequest
+    request: NativeWebRequest,
   ): ResponseEntity<Problem> {
     val responseBuilder = Problem.builder()
       .withStatus(Status.BAD_REQUEST)
@@ -81,8 +81,8 @@ class ExceptionHandling(
           BadRequestProblem(
             invalidParams = deserializationValidationService.validateArray(
               targetType = arrayItemsType,
-              jsonArray = jsonTree as ArrayNode
-            )
+              jsonArray = jsonTree as ArrayNode,
+            ),
           )
         } else {
           val objectType = (mismatchedInputException.path[0].from as Class<*>).kotlin
@@ -90,8 +90,8 @@ class ExceptionHandling(
           BadRequestProblem(
             invalidParams = deserializationValidationService.validateObject(
               targetType = objectType,
-              jsonObject = jsonTree as ObjectNode
-            )
+              jsonObject = jsonTree as ObjectNode,
+            ),
           )
         }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUsageReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUsageReportGenerator.kt
@@ -47,7 +47,7 @@ class BedUsageReportGenerator(
         durationOfBookingDays = booking.arrivalDate.getDaysUntilInclusive(booking.departureDate).size,
         bookingStatus = bookingTransformer.determineStatus(booking),
         voidCategory = null,
-        voidNotes = null
+        voidNotes = null,
       )
 
       val turnaround = booking.turnaround
@@ -67,7 +67,7 @@ class BedUsageReportGenerator(
           durationOfBookingDays = turnaroundStartDate.getDaysUntilInclusive(endDate).size,
           bookingStatus = null,
           voidCategory = null,
-          voidNotes = null
+          voidNotes = null,
         )
       }
     }
@@ -85,7 +85,7 @@ class BedUsageReportGenerator(
         durationOfBookingDays = lostBed.startDate.getDaysUntilInclusive(lostBed.endDate).size,
         bookingStatus = null,
         voidCategory = lostBed.reason.name,
-        voidNotes = lostBed.notes
+        voidNotes = lostBed.notes,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
@@ -92,8 +92,8 @@ class BedUtilisationReportGenerator(
         voidDays = voidDays,
         totalBookedDays = totalBookedDays,
         totalDaysInTheMonth = daysInMonth,
-        occupancyRate = totalBookedDays.toDouble() / daysInMonth
-      )
+        occupancyRate = totalBookedDays.toDouble() / daysInMonth,
+      ),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
@@ -25,8 +25,8 @@ class BookingsReportGenerator : ReportGenerator<BookingEntity, BookingsReportRow
           this.arrival?.arrivalDate?.let { ChronoUnit.DAYS.between(it, LocalDate.now()).toInt() }
         },
         actualNightsStayed = if (this.arrival?.arrivalDate == null) null else this.departure?.dateTime?.let { ChronoUnit.DAYS.between(this.arrival?.arrivalDate, it.toLocalDate()).toInt() },
-        accommodationOutcome = this.departure?.moveOnCategory?.name
-      )
+        accommodationOutcome = this.departure?.moveOnCategory?.name,
+      ),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUsageReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUsageReportRow.kt
@@ -15,11 +15,11 @@ data class BedUsageReportRow(
   val durationOfBookingDays: Int,
   val bookingStatus: BookingStatus?,
   val voidCategory: String?,
-  val voidNotes: String?
+  val voidNotes: String?,
 )
 
 enum class BedUsageType {
   Booking,
   Turnaround,
-  Void
+  Void,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportRow.kt
@@ -13,5 +13,5 @@ data class BedUtilisationReportRow(
   val voidDays: Int,
   val totalBookedDays: Int,
   val totalDaysInTheMonth: Int,
-  val occupancyRate: Double
+  val occupancyRate: Double,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BedUsageReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BedUsageReportProperties.kt
@@ -7,5 +7,5 @@ data class BedUsageReportProperties(
   val serviceName: ServiceName,
   val probationRegionId: UUID?,
   val year: Int,
-  val month: Int
+  val month: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BedUtilisationReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BedUtilisationReportProperties.kt
@@ -7,5 +7,5 @@ data class BedUtilisationReportProperties(
   val serviceName: ServiceName,
   val probationRegionId: UUID?,
   val year: Int,
-  val month: Int
+  val month: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BookingsReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/BookingsReportProperties.kt
@@ -7,5 +7,5 @@ data class BookingsReportProperties(
   val serviceName: ServiceName,
   val probationRegionId: UUID?,
   val year: Int,
-  val month: Int
+  val month: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -214,7 +214,7 @@ WHERE
     probationDeliveryUnit: String,
     startDate: LocalDate,
     durationInDays: Int,
-    probationRegionId: UUID
+    probationRegionId: UUID,
   ): List<TemporaryAccommodationBedSearchResult> {
     val params = MapSqlParameterSource().apply {
       addValue("probation_region_id", probationRegionId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingSearchRepository.kt
@@ -130,7 +130,7 @@ class BookingSearchRepository(private val namedParameterJdbcTemplate: NamedParam
         }
 
         bookings
-      }
+      },
     )
 
     return result ?: emptyList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
@@ -20,10 +20,10 @@ class ApprovedPremisesSeedJob(
   private val premisesRepository: PremisesRepository,
   private val probationRegionRepository: ProbationRegionRepository,
   private val localAuthorityAreaRepository: LocalAuthorityAreaRepository,
-  private val characteristicRepository: CharacteristicRepository
+  private val characteristicRepository: CharacteristicRepository,
 ) : SeedJob<ApprovedPremisesSeedCsvRow>(
   fileName = fileName,
-  requiredColumns = 12
+  requiredColumns = 12,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -69,7 +69,7 @@ class ApprovedPremisesSeedJob(
     apCode = columns["apCode"]!!,
     qCode = columns["qCode"]!!,
     latitude = columns["latitude"]!!.toDoubleOrNull(),
-    longitude = columns["longitude"]!!.toDoubleOrNull()
+    longitude = columns["longitude"]!!.toDoubleOrNull(),
   )
 
   override fun processRow(row: ApprovedPremisesSeedCsvRow) {
@@ -126,7 +126,7 @@ class ApprovedPremisesSeedJob(
     row: ApprovedPremisesSeedCsvRow,
     probationRegion: ProbationRegionEntity,
     localAuthorityArea: LocalAuthorityAreaEntity,
-    characteristics: List<CharacteristicEntity>
+    characteristics: List<CharacteristicEntity>,
   ) {
     log.info("Creating new Approved Premises: ${row.apCode} ${row.name}")
 
@@ -153,8 +153,8 @@ class ApprovedPremisesSeedJob(
         status = row.status,
         longitude = row.longitude,
         latitude = row.latitude,
-        point = if (row.longitude != null && row.latitude != null) geometryFactory.createPoint(Coordinate(row.latitude, row.longitude)) else null
-      )
+        point = if (row.longitude != null && row.latitude != null) geometryFactory.createPoint(Coordinate(row.latitude, row.longitude)) else null,
+      ),
     )
 
     approvedPremises.characteristics.addAll(characteristics)
@@ -178,7 +178,7 @@ class ApprovedPremisesSeedJob(
     existingApprovedPremises: ApprovedPremisesEntity,
     probationRegion: ProbationRegionEntity,
     localAuthorityArea: LocalAuthorityAreaEntity,
-    characteristics: List<CharacteristicEntity>
+    characteristics: List<CharacteristicEntity>,
   ) {
     log.info("Updating existing Approved Premises: ${row.apCode} ${row.name}")
 
@@ -250,7 +250,7 @@ private fun requiredHeaders(): Set<String> {
 
 data class CharacteristicValue(
   val propertyName: String,
-  val value: Boolean
+  val value: Boolean,
 )
 
 data class ApprovedPremisesSeedCsvRow(
@@ -287,5 +287,5 @@ data class ApprovedPremisesSeedCsvRow(
   val apCode: String,
   val qCode: String,
   val latitude: Double?,
-  val longitude: Double?
+  val longitude: Double?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/CharacteristicsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/CharacteristicsSeedJob.kt
@@ -8,11 +8,11 @@ import java.util.UUID
 
 class CharacteristicsSeedJob(
   fileName: String,
-  private val characteristicRepository: CharacteristicRepository
+  private val characteristicRepository: CharacteristicRepository,
 ) : SeedJob<CharacteristicsSeedCsvRow>(
   id = UUID.randomUUID(),
   fileName = fileName,
-  requiredColumns = 4
+  requiredColumns = 4,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -24,7 +24,7 @@ class CharacteristicsSeedJob(
     name = throwIfBlank(columns["characteristic_name"]!!, "characteristic_name"),
     propertyName = columns["characteristic_property_name"]!!,
     serviceScope = throwIfBlankOrInvalid(columns["service_scope"]!!, "service_scope"),
-    modelScope = throwIfBlankOrInvalid(columns["model_scope"]!!, "model_scope")
+    modelScope = throwIfBlankOrInvalid(columns["model_scope"]!!, "model_scope"),
   )
 
   override fun processRow(row: CharacteristicsSeedCsvRow) {
@@ -36,7 +36,7 @@ class CharacteristicsSeedJob(
     val existingCharacteristic = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = row.propertyName,
       serviceName = row.serviceScope,
-      modelName = row.modelScope
+      modelName = row.modelScope,
     )
 
     if (existingCharacteristic != null) {
@@ -71,7 +71,7 @@ class CharacteristicsSeedJob(
   }
 
   private fun createNewCharacteristic(
-    row: CharacteristicsSeedCsvRow
+    row: CharacteristicsSeedCsvRow,
   ) {
     log.info("Creating new Characteristic: ${row.propertyName}")
 
@@ -83,13 +83,13 @@ class CharacteristicsSeedJob(
         serviceScope = row.serviceScope,
         modelScope = row.modelScope,
         isActive = true,
-      )
+      ),
     )
   }
 
   private fun updateExistingCharacteristic(
     row: CharacteristicsSeedCsvRow,
-    existingCharacteristic: CharacteristicEntity
+    existingCharacteristic: CharacteristicEntity,
   ) {
     log.info("Updating Characteristic: '${row.propertyName}' with name '${row.name}'")
 
@@ -105,5 +105,5 @@ data class CharacteristicsSeedCsvRow(
   val name: String,
   val propertyName: String,
   val serviceScope: String,
-  val modelScope: String
+  val modelScope: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
 import java.util.UUID
 
-abstract class SeedJob <RowType> (
+abstract class SeedJob<RowType> (
   val id: UUID = UUID.randomUUID(),
   val fileName: String,
-  val requiredColumns: Int
+  val requiredColumns: Int,
 ) {
   init {
     if (fileName.contains("/") || fileName.contains("\\") || fileName.contains(".")) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedUtils.kt
@@ -16,7 +16,6 @@ fun appendCharacteristicIfSet(
   characteristicName: String,
   csvColumnName: String? = null,
 ) {
-
   val columnName = csvColumnName ?: "$characteristicName"
 
   if (columns[columnName].toBoolean()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationBedspaceSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationBedspaceSeedJob.kt
@@ -56,7 +56,7 @@ class TemporaryAccommodationBedspaceSeedJob(
   private fun createNewRoom(
     row: TemporaryAccommodationBedspaceSeedCsvRow,
     premises: TemporaryAccommodationPremisesEntity,
-    characteristics: List<CharacteristicEntity>
+    characteristics: List<CharacteristicEntity>,
   ) {
     log.info("Creating new Temporary Accommodation bedspace '${row.bedspaceName}' on premises '${row.premisesName}'")
 
@@ -67,7 +67,7 @@ class TemporaryAccommodationBedspaceSeedJob(
     row: TemporaryAccommodationBedspaceSeedCsvRow,
     existingRoom: RoomEntity,
     premises: TemporaryAccommodationPremisesEntity,
-    characteristics: List<CharacteristicEntity>
+    characteristics: List<CharacteristicEntity>,
   ) {
     log.info("Updating existing Temporary Accommodation bedspace '${row.bedspaceName}' on premises '${row.premisesName}'")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationPremisesSeedJob.kt
@@ -87,7 +87,7 @@ class TemporaryAccommodationPremisesSeedJob(
     probationRegion: ProbationRegionEntity,
     localAuthorityArea: LocalAuthorityAreaEntity,
     probationDeliveryUnit: ProbationDeliveryUnitEntity,
-    characteristics: List<CharacteristicEntity>
+    characteristics: List<CharacteristicEntity>,
   ) {
     log.info("Creating new Temporary Accommodation premises: ${row.name}")
 
@@ -111,8 +111,8 @@ class TemporaryAccommodationPremisesSeedJob(
         characteristics = mutableListOf(),
         probationDeliveryUnit = probationDeliveryUnit,
         status = PropertyStatus.active,
-        turnaroundWorkingDayCount = 2
-      )
+        turnaroundWorkingDayCount = 2,
+      ),
     )
 
     characteristics.forEach {
@@ -128,7 +128,7 @@ class TemporaryAccommodationPremisesSeedJob(
     probationRegion: ProbationRegionEntity,
     localAuthorityArea: LocalAuthorityAreaEntity,
     probationDeliveryUnit: ProbationDeliveryUnitEntity,
-    characteristics: List<CharacteristicEntity>
+    characteristics: List<CharacteristicEntity>,
   ) {
     log.info("Updating existing Temporary Accommodation premises: ${row.name}")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -8,11 +8,11 @@ import java.util.UUID
 
 class UsersSeedJob(
   fileName: String,
-  private val userService: UserService
+  private val userService: UserService,
 ) : SeedJob<UsersSeedCsvRow>(
   id = UUID.randomUUID(),
   fileName = fileName,
-  requiredColumns = 2
+  requiredColumns = 2,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -23,7 +23,7 @@ class UsersSeedJob(
   override fun deserializeRow(columns: Map<String, String>) = UsersSeedCsvRow(
     deliusUsername = columns["deliusUsername"]!!.trim().uppercase(),
     roles = parseAllRolesOrThrow(columns["roles"]!!.split(",").filter(String::isNotBlank).map(String::trim)),
-    qualifications = parseAllQualificationsOrThrow(columns["qualifications"]!!.split(",").filter(String::isNotBlank).map(String::trim))
+    qualifications = parseAllQualificationsOrThrow(columns["qualifications"]!!.split(",").filter(String::isNotBlank).map(String::trim)),
   )
 
   private fun parseAllRolesOrThrow(roleNames: List<String>): List<UserRole> {
@@ -87,5 +87,5 @@ class UsersSeedJob(
 data class UsersSeedCsvRow(
   val deliusUsername: String,
   val roles: List<UserRole>,
-  val qualifications: List<UserQualification>
+  val qualifications: List<UserQualification>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -229,7 +229,7 @@ class ApplicationService(
         releaseType = null,
         arrivalDate = null,
         isInapplicable = null,
-        nomsNumber = offenderDetails.otherIds.nomsNumber
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
       ),
     )
 
@@ -312,7 +312,7 @@ class ApplicationService(
         riskRatings = riskRatings,
         assessments = mutableListOf(),
         probationRegion = user.probationRegion,
-        nomsNumber = offenderDetails.otherIds.nomsNumber
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
       ),
     )
 
@@ -327,7 +327,7 @@ class ApplicationService(
     arrivalDate: LocalDate?,
     data: String,
     isInapplicable: Boolean?,
-    username: String
+    username: String,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()
@@ -375,7 +375,7 @@ class ApplicationService(
   fun updateTemporaryAccommodationApplication(
     applicationId: UUID,
     data: String,
-    username: String
+    username: String,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()
@@ -487,7 +487,7 @@ class ApplicationService(
   @Transactional
   fun submitTemporaryAccommodationApplication(
     applicationId: UUID,
-    submitApplication: SubmitTemporaryAccommodationApplication
+    submitApplication: SubmitTemporaryAccommodationApplication,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     var application = applicationRepository.findByIdOrNullWithWriteLock(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -45,13 +45,15 @@ class AssessmentService(
   private val communityApiClient: CommunityApiClient,
   private val cruService: CruService,
   private val placementRequestService: PlacementRequestService,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String
+  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
 ) {
   fun getVisibleAssessmentSummariesForUser(user: UserEntity): List<DomainAssessmentSummary> =
     assessmentRepository.findAllAssessmentSummariesNotReallocated(
-      if (user.hasRole(UserRole.WORKFLOW_MANAGER)) null
-      else
+      if (user.hasRole(UserRole.WORKFLOW_MANAGER)) {
+        null
+      } else {
         user.id.toString()
+      },
     )
 
   fun getAllReallocatable(): List<AssessmentEntity> {
@@ -122,8 +124,8 @@ class AssessmentService(
         decision = null,
         schemaUpToDate = true,
         rejectionRationale = null,
-        clarificationNotes = mutableListOf()
-      )
+        clarificationNotes = mutableListOf(),
+      ),
     )
   }
 
@@ -137,19 +139,19 @@ class AssessmentService(
 
     if (!assessment.schemaUpToDate) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The schema version is outdated")
+        ValidatableActionResult.GeneralValidationError("The schema version is outdated"),
       )
     }
 
     if (assessment.submittedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment")
+        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment"),
       )
     }
 
     if (assessment.reallocatedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")
+        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only"),
       )
     }
 
@@ -158,7 +160,7 @@ class AssessmentService(
     val savedAssessment = assessmentRepository.save(assessment)
 
     return AuthorisableActionResult.Success(
-      ValidatableActionResult.Success(savedAssessment)
+      ValidatableActionResult.Success(savedAssessment),
     )
   }
 
@@ -175,19 +177,19 @@ class AssessmentService(
 
     if (!assessment.schemaUpToDate) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The schema version is outdated")
+        ValidatableActionResult.GeneralValidationError("The schema version is outdated"),
       )
     }
 
     if (assessment.submittedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment")
+        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment"),
       )
     }
 
     if (assessment.reallocatedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")
+        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only"),
       )
     }
 
@@ -202,7 +204,7 @@ class AssessmentService(
 
     if (validationErrors.any()) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(validationErrors)
+        ValidatableActionResult.FieldValidationError(validationErrors),
       )
     }
 
@@ -217,7 +219,7 @@ class AssessmentService(
 
       if (placementRequestValidationResult !is ValidatableActionResult.Success) {
         return AuthorisableActionResult.Success(
-          placementRequestValidationResult.translateError()
+          placementRequestValidationResult.translateError(),
         )
       }
     }
@@ -252,7 +254,7 @@ class AssessmentService(
               .replace("#id", application.id.toString()),
             personReference = PersonReference(
               crn = offenderDetails.otherIds.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!
+              noms = offenderDetails.otherIds.nomsNumber!!,
             ),
             deliusEventNumber = (application as ApprovedPremisesApplicationEntity).eventNumber,
             assessedAt = acceptedAt.toInstant(),
@@ -262,25 +264,25 @@ class AssessmentService(
                 staffIdentifier = staffDetails.staffIdentifier,
                 forenames = staffDetails.staff.forenames,
                 surname = staffDetails.staff.surname,
-                username = staffDetails.username
+                username = staffDetails.username,
               ),
               probationArea = ProbationArea(
                 code = staffDetails.probationArea.code,
-                name = staffDetails.probationArea.description
+                name = staffDetails.probationArea.description,
               ),
               cru = Cru(
-                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code)
-              )
+                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
+              ),
             ),
             decision = assessment.decision.toString(),
-            decisionRationale = assessment.rejectionRationale
-          )
-        )
-      )
+            decisionRationale = assessment.rejectionRationale,
+          ),
+        ),
+      ),
     )
 
     return AuthorisableActionResult.Success(
-      ValidatableActionResult.Success(savedAssessment)
+      ValidatableActionResult.Success(savedAssessment),
     )
   }
 
@@ -297,19 +299,19 @@ class AssessmentService(
 
     if (!assessment.schemaUpToDate) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The schema version is outdated")
+        ValidatableActionResult.GeneralValidationError("The schema version is outdated"),
       )
     }
 
     if (assessment.submittedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment")
+        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment"),
       )
     }
 
     if (assessment.reallocatedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")
+        ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only"),
       )
     }
 
@@ -324,7 +326,7 @@ class AssessmentService(
 
     if (validationErrors.any()) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(validationErrors)
+        ValidatableActionResult.FieldValidationError(validationErrors),
       )
     }
 
@@ -365,7 +367,7 @@ class AssessmentService(
               .replace("#id", application.id.toString()),
             personReference = PersonReference(
               crn = offenderDetails.otherIds.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!
+              noms = offenderDetails.otherIds.nomsNumber!!,
             ),
             deliusEventNumber = (application as ApprovedPremisesApplicationEntity).eventNumber,
             assessedAt = rejectedAt.toInstant(),
@@ -375,25 +377,25 @@ class AssessmentService(
                 staffIdentifier = staffDetails.staffIdentifier,
                 forenames = staffDetails.staff.forenames,
                 surname = staffDetails.staff.surname,
-                username = staffDetails.username
+                username = staffDetails.username,
               ),
               probationArea = ProbationArea(
                 code = staffDetails.probationArea.code,
-                name = staffDetails.probationArea.description
+                name = staffDetails.probationArea.description,
               ),
               cru = Cru(
-                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code)
-              )
+                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
+              ),
             ),
             decision = assessment.decision.toString(),
-            decisionRationale = assessment.rejectionRationale
-          )
-        )
-      )
+            decisionRationale = assessment.rejectionRationale,
+          ),
+        ),
+      ),
     )
 
     return AuthorisableActionResult.Success(
-      ValidatableActionResult.Success(savedAssessment)
+      ValidatableActionResult.Success(savedAssessment),
     )
   }
 
@@ -403,7 +405,7 @@ class AssessmentService(
 
     if (currentAssessment.submittedAt != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment")
+        ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment"),
       )
     }
 
@@ -411,13 +413,13 @@ class AssessmentService(
 
     if (!assigneeUser.hasRole(UserRole.ASSESSOR)) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingAssessorRole" })
+        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingAssessorRole" }),
       )
     }
 
     if (!assigneeUser.hasAllQualifications(requiredQualifications)) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingQualifications" })
+        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingQualifications" }),
       )
     }
 
@@ -442,14 +444,14 @@ class AssessmentService(
         decision = null,
         schemaUpToDate = true,
         rejectionRationale = null,
-        clarificationNotes = mutableListOf()
-      )
+        clarificationNotes = mutableListOf(),
+      ),
     )
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
-        newAssessment
-      )
+        newAssessment,
+      ),
     )
   }
 
@@ -470,7 +472,7 @@ class AssessmentService(
         query = text,
         response = null,
         responseReceivedOn = null,
-      )
+      ),
     )
 
     return AuthorisableActionResult.Success(clarificationNoteEntity)
@@ -495,7 +497,7 @@ class AssessmentService(
 
     if (clarificationNoteEntity.response !== null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("A response has already been added to this note")
+        ValidatableActionResult.GeneralValidationError("A response has already been added to this note"),
       )
     }
 
@@ -505,7 +507,7 @@ class AssessmentService(
     val savedNote = assessmentClarificationNoteRepository.save(clarificationNoteEntity)
 
     return AuthorisableActionResult.Success(
-      ValidatableActionResult.Success(savedNote)
+      ValidatableActionResult.Success(savedNote),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -108,7 +108,7 @@ class BedSearchService(
           probationDeliveryUnit = probationDeliveryUnit,
           startDate = startDate,
           durationInDays = durationInDays,
-          probationRegionId = user.probationRegion.id
+          probationRegionId = user.probationRegion.id,
         )
 
         val bedIds = candidateResults.map { it.bedId }
@@ -119,7 +119,7 @@ class BedSearchService(
         val results = candidateResults.filter { !bedsWithABookingInTurnaround.contains(it.bedId) }
 
         return@validated success(
-          results
+          results,
         )
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedService.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 @Service
 class BedService(
   private val bedRepository: BedRepository,
-  private val characteristicRepository: CharacteristicRepository
+  private val characteristicRepository: CharacteristicRepository,
 ) {
 
   fun getBedAndRoomCharacteristics(id: UUID): AuthorisableActionResult<Pair<DomainBedSummary, List<CharacteristicEntity>>> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
@@ -64,7 +64,7 @@ class BookingSearchService(
     return AuthorisableActionResult.Success(
       validated {
         return@validated success(results.sortedWith(comparator))
-      }
+      },
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -87,7 +87,7 @@ class BookingService(
   private val placementRequestRepository: PlacementRequestRepository,
   private val lostBedsRepository: LostBedsRepository,
   private val turnaroundRepository: TurnaroundRepository,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String
+  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
 ) {
   fun updateBooking(bookingEntity: BookingEntity): BookingEntity = bookingRepository.save(bookingEntity)
   fun getBooking(id: UUID) = bookingRepository.findByIdOrNull(id)
@@ -98,7 +98,7 @@ class BookingService(
     placementRequestId: UUID,
     bedId: UUID,
     arrivalDate: LocalDate,
-    departureDate: LocalDate
+    departureDate: LocalDate,
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
@@ -156,8 +156,8 @@ class BookingService(
           application = placementRequest.application,
           offlineApplication = null,
           turnarounds = mutableListOf(),
-          nomsNumber = placementRequest.application.nomsNumber
-        )
+          nomsNumber = placementRequest.application.nomsNumber,
+        ),
       )
 
       placementRequest.booking = booking
@@ -166,7 +166,7 @@ class BookingService(
       saveBookingMadeDomainEvent(
         booking = booking,
         user = user,
-        bookingCreatedAt = bookingCreatedAt
+        bookingCreatedAt = bookingCreatedAt,
       )
 
       return@validated success(booking)
@@ -182,7 +182,7 @@ class BookingService(
     nomsNumber: String,
     arrivalDate: LocalDate,
     departureDate: LocalDate,
-    bedId: UUID
+    bedId: UUID,
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
     if (!user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)) {
       return AuthorisableActionResult.Unauthorised()
@@ -226,7 +226,7 @@ class BookingService(
       val associateWithOfflineApplication = (newestOfflineApplication != null && newestSubmittedOnlineApplication == null) ||
         (newestOfflineApplication != null && newestSubmittedOnlineApplication != null && newestOfflineApplication.submittedAt > newestSubmittedOnlineApplication.submittedAt)
 
-      val associateWithOnlineApplication = newestSubmittedOnlineApplication != null && ! associateWithOfflineApplication
+      val associateWithOnlineApplication = newestSubmittedOnlineApplication != null && !associateWithOfflineApplication
 
       val bookingCreatedAt = OffsetDateTime.now()
 
@@ -252,15 +252,15 @@ class BookingService(
           application = if (associateWithOnlineApplication) newestSubmittedOnlineApplication else null,
           offlineApplication = if (associateWithOfflineApplication) newestOfflineApplication else null,
           turnarounds = mutableListOf(),
-          nomsNumber = nomsNumber
-        )
+          nomsNumber = nomsNumber,
+        ),
       )
 
       if (associateWithOnlineApplication) {
         saveBookingMadeDomainEvent(
           booking = booking,
           user = user,
-          bookingCreatedAt = bookingCreatedAt
+          bookingCreatedAt = bookingCreatedAt,
         )
       }
 
@@ -273,7 +273,7 @@ class BookingService(
   private fun saveBookingMadeDomainEvent(
     booking: BookingEntity,
     user: UserEntity,
-    bookingCreatedAt: OffsetDateTime
+    bookingCreatedAt: OffsetDateTime,
   ) {
     val domainEventId = UUID.randomUUID()
 
@@ -308,7 +308,7 @@ class BookingService(
             bookingId = booking.id,
             personReference = PersonReference(
               crn = booking.application?.crn ?: booking.offlineApplication!!.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!
+              noms = offenderDetails.otherIds.nomsNumber!!,
             ),
             deliusEventNumber = application.eventNumber,
             createdAt = bookingCreatedAt.toInstant(),
@@ -318,24 +318,24 @@ class BookingService(
                 staffIdentifier = staffDetails.staffIdentifier,
                 forenames = staffDetails.staff.forenames,
                 surname = staffDetails.staff.surname,
-                username = staffDetails.username
+                username = staffDetails.username,
               ),
               cru = Cru(
-                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code)
-              )
+                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
+              ),
             ),
             premises = Premises(
               id = approvedPremises.id,
               name = approvedPremises.name,
               apCode = approvedPremises.apCode,
               legacyApCode = approvedPremises.qCode,
-              localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+              localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
             ),
             arrivalOn = booking.arrivalDate,
-            departureOn = booking.departureDate
-          )
-        )
-      )
+            departureOn = booking.departureDate,
+          ),
+        ),
+      ),
     )
   }
 
@@ -401,7 +401,7 @@ class BookingService(
           application = null,
           offlineApplication = null,
           turnarounds = mutableListOf(),
-        )
+        ),
       )
 
       val turnaround = turnaroundRepository.save(
@@ -413,7 +413,7 @@ class BookingService(
           },
           createdAt = bookingCreatedAt,
           booking = booking,
-        )
+        ),
       )
 
       booking.turnarounds += turnaround
@@ -452,7 +452,7 @@ class BookingService(
         workingDayCount = workingDays,
         createdAt = OffsetDateTime.now(),
         booking = booking,
-      )
+      ),
     )
 
     return success(turnaround)
@@ -500,7 +500,7 @@ class BookingService(
         notes = notes,
         booking = booking,
         createdAt = occurredAt,
-      )
+      ),
     )
 
     booking.arrivalDate = arrivalDate
@@ -541,7 +541,7 @@ class BookingService(
               bookingId = booking.id,
               personReference = PersonReference(
                 crn = booking.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!
+                noms = offenderDetails.otherIds.nomsNumber!!,
               ),
               deliusEventNumber = application.eventNumber,
               premises = Premises(
@@ -549,7 +549,7 @@ class BookingService(
                 name = approvedPremises.name,
                 apCode = approvedPremises.apCode,
                 legacyApCode = approvedPremises.qCode,
-                localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+                localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
               ),
               applicationSubmittedOn = application.submittedAt!!.toLocalDate(),
               keyWorker = StaffMember(
@@ -557,14 +557,14 @@ class BookingService(
                 staffIdentifier = keyWorkerStaffDetails.staffIdentifier,
                 forenames = keyWorkerStaffDetails.staff.forenames,
                 surname = keyWorkerStaffDetails.staff.surname,
-                username = null
+                username = null,
               ),
               arrivedAt = arrivalDate.toLocalDateTime().toInstant(), // TODO: Endpoint should accept a date-time instead
               expectedDepartureOn = expectedDepartureDate,
-              notes = notes
-            )
-          )
-        )
+              notes = notes,
+            ),
+          ),
+        ),
       )
     }
 
@@ -576,7 +576,7 @@ class BookingService(
     booking: BookingEntity,
     date: LocalDate,
     reasonId: UUID,
-    notes: String?
+    notes: String?,
   ) = validated<NonArrivalEntity> {
     val occurredAt = OffsetDateTime.now()
 
@@ -605,7 +605,7 @@ class BookingService(
         reason = reason!!,
         booking = booking,
         createdAt = occurredAt,
-      )
+      ),
     )
 
     if (booking.service == ServiceName.approvedPremises.value && booking.application != null) {
@@ -642,7 +642,7 @@ class BookingService(
               bookingId = booking.id,
               personReference = PersonReference(
                 crn = booking.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!
+                noms = offenderDetails.otherIds.nomsNumber!!,
               ),
               deliusEventNumber = application.eventNumber,
               premises = Premises(
@@ -650,7 +650,7 @@ class BookingService(
                 name = approvedPremises.name,
                 apCode = approvedPremises.apCode,
                 legacyApCode = approvedPremises.qCode,
-                localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+                localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
               ),
               expectedArrivalOn = booking.originalArrivalDate,
               recordedBy = StaffMember(
@@ -658,12 +658,12 @@ class BookingService(
                 staffIdentifier = staffDetails.staffIdentifier,
                 forenames = staffDetails.staff.forenames,
                 surname = staffDetails.staff.surname,
-                username = staffDetails.username
+                username = staffDetails.username,
               ),
-              notes = notes
-            )
-          )
-        )
+              notes = notes,
+            ),
+          ),
+        ),
       )
     }
 
@@ -674,7 +674,7 @@ class BookingService(
     booking: BookingEntity,
     date: LocalDate,
     reasonId: UUID,
-    notes: String?
+    notes: String?,
   ) = validated<CancellationEntity> {
     if (booking.premises is ApprovedPremisesEntity && booking.cancellation != null) {
       return generalError("This Booking already has a Cancellation set")
@@ -699,7 +699,7 @@ class BookingService(
         notes = notes,
         booking = booking,
         createdAt = OffsetDateTime.now(),
-      )
+      ),
     )
 
     return success(cancellationEntity)
@@ -721,7 +721,7 @@ class BookingService(
         notes = notes,
         booking = booking,
         createdAt = OffsetDateTime.now(),
-      )
+      ),
     )
 
     return success(confirmationEntity)
@@ -734,7 +734,7 @@ class BookingService(
     reasonId: UUID,
     moveOnCategoryId: UUID,
     destinationProviderId: UUID?,
-    notes: String?
+    notes: String?,
   ) = validated<DepartureEntity> {
     val occurredAt = OffsetDateTime.now()
 
@@ -793,7 +793,7 @@ class BookingService(
         notes = notes,
         booking = booking,
         createdAt = OffsetDateTime.now(),
-      )
+      ),
     )
 
     booking.departureDate = dateTime.toLocalDate()
@@ -833,7 +833,7 @@ class BookingService(
               bookingId = booking.id,
               personReference = PersonReference(
                 crn = booking.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!
+                noms = offenderDetails.otherIds.nomsNumber!!,
               ),
               deliusEventNumber = application.eventNumber,
               premises = Premises(
@@ -841,14 +841,14 @@ class BookingService(
                 name = approvedPremises.name,
                 apCode = approvedPremises.apCode,
                 legacyApCode = approvedPremises.qCode,
-                localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+                localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
               ),
               keyWorker = StaffMember(
                 staffCode = booking.keyWorkerStaffCode!!,
                 staffIdentifier = keyWorkerStaffDetails.staffIdentifier,
                 forenames = keyWorkerStaffDetails.staff.forenames,
                 surname = keyWorkerStaffDetails.staff.surname,
-                username = null
+                username = null,
               ),
               departedAt = dateTime.toInstant(),
               reason = reason.name,
@@ -857,17 +857,17 @@ class BookingService(
                 moveOnCategory = MoveOnCategory(
                   description = moveOnCategory.name,
                   legacyMoveOnCategoryCode = moveOnCategory.legacyDeliusCategoryCode!!,
-                  id = moveOnCategory.id
+                  id = moveOnCategory.id,
                 ),
                 destinationProvider = DestinationProvider(
                   description = destinationProvider!!.name,
-                  id = destinationProvider.id
+                  id = destinationProvider.id,
                 ),
-                premises = null
-              )
-            )
-          )
-        )
+                premises = null,
+              ),
+            ),
+          ),
+        ),
       )
     }
 
@@ -878,7 +878,7 @@ class BookingService(
   fun createExtension(
     booking: BookingEntity,
     newDepartureDate: LocalDate,
-    notes: String?
+    notes: String?,
   ) = validated<ExtensionEntity> {
     val expectedLastUnavailableDate = workingDayCountService.addWorkingDays(newDepartureDate, booking.turnaround?.workingDayCount ?: 0)
     getBookingWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, booking.id, booking.bed!!.id)?.let {
@@ -979,12 +979,12 @@ class BookingService(
     startDate: LocalDate,
     endDate: LocalDate,
     thisEntityId: UUID?,
-    bedId: UUID
+    bedId: UUID,
   ) = lostBedsRepository.findByBedIdAndOverlappingDate(
     bedId,
     startDate,
     endDate,
-    thisEntityId
+    thisEntityId,
   ).firstOrNull()
 
   val BookingEntity.lastUnavailableDate: LocalDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CacheService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CacheService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CacheType
 class CacheService(
   private val cacheManager: CacheManager,
   private val redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") private val preemptiveCacheKeyPrefix: String
+  @Value("\${preemptive-cache-key-prefix}") private val preemptiveCacheKeyPrefix: String,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CruService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CruService.kt
@@ -15,7 +15,7 @@ class CruService {
     "North East" to listOf("N32", "N54", "N02", "N23"),
     "Wales" to listOf("N03", "C10", "N27", "WPT"),
     "Midlands" to listOf("MLW", "N30", "N52"),
-    "South West & South Central" to listOf("N36", "N58", "N26", "N37", "N59", "N05")
+    "South West & South Central" to listOf("N36", "N58", "N26", "N37", "N59", "N05"),
   )
 
   fun cruNameFromProbationAreaCode(code: String): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
@@ -91,7 +91,7 @@ class DeserializationValidationService {
           }
 
           result.putAll(
-            validateObject("$path.${it.name}", it.returnType.jvmErasure.java.kotlin, jsonObject.get(it.name) as ObjectNode)
+            validateObject("$path.${it.name}", it.returnType.jvmErasure.java.kotlin, jsonObject.get(it.name) as ObjectNode),
           )
           return@forEach
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -84,7 +84,7 @@ class DomainEventService(
       applicationId = domainEventEntity.applicationId,
       crn = domainEventEntity.crn,
       occurredAt = domainEventEntity.occurredAt.toInstant(),
-      data = data
+      data = data,
     )
   }
 
@@ -96,7 +96,7 @@ class DomainEventService(
       typeDescription = "An application has been submitted for an Approved Premises placement",
       detailUrl = applicationSubmittedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -107,7 +107,7 @@ class DomainEventService(
       typeDescription = "An application has been assessed for an Approved Premises placement",
       detailUrl = applicationAssessedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -118,7 +118,7 @@ class DomainEventService(
       typeDescription = "An Approved Premises booking has been made",
       detailUrl = bookingMadeDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -129,7 +129,7 @@ class DomainEventService(
       typeDescription = "Someone has arrived at an Approved Premises for their Booking",
       detailUrl = personArrivedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -140,7 +140,7 @@ class DomainEventService(
       typeDescription = "Someone has failed to arrive at an Approved Premises for their Booking",
       detailUrl = personNotArrivedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -151,7 +151,7 @@ class DomainEventService(
       typeDescription = "Someone has left an Approved Premises",
       detailUrl = personDepartedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -162,7 +162,7 @@ class DomainEventService(
       typeDescription = "It was not possible to create a Booking on this attempt",
       detailUrl = bookingNotMadeDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   private fun saveAndEmit(
@@ -171,7 +171,7 @@ class DomainEventService(
     typeDescription: String,
     detailUrl: String,
     crn: String,
-    nomsNumber: String
+    nomsNumber: String,
   ) {
     domainEventRepository.save(
       DomainEventEntity(
@@ -181,8 +181,8 @@ class DomainEventService(
         type = enumTypeFromDataType(domainEvent.data!!::class.java),
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),
-        data = objectMapper.writeValueAsString(domainEvent.data)
-      )
+        data = objectMapper.writeValueAsString(domainEvent.data),
+      ),
     )
 
     if (emitDomainEventsEnabled) {
@@ -193,19 +193,19 @@ class DomainEventService(
         detailUrl = detailUrl,
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         additionalInformation = SnsEventAdditionalInformation(
-          applicationId = domainEvent.applicationId
+          applicationId = domainEvent.applicationId,
         ),
         personReference = SnsEventPersonReferenceCollection(
           identifiers = listOf(
             SnsEventPersonReference("CRN", crn),
-            SnsEventPersonReference("NOMS", nomsNumber)
-          )
-        )
+            SnsEventPersonReference("NOMS", nomsNumber),
+          ),
+        ),
       )
 
       val publishResult = domainTopic.snsClient.publish(
         PublishRequest(domainTopic.arn, objectMapper.writeValueAsString(snsEvent))
-          .withMessageAttributes(mapOf("eventType" to MessageAttributeValue().withDataType("String").withStringValue(snsEvent.eventType)))
+          .withMessageAttributes(mapOf("eventType" to MessageAttributeValue().withDataType("String").withStringValue(snsEvent.eventType))),
       )
 
       log.info("Emitted SNS event (Message Id: ${publishResult.messageId}, Sequence Id: ${publishResult.sequenceNumber}) for Domain Event: ${domainEvent.id} of type: ${snsEvent.eventType}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class JsonSchemaService(
   private val objectMapper: ObjectMapper,
   private val jsonSchemaRepository: JsonSchemaRepository,
-  private val applicationRepository: ApplicationRepository
+  private val applicationRepository: ApplicationRepository,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsers
 class MigrationJobService(
   private val applicationContext: ApplicationContext,
   private val transactionTemplate: TransactionTemplate,
-  private val migrationLogger: MigrationLogger
+  private val migrationLogger: MigrationLogger,
 ) {
   @Async
   fun runMigrationJobAsync(migrationJobType: MigrationJobType) = runMigrationJob(migrationJobType)
@@ -26,7 +26,7 @@ class MigrationJobService(
       val job: MigrationJob = when (migrationJobType) {
         MigrationJobType.updateAllUsersFromCommunityApi -> UpdateAllUsersFromCommunityApiJob(
           applicationContext.getBean(UserRepository::class.java),
-          applicationContext.getBean(UserService::class.java)
+          applicationContext.getBean(UserService::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -43,7 +43,7 @@ class PlacementRequestService(
   private val offenderService: OffenderService,
   private val communityApiClient: CommunityApiClient,
   private val cruService: CruService,
-  @Value("\${application-url-template}") private val applicationUrlTemplate: String
+  @Value("\${application-url-template}") private val applicationUrlTemplate: String,
 ) {
 
   fun getVisiblePlacementRequestsForUser(user: UserEntity): List<PlacementRequestEntity> {
@@ -82,13 +82,13 @@ class PlacementRequestService(
 
     if (currentPlacementRequest.booking != null) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("This placement request has already been completed")
+        ValidatableActionResult.GeneralValidationError("This placement request has already been completed"),
       )
     }
 
     if (!assigneeUser.hasRole(UserRole.MATCHER)) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingMatcherRole" })
+        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingMatcherRole" }),
       )
     }
 
@@ -106,13 +106,13 @@ class PlacementRequestService(
         createdAt = dateTimeNow,
         desirableCriteria = currentPlacementRequest.desirableCriteria.toList(),
         essentialCriteria = currentPlacementRequest.essentialCriteria.toList(),
-      )
+      ),
     )
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
-        newPlacementRequest
-      )
+        newPlacementRequest,
+      ),
     )
   }
 
@@ -147,7 +147,7 @@ class PlacementRequestService(
           bookingNotMades = mutableListOf(),
           reallocatedAt = null,
           notes = requirements.notes,
-        )
+        ),
       )
 
       return success(placementRequestEntity)
@@ -157,7 +157,7 @@ class PlacementRequestService(
   fun createBookingNotMade(
     user: UserEntity,
     placementRequestId: UUID,
-    notes: String?
+    notes: String?,
   ): AuthorisableActionResult<BookingNotMadeEntity> {
     val bookingNotCreatedAt = OffsetDateTime.now()
 
@@ -172,13 +172,13 @@ class PlacementRequestService(
       id = UUID.randomUUID(),
       placementRequest = placementRequest,
       createdAt = bookingNotCreatedAt,
-      notes = notes
+      notes = notes,
     )
 
     saveBookingNotMadeDomainEvent(user, placementRequest, bookingNotCreatedAt, notes)
 
     return AuthorisableActionResult.Success(
-      bookingNotMadeRepository.save(bookingNotMade)
+      bookingNotMadeRepository.save(bookingNotMade),
     )
   }
 
@@ -186,7 +186,7 @@ class PlacementRequestService(
     user: UserEntity,
     placementRequest: PlacementRequestEntity,
     bookingNotCreatedAt: OffsetDateTime,
-    notes: String?
+    notes: String?,
   ) {
     val domainEventId = UUID.randomUUID()
 
@@ -219,7 +219,7 @@ class PlacementRequestService(
             applicationUrl = applicationUrlTemplate.replace("#id", application.id.toString()),
             personReference = PersonReference(
               crn = application.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!
+              noms = offenderDetails.otherIds.nomsNumber!!,
             ),
             deliusEventNumber = application.eventNumber,
             attemptedAt = bookingNotCreatedAt.toInstant(),
@@ -229,16 +229,16 @@ class PlacementRequestService(
                 staffIdentifier = staffDetails.staffIdentifier,
                 forenames = staffDetails.staff.forenames,
                 surname = staffDetails.staff.surname,
-                username = staffDetails.username
+                username = staffDetails.username,
               ),
               cru = Cru(
-                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code)
-              )
+                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
+              ),
             ),
-            failureDescription = notes
-          )
-        )
-      )
+            failureDescription = notes,
+          ),
+        ),
+      ),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -43,7 +43,7 @@ class PremisesService(
   private val lostBedCancellationRepository: LostBedCancellationRepository,
   private val probationDeliveryUnitRepository: ProbationDeliveryUnitRepository,
   private val characteristicService: CharacteristicService,
-  private val bedRepository: BedRepository
+  private val bedRepository: BedRepository,
 ) {
   private val serviceNameToEntityType = mapOf(
     ServiceName.approvedPremises to ApprovedPremisesEntity::class.java,
@@ -68,7 +68,7 @@ class PremisesService(
 
   fun getAllPremisesInRegionForService(
     probationRegionId: UUID,
-    service: ServiceName
+    service: ServiceName,
   ): List<PremisesEntity> = serviceNameToEntityType[service]?.let {
     premisesRepository.findAllByProbationRegion_IdAndType(probationRegionId, it)
   } ?: listOf()
@@ -81,7 +81,7 @@ class PremisesService(
   fun getAvailabilityForRange(
     premises: PremisesEntity,
     startDate: LocalDate,
-    endDate: LocalDate
+    endDate: LocalDate,
   ): Map<LocalDate, Availability> {
     if (endDate.isBefore(startDate)) throw RuntimeException("startDate must be before endDate when calculating availability for range")
 
@@ -98,7 +98,7 @@ class PremisesService(
         arrivedBookings = bookingsOnDay.count { it.arrival != null },
         nonArrivedBookings = bookingsOnDay.count { it.nonArrival != null },
         cancelledBookings = bookingsOnDay.count { it.cancellation != null },
-        lostBeds = lostBedsOnDay.size
+        lostBeds = lostBedsOnDay.size,
       )
     }.associateBy { it.date }
   }
@@ -143,8 +143,8 @@ class PremisesService(
           reason = reason!!,
           referenceNumber = referenceNumber,
           notes = notes,
-          cancellation = null
-        )
+          cancellation = null,
+        ),
       )
 
       return success(lostBedsEntity)
@@ -156,7 +156,7 @@ class PremisesService(
     endDate: LocalDate,
     reasonId: UUID,
     referenceNumber: String?,
-    notes: String?
+    notes: String?,
   ): AuthorisableActionResult<ValidatableActionResult<LostBedsEntity>> {
     val lostBed = lostBedsRepository.findByIdOrNull(lostBedId)
       ?: return AuthorisableActionResult.NotFound()
@@ -185,17 +185,17 @@ class PremisesService(
             this.reason = reason!!
             this.referenceNumber = referenceNumber
             this.notes = notes
-          }
+          },
         )
 
         success(updatedLostBedsEntity)
-      }
+      },
     )
   }
 
   fun cancelLostBed(
     lostBed: LostBedsEntity,
-    notes: String?
+    notes: String?,
   ) = validated<LostBedCancellationEntity> {
     if (lostBed.cancellation != null) {
       return generalError("This Lost Bed already has a cancellation set")
@@ -207,7 +207,7 @@ class PremisesService(
         lostBed = lostBed,
         notes = notes,
         createdAt = OffsetDateTime.now(),
-      )
+      ),
     )
 
     return success(cancellationEntity)
@@ -228,7 +228,7 @@ class PremisesService(
     characteristicIds: List<UUID>,
     status: PropertyStatus,
     probationDeliveryUnitIdentifier: Either<String, UUID>?,
-    turnaroundWorkingDayCount: Int?
+    turnaroundWorkingDayCount: Int?,
   ) = validated {
     val probationRegion = probationRegionRepository.findByIdOrNull(probationRegionId)
     if (probationRegion == null) {
@@ -302,7 +302,7 @@ class PremisesService(
       characteristics = mutableListOf(),
       status = status,
       probationDeliveryUnit = probationDeliveryUnit!!,
-      turnaroundWorkingDayCount = turnaroundWorkingDayCount ?: 2
+      turnaroundWorkingDayCount = turnaroundWorkingDayCount ?: 2,
     )
 
     val characteristicEntities = characteristicIds.mapIndexed { index, uuid ->
@@ -344,9 +344,8 @@ class PremisesService(
     notes: String?,
     status: PropertyStatus,
     probationDeliveryUnitIdentifier: Either<String, UUID>?,
-    turnaroundWorkingDayCount: Int?
+    turnaroundWorkingDayCount: Int?,
   ): AuthorisableActionResult<ValidatableActionResult<PremisesEntity>> {
-
     val premises = premisesRepository.findByIdOrNull(premisesId)
       ?: return AuthorisableActionResult.NotFound()
 
@@ -403,7 +402,7 @@ class PremisesService(
 
     if (validationErrors.any()) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(validationErrors)
+        ValidatableActionResult.FieldValidationError(validationErrors),
       )
     }
 
@@ -428,7 +427,7 @@ class PremisesService(
     val savedPremises = premisesRepository.save(premises)
 
     return AuthorisableActionResult.Success(
-      ValidatableActionResult.Success(savedPremises)
+      ValidatableActionResult.Success(savedPremises),
     )
   }
 
@@ -471,7 +470,7 @@ class PremisesService(
         }
 
         result
-      })
+      },)
     }
 
     return probationDeliveryUnit

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -24,7 +24,7 @@ class TaskService(
   private val applicationRepository: ApplicationRepository,
   private val userService: UserService,
   private val placementRequestService: PlacementRequestService,
-  private val userTransformer: UserTransformer
+  private val userTransformer: UserTransformer,
 ) {
   fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, applicationId: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
     if (!requestUser.hasRole(UserRole.WORKFLOW_MANAGER)) {
@@ -67,8 +67,8 @@ class TaskService(
       is ValidatableActionResult.ConflictError -> AuthorisableActionResult.Success(ValidatableActionResult.ConflictError(validationResult.conflictingEntityId, validationResult.message))
       is ValidatableActionResult.Success -> AuthorisableActionResult.Success(
         ValidatableActionResult.Success(
-          entityToReallocation(validationResult.entity, taskType)
-        )
+          entityToReallocation(validationResult.entity, taskType),
+        ),
       )
     }
   }
@@ -82,7 +82,7 @@ class TaskService(
 
     return Reallocation(
       taskType = taskType,
-      user = userTransformer.transformJpaToApi(allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser
+      user = userTransformer.transformJpaToApi(allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -103,7 +103,7 @@ class UserService(
         roles = mutableListOf(),
         qualifications = mutableListOf(),
         probationRegion = staffProbationRegion,
-      )
+      ),
     )
   }
 
@@ -134,9 +134,9 @@ class UserService(
         UserRoleAssignmentEntity(
           id = UUID.randomUUID(),
           user = user,
-          role = role
-        )
-      )
+          role = role,
+        ),
+      ),
     )
   }
 
@@ -148,9 +148,9 @@ class UserService(
         UserQualificationAssignmentEntity(
           id = UUID.randomUUID(),
           user = user,
-          qualification = qualification
-        )
-      )
+          qualification = qualification,
+        ),
+      ),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 
 @Service
 class WorkingDayCountService(
-  private val govUKBankHolidaysApiClient: GovUKBankHolidaysApiClient
+  private val govUKBankHolidaysApiClient: GovUKBankHolidaysApiClient,
 ) {
 
   fun getWorkingDaysCount(from: LocalDate, to: LocalDate): Int {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AdjudicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AdjudicationTransformer.kt
@@ -15,7 +15,7 @@ class AdjudicationTransformer {
         establishment = adjudicationsPage.agencies.firstOrNull { it.agencyId == result.agencyId }?.description ?: throw RuntimeException("Agency ${result.agencyId} not found"),
         offenceDescription = charge.offenceDescription,
         hearingHeld = charge.findingCode != null,
-        finding = charge.findingCode
+        finding = charge.findingCode,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AlertTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AlertTransformer.kt
@@ -12,6 +12,6 @@ class AlertTransformer {
     dateCreated = alert.dateCreated,
     expired = alert.expired,
     active = alert.active,
-    dateExpires = alert.dateExpires
+    dateExpires = alert.dateExpires,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 class ApplicationsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
-  private val risksTransformer: RisksTransformer
+  private val risksTransformer: RisksTransformer,
 ) {
   fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): Application = when (jpa) {
     is ApprovedPremisesApplicationEntity -> ApprovedPremisesApplication(
@@ -45,7 +45,7 @@ class ApplicationsTransformer(
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null,
-      status = getStatus(jpa)
+      status = getStatus(jpa),
     )
     is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
       id = jpa.id,
@@ -58,7 +58,7 @@ class ApplicationsTransformer(
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       risks = if (jpa.riskRatings != null) risksTransformer.transformDomainToApi(jpa.riskRatings!!, jpa.crn) else null,
-      status = getStatus(jpa)
+      status = getStatus(jpa),
     )
     else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
   }
@@ -78,7 +78,7 @@ class ApplicationsTransformer(
         isPipeApplication = domain.getIsPipeApplication(),
         arrivalDate = domain.getArrivalDate()?.toInstant(),
         risks = if (riskRatings != null) risksTransformer.transformDomainToApi(riskRatings, domain.getCrn()) else null,
-        status = getStatusFromSummary(domain)
+        status = getStatusFromSummary(domain),
       )
     }
 
@@ -93,7 +93,7 @@ class ApplicationsTransformer(
         createdAt = domain.getCreatedAt().toInstant(),
         submittedAt = domain.getSubmittedAt()?.toInstant(),
         risks = if (riskRatings != null) risksTransformer.transformDomainToApi(riskRatings, domain.getCrn()) else null,
-        status = getStatusFromSummary(domain)
+        status = getStatusFromSummary(domain),
       )
     }
     else -> throw RuntimeException("Unrecognised application type when transforming: ${domain::class.qualifiedName}")
@@ -103,14 +103,14 @@ class ApplicationsTransformer(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),
-    submittedAt = jpa.submittedAt.toInstant()
+    submittedAt = jpa.submittedAt.toInstant(),
   )
 
   fun transformJpaToApiSummary(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplicationSummary(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),
-    submittedAt = jpa.submittedAt.toInstant()
+    submittedAt = jpa.submittedAt.toInstant(),
   )
 
   private fun getStatus(entity: ApplicationEntity): ApplicationStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -45,7 +45,7 @@ class AssessmentTransformer(
       submittedAt = jpa.submittedAt?.toInstant(),
       decision = transformJpaDecisionToApi(jpa.decision),
       rejectionRationale = jpa.rejectionRationale,
-      status = getStatus(jpa)
+      status = getStatus(jpa),
     )
 
     is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationAssessment(
@@ -61,7 +61,7 @@ class AssessmentTransformer(
       submittedAt = jpa.submittedAt?.toInstant(),
       decision = transformJpaDecisionToApi(jpa.decision),
       rejectionRationale = jpa.rejectionRationale,
-      status = getStatus(jpa)
+      status = getStatus(jpa),
     )
 
     else -> throw RuntimeException("Unsupported Application type when transforming Assessment: ${jpa.application::class.qualifiedName}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedDetailTransformer.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSumm
 
 @Component
 class BedDetailTransformer(
-  private val bedSummaryTransformer: BedSummaryTransformer
+  private val bedSummaryTransformer: BedSummaryTransformer,
 ) {
   fun transformToApi(summaryAndCharacteristics: Pair<DomainBedSummary, List<CharacteristicEntity>>): BedDetail {
     val summary = summaryAndCharacteristics.first

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingNotMadeTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingNotMadeTransformer.kt
@@ -10,6 +10,6 @@ class BookingNotMadeTransformer {
     id = jpa.id,
     placementRequestId = jpa.placementRequest.id,
     createdAt = jpa.createdAt.toInstant(),
-    notes = jpa.notes
+    notes = jpa.notes,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -76,8 +76,11 @@ class BookingTransformer(
   private fun determineTemporaryAccommodationStatus(jpa: BookingEntity): BookingStatus {
     val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
     val hasZeroDayTurnaround = jpa.turnaround == null || jpa.turnaround!!.workingDayCount == 0
-    val turnaroundPeriodEnded = if (! hasNonZeroDayTurnaround) false else
+    val turnaroundPeriodEnded = if (!hasNonZeroDayTurnaround) {
+      false
+    } else {
       workingDayCountService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount).isBefore(LocalDate.now())
+    }
 
     return when {
       jpa.cancellation != null -> BookingStatus.cancelled

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CharacteristicTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CharacteristicTransformer.kt
@@ -22,6 +22,6 @@ class CharacteristicTransformer {
       "room" -> Characteristic.ModelScope.room
       "*" -> Characteristic.ModelScope.star
       else -> throw RuntimeException("Unsupported service scope: ${jpa.modelScope}")
-    }
+    },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ConvictionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ConvictionTransformer.kt
@@ -13,7 +13,7 @@ class ConvictionTransformer {
       offenceDescription = nonRedundantDescription(it.detail),
       offenceId = it.offenceId,
       convictionId = conviction.convictionId,
-      offenceDate = it.offenceDate.toLocalDate()
+      offenceDate = it.offenceDate.toLocalDate(),
     )
   } ?: emptyList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureTransformer.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEnti
 class DepartureTransformer(
   private val destinationProviderTransformer: DestinationProviderTransformer,
   private val departureReasonTransformer: DepartureReasonTransformer,
-  private val moveOnCategoryTransformer: MoveOnCategoryTransformer
+  private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
 ) {
   fun transformJpaToApi(jpa: DepartureEntity?) = jpa?.let {
     Departure(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DestinationProviderTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DestinationProviderTransformer.kt
@@ -9,6 +9,6 @@ class DestinationProviderTransformer() {
   fun transformJpaToApi(jpa: DestinationProviderEntity) = DestinationProvider(
     id = jpa.id,
     name = jpa.name,
-    isActive = jpa.isActive
+    isActive = jpa.isActive,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
@@ -17,7 +17,7 @@ class DocumentTransformer {
         createdAt = it.createdAt.toInstant(ZoneOffset.UTC),
         typeCode = it.type.code,
         typeDescription = it.type.description,
-        description = it.extendedDescription
+        description = it.extendedDescription,
       )
     }
 
@@ -32,7 +32,7 @@ class DocumentTransformer {
           createdAt = it.createdAt.toInstant(ZoneOffset.UTC),
           typeCode = it.type.code,
           typeDescription = it.type.description,
-          description = it.extendedDescription
+          description = it.extendedDescription,
         )
       } ?: emptyList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
@@ -19,7 +19,7 @@ class LostBedsTransformer(
     notes = jpa.notes,
     status = determineStatus(jpa),
     cancellation = jpa.cancellation?.let { lostBedCancellationTransformer.transformJpaToApi(it) },
-    bedId = jpa.bed.id
+    bedId = jpa.bed.id,
   )
 
   private fun determineStatus(jpa: LostBedsEntity) = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NeedsDetailsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NeedsDetailsTransformer.kt
@@ -11,55 +11,55 @@ class NeedsDetailsTransformer {
       section = 3,
       name = "Accommodation",
       linkedToHarm = needsDetails.linksToHarm?.accommodationLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.accommodationLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.accommodationLinkedToReOffending,
     ),
     OASysSection(
       section = 4,
       name = "Education, Training and Employment",
       linkedToHarm = needsDetails.linksToHarm?.educationTrainingEmploymentLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.educationTrainingEmploymentLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.educationTrainingEmploymentLinkedToReOffending,
     ),
     OASysSection(
       section = 5,
       name = "Finance",
       linkedToHarm = needsDetails.linksToHarm?.financeLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.financeLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.financeLinkedToReOffending,
     ),
     OASysSection(
       section = 6,
       name = "Relationships",
       linkedToHarm = needsDetails.linksToHarm?.relationshipLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.relationshipLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.relationshipLinkedToReOffending,
     ),
     OASysSection(
       section = 7,
       name = "Lifestyle",
       linkedToHarm = needsDetails.linksToHarm?.lifestyleLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.lifestyleLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.lifestyleLinkedToReOffending,
     ),
     OASysSection(
       section = 10,
       name = "Emotional",
       linkedToHarm = needsDetails.linksToHarm?.emotionalLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.emotionalLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.emotionalLinkedToReOffending,
     ),
     OASysSection(
       section = 11,
       name = "Thinking and Behavioural",
       linkedToHarm = needsDetails.linksToHarm?.thinkingBehaviouralLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.thinkingBehaviouralLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.thinkingBehaviouralLinkedToReOffending,
     ),
     OASysSection(
       section = 12,
       name = "Attitude",
       linkedToHarm = needsDetails.linksToHarm?.attitudeLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.attitudeLinkedToReOffending
+      linkedToReOffending = needsDetails.linksToReOffending?.attitudeLinkedToReOffending,
     ),
     OASysSection(
       section = 13,
       name = "Health",
       linkedToHarm = null,
-      linkedToReOffending = null
-    )
+      linkedToReOffending = null,
+    ),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NonArrivalReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NonArrivalReasonTransformer.kt
@@ -9,6 +9,6 @@ class NonArrivalReasonTransformer() {
   fun transformJpaToApi(jpa: NonArrivalReasonEntity) = NonArrivalReason(
     id = jpa.id,
     name = jpa.name,
-    isActive = jpa.isActive
+    isActive = jpa.isActive,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
@@ -18,7 +18,7 @@ class OASysSectionsTransformer : OASysTransformer() {
     risksToTheIndividual: RisksToTheIndividual,
     riskManagementPlan: RiskManagementPlan,
     needsDetails: NeedsDetails,
-    requestedOptionalSections: List<Int>
+    requestedOptionalSections: List<Int>,
   ): OASysSections {
     return OASysSections(
       assessmentId = offenceDetails.assessmentId,
@@ -32,14 +32,14 @@ class OASysSectionsTransformer : OASysTransformer() {
         oASysQuestionWithSingleAnswer("Impact on the victim", "2.5", offenceDetails.offence?.victimImpact),
         oASysQuestionWithSingleAnswer("Motivation and triggers", "2.8.3", offenceDetails.offence?.offenceMotivation),
         oASysQuestionWithSingleAnswer("Issues contributing to risks", "2.98", offenceDetails.offence?.issueContributingToRisk),
-        oASysQuestionWithSingleAnswer("Pattern of offending", "2.12", offenceDetails.offence?.patternOffending)
+        oASysQuestionWithSingleAnswer("Pattern of offending", "2.12", offenceDetails.offence?.patternOffending),
       ),
       roshSummary = listOf(
         oASysQuestionWithSingleAnswer("Who is at risk", "R10.1", roshSummary.roshSummary?.whoIsAtRisk),
         oASysQuestionWithSingleAnswer("What is the nature of the risk", "R10.2", roshSummary.roshSummary?.natureOfRisk),
         oASysQuestionWithSingleAnswer("When is the risk likely to be the greatest", "R10.3", roshSummary.roshSummary?.riskGreatest),
         oASysQuestionWithSingleAnswer("What circumstances are likely to increase risk", "R10.4", roshSummary.roshSummary?.riskIncreaseLikelyTo),
-        oASysQuestionWithSingleAnswer("What circumstances are likely to reduce the risk", "R10.5", roshSummary.roshSummary?.riskReductionLikelyTo)
+        oASysQuestionWithSingleAnswer("What circumstances are likely to reduce the risk", "R10.5", roshSummary.roshSummary?.riskReductionLikelyTo),
       ),
       supportingInformation = transformSupportingInformation(needsDetails, requestedOptionalSections),
       riskToSelf = listOf(
@@ -55,8 +55,8 @@ class OASysSectionsTransformer : OASysTransformer() {
         oASysQuestionWithSingleAnswer("Interventions and treatment", "RM32", riskManagementPlan.riskManagementPlan?.interventionsAndTreatment),
         oASysQuestionWithSingleAnswer("Monitoring and control", "RM31", riskManagementPlan.riskManagementPlan?.monitoringAndControl),
         oASysQuestionWithSingleAnswer("Supervision", "RM30", riskManagementPlan.riskManagementPlan?.supervision),
-        oASysQuestionWithSingleAnswer("Key information about current situation", "RM28.1", riskManagementPlan.riskManagementPlan?.keyInformationAboutCurrentSituation)
-      )
+        oASysQuestionWithSingleAnswer("Key information about current situation", "RM28.1", riskManagementPlan.riskManagementPlan?.keyInformationAboutCurrentSituation),
+      ),
     )
   }
 
@@ -70,7 +70,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 3,
         linkedToHarm = needsDetails.linksToHarm?.accommodationLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.accommodationLinkedToReOffending,
-        answer = needsDetails.needs?.accommodationIssuesDetails
+        answer = needsDetails.needs?.accommodationIssuesDetails,
       )
     }
 
@@ -81,7 +81,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 4,
         linkedToHarm = needsDetails.linksToHarm?.educationTrainingEmploymentLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.educationTrainingEmploymentLinkedToReOffending,
-        answer = needsDetails.needs?.educationTrainingEmploymentIssuesDetails
+        answer = needsDetails.needs?.educationTrainingEmploymentIssuesDetails,
       )
     }
 
@@ -92,7 +92,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 5,
         linkedToHarm = needsDetails.linksToHarm?.financeLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.financeLinkedToReOffending,
-        answer = needsDetails.needs?.financeIssuesDetails
+        answer = needsDetails.needs?.financeIssuesDetails,
       )
     }
 
@@ -103,7 +103,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 6,
         linkedToHarm = needsDetails.linksToHarm?.relationshipLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.relationshipLinkedToReOffending,
-        answer = needsDetails.needs?.relationshipIssuesDetails
+        answer = needsDetails.needs?.relationshipIssuesDetails,
       )
     }
 
@@ -114,7 +114,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 7,
         linkedToHarm = needsDetails.linksToHarm?.lifestyleLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.lifestyleLinkedToReOffending,
-        answer = needsDetails.needs?.lifestyleIssuesDetails
+        answer = needsDetails.needs?.lifestyleIssuesDetails,
       )
     }
 
@@ -124,7 +124,7 @@ class OASysSectionsTransformer : OASysTransformer() {
       sectionNumber = 8,
       linkedToHarm = needsDetails.linksToHarm?.drugLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.drugLinkedToReOffending,
-      answer = needsDetails.needs?.drugIssuesDetails
+      answer = needsDetails.needs?.drugIssuesDetails,
     )
 
     supportingInformation += OASysSupportingInformationQuestion(
@@ -133,7 +133,7 @@ class OASysSectionsTransformer : OASysTransformer() {
       sectionNumber = 9,
       linkedToHarm = needsDetails.linksToHarm?.alcoholLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.alcoholLinkedToReOffending,
-      answer = needsDetails.needs?.alcoholIssuesDetails
+      answer = needsDetails.needs?.alcoholIssuesDetails,
     )
 
     if (needsDetails.linksToHarm?.emotionalLinkedToHarm == true || requestedOptionalSections.contains(10)) {
@@ -143,7 +143,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 10,
         linkedToHarm = needsDetails.linksToHarm?.emotionalLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.emotionalLinkedToReOffending,
-        answer = needsDetails.needs?.emotionalIssuesDetails
+        answer = needsDetails.needs?.emotionalIssuesDetails,
       )
     }
 
@@ -154,7 +154,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 11,
         linkedToHarm = needsDetails.linksToHarm?.thinkingBehaviouralLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.thinkingBehaviouralLinkedToReOffending,
-        answer = needsDetails.needs?.thinkingBehaviouralIssuesDetails
+        answer = needsDetails.needs?.thinkingBehaviouralIssuesDetails,
       )
     }
 
@@ -165,7 +165,7 @@ class OASysSectionsTransformer : OASysTransformer() {
         sectionNumber = 12,
         linkedToHarm = needsDetails.linksToHarm?.attitudeLinkedToHarm,
         linkedToReOffending = needsDetails.linksToReOffending?.attitudeLinkedToReOffending,
-        answer = needsDetails.needs?.attitudeIssuesDetails
+        answer = needsDetails.needs?.attitudeIssuesDetails,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysTransformer.kt
@@ -6,6 +6,6 @@ abstract class OASysTransformer {
   protected fun oASysQuestionWithSingleAnswer(label: String, questionNumber: String, answer: String?) = OASysQuestion(
     label = label,
     questionNumber = questionNumber,
-    answer = answer
+    answer = answer,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -23,7 +23,7 @@ class PersonTransformer {
     },
     prisonName = inOutStatusToApiStatus(inmateDetail.inOutStatus).takeIf { it == Person.Status.inCustody }?.let {
       inmateDetail.assignedLivingUnit?.agencyName ?: inmateDetail.assignedLivingUnit?.agencyId
-    }
+    },
   )
 
   private fun inOutStatusToApiStatus(inOutStatus: InOutStatus) = when (inOutStatus) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -17,7 +17,7 @@ class PlacementRequestTransformer(
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
   private val assessmentTransformer: AssessmentTransformer,
-  private val userTransformer: UserTransformer
+  private val userTransformer: UserTransformer,
 ) {
   fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): PlacementRequest {
     return PlacementRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -54,7 +54,7 @@ class PremisesTransformer(
       status = jpa.status,
       pdu = jpa.probationDeliveryUnit?.name ?: "Not specified",
       probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
-      turnaroundWorkingDayCount = jpa.turnaroundWorkingDayCount
+      turnaroundWorkingDayCount = jpa.turnaroundWorkingDayCount,
     )
     else -> throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PrisonCaseNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PrisonCaseNoteTransformer.kt
@@ -15,6 +15,6 @@ class PrisonCaseNoteTransformer {
     authorName = domain.authorName,
     type = domain.typeDescription ?: domain.type,
     subType = domain.subTypeDescription ?: domain.subType,
-    note = domain.text
+    note = domain.text,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RisksTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RisksTransformer.kt
@@ -22,32 +22,32 @@ class RisksTransformer {
           riskToPublic = it.riskToPublic,
           riskToKnownAdult = it.riskToKnownAdult,
           riskToStaff = it.riskToStaff,
-          lastUpdated = it.lastUpdated
+          lastUpdated = it.lastUpdated,
         )
-      }
+      },
     ),
     mappa = MappaEnvelope(
       status = transformDomainToApi(domain.mappa.status),
       value = domain.mappa.value?.let {
         uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Mappa(
           level = it.level,
-          lastUpdated = it.lastUpdated
+          lastUpdated = it.lastUpdated,
         )
-      }
+      },
     ),
     tier = RiskTierEnvelope(
       status = transformDomainToApi(domain.tier.status),
       value = domain.tier.value?.let {
         uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTier(
           level = it.level,
-          lastUpdated = it.lastUpdated
+          lastUpdated = it.lastUpdated,
         )
-      }
+      },
     ),
     flags = FlagsEnvelope(
       status = transformDomainToApi(domain.flags.status),
-      value = domain.flags.value
-    )
+      value = domain.flags.value,
+    ),
   )
 
   private fun transformDomainToApi(domain: RiskStatus) = when (domain) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/StaffMemberTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/StaffMemberTransformer.kt
@@ -9,6 +9,6 @@ class StaffMemberTransformer() {
   fun transformDomainToApi(domain: StaffMember) = ApiStaffMember(
     code = domain.code,
     keyWorker = domain.keyWorker,
-    name = "${domain.name.forename} ${domain.name.surname}"
+    name = "${domain.name.forename} ${domain.name.surname}",
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 @Component
 class TaskTransformer(
   private val personTransformer: PersonTransformer,
-  private val userTransformer: UserTransformer
+  private val userTransformer: UserTransformer,
 ) {
   fun transformAssessmentToTask(assessment: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Task(
     applicationId = assessment.application.id,
@@ -22,7 +22,7 @@ class TaskTransformer(
     dueDate = assessment.createdAt.plusDays(10).toLocalDate(),
     allocatedToStaffMember = userTransformer.transformJpaToApi(assessment.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
     status = getAssessmentStatus(assessment),
-    taskType = TaskType.assessment
+    taskType = TaskType.assessment,
   )
 
   fun transformPlacementRequestToTask(placementRequest: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Task(
@@ -31,7 +31,7 @@ class TaskTransformer(
     dueDate = placementRequest.createdAt.plusDays(10).toLocalDate(),
     allocatedToStaffMember = userTransformer.transformJpaToApi(placementRequest.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
     status = getPlacementRequestStatus(placementRequest),
-    taskType = TaskType.placementRequest
+    taskType = TaskType.placementRequest,
   )
 
   private fun getAssessmentStatus(entity: AssessmentEntity): Status = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -13,7 +13,7 @@ fun <T> mapAndTransformAssessments(
   assessments: List<AssessmentEntity>,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (AssessmentEntity, OffenderDetailSummary, InmateDetail) -> T
+  transformer: (AssessmentEntity, OffenderDetailSummary, InmateDetail) -> T,
 ): List<T> {
   return assessments.mapNotNull {
     val assessment = transformAssessment(log, it, deliusUsername, offenderService, transformer) ?: return@mapNotNull null
@@ -27,7 +27,7 @@ fun <T> transformAssessment(
   assessment: AssessmentEntity,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (AssessmentEntity, OffenderDetailSummary, InmateDetail) -> T
+  transformer: (AssessmentEntity, OffenderDetailSummary, InmateDetail) -> T,
 ): T {
   val (offenderDetailSummary, inmateDetail) = getPersonDetailsForCrn(log, assessment.application.crn, deliusUsername, offenderService)
     ?: throw NotFoundProblem(assessment.application.crn, "Offender")
@@ -40,7 +40,7 @@ fun <T> mapAndTransformAssessmentSummaries(
   assessments: List<DomainAssessmentSummary>,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T
+  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T,
 ): List<T> {
   return assessments.mapNotNull {
     transformAssessmentSummary(log, it, deliusUsername, offenderService, transformer) ?: return@mapNotNull null
@@ -52,7 +52,7 @@ fun <T> transformAssessmentSummary(
   assessment: DomainAssessmentSummary,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T
+  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T,
 ): T {
   val (offenderDetailSummary, inmateDetail) = getPersonDetailsForCrn(log, assessment.crn, deliusUsername, offenderService)
     ?: throw NotFoundProblem(assessment.crn, "Offender")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
@@ -10,7 +10,7 @@ fun getPersonDetailsForCrn(
   log: Logger,
   crn: String,
   deliusUsername: String,
-  offenderService: OffenderService
+  offenderService: OffenderService,
 ): Pair<OffenderDetailSummary, InmateDetail>? {
   val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(crn, deliusUsername)) {
     is AuthorisableActionResult.Success -> offenderDetailsResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PlacementRequestUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PlacementRequestUtils.kt
@@ -11,7 +11,7 @@ fun <T> mapAndTransformPlacementRequests(
   placementRequests: List<PlacementRequestEntity>,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (PlacementRequestEntity, OffenderDetailSummary, InmateDetail) -> T
+  transformer: (PlacementRequestEntity, OffenderDetailSummary, InmateDetail) -> T,
 ): List<T> {
   return placementRequests.mapNotNull {
     val assessment = transformPlacementRequest<T>(log, it, deliusUsername, offenderService, transformer)
@@ -26,7 +26,7 @@ fun <T> transformPlacementRequest(
   placementRequest: PlacementRequestEntity,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (PlacementRequestEntity, OffenderDetailSummary, InmateDetail) -> T
+  transformer: (PlacementRequestEntity, OffenderDetailSummary, InmateDetail) -> T,
 ): T? {
   val personDetail = getPersonDetailsForCrn(log, placementRequest.application.crn, deliusUsername, offenderService)
     ?: return null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationChargeFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationChargeFactory.kt
@@ -32,6 +32,6 @@ class AdjudicationChargeFactory : Factory<AdjudicationCharge> {
     oicChargeId = this.oicChargeId(),
     offenceCode = this.offenceCode(),
     offenceDescription = this.offenceDescription(),
-    findingCode = this.findingCode()
+    findingCode = this.findingCode(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationFactory.kt
@@ -46,6 +46,6 @@ class AdjudicationFactory : Factory<Adjudication> {
     agencyIncidentId = this.agencyIncidentId(),
     agencyId = this.agencyId(),
     partySeq = this.partySeq(),
-    adjudicationCharges = this.charges()
+    adjudicationCharges = this.charges(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationsPageFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationsPageFactory.kt
@@ -9,13 +9,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.Agency
 class AdjudicationsPageFactory : Factory<AdjudicationsPage> {
   private var results: Yielded<List<Adjudication>> = {
     listOf(
-      AdjudicationFactory().produce()
+      AdjudicationFactory().produce(),
     )
   }
 
   private var agencies: Yielded<List<Agency>> = {
     listOf(
-      AgencyFactory().produce()
+      AgencyFactory().produce(),
     )
   }
 
@@ -29,6 +29,6 @@ class AdjudicationsPageFactory : Factory<AdjudicationsPage> {
 
   override fun produce(): AdjudicationsPage = AdjudicationsPage(
     results = this.results(),
-    agencies = this.agencies()
+    agencies = this.agencies(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AgencyFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AgencyFactory.kt
@@ -24,6 +24,6 @@ class AgencyFactory : Factory<Agency> {
   override fun produce(): Agency = Agency(
     agencyId = this.agencyId(),
     description = this.description(),
-    agencyType = this.agencyType()
+    agencyType = this.agencyType(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AlertFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AlertFactory.kt
@@ -58,6 +58,6 @@ class AlertFactory : Factory<Alert> {
     dateCreated = this.dateCreated(),
     dateExpires = this.dateExpires(),
     expired = this.dateExpires() != null,
-    active = this.active()
+    active = this.active(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -28,6 +28,6 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
     id = this.id(),
     name = this.name(),
     identifier = this.identifier(),
-    probationRegions = mutableListOf()
+    probationRegions = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTeamCodeEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTeamCodeEntityFactory.kt
@@ -25,6 +25,6 @@ class ApplicationTeamCodeEntityFactory : Factory<ApplicationTeamCodeEntity> {
   override fun produce() = ApplicationTeamCodeEntity(
     id = this.id(),
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an Application"),
-    teamCode = this.teamCode()
+    teamCode = this.teamCode(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -151,6 +151,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     releaseType = this.releaseType(),
     arrivalDate = this.arrivalDate(),
     isInapplicable = this.isInapplicable(),
-    nomsNumber = this.nomsNumber()
+    nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationJsonSchemaEntityFactory.kt
@@ -35,7 +35,7 @@ class ApprovedPremisesApplicationJsonSchemaEntityFactory : Factory<ApprovedPremi
           "type": "object",
           "properties": { }
         }
-        """
+        """,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentJsonSchemaEntityFactory.kt
@@ -35,13 +35,13 @@ class ApprovedPremisesAssessmentJsonSchemaEntityFactory : Factory<ApprovedPremis
           "type": "object",
           "properties": { }
         }
-        """
+        """,
     )
   }
 
   override fun produce(): ApprovedPremisesAssessmentJsonSchemaEntity = ApprovedPremisesAssessmentJsonSchemaEntity(
     id = this.id(),
     addedAt = this.addedAt(),
-    schema = this.schema()
+    schema = this.schema(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -120,7 +120,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.withLocalAuthorityArea(
       LocalAuthorityEntityFactory()
         .withIdentifier("LOCALAUTHORITY")
-        .produce()
+        .produce(),
     )
 
     this.withProbationRegion(
@@ -129,9 +129,9 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
         .withApArea(
           ApAreaEntityFactory()
             .withIdentifier("APAREA")
-            .produce()
+            .produce(),
         )
-        .produce()
+        .produce(),
     )
   }
 
@@ -160,6 +160,6 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     characteristics = this.characteristics(),
     status = this.status(),
     point = this.point?.invoke() ?: GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), 4326)
-      .createPoint(Coordinate(this.latitude(), this.longitude()))
+      .createPoint(Coordinate(this.latitude(), this.longitude())),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -55,6 +55,6 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
     query = this.query(),
     response = this.response(),
-    responseReceivedOn = this.responseReceivedOn()
+    responseReceivedOn = this.responseReceivedOn(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentEntityFactory.kt
@@ -22,7 +22,7 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
   }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
@@ -100,6 +100,6 @@ class AssessmentEntityFactory : Factory<AssessmentEntity> {
     allocatedAt = this.allocatedAt(),
     reallocatedAt = this.reallocatedAt(),
     rejectionRationale = this.rejectionRationale(),
-    clarificationNotes = this.clarificationNotes()
+    clarificationNotes = this.clarificationNotes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedSummaryFactory.kt
@@ -36,6 +36,6 @@ class BedSummaryFactory : Factory<DomainBedSummary> {
     roomId = this.roomId(),
     roomName = this.roomName(),
     bedBooked = this.bedBooked,
-    bedOutOfService = this.bedOutOfService
+    bedOutOfService = this.bedOutOfService,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -188,6 +188,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     application = this.application(),
     offlineApplication = this.offlineApplication(),
     turnarounds = this.turnarounds?.invoke() ?: mutableListOf(),
-    nomsNumber = this.nomsNumber()
+    nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingNotMadeEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingNotMadeEntityFactory.kt
@@ -34,6 +34,6 @@ class BookingNotMadeEntityFactory : Factory<BookingNotMadeEntity> {
     id = this.id(),
     createdAt = this.createdAt(),
     placementRequest = this.placementRequest?.invoke() ?: throw RuntimeException("Must provide a Placement Request"),
-    notes = this.notes()
+    notes = this.notes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSearchResultFactory.kt
@@ -27,7 +27,7 @@ class BookingSearchResultFactory : Factory<BookingSearchResult> {
         "cancelled",
         "provisional",
         "confirmed",
-      )
+      ),
     )
   }
   private var bookingStartDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseNoteFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseNoteFactory.kt
@@ -101,6 +101,6 @@ class CaseNoteFactory : Factory<CaseNote> {
     amendments = listOf(),
     offenderIdentifier = this.offenderIdentifier(),
     eventId = this.eventId(),
-    sensitive = this.sensitive()
+    sensitive = this.sensitive(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ContextStaffMemberFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ContextStaffMemberFactory.kt
@@ -17,7 +17,7 @@ class ContextStaffMemberFactory : Factory<StaffMember> {
     name = StaffMemberName(
       forename = this.forenames(),
       middleName = null,
-      surname = this.surname()
-    )
+      surname = this.surname(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConvictionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConvictionFactory.kt
@@ -70,6 +70,6 @@ class ConvictionFactory : Factory<Conviction> {
     awaitingPsr = this.awaitingPsr(),
     convictionDate = this.convictionDate(),
     referralDate = this.referralDate(),
-    offences = this.offences()
+    offences = this.offences(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
@@ -39,6 +39,6 @@ class DepartureReasonEntityFactory : Factory<DepartureReasonEntity> {
     name = this.name(),
     isActive = this.isActive(),
     serviceScope = this.serviceScope(),
-    legacyDeliusReasonCode = this.legacyDeliusCategoryCode()
+    legacyDeliusReasonCode = this.legacyDeliusCategoryCode(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DestinationProviderEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DestinationProviderEntityFactory.kt
@@ -26,6 +26,6 @@ class DestinationProviderEntityFactory : Factory<DestinationProviderEntity> {
   override fun produce(): DestinationProviderEntity = DestinationProviderEntity(
     id = this.id(),
     name = this.name(),
-    isActive = this.isActive()
+    isActive = this.isActive(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
@@ -65,11 +65,11 @@ class DocumentFactory : Factory<Document> {
     author = this.author(),
     type = DocumentType(
       code = this.typeCode(),
-      description = this.typeDescription()
+      description = this.typeDescription(),
     ),
     extendedDescription = this.extendedDescription(),
     lastModifiedAt = this.lastModifiedAt(),
     createdAt = this.createdAt(),
-    parentPrimaryKeyId = this.parentPrimaryKeyId()
+    parentPrimaryKeyId = this.parentPrimaryKeyId(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -53,6 +53,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     type = this.type(),
     occurredAt = this.occurredAt(),
     createdAt = this.createdAt(),
-    data = this.data()
+    data = this.data(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/GroupedDocumentsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/GroupedDocumentsFactory.kt
@@ -14,7 +14,7 @@ class GroupedDocumentsFactory : Factory<GroupedDocuments> {
   }
 
   fun withConvictionLevelDocument(convictionId: String, convictionLevelDocument: Document) = apply {
-    if (! this.convictionLevelDocuments.containsKey(convictionId)) {
+    if (!this.convictionLevelDocuments.containsKey(convictionId)) {
       this.convictionLevelDocuments[convictionId] = mutableListOf()
     }
 
@@ -26,8 +26,8 @@ class GroupedDocumentsFactory : Factory<GroupedDocuments> {
     convictions = convictionLevelDocuments.map {
       ConvictionDocuments(
         convictionId = it.key,
-        documents = it.value
+        documents = it.value,
       )
-    }
+    },
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/HealthDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/HealthDetailsFactory.kt
@@ -47,7 +47,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -57,7 +57,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -67,7 +67,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -77,7 +77,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -87,7 +87,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -97,7 +97,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -107,7 +107,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -117,7 +117,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -127,7 +127,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -137,7 +137,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -147,7 +147,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -157,7 +157,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -167,7 +167,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -177,7 +177,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -187,7 +187,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -197,7 +197,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       HealthDetail(
         community = community,
         electronicMonitoring = electronicMonitoring,
-        programme = programme
+        programme = programme,
       )
     }
   }
@@ -232,7 +232,7 @@ class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
       literacyProblems = this.literacyProblems(),
       poorCommunicationSkills = this.poorCommunicationSkills(),
       needForInterpreter = this.needForInterpreter(),
-      alcoholMisuse = this.alcoholMisuse()
-    )
+      alcoholMisuse = this.alcoholMisuse(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/InmateDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/InmateDetailFactory.kt
@@ -27,6 +27,6 @@ class InmateDetailFactory : Factory<InmateDetail> {
   override fun produce(): InmateDetail = InmateDetail(
     offenderNo = this.offenderNo(),
     inOutStatus = this.inOutStatus(),
-    assignedLivingUnit = this.assignedLivingUnit()
+    assignedLivingUnit = this.assignedLivingUnit(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
@@ -28,6 +28,6 @@ class LocalAuthorityEntityFactory : Factory<LocalAuthorityAreaEntity> {
     id = this.id(),
     identifier = this.identifier(),
     name = this.name(),
-    premises = mutableListOf()
+    premises = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
@@ -81,6 +81,6 @@ class LostBedsEntityFactory : Factory<LostBedsEntity> {
     notes = this.notes(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
     bed = this.bed?.invoke() ?: throw RuntimeException("Must provide a Bed"),
-    cancellation = this.lostBedCancellation?.invoke()
+    cancellation = this.lostBedCancellation?.invoke(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
@@ -39,6 +39,6 @@ class MoveOnCategoryEntityFactory : Factory<MoveOnCategoryEntity> {
     name = this.name(),
     isActive = this.isActive(),
     serviceScope = this.serviceScope(),
-    legacyDeliusCategoryCode = this.legacyDeliusCategoryCode()
+    legacyDeliusCategoryCode = this.legacyDeliusCategoryCode(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NeedsDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NeedsDetailsFactory.kt
@@ -124,7 +124,7 @@ class NeedsDetailsFactory : AssessmentInfoFactory<NeedsDetails>() {
       educationTrainingEmploymentIssuesDetails = this.educationTrainingEmploymentIssuesDetails(),
       accommodationIssuesDetails = this.accommodationIssuesDetails(),
       attitudeIssuesDetails = this.attitudeIssuesDetails(),
-      thinkingBehaviouralIssuesDetails = this.thinkingBehaviouralIssuesDetails()
+      thinkingBehaviouralIssuesDetails = this.thinkingBehaviouralIssuesDetails(),
     ),
     linksToHarm = LinksToHarm(
       accommodationLinkedToHarm = this.accommodationLinkedToHarm(),
@@ -136,7 +136,7 @@ class NeedsDetailsFactory : AssessmentInfoFactory<NeedsDetails>() {
       alcoholLinkedToHarm = this.alcoholIssuesLinkedToHarm(),
       emotionalLinkedToHarm = this.emotionalIssuesLinkedToHarm(),
       thinkingBehaviouralLinkedToHarm = this.thinkingBehaviouralIssuesLinkedToHarm(),
-      attitudeLinkedToHarm = this.attitudeIssuesLinkedToHarm()
+      attitudeLinkedToHarm = this.attitudeIssuesLinkedToHarm(),
     ),
     linksToReOffending = LinksToReOffending(
       accommodationLinkedToReOffending = this.accommodationLinkedToReOffending(),
@@ -148,7 +148,7 @@ class NeedsDetailsFactory : AssessmentInfoFactory<NeedsDetails>() {
       alcoholLinkedToReOffending = this.alcoholIssuesLinkedToReOffending(),
       emotionalLinkedToReOffending = this.emotionalIssuesLinkedToReOffending(),
       thinkingBehaviouralLinkedToReOffending = this.thinkingBehaviouralIssuesLinkedToReOffending(),
-      attitudeLinkedToReOffending = this.attitudeIssuesLinkedToReOffending()
-    )
+      attitudeLinkedToReOffending = this.attitudeIssuesLinkedToReOffending(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalReasonEntityFactory.kt
@@ -26,6 +26,6 @@ class NonArrivalReasonEntityFactory : Factory<NonArrivalReasonEntity> {
   override fun produce(): NonArrivalReasonEntity = NonArrivalReasonEntity(
     id = this.id(),
     name = this.name(),
-    isActive = this.isActive()
+    isActive = this.isActive(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenceDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenceDetailsFactory.kt
@@ -70,7 +70,7 @@ class OffenceDetailsFactory : AssessmentInfoFactory<OffenceDetails>() {
       victimPerpetratorRel = this.victimPerpetratorRel(),
       victimInfo = this.victimInfo(),
       patternOffending = this.patternOffending(),
-      acceptsResponsibility = this.acceptsResponsibility()
-    )
+      acceptsResponsibility = this.acceptsResponsibility(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenceFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenceFactory.kt
@@ -131,7 +131,7 @@ class OffenceFactory : Factory<Offence> {
       subCategoryDescription = this.subCategoryDescription(),
       form20Code = this.form20Code(),
       subCategoryAbbreviation = this.subCategoryAbbreviation(),
-      cjitCode = this.cjitCode()
+      cjitCode = this.cjitCode(),
     ),
     offenceDate = this.offenceDate(),
     offenceCount = this.offenceCount(),
@@ -139,6 +139,6 @@ class OffenceFactory : Factory<Offence> {
     verdict = this.verdict(),
     offenderId = this.offenderId(),
     createdDatetime = this.createdDatetime(),
-    lastUpdatedDatetime = this.lastUpdatedDatetime()
+    lastUpdatedDatetime = this.lastUpdatedDatetime(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
@@ -105,7 +105,7 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
       mostRecentPrisonNumber = null,
       niNumber = null,
       nomsNumber = this.nomsNumber(),
-      pncNumber = null
+      pncNumber = null,
     ),
     offenderProfile = OffenderProfile(
       ethnicity = null,
@@ -117,7 +117,7 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
         primaryLanguage = null,
         otherLanguages = listOf(),
         languageConcerns = null,
-        requiresInterpreter = null
+        requiresInterpreter = null,
       ),
       religion = this.religionOrBelief(),
       sexualOrientation = null,
@@ -126,13 +126,13 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
       riskColour = null,
       disabilities = listOf(),
       genderIdentity = this.genderIdentity(),
-      selfDescribedGender = this.selfDescribedGenderIdentity()
+      selfDescribedGender = this.selfDescribedGenderIdentity(),
     ),
     softDeleted = null,
     currentDisposal = "",
     partitionArea = null,
     currentRestriction = this.currentRestriction(),
     currentExclusion = this.currentExclusion(),
-    isActiveProbationManagedSentence = false
+    isActiveProbationManagedSentence = false,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
@@ -40,6 +40,6 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
     crn = this.crn(),
     service = this.service(),
     submittedAt = this.submittedAt(),
-    createdAt = this.createdAt()
+    createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersonRisksFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersonRisksFactory.kt
@@ -35,6 +35,6 @@ class PersonRisksFactory : Factory<PersonRisks> {
     roshRisks = this.roshRisks(),
     mappa = this.mappa(),
     tier = this.tier(),
-    flags = this.flags()
+    flags = this.flags(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PostCodeDistrictEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PostCodeDistrictEntityFactory.kt
@@ -44,6 +44,6 @@ class PostCodeDistrictEntityFactory : Factory<PostCodeDistrictEntity> {
     latitude = this.latitude(),
     longitude = this.longitude(),
     point = this.point?.invoke() ?: GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), 4326)
-      .createPoint(Coordinate(this.latitude(), this.longitude()))
+      .createPoint(Coordinate(this.latitude(), this.longitude())),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
@@ -22,7 +22,7 @@ class RegistrationClientResponseFactory : Factory<Registration> {
   private var type: Yielded<RegistrationKeyValue> = {
     RegistrationKeyValue(
       code = "MAPP",
-      description = "MAPPA"
+      description = "MAPPA",
     )
   }
   private var riskColour: Yielded<String> = { "Red" }
@@ -33,32 +33,32 @@ class RegistrationClientResponseFactory : Factory<Registration> {
   private var registeringTeam: Yielded<RegistrationKeyValue> = {
     RegistrationKeyValue(
       code = randomStringMultiCaseWithNumbers(5),
-      description = randomStringMultiCaseWithNumbers(10)
+      description = randomStringMultiCaseWithNumbers(10),
     )
   }
   private var registeringOfficer: Yielded<RegistrationStaffHuman> = {
     RegistrationStaffHuman(
       code = randomStringMultiCaseWithNumbers(5),
       forenames = randomStringUpperCase(10),
-      surname = randomStringUpperCase(10)
+      surname = randomStringUpperCase(10),
     )
   }
   private var registeringProbationArea: Yielded<RegistrationKeyValue> = {
     RegistrationKeyValue(
       code = randomStringUpperCase(5),
-      description = randomStringUpperCase(20)
+      description = randomStringUpperCase(20),
     )
   }
   private var registerLevel: Yielded<RegistrationKeyValue?> = {
     RegistrationKeyValue(
       code = randomStringUpperCase(5),
-      description = randomStringUpperCase(20)
+      description = randomStringUpperCase(20),
     )
   }
   private var registerCategory: Yielded<RegistrationKeyValue> = {
     RegistrationKeyValue(
       code = "M2",
-      description = "MAPPA Cat 2"
+      description = "MAPPA Cat 2",
     )
   }
   private var warnUser: Yielded<Boolean> = { false }
@@ -68,13 +68,13 @@ class RegistrationClientResponseFactory : Factory<Registration> {
     RegistrationStaffHuman(
       code = randomStringUpperCase(5),
       forenames = randomStringUpperCase(5),
-      surname = randomStringUpperCase(5)
+      surname = randomStringUpperCase(5),
     )
   }
   private var deregisteringProbationArea: Yielded<RegistrationKeyValue?> = {
     RegistrationKeyValue(
       code = randomStringUpperCase(5),
-      description = randomStringUpperCase(20)
+      description = randomStringUpperCase(20),
     )
   }
   private var deregisteringNotes: Yielded<String?> = { randomStringUpperCase(10) }
@@ -187,6 +187,6 @@ class RegistrationClientResponseFactory : Factory<Registration> {
     deregisteringProbationArea = this.deregisteringProbationArea(),
     deregisteringNotes = this.deregisteringNotes(),
     numberOfPreviousDeregistrations = this.numberOfPreviousDeregistrations(),
-    registrationReviews = this.registrationReviews()
+    registrationReviews = this.registrationReviews(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskManagementPlanFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskManagementPlanFactory.kt
@@ -64,7 +64,7 @@ class RiskManagementPlanFactory : AssessmentInfoFactory<RiskManagementPlan>() {
       interventionsAndTreatment = this.interventionsAndTreatment(),
       monitoringAndControl = this.monitoringAndControl(),
       supervision = this.supervision(),
-      keyInformationAboutCurrentSituation = this.keyInformationAboutCurrentSituation()
-    )
+      keyInformationAboutCurrentSituation = this.keyInformationAboutCurrentSituation(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskToTheIndividualFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskToTheIndividualFactory.kt
@@ -64,7 +64,7 @@ class RiskToTheIndividualFactory : AssessmentInfoFactory<RisksToTheIndividual>()
       currentVulnerability = this.currentVulnerability(),
       previousVulnerability = this.previousVulnerability(),
       riskOfSeriousHarm = this.riskOfSeriousHarm(),
-      currentConcernsBreachOfTrustText = this.currentConcernsBreachOfTrustText()
-    )
+      currentConcernsBreachOfTrustText = this.currentConcernsBreachOfTrustText(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshRatingsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshRatingsFactory.kt
@@ -70,7 +70,7 @@ class RoshRatingsFactory : AssessmentInfoFactory<RoshRatings>() {
       riskKnownAdultCustody = this.riskKnownAdultCustody(),
       riskKnownAdultCommunity = this.riskKnownAdultCommunity(),
       riskPublicCustody = this.riskPublicCustody(),
-      riskPublicCommunity = this.riskPublicCommunity()
-    )
+      riskPublicCommunity = this.riskPublicCommunity(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshSummaryFactory.kt
@@ -46,7 +46,7 @@ class RoshSummaryFactory : AssessmentInfoFactory<RoshSummary>() {
       natureOfRisk = this.natureOfRisk(),
       riskGreatest = this.riskGreatest(),
       riskIncreaseLikelyTo = this.riskIncreaseLikelyTo(),
-      riskReductionLikelyTo = this.riskReductionLikelyTo()
-    )
+      riskReductionLikelyTo = this.riskReductionLikelyTo(),
+    ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
@@ -74,12 +74,12 @@ class StaffUserDetailsFactory : Factory<StaffUserDetails> {
     staffIdentifier = this.staffIdentifier(),
     staff = StaffNames(
       forenames = this.forenames(),
-      surname = this.surname()
+      surname = this.surname(),
     ),
     teams = this.teams(),
     probationArea = StaffProbationArea(
       code = this.probationAreaCode(),
-      description = this.probationAreaDescription()
+      description = this.probationAreaDescription(),
     ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserTeamMembershipFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserTeamMembershipFactory.kt
@@ -70,11 +70,11 @@ class StaffUserTeamMembershipFactory : Factory<StaffUserTeamMembership> {
     district = this.district(),
     borough = this.borough(),
     startDate = this.startDate(),
-    endDate = this.endDate()
+    endDate = this.endDate(),
   )
 
   private fun randomKeyValue() = KeyValue(
     code = randomStringMultiCaseWithNumbers(5),
-    description = randomStringMultiCaseWithNumbers(10)
+    description = randomStringMultiCaseWithNumbers(10),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffWithoutUsernameUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffWithoutUsernameUserDetailsFactory.kt
@@ -52,12 +52,12 @@ class StaffWithoutUsernameUserDetailsFactory : Factory<StaffWithoutUsernameUserD
     staffIdentifier = this.staffIdentifier(),
     staff = StaffNames(
       forenames = this.forenames(),
-      surname = this.surname()
+      surname = this.surname(),
     ),
     teams = this.teams(),
     probationArea = StaffProbationArea(
       code = this.probationAreaCode(),
-      description = this.probationAreaDescription()
+      description = this.probationAreaDescription(),
     ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -118,6 +118,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     offenceId = this.offenceId(),
     riskRatings = this.riskRatings(),
     probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided"),
-    nomsNumber = this.nomsNumber()
+    nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationJsonSchemaEntityFactory.kt
@@ -35,7 +35,7 @@ class TemporaryAccommodationApplicationJsonSchemaEntityFactory : Factory<Tempora
           "type": "object",
           "properties": { }
         }
-        """
+        """,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -103,7 +103,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     this.withLocalAuthorityArea(
       LocalAuthorityEntityFactory()
         .withIdentifier("LOCALAUTHORITY")
-        .produce()
+        .produce(),
     )
 
     this.withProbationRegion(
@@ -112,9 +112,9 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
         .withApArea(
           ApAreaEntityFactory()
             .withIdentifier("APAREA")
-            .produce()
+            .produce(),
         )
-        .produce()
+        .produce(),
     )
   }
 
@@ -137,6 +137,6 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     characteristics = mutableListOf(),
     status = this.status(),
     probationDeliveryUnit = this.probationDeliveryUnit?.invoke(),
-    turnaroundWorkingDayCount = this.turnaroundWorkingDayCount?.invoke() ?: 2
+    turnaroundWorkingDayCount = this.turnaroundWorkingDayCount?.invoke() ?: 2,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -79,9 +79,9 @@ class UserEntityFactory : Factory<UserEntity> {
         .withApArea(
           ApAreaEntityFactory()
             .withIdentifier("APAREA")
-            .produce()
+            .produce(),
         )
-        .produce()
+        .produce(),
     )
   }
 
@@ -96,6 +96,6 @@ class UserEntityFactory : Factory<UserEntity> {
     applications = this.applications(),
     roles = mutableListOf(),
     qualifications = this.qualifications(),
-    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided")
+    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided"),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserQualificationAssignmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserQualificationAssignmentEntityFactory.kt
@@ -27,6 +27,6 @@ class UserQualificationAssignmentEntityFactory : Factory<UserQualificationAssign
   override fun produce(): UserQualificationAssignmentEntity = UserQualificationAssignmentEntity(
     id = this.id(),
     user = this.user?.invoke() ?: throw RuntimeException("Must provide a User"),
-    qualification = this.qualification()
+    qualification = this.qualification(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserRoleAssignmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserRoleAssignmentEntityFactory.kt
@@ -27,6 +27,6 @@ class UserRoleAssignmentEntityFactory : Factory<UserRoleAssignmentEntity> {
   override fun produce(): UserRoleAssignmentEntity = UserRoleAssignmentEntity(
     id = this.id(),
     user = this.user?.invoke() ?: throw RuntimeException("Must provide a User"),
-    role = this.role()
+    role = this.role(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationAssessedAssessedByFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationAssessedAssessedByFactory.kt
@@ -27,6 +27,6 @@ class ApplicationAssessedAssessedByFactory : Factory<ApplicationAssessedAssessed
   override fun produce() = ApplicationAssessedAssessedBy(
     staffMember = this.staffMember(),
     probationArea = this.probationArea(),
-    cru = this.cru()
+    cru = this.cru(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationAssessedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationAssessedFactory.kt
@@ -60,6 +60,6 @@ class ApplicationAssessedFactory : Factory<ApplicationAssessed> {
     assessedAt = this.assessedAt(),
     assessedBy = this.assessedBy(),
     decision = this.decision(),
-    decisionRationale = this.decisionRationale()
+    decisionRationale = this.decisionRationale(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationSubmittedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationSubmittedFactory.kt
@@ -121,8 +121,8 @@ class ApplicationSubmittedFactory : Factory<ApplicationSubmitted> {
       probationArea = this.submittedByProbationArea(),
       team = this.submittedByTeam(),
       ldu = this.submittedByLdu(),
-      region = this.submittedByRegion()
+      region = this.submittedByRegion(),
     ),
-    sentenceLengthInMonths = this.sentenceLengthInMonths()
+    sentenceLengthInMonths = this.sentenceLengthInMonths(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingMadeBookedByFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingMadeBookedByFactory.kt
@@ -20,6 +20,6 @@ class BookingMadeBookedByFactory : Factory<BookingMadeBookedBy> {
 
   override fun produce() = BookingMadeBookedBy(
     staffMember = this.staffMember(),
-    cru = this.cru()
+    cru = this.cru(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingMadeFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingMadeFactory.kt
@@ -73,6 +73,6 @@ class BookingMadeFactory : Factory<BookingMade> {
     bookedBy = this.bookedBy(),
     premises = this.premises(),
     arrivalOn = this.arrivalOn(),
-    departureOn = this.departureOn()
+    departureOn = this.departureOn(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingNotMadeFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingNotMadeFactory.kt
@@ -54,6 +54,6 @@ class BookingNotMadeFactory : Factory<BookingNotMade> {
     applicationUrl = this.applicationUrl(),
     attemptedAt = this.attemptedAt(),
     attemptedBy = this.attemptedBy(),
-    failureDescription = this.failureDescription()
+    failureDescription = this.failureDescription(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/CruFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/CruFactory.kt
@@ -13,6 +13,6 @@ class CruFactory : Factory<Cru> {
   }
 
   override fun produce() = Cru(
-    name = this.name()
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/DestinationProviderFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/DestinationProviderFactory.kt
@@ -20,6 +20,6 @@ class DestinationProviderFactory : Factory<DestinationProvider> {
 
   override fun produce() = DestinationProvider(
     id = this.id(),
-    description = this.description()
+    description = this.description(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/EventPremisesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/EventPremisesFactory.kt
@@ -39,6 +39,6 @@ class EventPremisesFactory : Factory<Premises> {
     name = this.name(),
     apCode = this.apCode(),
     legacyApCode = this.legacyApCode(),
-    localAuthorityAreaName = this.localAuthorityAreaName()
+    localAuthorityAreaName = this.localAuthorityAreaName(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/LduFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/LduFactory.kt
@@ -19,6 +19,6 @@ class LduFactory : Factory<Ldu> {
 
   override fun produce() = Ldu(
     code = this.code(),
-    name = this.name()
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/MoveOnCategoryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/MoveOnCategoryFactory.kt
@@ -27,6 +27,6 @@ class MoveOnCategoryFactory : Factory<MoveOnCategory> {
   override fun produce() = MoveOnCategory(
     description = this.description(),
     legacyMoveOnCategoryCode = this.legacyMoveOnCategoryCode(),
-    id = this.id()
+    id = this.id(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonArrivedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonArrivedFactory.kt
@@ -80,6 +80,6 @@ class PersonArrivedFactory : Factory<PersonArrived> {
     keyWorker = this.keyWorker(),
     arrivedAt = this.arrivedAt(),
     expectedDepartureOn = this.expectedDepartureOn(),
-    notes = this.notes()
+    notes = this.notes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonDepartedDestinationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonDepartedDestinationFactory.kt
@@ -27,6 +27,6 @@ class PersonDepartedDestinationFactory : Factory<PersonDepartedDestination> {
   override fun produce() = PersonDepartedDestination(
     premises = this.premises(),
     moveOnCategory = this.moveOnCategory(),
-    destinationProvider = this.destinationProvider()
+    destinationProvider = this.destinationProvider(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonDepartedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonDepartedFactory.kt
@@ -74,6 +74,6 @@ class PersonDepartedFactory : Factory<PersonDeparted> {
     departedAt = this.departedAt(),
     reason = this.reason(),
     legacyReasonCode = this.legacyReasonCode(),
-    destination = this.personDepartedDestination()
+    destination = this.personDepartedDestination(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonNotArrivedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonNotArrivedFactory.kt
@@ -66,6 +66,6 @@ class PersonNotArrivedFactory : Factory<PersonNotArrived> {
     premises = this.premises(),
     notes = this.notes(),
     expectedArrivalOn = this.expectedArrivalOn(),
-    recordedBy = this.recordedBy()
+    recordedBy = this.recordedBy(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonReferenceFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonReferenceFactory.kt
@@ -19,6 +19,6 @@ class PersonReferenceFactory : Factory<PersonReference> {
 
   override fun produce() = PersonReference(
     crn = this.crn(),
-    noms = this.noms()
+    noms = this.noms(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ProbationAreaFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ProbationAreaFactory.kt
@@ -19,6 +19,6 @@ class ProbationAreaFactory : Factory<ProbationArea> {
 
   override fun produce() = ProbationArea(
     code = this.code(),
-    name = this.name()
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RegionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RegionFactory.kt
@@ -19,6 +19,6 @@ class RegionFactory : Factory<Region> {
 
   override fun produce() = Region(
     code = this.code(),
-    name = this.name()
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/StaffMemberFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/StaffMemberFactory.kt
@@ -39,6 +39,6 @@ class StaffMemberFactory : Factory<StaffMember> {
     staffIdentifier = this.staffIdentifier(),
     forenames = this.forenames(),
     surname = this.surname(),
-    username = this.username()
+    username = this.username(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/TeamFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/TeamFactory.kt
@@ -19,6 +19,6 @@ class TeamFactory : Factory<Team> {
 
   override fun produce() = Team(
     code = this.code(),
-    name = this.name()
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -86,7 +86,7 @@ class AllocationQueryTest : IntegrationTestBase() {
         approvedPremisesApplicationEntityFactory.produceAndPersist {
           withCreatedByUser(user)
           withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-        }
+        },
       )
       withSubmittedAt(null)
       withAssessmentSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
@@ -69,7 +69,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 1 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
               .withExtendedDescription("Extended Description 1")
-              .produce()
+              .produce(),
           )
           .withConvictionLevelDocument(
             "12345",
@@ -80,7 +80,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 2 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
               .withExtendedDescription("Extended Description 2")
-              .produce()
+              .produce(),
           )
           .produce()
 
@@ -95,8 +95,8 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              documentTransformer.transformToApi(groupedDocuments, 12345)
-            )
+              documentTransformer.transformToApi(groupedDocuments, 12345),
+            ),
           )
       }
     }
@@ -123,7 +123,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 1 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
               .withExtendedDescription("Extended Description 1")
-              .produce()
+              .produce(),
           )
           .withConvictionLevelDocument(
             "12345",
@@ -134,7 +134,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 2 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
               .withExtendedDescription("Extended Description 2")
-              .produce()
+              .produce(),
           )
           .produce()
 
@@ -150,8 +150,8 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              documentTransformer.transformToApi(groupedDocuments, 12345)
-            )
+              documentTransformer.transformToApi(groupedDocuments, 12345),
+            ),
           )
       }
     }
@@ -177,7 +177,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 1 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
               .withExtendedDescription("Extended Description 1")
-              .produce()
+              .produce(),
           )
           .withConvictionLevelDocument(
             "12345",
@@ -188,7 +188,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 2 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
               .withExtendedDescription("Extended Description 2")
-              .produce()
+              .produce(),
           )
           .produce()
 
@@ -224,7 +224,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 1 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
               .withExtendedDescription("Extended Description 1")
-              .produce()
+              .produce(),
           )
           .withConvictionLevelDocument(
             "12345",
@@ -235,7 +235,7 @@ class ApplicationDocumentsTest : IntegrationTestBase() {
               .withTypeDescription("Type 2 Description")
               .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
               .withExtendedDescription("Extended Description 2")
-              .produce()
+              .produce(),
           )
           .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -30,7 +30,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withProbationRegion(
             probationRegionEntityFactory.produceAndPersist {
               withApArea(apAreaEntityFactory.produceAndPersist())
-            }
+            },
           )
           withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
         }
@@ -153,7 +153,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withProbationRegion(
             probationRegionEntityFactory.produceAndPersist {
               withApArea(apAreaEntityFactory.produceAndPersist())
-            }
+            },
           )
           withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -93,7 +93,7 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM1").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       `Given a User` { otherUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
@@ -118,7 +118,7 @@ class ApplicationTest : IntegrationTestBase() {
             },
             "required": [ "thingId" ]
           }
-          """
+          """,
               )
             }
 
@@ -134,7 +134,7 @@ class ApplicationTest : IntegrationTestBase() {
                 "type": "object",
                 "properties": { }
               }
-            """
+            """,
               )
             }
 
@@ -147,7 +147,7 @@ class ApplicationTest : IntegrationTestBase() {
                 {
                    "thingId": 123
                 }
-              """
+              """,
               )
             }
 
@@ -155,8 +155,8 @@ class ApplicationTest : IntegrationTestBase() {
               ApplicationTeamCodeEntity(
                 id = UUID.randomUUID(),
                 application = upToDateApplicationEntityManagedByTeam,
-                teamCode = "TEAM1"
-              )
+                teamCode = "TEAM1",
+              ),
             )
 
             val outdatedApplicationEntityManagedByTeam = approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -170,8 +170,8 @@ class ApplicationTest : IntegrationTestBase() {
               ApplicationTeamCodeEntity(
                 id = UUID.randomUUID(),
                 application = outdatedApplicationEntityManagedByTeam,
-                teamCode = "TEAM1"
-              )
+                teamCode = "TEAM1",
+              ),
             )
 
             val outdatedApplicationEntityNotManagedByTeam = approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -247,7 +247,7 @@ class ApplicationTest : IntegrationTestBase() {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
               )
             }
 
@@ -263,7 +263,7 @@ class ApplicationTest : IntegrationTestBase() {
           "type": "object",
           "properties": { }
         }
-        """
+        """,
               )
             }
 
@@ -276,7 +276,7 @@ class ApplicationTest : IntegrationTestBase() {
           {
              "thingId": 123
           }
-          """
+          """,
               )
             }
 
@@ -368,7 +368,7 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM1").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       val crn = "X1234"
 
@@ -394,10 +394,10 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM1").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       `Given an Offender`(
-        offenderDetailsConfigBlock = { withoutNomsNumber() }
+        offenderDetailsConfigBlock = { withoutNomsNumber() },
       ) { offenderDetails, inmateDetails ->
         produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
@@ -420,7 +420,7 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM1").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       val crn = "X1234"
 
@@ -482,7 +482,7 @@ class ApplicationTest : IntegrationTestBase() {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
           )
         }
 
@@ -495,7 +495,7 @@ class ApplicationTest : IntegrationTestBase() {
           {
              "thingId": 123
           }
-          """
+          """,
           )
         }
 
@@ -531,7 +531,7 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM2").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       `Given a User` { otherUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
@@ -557,10 +557,10 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM1").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       `Given an Offender`(
-        offenderDetailsConfigBlock = { withoutNomsNumber() }
+        offenderDetailsConfigBlock = { withoutNomsNumber() },
       ) { offenderDetails, inmateDetails ->
         val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
@@ -583,7 +583,7 @@ class ApplicationTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = {
         withTeams(listOf(StaffUserTeamMembershipFactory().withCode("TEAM1").produce()))
-      }
+      },
     ) { userEntity, jwt ->
       val crn = "X1234"
 
@@ -636,7 +636,7 @@ class ApplicationTest : IntegrationTestBase() {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
           )
         }
 
@@ -652,7 +652,7 @@ class ApplicationTest : IntegrationTestBase() {
           "type": "object",
           "properties": { }
         }
-        """
+        """,
           )
         }
 
@@ -749,8 +749,8 @@ class ApplicationTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewApplication(
-            crn = crn
-          )
+            crn = crn,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -764,7 +764,7 @@ class ApplicationTest : IntegrationTestBase() {
   fun `Create new application returns 500 when a person has no NOMS number`() {
     `Given a User` { userEntity, jwt ->
       `Given an Offender`(
-        offenderDetailsConfigBlock = { withoutNomsNumber() }
+        offenderDetailsConfigBlock = { withoutNomsNumber() },
       ) { offenderDetails, inmateDetails ->
         approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
           withAddedAt(OffsetDateTime.now())
@@ -776,8 +776,8 @@ class ApplicationTest : IntegrationTestBase() {
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             NewApplication(
-              crn = offenderDetails.otherIds.crn
-            )
+              crn = offenderDetails.otherIds.crn,
+            ),
           )
           .exchange()
           .expectStatus()
@@ -805,8 +805,8 @@ class ApplicationTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewApplication(
-            crn = offenderDetails.otherIds.crn
-          )
+            crn = offenderDetails.otherIds.crn,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -829,8 +829,8 @@ class ApplicationTest : IntegrationTestBase() {
           offenderDetails.otherIds.crn,
           userEntity.deliusStaffCode!!,
           ManagingTeamsResponse(
-            teamCodes = emptyList()
-          )
+            teamCodes = emptyList(),
+          ),
         )
 
         val result = webTestClient.post()
@@ -841,8 +841,8 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789"
-            )
+              offenceId = "789",
+            ),
           )
           .exchange()
           .expectStatus()
@@ -872,8 +872,8 @@ class ApplicationTest : IntegrationTestBase() {
           offenderDetails.otherIds.crn,
           userEntity.deliusStaffCode!!,
           ManagingTeamsResponse(
-            teamCodes = listOf(offenderDetails.otherIds.crn)
-          )
+            teamCodes = listOf(offenderDetails.otherIds.crn),
+          ),
         )
 
         every { realApplicationTeamCodeRepository.save(any()) } throws RuntimeException("Database Error")
@@ -886,8 +886,8 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789"
-            )
+              offenceId = "789",
+            ),
           )
           .exchange()
           .expectStatus()
@@ -911,8 +911,8 @@ class ApplicationTest : IntegrationTestBase() {
           offenderDetails.otherIds.crn,
           userEntity.deliusStaffCode!!,
           ManagingTeamsResponse(
-            teamCodes = listOf("TEAM1")
-          )
+            teamCodes = listOf("TEAM1"),
+          ),
         )
 
         val result = webTestClient.post()
@@ -923,8 +923,8 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789"
-            )
+              offenceId = "789",
+            ),
           )
           .exchange()
           .expectStatus()
@@ -956,8 +956,8 @@ class ApplicationTest : IntegrationTestBase() {
           offenderDetails.otherIds.crn,
           userEntity.deliusStaffCode!!,
           ManagingTeamsResponse(
-            teamCodes = listOf("TEAM1")
-          )
+            teamCodes = listOf("TEAM1"),
+          ),
         )
 
         val result = webTestClient.post()
@@ -968,8 +968,8 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789"
-            )
+              offenceId = "789",
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1006,8 +1006,8 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789"
-            )
+              offenceId = "789",
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1052,7 +1052,7 @@ class ApplicationTest : IntegrationTestBase() {
                 },
                 "required": [ "thingId" ]
               }
-            """
+            """,
             )
           }
 
@@ -1070,8 +1070,8 @@ class ApplicationTest : IntegrationTestBase() {
               UpdateApprovedPremisesApplication(
                 data = mapOf("thingId" to 123),
                 isWomensApplication = false,
-                isPipeApplication = true
-              )
+                isPipeApplication = true,
+              ),
             )
             .exchange()
             .expectStatus()
@@ -1094,10 +1094,10 @@ class ApplicationTest : IntegrationTestBase() {
       staffUserDetailsConfigBlock = {
         withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().produce()
-          )
+            StaffUserTeamMembershipFactory().produce(),
+          ),
         )
-      }
+      },
     ) { submittingUser, jwt ->
       `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
@@ -1126,7 +1126,7 @@ class ApplicationTest : IntegrationTestBase() {
                 },
                 "required": [ "isWomensApplication", "isPipeApplication" ]
               }
-            """
+            """,
             )
           }
 
@@ -1141,7 +1141,7 @@ class ApplicationTest : IntegrationTestBase() {
                  "isWomensApplication": true,
                  "isPipeApplication": true
               }
-            """
+            """,
             )
           }
 
@@ -1153,24 +1153,24 @@ class ApplicationTest : IntegrationTestBase() {
                   .withType(
                     RegistrationKeyValue(
                       code = "MAPP",
-                      description = "MAPPA"
-                    )
+                      description = "MAPPA",
+                    ),
                   )
                   .withRegisterCategory(
                     RegistrationKeyValue(
                       code = "A",
-                      description = "A"
-                    )
+                      description = "A",
+                    ),
                   )
                   .withRegisterLevel(
                     RegistrationKeyValue(
                       code = "1",
-                      description = "1"
-                    )
+                      description = "1",
+                    ),
                   )
-                  .produce()
-              )
-            )
+                  .produce(),
+              ),
+            ),
           )
 
           webTestClient.post()
@@ -1182,8 +1182,8 @@ class ApplicationTest : IntegrationTestBase() {
                 isPipeApplication = true,
                 isWomensApplication = true,
                 targetLocation = "SW1A 1AA",
-                releaseType = ReleaseTypeOption.licence
-              )
+                releaseType = ReleaseTypeOption.licence,
+              ),
             )
             .exchange()
             .expectStatus()
@@ -1211,7 +1211,7 @@ class ApplicationTest : IntegrationTestBase() {
           assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(applicationId)
           assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
             SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-            SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!)
+            SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
           )
         }
       }
@@ -1224,10 +1224,10 @@ class ApplicationTest : IntegrationTestBase() {
       staffUserDetailsConfigBlock = {
         withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().produce()
-          )
+            StaffUserTeamMembershipFactory().produce(),
+          ),
         )
-      }
+      },
     ) { submittingUser, jwt ->
       `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
@@ -1256,7 +1256,7 @@ class ApplicationTest : IntegrationTestBase() {
                 },
                 "required": [ "isWomensApplication", "isPipeApplication" ]
               }
-            """
+            """,
             )
           }
 
@@ -1271,7 +1271,7 @@ class ApplicationTest : IntegrationTestBase() {
                  "isWomensApplication": true,
                  "isPipeApplication": true
               }
-            """
+            """,
             )
           }
 
@@ -1283,24 +1283,24 @@ class ApplicationTest : IntegrationTestBase() {
                   .withType(
                     RegistrationKeyValue(
                       code = "MAPP",
-                      description = "MAPPA"
-                    )
+                      description = "MAPPA",
+                    ),
                   )
                   .withRegisterCategory(
                     RegistrationKeyValue(
                       code = "A",
-                      description = "A"
-                    )
+                      description = "A",
+                    ),
                   )
                   .withRegisterLevel(
                     RegistrationKeyValue(
                       code = "1",
-                      description = "1"
-                    )
+                      description = "1",
+                    ),
                   )
-                  .produce()
-              )
-            )
+                  .produce(),
+              ),
+            ),
           )
 
           every { realApplicationRepository.save(any()) } answers {
@@ -1321,8 +1321,8 @@ class ApplicationTest : IntegrationTestBase() {
                     isPipeApplication = true,
                     isWomensApplication = true,
                     targetLocation = "SW1A 1AA",
-                    releaseType = ReleaseTypeOption.licence
-                  )
+                    releaseType = ReleaseTypeOption.licence,
+                  ),
                 )
                 .exchange()
                 .returnResult<String>()
@@ -1354,10 +1354,10 @@ class ApplicationTest : IntegrationTestBase() {
       staffUserDetailsConfigBlock = {
         withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().produce()
-          )
+            StaffUserTeamMembershipFactory().produce(),
+          ),
         )
-      }
+      },
     ) { submittingUser, jwt ->
       `Given a User` { userEntity, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
@@ -1377,7 +1377,7 @@ class ApplicationTest : IntegrationTestBase() {
                 "properties": {},
                 "required": []
               }
-            """
+            """,
             )
           }
 
@@ -1390,7 +1390,7 @@ class ApplicationTest : IntegrationTestBase() {
             withData(
               """
               {}
-            """
+            """,
             )
           }
 
@@ -1401,7 +1401,7 @@ class ApplicationTest : IntegrationTestBase() {
             .bodyValue(
               SubmitTemporaryAccommodationApplication(
                 translatedDocument = {},
-              )
+              ),
             )
             .exchange()
             .expectStatus()
@@ -1429,8 +1429,8 @@ class ApplicationTest : IntegrationTestBase() {
               .expectBody()
               .json(
                 objectMapper.writeValueAsString(
-                  assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
-                )
+                  assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+                ),
               )
           }
         }
@@ -1446,7 +1446,7 @@ class ApplicationTest : IntegrationTestBase() {
               val (application, assessment) = produceAndPersistApplicationAndAssessment(
                 applicant,
                 assignee,
-                offenderDetails
+                offenderDetails,
               )
 
               webTestClient.get()
@@ -1458,8 +1458,8 @@ class ApplicationTest : IntegrationTestBase() {
                 .expectBody()
                 .json(
                   objectMapper.writeValueAsString(
-                    assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
-                  )
+                    assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+                  ),
                 )
             }
           }
@@ -1542,7 +1542,7 @@ class ApplicationTest : IntegrationTestBase() {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
       )
     }
 
@@ -1555,7 +1555,7 @@ class ApplicationTest : IntegrationTestBase() {
           {
              "thingId": 123
           }
-          """
+          """,
       )
     }
 
@@ -1563,8 +1563,8 @@ class ApplicationTest : IntegrationTestBase() {
       ApplicationTeamCodeEntity(
         id = UUID.randomUUID(),
         application = application,
-        teamCode = managingTeamCode
-      )
+        teamCode = managingTeamCode,
+      ),
     )
 
     return application
@@ -1614,5 +1614,5 @@ data class MessageAttributes(val eventType: EventType)
 data class Message(
   val Message: String,
   val MessageId: String,
-  val MessageAttributes: MessageAttributes
+  val MessageAttributes: MessageAttributes,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -99,8 +99,8 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offenderDetails, inmateDetails))
-            )
+              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offenderDetails, inmateDetails)),
+            ),
           )
       }
     }
@@ -139,7 +139,7 @@ class AssessmentTest : IntegrationTestBase() {
       completed = assessment.decision != null,
       decision = assessment.decision?.name,
       crn = assessment.application.crn,
-      isStarted = assessment.data != null
+      isStarted = assessment.data != null,
     )
 
   @Test
@@ -187,8 +187,8 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails)
-            )
+              assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+            ),
           )
       }
     }
@@ -219,7 +219,7 @@ class AssessmentTest : IntegrationTestBase() {
   @Test
   fun `Accept assessment returns 200, persists decision, creates and allocates a placement request, and emits SNS domain event message when requirements provided`() {
     `Given a User`(
-      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") }
+      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
       `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher1, _ ->
         `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher2, _ ->
@@ -285,7 +285,7 @@ class AssessmentTest : IntegrationTestBase() {
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
             assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
               SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-              SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!)
+              SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
             )
 
             val persistedPlacementRequest = placementRequestRepository.findByApplication(application)!!
@@ -311,7 +311,7 @@ class AssessmentTest : IntegrationTestBase() {
   @Test
   fun `Accept assessment returns 200, persists decision, does not create a Placement Request, and emits SNS domain event message when requirements not provided`() {
     `Given a User`(
-      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") }
+      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
       `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher1, _ ->
         `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher2, _ ->
@@ -362,7 +362,7 @@ class AssessmentTest : IntegrationTestBase() {
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
             assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
               SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-              SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!)
+              SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
             )
 
             assertThat(placementRequestRepository.findByApplication(application)).isNull()
@@ -375,7 +375,7 @@ class AssessmentTest : IntegrationTestBase() {
   @Test
   fun `Accept assessment returns an error if the postcode cannot be found`() {
     `Given a User`(
-      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") }
+      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
       `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher1, _ ->
         `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher2, _ ->
@@ -447,7 +447,7 @@ class AssessmentTest : IntegrationTestBase() {
   @Test
   fun `Reject assessment returns 200, persists decision, emits SNS domain event message`() {
     `Given a User`(
-      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") }
+      staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -494,7 +494,7 @@ class AssessmentTest : IntegrationTestBase() {
         assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
         assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
           SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-          SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!)
+          SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
         )
       }
     }
@@ -529,8 +529,8 @@ class AssessmentTest : IntegrationTestBase() {
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             NewClarificationNote(
-              query = "some text"
-            )
+              query = "some text",
+            ),
           )
           .exchange()
           .expectStatus()
@@ -576,8 +576,8 @@ class AssessmentTest : IntegrationTestBase() {
           .bodyValue(
             UpdatedClarificationNote(
               response = "some text",
-              responseReceivedOn = LocalDate.parse("2022-03-04")
-            )
+              responseReceivedOn = LocalDate.parse("2022-03-04"),
+            ),
           )
           .exchange()
           .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
@@ -717,7 +717,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       probationDeliveryUnit = searchPdu.name,
       startDate = LocalDate.parse("2023-03-09"),
       durationInDays = 7,
-      probationRegionId = probationRegion.id
+      probationRegionId = probationRegion.id,
     )
 
     assertThat(results.size).isEqualTo(bedsThatShouldAppearInSearchResults.size)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -165,7 +165,7 @@ class BedSearchTest : IntegrationTestBase() {
     }
 
     `Given a User`(
-      probationRegion = probationRegion
+      probationRegion = probationRegion,
     ) { _, jwt ->
       val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
@@ -250,7 +250,7 @@ class BedSearchTest : IntegrationTestBase() {
     }
 
     `Given a User`(
-      probationRegion = probationRegion
+      probationRegion = probationRegion,
     ) { _, jwt ->
       val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -403,7 +403,7 @@ class BookingSearchTest : IntegrationTestBase() {
             name = booking.bed!!.name,
           ),
         )
-      }
+      },
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -80,8 +80,8 @@ class BookingTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, keyWorker)
-            )
+              bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, keyWorker),
+            ),
           )
       }
     }
@@ -122,8 +122,8 @@ class BookingTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, null)
-            )
+              bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, null),
+            ),
           )
       }
     }
@@ -262,7 +262,7 @@ class BookingTest : IntegrationTestBase() {
         val expectedJson = objectMapper.writeValueAsString(
           bookings.map {
             bookingTransformer.transformJpaToApi(it, offenderDetails, inmateDetails, keyWorker)
-          }
+          },
         )
 
         webTestClient.get()
@@ -348,8 +348,8 @@ class BookingTest : IntegrationTestBase() {
           arrivalDate = LocalDate.parse("2022-08-12"),
           departureDate = LocalDate.parse("2022-08-30"),
           serviceName = ServiceName.approvedPremises,
-          bedId = UUID.randomUUID()
-        )
+          bedId = UUID.randomUUID(),
+        ),
       )
       .exchange()
       .expectStatus()
@@ -359,7 +359,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Approved Premises Booking returns Bad Request when no application exists for CRN`() {
     `Given a User`(
-      roles = listOf(UserRole.MATCHER)
+      roles = listOf(UserRole.MATCHER),
     ) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -386,8 +386,8 @@ class BookingTest : IntegrationTestBase() {
               arrivalDate = LocalDate.parse("2022-08-12"),
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.approvedPremises,
-              bedId = bed.id
-            )
+              bedId = bed.id,
+            ),
           )
           .exchange()
           .expectStatus()
@@ -433,8 +433,8 @@ class BookingTest : IntegrationTestBase() {
               arrivalDate = LocalDate.parse("2022-08-12"),
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.approvedPremises,
-              bedId = bed.id
-            )
+              bedId = bed.id,
+            ),
           )
           .exchange()
           .expectStatus()
@@ -465,7 +465,7 @@ class BookingTest : IntegrationTestBase() {
         assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
         assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
           SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-          SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!)
+          SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
         )
       }
     }
@@ -504,7 +504,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -554,7 +554,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = UUID.randomUUID(),
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -599,7 +599,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -653,7 +653,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -716,7 +716,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-09-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -777,7 +777,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -845,7 +845,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -901,7 +901,7 @@ class BookingTest : IntegrationTestBase() {
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
               enableTurnarounds = true,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -962,7 +962,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1024,7 +1024,7 @@ class BookingTest : IntegrationTestBase() {
               departureDate = LocalDate.parse("2022-08-30"),
               serviceName = ServiceName.temporaryAccommodation,
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1042,8 +1042,8 @@ class BookingTest : IntegrationTestBase() {
           arrivalDate = LocalDate.parse("2022-08-12"),
           expectedDepartureDate = LocalDate.parse("2022-08-14"),
           notes = null,
-          keyWorkerStaffCode = "123"
-        )
+          keyWorkerStaffCode = "123",
+        ),
       )
       .exchange()
       .expectStatus()
@@ -1100,7 +1100,7 @@ class BookingTest : IntegrationTestBase() {
               expectedDepartureDate = LocalDate.parse("2022-07-16"),
               notes = "Moved in late due to sickness",
               keyWorkerStaffCode = null,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1160,7 +1160,7 @@ class BookingTest : IntegrationTestBase() {
               expectedDepartureDate = LocalDate.parse("2022-07-16"),
               notes = "Moved in late due to sickness",
               keyWorkerStaffCode = null,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1211,8 +1211,8 @@ class BookingTest : IntegrationTestBase() {
             arrivalDate = LocalDate.parse("2022-08-12"),
             expectedDepartureDate = LocalDate.parse("2022-08-14"),
             notes = "Hello",
-            keyWorkerStaffCode = keyWorker.code
-          )
+            keyWorkerStaffCode = keyWorker.code,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1268,8 +1268,8 @@ class BookingTest : IntegrationTestBase() {
               arrivalDate = LocalDate.parse("2022-08-12"),
               expectedDepartureDate = LocalDate.parse("2022-08-14"),
               notes = "Hello",
-              keyWorkerStaffCode = keyWorker.code
-            )
+              keyWorkerStaffCode = keyWorker.code,
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1330,8 +1330,8 @@ class BookingTest : IntegrationTestBase() {
               arrivalDate = LocalDate.parse("2022-08-12"),
               expectedDepartureDate = LocalDate.parse("2022-08-14"),
               notes = "Hello",
-              keyWorkerStaffCode = null
-            )
+              keyWorkerStaffCode = null,
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1394,8 +1394,8 @@ class BookingTest : IntegrationTestBase() {
               arrivalDate = LocalDate.parse("2022-08-12"),
               expectedDepartureDate = LocalDate.parse("2022-08-14"),
               notes = "Hello",
-              keyWorkerStaffCode = null
-            )
+              keyWorkerStaffCode = null,
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1446,7 +1446,7 @@ class BookingTest : IntegrationTestBase() {
             moveOnCategoryId = moveOnCategory.id,
             destinationProviderId = destinationProvider.id,
             notes = "Hello",
-          )
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1514,7 +1514,7 @@ class BookingTest : IntegrationTestBase() {
               moveOnCategoryId = moveOnCategory.id,
               destinationProviderId = destinationProvider.id,
               notes = "Hello",
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1586,7 +1586,7 @@ class BookingTest : IntegrationTestBase() {
             moveOnCategoryId = moveOnCategory.id,
             destinationProviderId = destinationProvider.id,
             notes = "Corrected date",
-          )
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1635,7 +1635,7 @@ class BookingTest : IntegrationTestBase() {
               moveOnCategoryId = moveOnCategory.id,
               destinationProviderId = null,
               notes = "Hello",
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1703,7 +1703,7 @@ class BookingTest : IntegrationTestBase() {
               moveOnCategoryId = moveOnCategory.id,
               destinationProviderId = null,
               notes = "Corrected date",
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1759,7 +1759,7 @@ class BookingTest : IntegrationTestBase() {
               moveOnCategoryId = moveOnCategory.id,
               destinationProviderId = null,
               notes = "Hello",
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1776,8 +1776,8 @@ class BookingTest : IntegrationTestBase() {
         NewCancellation(
           date = LocalDate.parse("2022-08-17"),
           reason = UUID.fromString("070149f6-c194-4558-a027-f67a10da7865"),
-          notes = null
-        )
+          notes = null,
+        ),
       )
       .exchange()
       .expectStatus()
@@ -1810,8 +1810,8 @@ class BookingTest : IntegrationTestBase() {
           NewCancellation(
             date = LocalDate.parse("2022-08-17"),
             reason = cancellationReason.id,
-            notes = null
-          )
+            notes = null,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1859,8 +1859,8 @@ class BookingTest : IntegrationTestBase() {
           NewCancellation(
             date = LocalDate.parse("2022-08-18"),
             reason = cancellationReason.id,
-            notes = "Corrected date"
-          )
+            notes = "Corrected date",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1899,8 +1899,8 @@ class BookingTest : IntegrationTestBase() {
           NewCancellation(
             date = LocalDate.parse("2022-08-17"),
             reason = cancellationReason.id,
-            notes = null
-          )
+            notes = null,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1938,8 +1938,8 @@ class BookingTest : IntegrationTestBase() {
           NewCancellation(
             date = LocalDate.parse("2022-08-18"),
             reason = cancellationReason.id,
-            notes = "Corrected date"
-          )
+            notes = "Corrected date",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1962,8 +1962,8 @@ class BookingTest : IntegrationTestBase() {
       .bodyValue(
         NewExtension(
           newDepartureDate = LocalDate.parse("2022-08-20"),
-          notes = null
-        )
+          notes = null,
+        ),
       )
       .exchange()
       .expectStatus()
@@ -2018,7 +2018,7 @@ class BookingTest : IntegrationTestBase() {
             NewExtension(
               newDepartureDate = LocalDate.parse("2022-07-16"),
               notes = null,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -2087,7 +2087,7 @@ class BookingTest : IntegrationTestBase() {
             NewExtension(
               newDepartureDate = LocalDate.parse("2022-07-13"),
               notes = null,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -2145,7 +2145,7 @@ class BookingTest : IntegrationTestBase() {
             NewExtension(
               newDepartureDate = LocalDate.parse("2022-07-16"),
               notes = null,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -2213,7 +2213,7 @@ class BookingTest : IntegrationTestBase() {
             NewExtension(
               newDepartureDate = LocalDate.parse("2022-07-13"),
               notes = null,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -2265,8 +2265,8 @@ class BookingTest : IntegrationTestBase() {
         .bodyValue(
           NewExtension(
             newDepartureDate = LocalDate.parse("2022-08-22"),
-            notes = "notes"
-          )
+            notes = "notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -2310,8 +2310,8 @@ class BookingTest : IntegrationTestBase() {
         .bodyValue(
           NewExtension(
             newDepartureDate = LocalDate.parse("2022-08-22"),
-            notes = "notes"
-          )
+            notes = "notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -2325,8 +2325,8 @@ class BookingTest : IntegrationTestBase() {
       .uri("/premises/e0f03aa2-1468-441c-aa98-0b98d86b67f9/bookings/1617e729-13f3-4158-bd88-c59affdb8a45/confirmations")
       .bodyValue(
         NewConfirmation(
-          notes = null
-        )
+          notes = null,
+        ),
       )
       .exchange()
       .expectStatus()
@@ -2354,8 +2354,8 @@ class BookingTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewConfirmation(
-            notes = null
-          )
+            notes = null,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -2388,8 +2388,8 @@ class BookingTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewConfirmation(
-            notes = null
-          )
+            notes = null,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -2432,8 +2432,8 @@ class BookingTest : IntegrationTestBase() {
           NewNonarrival(
             date = booking.arrivalDate,
             reason = nonArrivalReason.id,
-            notes = "Notes"
-          )
+            notes = "Notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -2445,6 +2445,7 @@ class BookingTest : IntegrationTestBase() {
         .jsonPath("$.notes").isEqualTo("Notes")
     }
   }
+
   @Test
   fun `Create Confirmation on Temporary Accommodation Booking for a premises that's not in the user's region returns 403 Forbidden`() {
     `Given a User` { userEntity, jwt ->
@@ -2469,8 +2470,8 @@ class BookingTest : IntegrationTestBase() {
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewConfirmation(
-            notes = null
-          )
+            notes = null,
+          ),
         )
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
@@ -81,7 +81,7 @@ class CacheClearTest : IntegrationTestBase() {
       withProbationRegion(
         probationRegionEntityFactory.produceAndPersist {
           withApArea(apAreaEntityFactory.produceAndPersist())
-        }
+        },
       )
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -135,7 +135,7 @@ class CapacityTest : IntegrationTestBase() {
           DateCapacity(date = LocalDate.now().plusDays(2), availableBeds = 30),
           DateCapacity(date = LocalDate.now().plusDays(3), availableBeds = 30),
           DateCapacity(date = LocalDate.now().plusDays(4), availableBeds = 29),
-          DateCapacity(date = LocalDate.now().plusDays(5), availableBeds = 29)
+          DateCapacity(date = LocalDate.now().plusDays(5), availableBeds = 29),
         )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
@@ -28,7 +28,7 @@ class CaseNotesTest : IntegrationTestBase() {
   fun `Getting case notes with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -43,7 +43,7 @@ class CaseNotesTest : IntegrationTestBase() {
   fun `Getting case notes without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -64,8 +64,8 @@ class CaseNotesTest : IntegrationTestBase() {
           .willReturn(
             WireMock.aResponse()
               .withHeader("Content-Type", "application/json")
-              .withStatus(404)
-          )
+              .withStatus(404),
+          ),
       )
       loadPreemptiveCacheForOffenderDetails(crn)
 
@@ -86,7 +86,7 @@ class CaseNotesTest : IntegrationTestBase() {
           CaseNoteFactory().produce(),
           CaseNoteFactory().produce(),
           CaseNoteFactory().produce(),
-          CaseNoteFactory().produce()
+          CaseNoteFactory().produce(),
         )
 
         CaseNotesAPI_mockSuccessfulCaseNotesCall(
@@ -97,8 +97,8 @@ class CaseNotesTest : IntegrationTestBase() {
             totalElements = 4,
             totalPages = 1,
             number = 1,
-            content = caseNotes
-          )
+            content = caseNotes,
+          ),
         )
 
         webTestClient.get()
@@ -109,7 +109,7 @@ class CaseNotesTest : IntegrationTestBase() {
           .isOk
           .expectBody()
           .json(
-            objectMapper.writeValueAsString(caseNotes.map(caseNoteTransformer::transformModelToApi))
+            objectMapper.writeValueAsString(caseNotes.map(caseNoteTransformer::transformModelToApi)),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteBookingTest.kt
@@ -133,7 +133,7 @@ class DeleteBookingTest : IntegrationTestBase() {
     withProbationRegion(
       probationRegionEntityFactory.produceAndPersist {
         withApArea(apAreaEntityFactory.produceAndPersist())
-      }
+      },
     )
 
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -33,7 +33,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Application Submitted Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -48,7 +48,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Application Submitted Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -57,7 +57,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.application.submitted",
-      eventDetails = ApplicationSubmittedFactory().produce()
+      eventDetails = ApplicationSubmittedFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {
@@ -90,7 +90,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Application Assessed Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -105,7 +105,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Application Assessed Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -114,7 +114,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.application.assessed",
-      eventDetails = ApplicationAssessedFactory().produce()
+      eventDetails = ApplicationAssessedFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {
@@ -147,7 +147,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Booking Made Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -162,7 +162,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Booking Made Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -171,7 +171,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.booking.made",
-      eventDetails = BookingMadeFactory().produce()
+      eventDetails = BookingMadeFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {
@@ -204,7 +204,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Person Arrived Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -219,7 +219,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Person Arrived Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -228,7 +228,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.person.arrived",
-      eventDetails = PersonArrivedFactory().produce()
+      eventDetails = PersonArrivedFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {
@@ -261,7 +261,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Person Not Arrived Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -276,7 +276,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Person Not Arrived Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -285,7 +285,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.person.not-arrived",
-      eventDetails = PersonNotArrivedFactory().produce()
+      eventDetails = PersonNotArrivedFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {
@@ -318,7 +318,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Person Departed Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -333,7 +333,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Person Departed Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -342,7 +342,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.person.departed",
-      eventDetails = PersonDepartedFactory().produce()
+      eventDetails = PersonDepartedFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {
@@ -375,7 +375,7 @@ class DomainEventTest : IntegrationTestBase() {
   @Test
   fun `Get Booking Not Made Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username"
+      username = "username",
     )
 
     webTestClient.get()
@@ -390,7 +390,7 @@ class DomainEventTest : IntegrationTestBase() {
   fun `Get Booking Not Made Event returns 200 with correct body`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS")
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
     val eventId = UUID.randomUUID()
@@ -399,7 +399,7 @@ class DomainEventTest : IntegrationTestBase() {
       id = eventId,
       timestamp = Instant.now(),
       eventType = "approved-premises.booking.not-made",
-      eventDetails = BookingNotMadeFactory().produce()
+      eventDetails = BookingNotMadeFactory().produce(),
     )
 
     val event = domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -480,7 +480,7 @@ abstract class IntegrationTestBase {
   fun mockClientCredentialsJwtRequest(
     username: String? = null,
     roles: List<String> = listOf(),
-    authSource: String = "none"
+    authSource: String = "none",
   ) {
     wiremockServer.stubFor(
       post(urlEqualTo("/auth/oauth/token"))
@@ -494,7 +494,7 @@ abstract class IntegrationTestBase {
                   accessToken = jwtAuthHelper.createClientCredentialsJwt(
                     username = username,
                     roles = roles,
-                    authSource = authSource
+                    authSource = authSource,
                   ),
                   tokenType = "bearer",
                   expiresIn = Duration.ofHours(1).toSeconds().toInt(),
@@ -502,11 +502,11 @@ abstract class IntegrationTestBase {
                   sub = username?.uppercase() ?: "integration-test-client-id",
                   authSource = authSource,
                   jti = UUID.randomUUID().toString(),
-                  iss = "http://localhost:9092/auth/issuer"
-                )
-              )
-            )
-        )
+                  iss = "http://localhost:9092/auth/issuer",
+                ),
+              ),
+            ),
+        ),
     )
   }
 
@@ -517,9 +517,9 @@ abstract class IntegrationTestBase {
           .withHeader("Content-Type", "application/json")
           .withStatus(200)
           .withBody(
-            objectMapper.writeValueAsString(offenderDetails)
-          )
-      )
+            objectMapper.writeValueAsString(offenderDetails),
+          ),
+      ),
   )
 
   fun mockOffenderUserAccessCommunityApiCall(username: String, crn: String, inclusion: Boolean, exclusion: Boolean) {
@@ -535,11 +535,11 @@ abstract class IntegrationTestBase {
                   UserOffenderAccess(
                     userRestricted = false,
                     userExcluded = false,
-                    restrictionMessage = null
-                  )
-                )
-              )
-          )
+                    restrictionMessage = null,
+                  ),
+                ),
+              ),
+          ),
       )
       return
     }
@@ -555,11 +555,11 @@ abstract class IntegrationTestBase {
                 UserOffenderAccess(
                   userRestricted = inclusion,
                   userExcluded = exclusion,
-                  restrictionMessage = null
-                )
-              )
-            )
-        )
+                  restrictionMessage = null,
+                ),
+              ),
+            ),
+        ),
     )
   }
 
@@ -572,11 +572,11 @@ abstract class IntegrationTestBase {
           .withBody(
             objectMapper.writeValueAsString(
               StaffMembersPage(
-                content = listOf(staffMember)
-              )
-            )
-          )
-      )
+                content = listOf(staffMember),
+              ),
+            ),
+          ),
+      ),
   )
 
   fun mockInmateDetailPrisonsApiCall(inmateDetail: InmateDetail) = wiremockServer.stubFor(
@@ -586,9 +586,9 @@ abstract class IntegrationTestBase {
           .withHeader("Content-Type", "application/json")
           .withStatus(200)
           .withBody(
-            objectMapper.writeValueAsString(inmateDetail)
-          )
-      )
+            objectMapper.writeValueAsString(inmateDetail),
+          ),
+      ),
   )
 
   fun mockStaffUserInfoCommunityApiCall(staffUserDetails: StaffUserDetails, createProbationRegionForStaffAreaCode: Boolean = true): StubMapping? {
@@ -606,9 +606,9 @@ abstract class IntegrationTestBase {
             .withHeader("Content-Type", "application/json")
             .withStatus(200)
             .withBody(
-              objectMapper.writeValueAsString(staffUserDetails)
-            )
-        )
+              objectMapper.writeValueAsString(staffUserDetails),
+            ),
+        ),
     )
   }
 
@@ -617,8 +617,8 @@ abstract class IntegrationTestBase {
       .willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(404)
-      )
+          .withStatus(404),
+      ),
   )
 
   fun mockSuccessfulGetCallWithJsonResponse(url: String, responseBody: Any, responseStatus: Int = 200) =
@@ -630,9 +630,9 @@ abstract class IntegrationTestBase {
               .withHeader("Content-Type", "application/json")
               .withStatus(responseStatus)
               .withBody(
-                objectMapper.writeValueAsString(responseBody)
-              )
-          )
+                objectMapper.writeValueAsString(responseBody),
+              ),
+          ),
       )
     }
 
@@ -642,13 +642,13 @@ abstract class IntegrationTestBase {
         WireMock.get(urlEqualTo(url))
           .willReturn(
             aResponse()
-              .withStatus(responseStatus)
-          )
+              .withStatus(responseStatus),
+          ),
       )
     }
 
   fun mockOAuth2ClientCredentialsCallIfRequired(block: () -> Unit) {
-    if (! clientCredentialsCallMocked) {
+    if (!clientCredentialsCallMocked) {
       mockClientCredentialsJwtRequest()
 
       clientCredentialsCallMocked = true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -111,7 +111,7 @@ class LostBedsTest : IntegrationTestBase() {
                 withYieldedPremises { premises }
               }
             }
-          }
+          },
         )
         withPremises(premises)
       }
@@ -188,7 +188,7 @@ class LostBedsTest : IntegrationTestBase() {
               withYieldedPremises { premises }
             }
           }
-        }
+        },
       )
       withPremises(premises)
     }
@@ -254,7 +254,7 @@ class LostBedsTest : IntegrationTestBase() {
                 withYieldedPremises { premises }
               }
             }
-          }
+          },
         )
         withPremises(premises)
       }
@@ -378,8 +378,8 @@ class LostBedsTest : IntegrationTestBase() {
           bedId = bed.id,
           reason = UUID.randomUUID(),
           referenceNumber = "REF-123",
-          notes = null
-        )
+          notes = null,
+        ),
       )
       .exchange()
       .expectStatus()
@@ -414,8 +414,8 @@ class LostBedsTest : IntegrationTestBase() {
             reason = reason.id,
             referenceNumber = "REF-123",
             notes = "notes",
-            bedId = UUID.randomUUID()
-          )
+            bedId = UUID.randomUUID(),
+          ),
         )
         .exchange()
         .expectStatus()
@@ -460,8 +460,8 @@ class LostBedsTest : IntegrationTestBase() {
             bedId = bed.id,
             reason = reason.id,
             referenceNumber = "REF-123",
-            notes = "notes"
-          )
+            notes = "notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -518,8 +518,8 @@ class LostBedsTest : IntegrationTestBase() {
             reason = reason.id,
             referenceNumber = "REF-123",
             notes = "notes",
-            bedId = bed.id
-          )
+            bedId = bed.id,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -578,8 +578,8 @@ class LostBedsTest : IntegrationTestBase() {
             reason = reason.id,
             referenceNumber = "REF-123",
             notes = "notes",
-            bedId = bed.id
-          )
+            bedId = bed.id,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -607,7 +607,7 @@ class LostBedsTest : IntegrationTestBase() {
                 withYieldedPremises { premises }
               }
             }
-          }
+          },
         )
         withStartDate(LocalDate.now().minusDays(2))
         withEndDate(LocalDate.now().plusDays(2))
@@ -651,7 +651,7 @@ class LostBedsTest : IntegrationTestBase() {
               withYieldedPremises { premises }
             }
           }
-        }
+        },
       )
       withPremises(premises)
     }
@@ -673,7 +673,7 @@ class LostBedsTest : IntegrationTestBase() {
           reason = UUID.randomUUID(),
           referenceNumber = "REF-123",
           notes = null,
-        )
+        ),
       )
       .exchange()
       .expectStatus()
@@ -693,8 +693,8 @@ class LostBedsTest : IntegrationTestBase() {
           endDate = LocalDate.parse("2022-08-18"),
           reason = UUID.randomUUID(),
           referenceNumber = "REF-123",
-          notes = null
-        )
+          notes = null,
+        ),
       )
       .exchange()
       .expectStatus()
@@ -721,8 +721,8 @@ class LostBedsTest : IntegrationTestBase() {
           endDate = LocalDate.parse("2022-08-18"),
           reason = UUID.randomUUID(),
           referenceNumber = "REF-123",
-          notes = null
-        )
+          notes = null,
+        ),
       )
       .exchange()
       .expectStatus()
@@ -770,8 +770,8 @@ class LostBedsTest : IntegrationTestBase() {
             endDate = LocalDate.parse("2022-08-18"),
             reason = reason.id,
             referenceNumber = "REF-123",
-            notes = "notes"
-          )
+            notes = "notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -833,8 +833,8 @@ class LostBedsTest : IntegrationTestBase() {
             endDate = LocalDate.parse("2022-08-18"),
             reason = reason.id,
             referenceNumber = "REF-123",
-            notes = "notes"
-          )
+            notes = "notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -898,8 +898,8 @@ class LostBedsTest : IntegrationTestBase() {
             endDate = LocalDate.parse("2022-08-18"),
             reason = reason.id,
             referenceNumber = "REF-123",
-            notes = "notes"
-          )
+            notes = "notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -927,7 +927,7 @@ class LostBedsTest : IntegrationTestBase() {
               withYieldedPremises { premises }
             }
           }
-        }
+        },
       )
       withPremises(premises)
     }
@@ -936,8 +936,8 @@ class LostBedsTest : IntegrationTestBase() {
       .uri("/premises/${premises.id}/lost-beds/${lostBeds.id}/cancellations")
       .bodyValue(
         NewLostBedCancellation(
-          notes = "Unauthorized"
-        )
+          notes = "Unauthorized",
+        ),
       )
       .exchange()
       .expectStatus()
@@ -953,8 +953,8 @@ class LostBedsTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewLostBedCancellation(
-          notes = "Non-existent premises"
-        )
+          notes = "Non-existent premises",
+        ),
       )
       .exchange()
       .expectStatus()
@@ -977,8 +977,8 @@ class LostBedsTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewLostBedCancellation(
-          notes = "Non-existent lost bed"
-        )
+          notes = "Non-existent lost bed",
+        ),
       )
       .exchange()
       .expectStatus()
@@ -1008,7 +1008,7 @@ class LostBedsTest : IntegrationTestBase() {
                 withYieldedPremises { premises }
               }
             }
-          }
+          },
         )
         withPremises(premises)
       }
@@ -1022,8 +1022,8 @@ class LostBedsTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewLostBedCancellation(
-            notes = "Some cancellation notes"
-          )
+            notes = "Some cancellation notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1073,8 +1073,8 @@ class LostBedsTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewLostBedCancellation(
-            notes = "Some cancellation notes"
-          )
+            notes = "Some cancellation notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1126,8 +1126,8 @@ class LostBedsTest : IntegrationTestBase() {
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewLostBedCancellation(
-            notes = "Some cancellation notes"
-          )
+            notes = "Some cancellation notes",
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1180,7 +1180,7 @@ class LostBedsTest : IntegrationTestBase() {
               referenceNumber = "REF-123",
               notes = "notes",
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1242,7 +1242,7 @@ class LostBedsTest : IntegrationTestBase() {
               referenceNumber = "REF-123",
               notes = "notes",
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1304,7 +1304,7 @@ class LostBedsTest : IntegrationTestBase() {
               referenceNumber = "REF-123",
               notes = "notes",
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1366,7 +1366,7 @@ class LostBedsTest : IntegrationTestBase() {
               referenceNumber = "REF-123",
               notes = "notes",
               bedId = bed.id,
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1441,7 +1441,7 @@ class LostBedsTest : IntegrationTestBase() {
             reason = reason.id,
             referenceNumber = "REF-123",
             notes = "notes",
-          )
+          ),
         )
         .exchange()
         .expectStatus()
@@ -1513,7 +1513,7 @@ class LostBedsTest : IntegrationTestBase() {
               reason = reason.id,
               referenceNumber = "REF-123",
               notes = "notes",
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1582,7 +1582,7 @@ class LostBedsTest : IntegrationTestBase() {
               reason = reason.id,
               referenceNumber = "REF-123",
               notes = "notes",
-            )
+            ),
           )
           .exchange()
           .expectStatus()
@@ -1651,7 +1651,7 @@ class LostBedsTest : IntegrationTestBase() {
               reason = reason.id,
               referenceNumber = "REF-123",
               notes = "notes",
-            )
+            ),
           )
           .exchange()
           .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
@@ -13,8 +13,8 @@ class MigrationJobScaffoldingTest : SeedTestBase() {
       .uri("/migration-job")
       .bodyValue(
         MigrationJobRequest(
-          jobType = MigrationJobType.updateAllUsersFromCommunityApi
-        )
+          jobType = MigrationJobType.updateAllUsersFromCommunityApi,
+        ),
       )
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
@@ -26,7 +26,7 @@ class PersonAcctAlertsTest : IntegrationTestBase() {
   fun `Getting ACCT alerts for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -41,7 +41,7 @@ class PersonAcctAlertsTest : IntegrationTestBase() {
   fun `Getting ACCT alerts for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -76,7 +76,7 @@ class PersonAcctAlertsTest : IntegrationTestBase() {
         val alerts = listOf(
           AlertFactory().produce(),
           AlertFactory().produce(),
-          AlertFactory().produce()
+          AlertFactory().produce(),
         )
 
         PrisonAPI_mockSuccessfulAlertsCall(offenderDetails.otherIds.nomsNumber!!, alerts)
@@ -90,8 +90,8 @@ class PersonAcctAlertsTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              alerts.map(alertTransformer::transformToApi)
-            )
+              alerts.map(alertTransformer::transformToApi),
+            ),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -28,7 +28,7 @@ class PersonAdjudicationsTest : IntegrationTestBase() {
   fun `Getting adjudications for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -43,7 +43,7 @@ class PersonAdjudicationsTest : IntegrationTestBase() {
   fun `Getting adjudications for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -79,14 +79,14 @@ class PersonAdjudicationsTest : IntegrationTestBase() {
           .withResults(
             listOf(
               AdjudicationFactory().withAgencyId("AGNCY1").produce(),
-              AdjudicationFactory().withAgencyId("AGNCY2").produce()
-            )
+              AdjudicationFactory().withAgencyId("AGNCY2").produce(),
+            ),
           )
           .withAgencies(
             listOf(
               AgencyFactory().withAgencyId("AGNCY1").produce(),
-              AgencyFactory().withAgencyId("AGNCY2").produce()
-            )
+              AgencyFactory().withAgencyId("AGNCY2").produce(),
+            ),
           )
           .produce()
 
@@ -100,7 +100,7 @@ class PersonAdjudicationsTest : IntegrationTestBase() {
           .isOk
           .expectBody()
           .json(
-            objectMapper.writeValueAsString(adjudicationTransformer.transformToApi(adjudicationsResponse))
+            objectMapper.writeValueAsString(adjudicationTransformer.transformToApi(adjudicationsResponse)),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -34,7 +34,7 @@ class PersonOASysSectionsTest : IntegrationTestBase() {
   fun `Getting oasys sections for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -49,7 +49,7 @@ class PersonOASysSectionsTest : IntegrationTestBase() {
   fun `Getting oasys sections for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -117,9 +117,9 @@ class PersonOASysSectionsTest : IntegrationTestBase() {
                 risksToTheIndividual,
                 riskManagementPlan,
                 needsDetails,
-                listOf(11, 12)
-              )
-            )
+                listOf(11, 12),
+              ),
+            ),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSelectionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSelectionTest.kt
@@ -26,7 +26,7 @@ class PersonOASysSelectionTest : IntegrationTestBase() {
   fun `Getting oasys section selection for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -41,7 +41,7 @@ class PersonOASysSelectionTest : IntegrationTestBase() {
   fun `Getting oasys section selection for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -91,8 +91,8 @@ class PersonOASysSelectionTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              needsDetailsTransformer.transformToApi(needsDetails)
-            )
+              needsDetailsTransformer.transformToApi(needsDetails),
+            ),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
@@ -27,7 +27,7 @@ class PersonOffencesTest : IntegrationTestBase() {
   fun `Getting offences for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -42,7 +42,7 @@ class PersonOffencesTest : IntegrationTestBase() {
   fun `Getting offences for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -90,8 +90,8 @@ class PersonOffencesTest : IntegrationTestBase() {
                 .withOffenceId("2")
                 .withMainCategoryDescription("Main Category 2")
                 .withSubCategoryDescription("Sub Category 2")
-                .produce()
-            )
+                .produce(),
+            ),
           )
           .produce()
 
@@ -110,8 +110,8 @@ class PersonOffencesTest : IntegrationTestBase() {
                 .withOffenceId("4")
                 .withMainCategoryDescription("Main Category 2")
                 .withSubCategoryDescription("Sub Category 2")
-                .produce()
-            )
+                .produce(),
+            ),
           )
           .produce()
 
@@ -125,7 +125,7 @@ class PersonOffencesTest : IntegrationTestBase() {
           .isOk
           .expectBody()
           .json(
-            objectMapper.writeValueAsString(convictionTransformer.transformToApi(activeConviction))
+            objectMapper.writeValueAsString(convictionTransformer.transformToApi(activeConviction)),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -41,7 +41,7 @@ class PersonRisksTest : IntegrationTestBase() {
   fun `Getting risks for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -56,7 +56,7 @@ class PersonRisksTest : IntegrationTestBase() {
   fun `Getting risks for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -97,7 +97,7 @@ class PersonRisksTest : IntegrationTestBase() {
             withRiskPublicCommunity(RiskLevel.MEDIUM)
             withRiskKnownAdultCommunity(RiskLevel.HIGH)
             withRiskStaffCommunity(RiskLevel.VERY_HIGH)
-          }.produce()
+          }.produce(),
         )
 
         HMPPSTier_mockSuccessfulTierCall(
@@ -105,8 +105,8 @@ class PersonRisksTest : IntegrationTestBase() {
           Tier(
             tierScore = "M2",
             calculationId = UUID.randomUUID(),
-            calculationDate = LocalDateTime.parse("2022-09-06T14:59:00")
-          )
+            calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+          ),
         )
 
         CommunityAPI_mockSuccessfulRegistrationsCall(
@@ -121,9 +121,9 @@ class PersonRisksTest : IntegrationTestBase() {
                 .produce(),
               RegistrationClientResponseFactory()
                 .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
-                .produce()
-            )
-          )
+                .produce(),
+            ),
+          ),
         )
 
         webTestClient.get()
@@ -145,29 +145,29 @@ class PersonRisksTest : IntegrationTestBase() {
                     riskToPublic = "Medium",
                     riskToKnownAdult = "High",
                     riskToStaff = "Very High",
-                    lastUpdated = LocalDate.parse("2022-09-06")
-                  )
+                    lastUpdated = LocalDate.parse("2022-09-06"),
+                  ),
                 ),
                 tier = RiskTierEnvelope(
                   status = RiskEnvelopeStatus.retrieved,
                   value = RiskTier(
                     level = "M2",
-                    lastUpdated = LocalDate.parse("2022-09-06")
-                  )
+                    lastUpdated = LocalDate.parse("2022-09-06"),
+                  ),
                 ),
                 flags = FlagsEnvelope(
                   status = RiskEnvelopeStatus.retrieved,
-                  value = listOf("RISK FLAG")
+                  value = listOf("RISK FLAG"),
                 ),
                 mappa = MappaEnvelope(
                   status = RiskEnvelopeStatus.retrieved,
                   value = Mappa(
                     level = "CAT C1/LEVEL L1",
-                    lastUpdated = LocalDate.parse("2022-09-06")
-                  )
-                )
-              )
-            )
+                    lastUpdated = LocalDate.parse("2022-09-06"),
+                  ),
+                ),
+              ),
+            ),
           )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -27,7 +27,7 @@ class PersonSearchTest : IntegrationTestBase() {
   fun `Searching for a CRN with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -42,7 +42,7 @@ class PersonSearchTest : IntegrationTestBase() {
   fun `Searching for a CRN without ROLE_PROBATION returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
-      authSource = "delius"
+      authSource = "delius",
     )
 
     webTestClient.get()
@@ -62,14 +62,14 @@ class PersonSearchTest : IntegrationTestBase() {
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withStatus(404)
-        )
+            .withStatus(404),
+        ),
     )
 
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
       authSource = "delius",
-      roles = listOf("ROLE_PROBATION")
+      roles = listOf("ROLE_PROBATION"),
     )
 
     webTestClient.get()
@@ -104,10 +104,10 @@ class PersonSearchTest : IntegrationTestBase() {
               agencyId = "BRI",
               locationId = 5,
               description = "B-2F-004",
-              agencyName = "HMP Bristol"
-            )
+              agencyName = "HMP Bristol",
+            ),
           )
-        }
+        },
       ) { offenderDetails, inmateDetails ->
         webTestClient.get()
           .uri("/people/search?crn=CRN")
@@ -128,9 +128,9 @@ class PersonSearchTest : IntegrationTestBase() {
                 nationality = "English",
                 religionOrBelief = "Judaism",
                 genderIdentity = "This is a self described identity",
-                prisonName = "HMP Bristol"
-              )
-            )
+                prisonName = "HMP Bristol",
+              ),
+            ),
           )
       }
     }
@@ -142,10 +142,11 @@ class PersonSearchTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, _ ->
 
         APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
-          offenderDetails.otherIds.crn, userEntity.deliusStaffCode,
+          offenderDetails.otherIds.crn,
+          userEntity.deliusStaffCode,
           ManagingTeamsResponse(
-            teamCodes = listOf("TEAM1")
-          )
+            teamCodes = listOf("TEAM1"),
+          ),
         )
 
         webTestClient.get()
@@ -164,10 +165,11 @@ class PersonSearchTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, _ ->
 
         APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
-          offenderDetails.otherIds.crn, userEntity.deliusStaffCode,
+          offenderDetails.otherIds.crn,
+          userEntity.deliusStaffCode,
           ManagingTeamsResponse(
-            teamCodes = emptyList()
-          )
+            teamCodes = emptyList(),
+          ),
         )
 
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
@@ -58,7 +58,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
 
     mockSuccessfulGetCallWithJsonResponse(
       url = "/secure/offenders/crn/$crn",
-      responseBody = offenderDetailsResponseOne
+      responseBody = offenderDetailsResponseOne,
     )
 
     every { Instant.now() } returns firstCallInstant
@@ -79,7 +79,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
 
     mockSuccessfulGetCallWithJsonResponse(
       url = "/secure/offenders/crn/$crn",
-      responseBody = offenderDetailsResponseTwo
+      responseBody = offenderDetailsResponseTwo,
     )
 
     // The next call after successSoftTtlSeconds should make an upstream request and replace the original cached value
@@ -107,7 +107,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
 
     mockSuccessfulGetCallWithJsonResponse(
       url = "/secure/offenders/crn/$crn",
-      responseBody = offenderDetailsResponse
+      responseBody = offenderDetailsResponse,
     )
 
     // The first call should return a ClientResult.Failure.PreemptiveCacheTimeout as no cache entry is present in Redis
@@ -125,17 +125,17 @@ class PreemptiveCacheTest : IntegrationTestBase() {
         refreshableAfter = Instant.now().plusSeconds(10),
         method = null,
         path = null,
-        hasResponseBody = true
+        hasResponseBody = true,
       )
 
       redisTemplate.boundValueOps(qualifiedMetadataKey).set(
         objectMapper.writeValueAsString(cacheEntry),
-        Duration.ofSeconds(10)
+        Duration.ofSeconds(10),
       )
 
       redisTemplate.boundValueOps(qualifiedDataKey).set(
         objectMapper.writeValueAsString(offenderDetailsResponse),
-        Duration.ofSeconds(10)
+        Duration.ofSeconds(10),
       )
     }.start()
 
@@ -157,7 +157,7 @@ class PreemptivelyCachedClient(
     cacheName = "offenderDetailSummary",
     successSoftTtlSeconds = 5,
     failureSoftTtlSeconds = 1,
-    hardTtlSeconds = 30
+    hardTtlSeconds = 30,
   )
 
   fun getOffenderDetailSummaryWithCall(crn: String) = getRequest<OffenderDetailSummary> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -94,7 +94,7 @@ class PremisesTest : IntegrationTestBase() {
             characteristicIds = mutableListOf(),
             status = PropertyStatus.pending,
             probationDeliveryUnitId = probationDeliveryUnit.id,
-            turnaroundWorkingDayCount = 5
+            turnaroundWorkingDayCount = 5,
           ),
         )
         .exchange()
@@ -190,7 +190,7 @@ class PremisesTest : IntegrationTestBase() {
             localAuthorityAreaId = UUID.fromString("d1bd139b-7b90-4aae-87aa-9f93e183a7ff"), // Allerdale
             probationRegionId = UUID.fromString("a02b7727-63aa-46f2-80f1-e0b05b31903c"), // North West
             characteristicIds = mutableListOf(),
-            status = PropertyStatus.archived
+            status = PropertyStatus.archived,
           ),
         )
         .exchange()
@@ -246,7 +246,7 @@ class PremisesTest : IntegrationTestBase() {
             characteristicIds = mutableListOf(),
             status = PropertyStatus.archived,
             probationDeliveryUnitId = probationDeliveryUnit.id,
-            turnaroundWorkingDayCount = 5
+            turnaroundWorkingDayCount = 5,
           ),
         )
         .exchange()
@@ -305,7 +305,7 @@ class PremisesTest : IntegrationTestBase() {
             characteristicIds = mutableListOf(),
             status = PropertyStatus.archived,
             pdu = probationDeliveryUnit.name,
-            turnaroundWorkingDayCount = 5
+            turnaroundWorkingDayCount = 5,
           ),
         )
         .exchange()
@@ -2281,7 +2281,7 @@ class PremisesTest : IntegrationTestBase() {
   @MethodSource("turnaroundWorkingDayCountProvider")
   fun `Trying to create a new Temporary Accommodation premises with turnaround working day count less than 1 returns 400`(
     turnaroundWorkingDayCount: Int,
-    expectedErrorType: String
+    expectedErrorType: String,
   ) {
     `Given a User` { user, jwt ->
       val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
@@ -2305,7 +2305,7 @@ class PremisesTest : IntegrationTestBase() {
             characteristicIds = mutableListOf(),
             status = PropertyStatus.pending,
             probationDeliveryUnitId = probationDeliveryUnit.id,
-            turnaroundWorkingDayCount = 0
+            turnaroundWorkingDayCount = 0,
           ),
         )
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
@@ -88,7 +88,7 @@ class ProblemResponsesTest : IntegrationTestBase() {
              "anInstant": "not an instant",
              "aUUID": "not a uuid"
           }
-        """
+        """,
       )
       .exchange()
       .expectStatus()
@@ -116,8 +116,8 @@ class ProblemResponsesTest : IntegrationTestBase() {
         InvalidParam(propertyName = "$.aLocalDateTime", errorType = "invalid"),
         InvalidParam(propertyName = "$.anOffsetDateTime", errorType = "invalid"),
         InvalidParam(propertyName = "$.anInstant", errorType = "invalid"),
-        InvalidParam(propertyName = "$.aUUID", errorType = "invalid")
-      )
+        InvalidParam(propertyName = "$.aUUID", errorType = "invalid"),
+      ),
     )
   }
 
@@ -159,7 +159,7 @@ class ProblemResponsesTest : IntegrationTestBase() {
              "anInstant": "not an instant",
              "aUUID": "not a uuid"
           }]
-        """
+        """,
       )
       .exchange()
       .expectStatus()
@@ -187,8 +187,8 @@ class ProblemResponsesTest : IntegrationTestBase() {
         InvalidParam(propertyName = "$[0].aLocalDateTime", errorType = "invalid"),
         InvalidParam(propertyName = "$[0].anOffsetDateTime", errorType = "invalid"),
         InvalidParam(propertyName = "$[0].anInstant", errorType = "invalid"),
-        InvalidParam(propertyName = "$[0].aUUID", errorType = "invalid")
-      )
+        InvalidParam(propertyName = "$[0].aUUID", errorType = "invalid"),
+      ),
     )
   }
 
@@ -210,7 +210,7 @@ class ProblemResponsesTest : IntegrationTestBase() {
             "instant": "2023-04-12T16:52:00+01:00",
             "uuid": "61f22c65-4d42-4cc1-8955-e4ea89088194"
           }
-        """
+        """,
       )
       .exchange()
       .expectStatus()
@@ -220,7 +220,7 @@ class ProblemResponsesTest : IntegrationTestBase() {
       .blockFirst()
 
     assertThat(validationResult!!.invalidParams).containsExactly(
-      InvalidParam(propertyName = "$.missingString", errorType = "empty")
+      InvalidParam(propertyName = "$.missingString", errorType = "empty"),
     )
   }
 
@@ -277,13 +277,13 @@ data class DeserializationTestBody(
   val aLocalDateTime: LocalDateTime,
   val anOffsetDateTime: OffsetDateTime,
   val anInstant: Instant,
-  val aUUID: UUID
+  val aUUID: UUID,
 )
 
 data class DeserializationTestBodyNested(
   val requiredString: String,
   val optionalBoolean: Boolean?,
-  val optionalLocalDate: LocalDate?
+  val optionalLocalDate: LocalDate?,
 )
 
 data class AllSpecialJSONPrimitives(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -25,7 +25,7 @@ class ProfileTest : IntegrationTestBase() {
   fun `Getting own profile with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -71,7 +71,7 @@ class ProfileTest : IntegrationTestBase() {
         withEmail(email)
         withTelephoneNumber(telephoneNumber)
       },
-      probationRegion = region
+      probationRegion = region,
     ) { userEntity, jwt ->
       webTestClient.get()
         .uri("/profile")
@@ -93,8 +93,8 @@ class ProfileTest : IntegrationTestBase() {
               roles = listOf(ApiUserRole.assessor),
               qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
               service = ServiceName.approvedPremises.value,
-            )
-          )
+            ),
+          ),
         )
     }
   }
@@ -109,7 +109,7 @@ class ProfileTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = deliusUsername,
       authSource = "delius",
-      roles = listOf("ROLE_PROBATION")
+      roles = listOf("ROLE_PROBATION"),
     )
 
     val region = probationRegionEntityFactory.produceAndPersist {
@@ -149,8 +149,8 @@ class ProfileTest : IntegrationTestBase() {
             region = ProbationRegion(region.id, region.name),
             roles = listOf(ApiUserRole.assessor),
             service = ServiceName.temporaryAccommodation.value,
-          )
-        )
+          ),
+        ),
       )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -39,8 +39,8 @@ class ReallocationAtomicTest : IntegrationTestBase() {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewReallocation(
-                userId = assigneeUser.id
-              )
+                userId = assigneeUser.id,
+              ),
             )
             .exchange()
             .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -56,7 +56,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val characteristics = characteristicEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      characteristics.map(characteristicTransformer::transformJpaToApi)
+      characteristics.map(characteristicTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -79,7 +79,7 @@ class ReferenceDataTest : IntegrationTestBase() {
       withServiceScope(ServiceName.temporaryAccommodation.value)
     }
     val expectedJson = objectMapper.writeValueAsString(
-      characteristics.map(characteristicTransformer::transformJpaToApi)
+      characteristics.map(characteristicTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -103,7 +103,7 @@ class ReferenceDataTest : IntegrationTestBase() {
       withServiceScope(ServiceName.approvedPremises.value)
     }
     val expectedJson = objectMapper.writeValueAsString(
-      characteristics.map(characteristicTransformer::transformJpaToApi)
+      characteristics.map(characteristicTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -133,7 +133,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      characteristics.map(characteristicTransformer::transformJpaToApi)
+      characteristics.map(characteristicTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -163,7 +163,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     val characteristics = activeCharacteristics + inactiveCharacteristics
 
     val expectedJson = objectMapper.writeValueAsString(
-      characteristics.map(characteristicTransformer::transformJpaToApi)
+      characteristics.map(characteristicTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -184,7 +184,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val localAuthorities = localAuthorityEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi)
+      localAuthorities.map(localAuthorityAreaTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -205,7 +205,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val departureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      departureReasons.map(departureReasonTransformer::transformJpaToApi)
+      departureReasons.map(departureReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -231,7 +231,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedDepartureReasons.map(departureReasonTransformer::transformJpaToApi)
+      expectedDepartureReasons.map(departureReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -258,7 +258,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedDepartureReasons.map(departureReasonTransformer::transformJpaToApi)
+      expectedDepartureReasons.map(departureReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -288,7 +288,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      departureReasons.map(departureReasonTransformer::transformJpaToApi)
+      departureReasons.map(departureReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -318,7 +318,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     val departureReasons = activeDepartureReasons + inactiveDepartureReasons
 
     val expectedJson = objectMapper.writeValueAsString(
-      departureReasons.map(departureReasonTransformer::transformJpaToApi)
+      departureReasons.map(departureReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -339,7 +339,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val moveOnCategories = moveOnCategoryEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+      moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -365,7 +365,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedMoveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+      expectedMoveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -392,7 +392,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedMoveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+      expectedMoveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -422,7 +422,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+      moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -452,7 +452,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     val moveOnCategories = activeMoveOnCategories + inactiveMoveOnCategories
 
     val expectedJson = objectMapper.writeValueAsString(
-      moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi)
+      moveOnCategories.map(moveOnCategoryTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -473,7 +473,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val destinationProviders = destinationProviderEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      destinationProviders.map(destinationProviderTransformer::transformJpaToApi)
+      destinationProviders.map(destinationProviderTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -494,7 +494,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val departureReasons = cancellationReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      departureReasons.map(cancellationReasonTransformer::transformJpaToApi)
+      departureReasons.map(cancellationReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -520,7 +520,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi)
+      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -547,7 +547,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi)
+      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -569,7 +569,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val lostBedReasons = lostBedReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      lostBedReasons.map(lostBedReasonTransformer::transformJpaToApi)
+      lostBedReasons.map(lostBedReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -594,7 +594,7 @@ class ReferenceDataTest : IntegrationTestBase() {
       withServiceScope(ServiceName.approvedPremises.value)
     }
     val expectedJson = objectMapper.writeValueAsString(
-      expectedLostBedReasons.map(lostBedReasonTransformer::transformJpaToApi)
+      expectedLostBedReasons.map(lostBedReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -620,7 +620,7 @@ class ReferenceDataTest : IntegrationTestBase() {
       withServiceScope(ServiceName.temporaryAccommodation.value)
     }
     val expectedJson = objectMapper.writeValueAsString(
-      expectedLostBedReasons.map(lostBedReasonTransformer::transformJpaToApi)
+      expectedLostBedReasons.map(lostBedReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -645,7 +645,7 @@ class ReferenceDataTest : IntegrationTestBase() {
       withApArea(apAreaEntityFactory.produceAndPersist())
     }
     val expectedJson = objectMapper.writeValueAsString(
-      probationRegions.map(probationRegionTransformer::transformJpaToApi)
+      probationRegions.map(probationRegionTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -666,7 +666,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     val nonArrivalReasons = nonArrivalReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
-      nonArrivalReasons.map(nonArrivalReasonTransformer::transformJpaToApi)
+      nonArrivalReasons.map(nonArrivalReasonTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -699,7 +699,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     }
 
     val expectedJson = objectMapper.writeValueAsString(
-      probationDeliveryUnits.map(probationDeliveryUnitTransformer::transformJpaToApi)
+      probationDeliveryUnits.map(probationDeliveryUnitTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -736,7 +736,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     val expectedProbationDeliveryUnits = probationDeliveryUnits.filter { it.probationRegion.id == probationRegionId }
 
     val expectedJson = objectMapper.writeValueAsString(
-      expectedProbationDeliveryUnits.map(probationDeliveryUnitTransformer::transformJpaToApi)
+      expectedProbationDeliveryUnits.map(probationDeliveryUnitTransformer::transformJpaToApi),
     )
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
@@ -31,9 +31,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
             .withProbationRegion("Not Real Region")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "invalid-probation")
@@ -61,9 +61,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
           ApprovedPremisesSeedCsvRowFactory()
             .withProbationRegion(probationRegion.name)
             .withLocalAuthorityArea("Not Real Authority")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "invalid-local-authority")
@@ -101,9 +101,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
             .withProbationRegion(probationRegion.name)
             .withLocalAuthorityArea(localAuthorityArea.name)
             .withIsCatered("yes")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "invalid-service-scope")
@@ -141,9 +141,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
             .withProbationRegion(probationRegion.name)
             .withLocalAuthorityArea(localAuthorityArea.name)
             .withIsCatered("yes")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "invalid-model-scope")
@@ -168,9 +168,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       "new-ap-invalid-boolean",
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "new-ap-invalid-boolean")
@@ -190,7 +190,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     withCsv(
       "new-ap-missing-headers",
       "name,apCode,qCode,apArea,pdu,probationRegion,localAuthorityArea,town,addressLine1\n" +
-        "HOPE,Q00,North East,Leeds,Yorkshire & The Humber,Leeds,Leeds,1 The Street, Leeds"
+        "HOPE,Q00,North East,Leeds,Yorkshire & The Humber,Leeds,Leeds,1 The Street, Leeds",
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "new-ap-missing-headers")
@@ -249,9 +249,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       "new-ap",
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "new-ap")
@@ -305,9 +305,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       "update-ap",
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.approvedPremises, "update-ap")
@@ -362,7 +362,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
         "hasHearingLoop",
         "status",
         "apCode",
-        "qCode"
+        "qCode",
       )
       .newRow()
 
@@ -538,6 +538,6 @@ class ApprovedPremisesSeedCsvRowFactory : Factory<ApprovedPremisesSeedCsvRow> {
     hasHearingLoop = this.hasHearingLoop(),
     status = this.status(),
     apCode = this.apCode(),
-    qCode = this.qCode()
+    qCode = this.qCode(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
@@ -20,7 +20,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
       "invalid-characteristics-missing-name",
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,approved-premises,room\n" +
-        "hasWideDoor,,temporary-accommodation,room\n"
+        "hasWideDoor,,temporary-accommodation,room\n",
     )
 
     seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-name")
@@ -41,7 +41,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
       "invalid-characteristics-unknown-scope",
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,foo,room\n" +
-        "hasWideDoor,Is the entrance wide?,temporary-accommodation,bar\n"
+        "hasWideDoor,Is the entrance wide?,temporary-accommodation,bar\n",
     )
 
     seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-unknown-scope")
@@ -62,7 +62,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
       "invalid-characteristics-missing-scope",
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,,room\n" +
-        "hasWideDoor,Is the entrance wide?,temporary-accommodation,\n"
+        "hasWideDoor,Is the entrance wide?,temporary-accommodation,\n",
     )
 
     seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-scope")
@@ -84,7 +84,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,approved-premises,room\n" +
         "hasWideDoor,Is the room entrance wide?,temporary-accommodation,room\n" +
-        "isIap,Is this an IAP?,approved-premises,premises\n"
+        "isIap,Is this an IAP?,approved-premises,premises\n",
     )
 
     seedService.seedData(SeedFileType.characteristics, "valid-characteristics")
@@ -93,17 +93,17 @@ class SeedCharacteristicsTest : SeedTestBase() {
     val apWideDoorRoom = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",
       serviceName = "approved-premises",
-      modelName = "room"
+      modelName = "room",
     )
     val taWideDoorRoom = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",
       serviceName = "temporary-accommodation",
-      modelName = "room"
+      modelName = "room",
     )
     val apIapPremises = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "isIap",
       serviceName = "approved-premises",
-      modelName = "premises"
+      modelName = "premises",
     )
 
     assertThat(apWideDoorRoom!!.name).isEqualTo("Is the door to this room at least 900mm wide?")
@@ -125,7 +125,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
     val characteristic = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",
       serviceName = "approved-premises",
-      modelName = "room"
+      modelName = "room",
     )
 
     assertThat(characteristicRepository.count()).isEqualTo(1)
@@ -134,7 +134,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
     withCsv(
       "valid-characteristics-update",
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
-        "hasWideDoor,Is the DOOR wide?,approved-premises,room\n"
+        "hasWideDoor,Is the DOOR wide?,approved-premises,room\n",
     )
 
     seedService.seedData(SeedFileType.characteristics, "valid-characteristics-update")
@@ -142,7 +142,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
     val updatedCharacteristic = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",
       serviceName = "approved-premises",
-      modelName = "room"
+      modelName = "room",
     )
 
     assertThat(characteristicRepository.count()).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedScaffoldingTest.kt
@@ -15,8 +15,8 @@ class SeedScaffoldingTest : SeedTestBase() {
       .bodyValue(
         SeedRequest(
           seedType = SeedFileType.approvedPremises,
-          fileName = "file.csv"
-        )
+          fileName = "file.csv",
+        ),
       )
       .exchange()
       .expectStatus()
@@ -32,7 +32,7 @@ class SeedScaffoldingTest : SeedTestBase() {
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
         it.throwable.message!!.contains(
-          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"
+          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied",
         )
     }
   }
@@ -46,7 +46,7 @@ class SeedScaffoldingTest : SeedTestBase() {
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
         it.throwable.message!!.contains(
-          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"
+          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied",
         )
     }
   }
@@ -60,7 +60,7 @@ class SeedScaffoldingTest : SeedTestBase() {
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
         it.throwable.message!!.contains(
-          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"
+          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied",
         )
     }
   }
@@ -74,7 +74,7 @@ class SeedScaffoldingTest : SeedTestBase() {
         it.message == "Unable to complete Seed Job" &&
         it.throwable != null &&
         it.throwable.message!!.contains(
-          "There was an issue opening the CSV file"
+          "There was an issue opening the CSV file",
         )
     }
   }
@@ -87,7 +87,7 @@ class SeedScaffoldingTest : SeedTestBase() {
 deliusUsername,roles,qualifications
 RogerSmith,MANAGER,
 ,
-      """.trimIndent()
+      """.trimIndent(),
     )
 
     seedService.seedData(SeedFileType.user, "malformed")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationBedspaceTest.kt
@@ -20,9 +20,9 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
         listOf(
           TemporaryAccommodationBedspaceSeedCsvRowFactory()
             .withPremisesName("Not a real premises")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "invalid-ta-bedspace-premises-name")
@@ -57,9 +57,9 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       "new-ta-bedspace",
       temporaryAccommodationBedspaceSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "new-ta-bedspace")
@@ -107,9 +107,9 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       "update-ta-bedspace",
       temporaryAccommodationBedspaceSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "update-ta-bedspace")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationPremisesTest.kt
@@ -20,9 +20,9 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
         listOf(
           TemporaryAccommodationPremisesSeedCsvRowFactory()
             .withProbationRegion("Not Real Region")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-probation-ta")
@@ -48,9 +48,9 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
           TemporaryAccommodationPremisesSeedCsvRowFactory()
             .withProbationRegion(probationRegion.name)
             .withLocalAuthorityArea("Not Real Authority")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-local-authority-ta")
@@ -86,9 +86,9 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       "new-ta-premises",
       temporaryAccommodationPremisesSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationPremises, "new-ta-premises")
@@ -147,9 +147,9 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       "update-ta-premises",
       temporaryAccommodationPremisesSeedCsvRowsToCsv(
         listOf(
-          csvRow
-        )
-      )
+          csvRow,
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationPremises, "update-ta-premises")
@@ -183,7 +183,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
         "Park nearby",
         "School nearby",
         // Sample of characteristics
-        "Optional notes"
+        "Optional notes",
       )
       .newRow()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTemporaryAccommodationSmokeTest.kt
@@ -16,7 +16,7 @@ class SeedTemporaryAccommodationSmokeTest : SeedTestBase() {
         "CHE,1 CherryTree Lane,,Sheffield,SH7 4PB,Yorkshire and the Humber,Sheffield,Sheffield,FALSE,FALSE,FALSE,TRUE,TRUE,FALSE,TRUE,TRUE,FALSE,Property is located on the same road as a primary school and a park.\n" +
         "SIL,12 Silverhill Lane,Broadheath,Bath,BA3 0EZ,South West,Bath and North East Somerset,Bath and North Somerset (Bath and North East Somerset and North Somerset),FALSE,FALSE,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,TRUE,\"This property has 3 bedspaces, with shared kitchen facilities.\"\n" +
         "STR,24 Strawberry Road,City Centre,Newport,NP1 0PA,Wales,Newport,\"Gwent (Blaenau Gwent, Caerphilly, Monmouthshire, Newport, Torfaen)\",FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,Not suitable to those who hold addictive behaviours\n" +
-        "APP,78 Applemill Court,Pudding Lane,Hereford,HR6 7ZP,West Midlands,Herefordshire,\"Herefordshire, Shropshire and Telford\",TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,"
+        "APP,78 Applemill Court,Pudding Lane,Hereford,HR6 7ZP,West Midlands,Herefordshire,\"Herefordshire, Shropshire and Telford\",TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,",
     )
 
     withCsv(
@@ -30,7 +30,7 @@ class SeedTemporaryAccommodationSmokeTest : SeedTestBase() {
         "SIL,SIL-3,TRUE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,\"Bedspace is 3 of 3 in the property, with access to a shared kitchen.\"\n" +
         "STR,STR-1,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,\n" +
         "APP,APP-1,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,\n" +
-        "APP,APP-2,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,"
+        "APP,APP-2,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,",
     )
 
     seedService.seedData(SeedFileType.temporaryAccommodationPremises, "ta-smoketest-premises")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTestBase.kt
@@ -43,8 +43,10 @@ abstract class SeedTestBase : IntegrationTestBase() {
       Files.createDirectory(Path(seedFilePrefix))
     }
     Files.writeString(
-      Path("$seedFilePrefix/$csvName.csv"), contents,
-      StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
+      Path("$seedFilePrefix/$csvName.csv"),
+      contents,
+      StandardOpenOption.CREATE,
+      StandardOpenOption.TRUNCATE_EXISTING,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
@@ -28,9 +28,9 @@ class SeedUsersTest : SeedTestBase() {
         listOf(
           UserRoleAssignmentsSeedCsvRowFactory()
             .withDeliusUsername("INVALID-USER")
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.user, "invalid-user")
@@ -56,7 +56,7 @@ class SeedUsersTest : SeedTestBase() {
         .withUsername("UNKNOWN-USER")
         .withStaffIdentifier(6789)
         .withProbationAreaCode(probationRegion.deliusCode)
-        .produce()
+        .produce(),
     )
 
     withCsv(
@@ -67,9 +67,9 @@ class SeedUsersTest : SeedTestBase() {
             .withDeliusUsername("unknown-user")
             .withTypedRoles(listOf(UserRole.ASSESSOR, UserRole.WORKFLOW_MANAGER))
             .withTypedQualifications(listOf(UserQualification.PIPE))
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.user, "unknown-user")
@@ -80,10 +80,10 @@ class SeedUsersTest : SeedTestBase() {
     assertThat(persistedUser!!.deliusStaffIdentifier).isEqualTo(6789)
     assertThat(persistedUser.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
       UserRole.ASSESSOR,
-      UserRole.WORKFLOW_MANAGER
+      UserRole.WORKFLOW_MANAGER,
     )
     assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification)).containsExactlyInAnyOrder(
-      UserQualification.PIPE
+      UserQualification.PIPE,
     )
   }
 
@@ -106,9 +106,9 @@ class SeedUsersTest : SeedTestBase() {
             .withDeliusUsername("KNOWN-USER")
             .withTypedRoles(listOf(UserRole.ASSESSOR, UserRole.WORKFLOW_MANAGER))
             .withTypedQualifications(listOf(UserQualification.PIPE))
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.user, "known-user")
@@ -118,10 +118,10 @@ class SeedUsersTest : SeedTestBase() {
     assertThat(persistedUser).isNotNull
     assertThat(persistedUser!!.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
       UserRole.ASSESSOR,
-      UserRole.WORKFLOW_MANAGER
+      UserRole.WORKFLOW_MANAGER,
     )
     assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification)).containsExactlyInAnyOrder(
-      UserQualification.PIPE
+      UserQualification.PIPE,
     )
   }
 
@@ -144,9 +144,9 @@ class SeedUsersTest : SeedTestBase() {
             .withDeliusUsername("known-user")
             .withUntypedRoles(listOf("WORKFLOW_MANAGEF"))
             .withTypedQualifications(listOf(UserQualification.PIPE))
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.user, "unknown-role")
@@ -178,9 +178,9 @@ class SeedUsersTest : SeedTestBase() {
           UserRoleAssignmentsSeedCsvRowFactory()
             .withDeliusUsername("known-user")
             .withUntypedQualifications(listOf("PIPEE"))
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     seedService.seedData(SeedFileType.user, "unknown-qualification")
@@ -199,7 +199,7 @@ class SeedUsersTest : SeedTestBase() {
       .withUnquotedFields(
         "deliusUsername",
         "roles",
-        "qualifications"
+        "qualifications",
       )
       .newRow()
 
@@ -243,12 +243,12 @@ class UserRoleAssignmentsSeedCsvRowFactory : Factory<UsersSeedUntypedEnumsCsvRow
   override fun produce() = UsersSeedUntypedEnumsCsvRow(
     deliusUsername = this.deliusUsername(),
     roles = this.roles(),
-    qualifications = this.qualifications()
+    qualifications = this.qualifications(),
   )
 }
 
 data class UsersSeedUntypedEnumsCsvRow(
   val deliusUsername: String,
   val roles: List<String>,
-  val qualifications: List<String>
+  val qualifications: List<String>,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -56,19 +56,19 @@ class TasksTest : IntegrationTestBase() {
           `Given an Assessment for Approved Premises`(
             allocatedToUser = otherUser,
             createdByUser = otherUser,
-            crn = offenderDetails.otherIds.crn
+            crn = offenderDetails.otherIds.crn,
           ) { assessment, _ ->
             `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              reallocated = true
+              reallocated = true,
             ) { _, _ ->
               `Given a Placement Request`(
                 placementRequestAllocatedTo = otherUser,
                 assessmentAllocatedTo = otherUser,
                 createdByUser = user,
-                crn = offenderDetails.otherIds.crn
+                crn = offenderDetails.otherIds.crn,
               ) { placementRequest, _ ->
                 webTestClient.get()
                   .uri("/tasks")
@@ -84,10 +84,10 @@ class TasksTest : IntegrationTestBase() {
                         taskTransformer.transformPlacementRequestToTask(
                           placementRequest,
                           offenderDetails,
-                          inmateDetails
-                        )
-                      )
-                    )
+                          inmateDetails,
+                        ),
+                      ),
+                    ),
                   )
               }
             }
@@ -113,7 +113,7 @@ class TasksTest : IntegrationTestBase() {
         `Given an Assessment for Approved Premises`(
           allocatedToUser = user,
           createdByUser = user,
-          crn = offenderDetails.otherIds.crn
+          crn = offenderDetails.otherIds.crn,
         ) { _, application ->
           webTestClient.get()
             .uri("/applications/${application.id}/tasks/unknown-task")
@@ -131,13 +131,13 @@ class TasksTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User` { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.ASSESSOR)
+          roles = listOf(UserRole.ASSESSOR),
         ) { allocatableUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             `Given an Assessment for Approved Premises`(
               allocatedToUser = user,
               createdByUser = user,
-              crn = offenderDetails.otherIds.crn
+              crn = offenderDetails.otherIds.crn,
             ) { assessment, application ->
               webTestClient.get()
                 .uri("/applications/${application.id}/tasks/assessment")
@@ -150,9 +150,9 @@ class TasksTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     TaskWrapper(
                       task = taskTransformer.transformAssessmentToTask(assessment, offenderDetails, inmateDetails),
-                      users = listOf(userTransformer.transformJpaToApi(allocatableUser, ServiceName.approvedPremises))
-                    )
-                  )
+                      users = listOf(userTransformer.transformJpaToApi(allocatableUser, ServiceName.approvedPremises)),
+                    ),
+                  ),
                 )
             }
           }
@@ -166,14 +166,14 @@ class TasksTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User` { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.MATCHER)
+          roles = listOf(UserRole.MATCHER),
         ) { allocatableUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             `Given a Placement Request`(
               placementRequestAllocatedTo = user,
               assessmentAllocatedTo = user,
               createdByUser = user,
-              crn = offenderDetails.otherIds.crn
+              crn = offenderDetails.otherIds.crn,
             ) { placementRequest, application ->
               webTestClient.get()
                 .uri("/applications/${application.id}/tasks/placement-request")
@@ -186,9 +186,9 @@ class TasksTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     TaskWrapper(
                       task = taskTransformer.transformPlacementRequestToTask(placementRequest, offenderDetails, inmateDetails),
-                      users = listOf(userTransformer.transformJpaToApi(allocatableUser, ServiceName.approvedPremises))
-                    )
-                  )
+                      users = listOf(userTransformer.transformJpaToApi(allocatableUser, ServiceName.approvedPremises)),
+                    ),
+                  ),
                 )
             }
           }
@@ -204,7 +204,7 @@ class TasksTest : IntegrationTestBase() {
         `Given an Assessment for Approved Premises`(
           allocatedToUser = user,
           createdByUser = user,
-          crn = offenderDetails.otherIds.crn
+          crn = offenderDetails.otherIds.crn,
         ) { _, application ->
           webTestClient.get()
             .uri("/applications/${application.id}/tasks/booking-appeal")
@@ -223,8 +223,8 @@ class TasksTest : IntegrationTestBase() {
       .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/assessment/allocations")
       .bodyValue(
         NewReallocation(
-          userId = UUID.randomUUID()
-        )
+          userId = UUID.randomUUID(),
+        ),
       )
       .exchange()
       .expectStatus()
@@ -239,8 +239,8 @@ class TasksTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewReallocation(
-            userId = UUID.randomUUID()
-          )
+            userId = UUID.randomUUID(),
+          ),
         )
         .exchange()
         .expectStatus()
@@ -253,13 +253,13 @@ class TasksTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User`(roles = listOf(UserRole.ASSESSOR)) { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.ASSESSOR)
+          roles = listOf(UserRole.ASSESSOR),
         ) { assigneeUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
             `Given an Assessment for Approved Premises`(
               allocatedToUser = user,
               createdByUser = user,
-              crn = offenderDetails.otherIds.crn
+              crn = offenderDetails.otherIds.crn,
             ) { existingAssessment, application ->
 
               webTestClient.post()
@@ -267,8 +267,8 @@ class TasksTest : IntegrationTestBase() {
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   NewReallocation(
-                    userId = assigneeUser.id
-                  )
+                    userId = assigneeUser.id,
+                  ),
                 )
                 .exchange()
                 .expectStatus()
@@ -278,9 +278,9 @@ class TasksTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     Reallocation(
                       user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
-                      taskType = TaskType.assessment
-                    )
-                  )
+                      taskType = TaskType.assessment,
+                    ),
+                  ),
                 )
 
               val assessments = assessmentRepository.findAll()
@@ -299,22 +299,22 @@ class TasksTest : IntegrationTestBase() {
   fun `Reallocating a placement request to different assessor returns 201, creates new placement request, deallocates old one`() {
     `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
       `Given a User`(
-        roles = listOf(UserRole.MATCHER)
+        roles = listOf(UserRole.MATCHER),
       ) { assigneeUser, _ ->
         `Given an Offender` { offenderDetails, _ ->
           `Given a Placement Request`(
             createdByUser = user,
             placementRequestAllocatedTo = user,
             assessmentAllocatedTo = user,
-            crn = offenderDetails.otherIds.crn
+            crn = offenderDetails.otherIds.crn,
           ) { existingPlacementRequest, application ->
             webTestClient.post()
               .uri("/applications/${application.id}/tasks/placement-request/allocations")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
                 NewReallocation(
-                  userId = assigneeUser.id
-                )
+                  userId = assigneeUser.id,
+                ),
               )
               .exchange()
               .expectStatus()
@@ -324,9 +324,9 @@ class TasksTest : IntegrationTestBase() {
                 objectMapper.writeValueAsString(
                   Reallocation(
                     user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
-                    taskType = TaskType.placementRequest
-                  )
-                )
+                    taskType = TaskType.placementRequest,
+                  ),
+                ),
               )
 
             val placementRequests = placementRequestRepository.findAll()
@@ -356,8 +356,8 @@ class TasksTest : IntegrationTestBase() {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewReallocation(
-                userId = userToReallocate.id
-              )
+                userId = userToReallocate.id,
+              ),
             )
             .exchange()
             .expectStatus()
@@ -377,8 +377,8 @@ class TasksTest : IntegrationTestBase() {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewReallocation(
-                userId = userToReallocate.id
-              )
+                userId = userToReallocate.id,
+              ),
             )
             .exchange()
             .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
@@ -19,8 +19,8 @@ class TurnaroundTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 2
-          )
+            workingDays = 2,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -45,8 +45,8 @@ class TurnaroundTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 2
-          )
+            workingDays = 2,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -84,8 +84,8 @@ class TurnaroundTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 0
-          )
+            workingDays = 0,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -135,8 +135,8 @@ class TurnaroundTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 2
-          )
+            workingDays = 2,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -190,8 +190,8 @@ class TurnaroundTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 2
-          )
+            workingDays = 2,
+          ),
         )
         .exchange()
         .expectStatus()
@@ -233,8 +233,8 @@ class TurnaroundTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 2
-          )
+            workingDays = 2,
+          ),
         )
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
@@ -31,14 +31,14 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
       StaffUserDetailsFactory()
         .withUsername(userOne.deliusUsername)
         .withStaffCode("STAFFCODE1")
-        .produce()
+        .produce(),
     )
 
     CommunityAPI_mockSuccessfulStaffUserDetailsCall(
       StaffUserDetailsFactory()
         .withUsername(userTwo.deliusUsername)
         .withStaffCode("STAFFCODE2")
-        .produce()
+        .produce(),
     )
 
     val startTime = System.currentTimeMillis()
@@ -78,7 +78,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
       StaffUserDetailsFactory()
         .withUsername(userTwo.deliusUsername)
         .withStaffCode("STAFFCODE2")
-        .produce()
+        .produce(),
     )
 
     migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -35,7 +35,7 @@ class UsersTest : IntegrationTestBase() {
   fun `Getting a user with a non-Delius JWT returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
-      authSource = "nomis"
+      authSource = "nomis",
     )
 
     webTestClient.get()
@@ -58,7 +58,7 @@ class UsersTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = deliusUsername,
       authSource = "delius",
-      roles = listOf("ROLE_PROBATION")
+      roles = listOf("ROLE_PROBATION"),
     )
 
     val region = probationRegionEntityFactory.produceAndPersist {
@@ -81,7 +81,7 @@ class UsersTest : IntegrationTestBase() {
         .withUsername(deliusUsername)
         .withEmail(email)
         .withTelephoneNumber(telephoneNumber)
-        .produce()
+        .produce(),
     )
 
     mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
@@ -109,7 +109,7 @@ class UsersTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = deliusUsername,
       authSource = "delius",
-      roles = listOf("ROLE_PROBATION")
+      roles = listOf("ROLE_PROBATION"),
     )
 
     val region = probationRegionEntityFactory.produceAndPersist {
@@ -132,7 +132,7 @@ class UsersTest : IntegrationTestBase() {
         .withUsername(deliusUsername)
         .withEmail(email)
         .withTelephoneNumber(telephoneNumber)
-        .produce()
+        .produce(),
     )
 
     mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
@@ -157,8 +157,8 @@ class UsersTest : IntegrationTestBase() {
             roles = emptyList(),
             qualifications = emptyList(),
             service = ServiceName.approvedPremises.value,
-          )
-        )
+          ),
+        ),
       )
   }
 
@@ -174,7 +174,7 @@ class UsersTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = deliusUsername,
       authSource = "delius",
-      roles = listOf("ROLE_PROBATION")
+      roles = listOf("ROLE_PROBATION"),
     )
 
     val region = probationRegionEntityFactory.produceAndPersist {
@@ -197,7 +197,7 @@ class UsersTest : IntegrationTestBase() {
         .withUsername(deliusUsername)
         .withEmail(email)
         .withTelephoneNumber(telephoneNumber)
-        .produce()
+        .produce(),
     )
 
     mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
@@ -217,8 +217,8 @@ class UsersTest : IntegrationTestBase() {
             region = ProbationRegion(region.id, region.name),
             roles = emptyList(),
             service = ServiceName.temporaryAccommodation.value,
-          )
-        )
+          ),
+        ),
       )
   }
 
@@ -270,8 +270,8 @@ class UsersTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     listOf(requestUser, userWithNoRole, matcher, manager).map {
                       userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
-                    }
-                  )
+                    },
+                  ),
                 )
             }
           }
@@ -298,8 +298,8 @@ class UsersTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     listOf(matcher, manager).map {
                       userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
-                    }
-                  )
+                    },
+                  ),
                 )
             }
           }
@@ -326,8 +326,8 @@ class UsersTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     listOf(womensUser).map {
                       userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
-                    }
-                  )
+                    },
+                  ),
                 )
             }
           }
@@ -355,8 +355,8 @@ class UsersTest : IntegrationTestBase() {
                     objectMapper.writeValueAsString(
                       listOf(womensAssessor1, womensAssessor2).map {
                         userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
-                      }
-                    )
+                      },
+                    ),
                   )
               }
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -14,7 +14,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
-  block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit
+  block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit,
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -45,10 +45,10 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withAssessment(assessment)
     withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
     withDesirableCriteria(
-      characteristicEntityFactory.produceAndPersistMultiple(5)
+      characteristicEntityFactory.produceAndPersistMultiple(5),
     )
     withEssentialCriteria(
-      characteristicEntityFactory.produceAndPersistMultiple(3)
+      characteristicEntityFactory.produceAndPersistMultiple(3),
     )
     if (reallocated) {
       withReallocatedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -15,7 +15,7 @@ fun IntegrationTestBase.`Given a User`(
   roles: List<UserRole> = emptyList(),
   qualifications: List<UserQualification> = emptyList(),
   probationRegion: ProbationRegionEntity? = null,
-  block: (userEntity: UserEntity, jwt: String) -> Unit
+  block: (userEntity: UserEntity, jwt: String) -> Unit,
 ) {
   val staffUserDetailsFactory = StaffUserDetailsFactory()
 
@@ -59,7 +59,7 @@ fun IntegrationTestBase.`Given a User`(
   val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt(staffUserDetails.username)
 
   CommunityAPI_mockSuccessfulStaffUserDetailsCall(
-    staffUserDetails
+    staffUserDetails,
   )
 
   block(user, jwt)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 fun IntegrationTestBase.`Given an Application`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
-  block: (application: ApplicationEntity) -> Unit
+  block: (application: ApplicationEntity) -> Unit,
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -14,7 +14,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
   data: String? = "{ \"some\": \"data\"}",
-  block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit
+  block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit,
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -51,7 +51,7 @@ fun IntegrationTestBase.`Given an Assessment for Temporary Accommodation`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
-  block: (assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit
+  block: (assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit,
 ) {
   val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 fun IntegrationTestBase.`Given an Offender`(
   offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -> Unit)? = null,
   inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
-  block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit
+  block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit,
 ) {
   val inmateDetailsFactory = InmateDetailFactory()
   if (inmateDetailsConfigBlock != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/health/HealthCheckTest.kt
@@ -28,7 +28,7 @@ class HealthCheckTest : IntegrationTestBase() {
       .expectBody().jsonPath("components.healthInfo.details.version").value(
         Consumer<String> {
           assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-        }
+        },
       )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -9,12 +9,12 @@ fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffMembersCall(staffMemb
   mockSuccessfulGetCallWithJsonResponse(
     url = "/approved-premises/$qCode/staff",
     responseBody = StaffMembersPage(
-      content = listOf(staffMember)
-    )
+      content = listOf(staffMember),
+    ),
   )
 
 fun IntegrationTestBase.APDeliusContext_mockSuccessfulTeamsManagingCaseCall(crn: String, staffCode: String, response: ManagingTeamsResponse) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/teams/managingCase/$crn?staffCode=$staffCode",
-    responseBody = response
+    responseBody = response,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
@@ -11,35 +11,35 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshS
 fun IntegrationTestBase.APOASysContext_mockSuccessfulOffenceDetailsCall(crn: String, response: OffenceDetails) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/offence-details/$crn",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.APOASysContext_mockSuccessfulRoSHSummaryCall(crn: String, response: RoshSummary) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/rosh-summary/$crn",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.APOASysContext_mockSuccessfulRiskToTheIndividualCall(crn: String, response: RisksToTheIndividual) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/risk-to-the-individual/$crn",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.APOASysContext_mockSuccessfulRiskManagementPlanCall(crn: String, response: RiskManagementPlan) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/risk-management-plan/$crn",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.APOASysContext_mockSuccessfulNeedsDetailsCall(crn: String, response: NeedsDetails) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/needs-details/$crn",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.APOASysContext_mockSuccessfulRoshRatingsCall(crn: String, response: RoshRatings) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/rosh/$crn",
-    responseBody = response
+    responseBody = response,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CaseNotesAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CaseNotesAPI.kt
@@ -11,6 +11,6 @@ fun IntegrationTestBase.CaseNotesAPI_mockSuccessfulCaseNotesCall(page: Int, from
 
   mockSuccessfulGetCallWithJsonResponse(
     url = "/case-notes/$nomsNumber?startDate=$fromLocalDateTime&page=$page&size=30",
-    responseBody = result
+    responseBody = result,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CommunityAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CommunityAPI.kt
@@ -12,25 +12,25 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffe
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulStaffUserDetailsCall(staffUserDetails: StaffUserDetails) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/staff/username/${staffUserDetails.username}",
-    responseBody = staffUserDetails
+    responseBody = staffUserDetails,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockNotFoundStaffUserDetailsCall(username: String) =
   mockUnsuccessfulGetCall(
     url = "/secure/staff/username/$username",
-    responseStatus = 404
+    responseStatus = 404,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails: OffenderDetailSummary) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/offenders/crn/${offenderDetails.otherIds.crn}",
-    responseBody = offenderDetails
+    responseBody = offenderDetails,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulDocumentsCall(crn: String, groupedDocuments: GroupedDocuments) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/offenders/crn/$crn/documents/grouped",
-    responseBody = groupedDocuments
+    responseBody = groupedDocuments,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulDocumentDownloadCall(crn: String, documentId: String, fileContents: ByteArray) =
@@ -41,27 +41,27 @@ fun IntegrationTestBase.CommunityAPI_mockSuccessfulDocumentDownloadCall(crn: Str
           WireMock.aResponse()
             .withHeader("Content-Type", "application/octet-stream")
             .withStatus(200)
-            .withBody(fileContents)
-        )
+            .withBody(fileContents),
+        ),
     )
   }
 
 fun IntegrationTestBase.CommunityAPI_mockNotFoundOffenderDetailsCall(crn: String) =
   mockUnsuccessfulGetCall(
     url = "/secure/offenders/crn/$crn",
-    responseStatus = 404
+    responseStatus = 404,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulConvictionsCall(crn: String, response: List<Conviction>) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/offenders/crn/$crn/convictions",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulRegistrationsCall(crn: String, response: Registrations) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/offenders/crn/$crn/registrations?activeOnly=true",
-    responseBody = response
+    responseBody = response,
   )
 
 fun IntegrationTestBase.CommunityAPI_mockOffenderUserAccessCall(username: String, crn: String, inclusion: Boolean, exclusion: Boolean) =
@@ -78,11 +78,11 @@ fun IntegrationTestBase.CommunityAPI_mockOffenderUserAccessCall(username: String
                   UserOffenderAccess(
                     userRestricted = false,
                     userExcluded = false,
-                    restrictionMessage = null
-                  )
-                )
-              )
-          )
+                    restrictionMessage = null,
+                  ),
+                ),
+              ),
+          ),
       )
       return@mockOAuth2ClientCredentialsCallIfRequired
     }
@@ -98,10 +98,10 @@ fun IntegrationTestBase.CommunityAPI_mockOffenderUserAccessCall(username: String
                 UserOffenderAccess(
                   userRestricted = inclusion,
                   userExcluded = exclusion,
-                  restrictionMessage = null
-                )
-              )
-            )
-        )
+                  restrictionMessage = null,
+                ),
+              ),
+            ),
+        ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/GovUKBankHolidaysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/GovUKBankHolidaysAPI.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UK
 fun IntegrationTestBase.GovUKBankHolidaysAPI_mockSuccessfulCall(bankHolidays: UKBankHolidays) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/bank-holidays.json",
-    responseBody = bankHolidays
+    responseBody = bankHolidays,
   )
 
 fun IntegrationTestBase.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse() =
@@ -16,5 +16,5 @@ fun IntegrationTestBase.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyRespons
       englandAndWales = CountryBankHolidays("england-and-wales", listOf()),
       scotland = CountryBankHolidays("scotland", listOf()),
       northernIreland = CountryBankHolidays("northern-ireland", listOf()),
-    )
+    ),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/HMPPSTier.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/HMPPSTier.kt
@@ -6,5 +6,5 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
 fun IntegrationTestBase.HMPPSTier_mockSuccessfulTierCall(crn: String, response: Tier) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/crn/$crn/tier",
-    responseBody = response
+    responseBody = response,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/PrisonAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/PrisonAPI.kt
@@ -8,23 +8,23 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 fun IntegrationTestBase.PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetail: InmateDetail) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/api/offenders/${inmateDetail.offenderNo}",
-    responseBody = inmateDetail
+    responseBody = inmateDetail,
   )
 
 fun IntegrationTestBase.PrisonAPI_mockNotFoundInmateDetailsCall(offenderNo: String) =
   mockUnsuccessfulGetCall(
     url = "/api/offenders/$offenderNo",
-    responseStatus = 404
+    responseStatus = 404,
   )
 
 fun IntegrationTestBase.PrisonAPI_mockSuccessfulAlertsCall(nomsNumber: String, alerts: List<Alert>) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/api/offenders/$nomsNumber/alerts/v2?alertCodes=HA&sort=dateCreated&direction=DESC",
-    responseBody = alerts
+    responseBody = alerts,
   )
 
 fun IntegrationTestBase.PrisonAPI_mockSuccessfulAdjudicationsCall(nomsNumber: String, response: AdjudicationsPage) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/api/offenders/$nomsNumber/adjudications",
-    responseBody = response
+    responseBody = response,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
@@ -26,7 +26,7 @@ class InmateDetailsCacheRefreshWorkerTest {
     mockPrisonsApiClient,
     false,
     0,
-    mockRedLock
+    mockRedLock,
   )
 
   @Test
@@ -57,7 +57,7 @@ class InmateDetailsCacheRefreshWorkerTest {
 
       every { mockPrisonsApiClient.getInmateDetailsWithCall(it.offenderNo) } returns ClientResult.Success(
         HttpStatus.OK,
-        it
+        it,
       )
     }
 
@@ -66,7 +66,7 @@ class InmateDetailsCacheRefreshWorkerTest {
 
       every { mockPrisonsApiClient.getInmateDetailsWithCall(it.offenderNo) } returns ClientResult.Success(
         HttpStatus.OK,
-        it
+        it,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/OffenderDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/OffenderDetailsCacheRefreshWorkerTest.kt
@@ -26,7 +26,7 @@ class OffenderDetailsCacheRefreshWorkerTest {
     mockCommunityApiClient,
     false,
     0,
-    mockRedLock
+    mockRedLock,
   )
 
   @Test
@@ -60,7 +60,7 @@ class OffenderDetailsCacheRefreshWorkerTest {
 
       every { mockCommunityApiClient.getOffenderDetailSummaryWithCall(it.otherIds.crn) } returns ClientResult.Success(
         HttpStatus.OK,
-        it
+        it,
       )
     }
 
@@ -69,7 +69,7 @@ class OffenderDetailsCacheRefreshWorkerTest {
 
       every { mockCommunityApiClient.getOffenderDetailSummaryWithCall(it.otherIds.crn) } returns ClientResult.Success(
         HttpStatus.OK,
-        it
+        it,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/ClientResultRedisSerializerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/ClientResultRedisSerializerTest.kt
@@ -19,7 +19,7 @@ class ClientResultRedisSerializerTest {
       method = HttpMethod.GET,
       path = "/an/endpoint",
       status = HttpStatus.BAD_REQUEST,
-      body = "Something went wrong"
+      body = "Something went wrong",
     )
 
     val cachedByteArray = clientResponseRedisSerializer.serialize(clientResult)
@@ -38,7 +38,7 @@ class ClientResultRedisSerializerTest {
     val clientResult = ClientResult.Failure.Other<ClientResponseBody>(
       method = HttpMethod.GET,
       path = "/an/endpoint",
-      exception = RuntimeException("Something went wrong")
+      exception = RuntimeException("Something went wrong"),
     )
 
     val cachedByteArray = clientResponseRedisSerializer.serialize(clientResult)
@@ -56,8 +56,8 @@ class ClientResultRedisSerializerTest {
     val clientResult = ClientResult.Success(
       status = HttpStatus.OK,
       body = ClientResponseBody(
-        property = "hello"
-      )
+        property = "hello",
+      ),
     )
 
     val cachedByteArray = clientResponseRedisSerializer.serialize(clientResult)
@@ -72,5 +72,5 @@ class ClientResultRedisSerializerTest {
 }
 
 data class ClientResponseBody(
-  val property: String
+  val property: String,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/convert/EnumConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/convert/EnumConverterTest.kt
@@ -8,11 +8,13 @@ class EnumConverterTest {
   @Suppress("UNUSED") // Should be accessed by the enum converter under test
   private enum class OpenApiLike(val value: String) {
     OPTION_ONE("the-first-option"),
-    OPTION_TWO("the-second-option");
+    OPTION_TWO("the-second-option"),
+    ;
   }
   private enum class Standard {
     OPTION_ONE,
-    OPTION_TWO;
+    OPTION_TWO,
+    ;
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/oasyscontext/RoshRatingsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/oasyscontext/RoshRatingsTest.kt
@@ -17,7 +17,7 @@ class RoshRatingsTest {
       riskKnownAdultCustody = RiskLevel.LOW,
       riskKnownAdultCommunity = RiskLevel.LOW,
       riskPublicCustody = RiskLevel.LOW,
-      riskPublicCommunity = RiskLevel.LOW
+      riskPublicCommunity = RiskLevel.LOW,
     )
 
     assertThat(roshRatings.determineOverallRiskLevel()).isEqualTo(RiskLevel.LOW)
@@ -34,7 +34,7 @@ class RoshRatingsTest {
       riskKnownAdultCustody = RiskLevel.LOW,
       riskKnownAdultCommunity = RiskLevel.LOW,
       riskPublicCustody = RiskLevel.LOW,
-      riskPublicCommunity = RiskLevel.MEDIUM
+      riskPublicCommunity = RiskLevel.MEDIUM,
     )
 
     assertThat(roshRatings.determineOverallRiskLevel()).isEqualTo(RiskLevel.MEDIUM)
@@ -51,7 +51,7 @@ class RoshRatingsTest {
       riskKnownAdultCustody = RiskLevel.LOW,
       riskKnownAdultCommunity = RiskLevel.LOW,
       riskPublicCustody = RiskLevel.LOW,
-      riskPublicCommunity = RiskLevel.HIGH
+      riskPublicCommunity = RiskLevel.HIGH,
     )
 
     assertThat(roshRatings.determineOverallRiskLevel()).isEqualTo(RiskLevel.HIGH)
@@ -68,7 +68,7 @@ class RoshRatingsTest {
       riskKnownAdultCustody = RiskLevel.LOW,
       riskKnownAdultCommunity = RiskLevel.LOW,
       riskPublicCustody = RiskLevel.LOW,
-      riskPublicCommunity = RiskLevel.VERY_HIGH
+      riskPublicCommunity = RiskLevel.VERY_HIGH,
     )
 
     assertThat(roshRatings.determineOverallRiskLevel()).isEqualTo(RiskLevel.VERY_HIGH)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -91,7 +91,7 @@ class BedUsageReportGeneratorTest {
 
     val result = bedUsageReportGenerator.createReport(
       listOf(approvedPremisesBed, temporaryAccommodationBed),
-      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -164,7 +164,7 @@ class BedUsageReportGeneratorTest {
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
-      BedUsageReportProperties(ServiceName.temporaryAccommodation, probationRegion1.id, 2023, 4)
+      BedUsageReportProperties(ServiceName.temporaryAccommodation, probationRegion1.id, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -237,7 +237,7 @@ class BedUsageReportGeneratorTest {
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
-      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(2)
@@ -287,7 +287,7 @@ class BedUsageReportGeneratorTest {
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBed),
-      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -356,7 +356,7 @@ class BedUsageReportGeneratorTest {
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBed),
-      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(2)
@@ -414,7 +414,7 @@ class BedUsageReportGeneratorTest {
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBed),
-      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -87,7 +87,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(approvedPremisesBed, temporaryAccommodationBed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -160,7 +160,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, probationRegion1.id, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, probationRegion1.id, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -233,7 +233,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(2)
@@ -302,7 +302,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(bed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -370,7 +370,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(bed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -417,7 +417,7 @@ class BedUtilisationReportGeneratorTest {
     every {
       mockWorkingDayCountService.addWorkingDays(
         relevantBookingStraddlingStartOfMonth.departureDate,
-        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
       )
     } returns LocalDate.parse("2023-04-10")
 
@@ -439,7 +439,7 @@ class BedUtilisationReportGeneratorTest {
     every {
       mockWorkingDayCountService.addWorkingDays(
         relevantBookingStraddlingEndOfMonth.departureDate,
-        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
       )
     } returns LocalDate.parse("2023-05-01")
 
@@ -450,7 +450,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(bed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -497,7 +497,7 @@ class BedUtilisationReportGeneratorTest {
     every {
       mockWorkingDayCountService.addWorkingDays(
         relevantBookingStraddlingStartOfMonth.departureDate,
-        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
       )
     } returns LocalDate.parse("2023-04-10")
 
@@ -519,7 +519,7 @@ class BedUtilisationReportGeneratorTest {
     every {
       mockWorkingDayCountService.addWorkingDays(
         relevantBookingStraddlingEndOfMonth.departureDate,
-        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
       )
     } returns LocalDate.parse("2023-05-01")
 
@@ -530,7 +530,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(bed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -582,7 +582,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(bed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)
@@ -629,7 +629,7 @@ class BedUtilisationReportGeneratorTest {
     every {
       mockWorkingDayCountService.addWorkingDays(
         relevantBookingStraddlingStartOfMonth.departureDate,
-        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
       )
     } returns LocalDate.parse("2023-04-09")
 
@@ -651,7 +651,7 @@ class BedUtilisationReportGeneratorTest {
     every {
       mockWorkingDayCountService.addWorkingDays(
         relevantBookingStraddlingEndOfMonth.departureDate,
-        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
       )
     } returns LocalDate.parse("2023-05-01")
 
@@ -678,7 +678,7 @@ class BedUtilisationReportGeneratorTest {
 
     val result = bedUtilisationReportGenerator.createReport(
       listOf(bed),
-      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4)
+      BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
 
     assertThat(result.count()).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -250,7 +250,7 @@ class BookingsReportGeneratorTest {
             .produce()
         }
         .withBooking(booking)
-        .produce()
+        .produce(),
     )
 
     val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
@@ -371,7 +371,7 @@ class BookingsReportGeneratorTest {
             .produce()
         }
         .withBooking(booking)
-        .produce()
+        .produce(),
     )
 
     val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
@@ -494,7 +494,7 @@ class BookingsReportGeneratorTest {
             .produce()
         }
         .withBooking(booking)
-        .produce()
+        .produce(),
     )
 
     val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
@@ -545,7 +545,7 @@ class BookingsReportGeneratorTest {
             .produce()
         }
         .withBooking(booking)
-        .produce()
+        .produce(),
     )
 
     val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
@@ -606,7 +606,7 @@ class BookingsReportGeneratorTest {
             .produce()
         }
         .withBooking(booking)
-        .produce()
+        .produce(),
     )
 
     val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -105,7 +105,7 @@ class ApplicationServiceTest {
     mockApDeliusContextApiClient,
     mockApplicationTeamCodeRepository,
     mockObjectMapper,
-    "http://frontend/applications/#id"
+    "http://frontend/applications/#id",
   )
 
   @Test
@@ -150,7 +150,7 @@ class ApplicationServiceTest {
         override fun getLatestAssessmentDecision(): AssessmentDecision? = null
         override fun getLatestAssessmentHasClarificationNotesWithoutResponse(): Boolean = false
         override fun getHasBooking(): Boolean = false
-      }
+      },
     )
 
     every { mockCommunityApiClient.getStaffUserDetails(distinguishedName) } returns ClientResult.Success(
@@ -160,10 +160,10 @@ class ApplicationServiceTest {
           listOf(
             StaffUserTeamMembershipFactory()
               .withCode("TEAM1")
-              .produce()
-          )
+              .produce(),
+          ),
         )
-        .produce()
+        .produce(),
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
@@ -209,7 +209,7 @@ class ApplicationServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -217,14 +217,14 @@ class ApplicationServiceTest {
       .withTeams(
         listOf(
           StaffUserTeamMembershipFactory()
-            .produce()
-        )
+            .produce(),
+        ),
       )
       .produce()
 
     every { mockCommunityApiClient.getStaffUserDetails(distinguishedName) } returns ClientResult.Success(
       status = HttpStatus.OK,
-      body = staffUserDetails
+      body = staffUserDetails,
     )
 
     assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.Unauthorised).isTrue
@@ -303,7 +303,7 @@ class ApplicationServiceTest {
     applicationEntity.teamCodes += ApplicationTeamCodeEntity(
       id = UUID.randomUUID(),
       application = applicationEntity,
-      teamCode = "TEAM1"
+      teamCode = "TEAM1",
     )
 
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
@@ -315,14 +315,14 @@ class ApplicationServiceTest {
         listOf(
           StaffUserTeamMembershipFactory()
             .withCode("TEAM1")
-            .produce()
-        )
+            .produce(),
+        ),
       )
       .produce()
 
     every { mockCommunityApiClient.getStaffUserDetails(distinguishedName) } returns ClientResult.Success(
       status = HttpStatus.OK,
-      body = staffUserDetails
+      body = staffUserDetails,
     )
 
     val result = applicationService.getApplicationForUsername(applicationId, distinguishedName)
@@ -366,7 +366,7 @@ class ApplicationServiceTest {
         UserRoleAssignmentEntityFactory()
           .withUser(userEntity)
           .withRole(role)
-          .produce()
+          .produce(),
       )
 
       val applicationEntity = ApprovedPremisesApplicationEntityFactory()
@@ -425,7 +425,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce()
+      OffenderDetailsSummaryFactory().produce(),
     )
 
     val user = userWithUsername(username)
@@ -433,8 +433,8 @@ class ApplicationServiceTest {
     every { mockApDeliusContextApiClient.getTeamsManagingCase(crn, user.deliusStaffCode!!) } returns ClientResult.Success(
       HttpStatus.OK,
       ManagingTeamsResponse(
-        teamCodes = emptyList()
-      )
+        teamCodes = emptyList(),
+      ),
     )
 
     val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", null, null, null)
@@ -450,7 +450,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce()
+      OffenderDetailsSummaryFactory().produce(),
     )
 
     val user = userWithUsername(username)
@@ -458,8 +458,8 @@ class ApplicationServiceTest {
     every { mockApDeliusContextApiClient.getTeamsManagingCase(crn, user.deliusStaffCode!!) } returns ClientResult.Success(
       HttpStatus.OK,
       ManagingTeamsResponse(
-        teamCodes = listOf("TEAMCODE")
-      )
+        teamCodes = listOf("TEAMCODE"),
+      ),
     )
 
     val result = applicationService.createApprovedPremisesApplication(crn, user, "jwt", null, null, null)
@@ -483,12 +483,12 @@ class ApplicationServiceTest {
     every { mockApDeliusContextApiClient.getTeamsManagingCase(crn, user.deliusStaffCode!!) } returns ClientResult.Success(
       HttpStatus.OK,
       ManagingTeamsResponse(
-        teamCodes = listOf("TEAMCODE")
-      )
+        teamCodes = listOf("TEAMCODE"),
+      ),
     )
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce()
+      OffenderDetailsSummaryFactory().produce(),
     )
     every { mockUserService.getUserForRequest() } returns user
     every { mockJsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns schema
@@ -504,25 +504,25 @@ class ApplicationServiceTest {
             riskToPublic = "Low",
             riskToKnownAdult = "High",
             riskToStaff = "High",
-            lastUpdated = null
-          )
-        )
+            lastUpdated = null,
+          ),
+        ),
       )
       .withMappa(
         RiskWithStatus(
           value = Mappa(
             level = "",
-            lastUpdated = LocalDate.parse("2022-12-12")
-          )
-        )
+            lastUpdated = LocalDate.parse("2022-12-12"),
+          ),
+        ),
       )
       .withFlags(
         RiskWithStatus(
           value = listOf(
             "flag1",
-            "flag2"
-          )
-        )
+            "flag2",
+          ),
+        ),
       )
       .produce()
 
@@ -576,7 +576,7 @@ class ApplicationServiceTest {
     val username = "SOMEPERSON"
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce()
+      OffenderDetailsSummaryFactory().produce(),
     )
 
     val user = userWithUsername(username)
@@ -600,7 +600,7 @@ class ApplicationServiceTest {
     val user = userWithUsername(username)
 
     every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce()
+      OffenderDetailsSummaryFactory().produce(),
     )
     every { mockUserService.getUserForRequest() } returns user
     every { mockJsonSchemaService.getNewestSchema(TemporaryAccommodationApplicationJsonSchemaEntity::class.java) } returns schema
@@ -615,25 +615,25 @@ class ApplicationServiceTest {
             riskToPublic = "Low",
             riskToKnownAdult = "High",
             riskToStaff = "High",
-            lastUpdated = null
-          )
-        )
+            lastUpdated = null,
+          ),
+        ),
       )
       .withMappa(
         RiskWithStatus(
           value = Mappa(
             level = "",
-            lastUpdated = LocalDate.parse("2022-12-12")
-          )
-        )
+            lastUpdated = LocalDate.parse("2022-12-12"),
+          ),
+        ),
       )
       .withFlags(
         RiskWithStatus(
           value = listOf(
             "flag1",
-            "flag2"
-          )
-        )
+            "flag2",
+          ),
+        ),
       )
       .produce()
 
@@ -665,8 +665,8 @@ class ApplicationServiceTest {
         arrivalDate = null,
         data = "{}",
         username = username,
-        isInapplicable = null
-      ) is AuthorisableActionResult.NotFound
+        isInapplicable = null,
+      ) is AuthorisableActionResult.NotFound,
     ).isTrue
   }
 
@@ -708,8 +708,8 @@ class ApplicationServiceTest {
         arrivalDate = null,
         data = "{}",
         username = username,
-        isInapplicable = null
-      ) is AuthorisableActionResult.Unauthorised
+        isInapplicable = null,
+      ) is AuthorisableActionResult.Unauthorised,
     ).isTrue
   }
 
@@ -748,7 +748,7 @@ class ApplicationServiceTest {
       arrivalDate = null,
       data = "{}",
       username = username,
-      isInapplicable = null
+      isInapplicable = null,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -798,7 +798,7 @@ class ApplicationServiceTest {
       arrivalDate = null,
       data = "{}",
       username = username,
-      isInapplicable = null
+      isInapplicable = null,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -855,7 +855,7 @@ class ApplicationServiceTest {
       arrivalDate = LocalDate.parse("2023-04-17"),
       data = updatedData,
       username = username,
-      isInapplicable = false
+      isInapplicable = false,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -885,8 +885,8 @@ class ApplicationServiceTest {
       applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = "{}",
-        username = username
-      ) is AuthorisableActionResult.NotFound
+        username = username,
+      ) is AuthorisableActionResult.NotFound,
     ).isTrue
   }
 
@@ -923,8 +923,8 @@ class ApplicationServiceTest {
       applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = "{}",
-        username = username
-      ) is AuthorisableActionResult.Unauthorised
+        username = username,
+      ) is AuthorisableActionResult.Unauthorised,
     ).isTrue
   }
 
@@ -959,7 +959,7 @@ class ApplicationServiceTest {
     val result = applicationService.updateTemporaryAccommodationApplication(
       applicationId = applicationId,
       data = "{}",
-      username = username
+      username = username,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1005,7 +1005,7 @@ class ApplicationServiceTest {
     val result = applicationService.updateTemporaryAccommodationApplication(
       applicationId = applicationId,
       data = "{}",
-      username = username
+      username = username,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1058,7 +1058,7 @@ class ApplicationServiceTest {
     val result = applicationService.updateTemporaryAccommodationApplication(
       applicationId = applicationId,
       data = updatedData,
-      username = username
+      username = username,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1090,7 +1090,7 @@ class ApplicationServiceTest {
       isPipeApplication = true,
       isWomensApplication = false,
       targetLocation = "SW1A 1AA",
-      releaseType = ReleaseTypeOption.licence
+      releaseType = ReleaseTypeOption.licence,
     )
 
     private val submitTemporaryAccommodationApplication = SubmitTemporaryAccommodationApplication(
@@ -1227,7 +1227,7 @@ class ApplicationServiceTest {
         .produce()
 
       every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(
-        offenderDetails
+        offenderDetails,
       )
 
       val risks = PersonRisksFactory()
@@ -1236,28 +1236,28 @@ class ApplicationServiceTest {
             status = RiskStatus.Retrieved,
             value = Mappa(
               level = "CAT C1/LEVEL L1",
-              lastUpdated = LocalDate.now()
-            )
-          )
+              lastUpdated = LocalDate.now(),
+            ),
+          ),
         )
         .produce()
 
       every { mockOffenderService.getRiskByCrn(application.crn, any(), user.deliusUsername) } returns AuthorisableActionResult.Success(
-        risks
+        risks,
       )
 
       val staffUserDetails = StaffUserDetailsFactory()
         .withTeams(
           listOf(
             StaffUserTeamMembershipFactory()
-              .produce()
-          )
+              .produce(),
+          ),
         )
         .produce()
 
       every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
         status = HttpStatus.OK,
-        body = staffUserDetails
+        body = staffUserDetails,
       )
 
       val schema = application.schemaVersion as ApprovedPremisesApplicationJsonSchemaEntity
@@ -1291,7 +1291,7 @@ class ApplicationServiceTest {
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
               crn = offenderDetails.otherIds.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!
+              noms = offenderDetails.otherIds.nomsNumber!!,
             ) &&
               data.deliusEventNumber == application.eventNumber &&
               data.releaseType == submitApprovedPremisesApplication.releaseType.toString() &&
@@ -1303,29 +1303,29 @@ class ApplicationServiceTest {
                 staffIdentifier = staffUserDetails.staffIdentifier,
                 forenames = staffUserDetails.staff.forenames,
                 surname = staffUserDetails.staff.surname,
-                username = staffUserDetails.username
+                username = staffUserDetails.username,
               ),
               probationArea = ProbationArea(
                 code = staffUserDetails.probationArea.code,
-                name = staffUserDetails.probationArea.description
+                name = staffUserDetails.probationArea.description,
               ),
               team = Team(
                 code = firstTeam.code,
-                name = firstTeam.description
+                name = firstTeam.description,
               ),
               ldu = Ldu(
                 code = firstTeam.teamType.code,
-                name = firstTeam.teamType.description
+                name = firstTeam.teamType.description,
               ),
               region = Region(
                 code = staffUserDetails.probationArea.code,
-                name = staffUserDetails.probationArea.description
-              )
+                name = staffUserDetails.probationArea.description,
+              ),
             ) &&
               data.mappa == risks.mappa.value!!.level &&
               data.sentenceLengthInMonths == null &&
               data.offenceId == application.offenceId
-          }
+          },
         )
       }
     }
@@ -1489,7 +1489,7 @@ class ApplicationServiceTest {
       OfflineApplicationEntityFactory()
         .produce(),
       OfflineApplicationEntityFactory()
-        .produce()
+        .produce(),
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
@@ -1528,7 +1528,7 @@ class ApplicationServiceTest {
       OfflineApplicationEntityFactory()
         .produce(),
       OfflineApplicationEntityFactory()
-        .produce()
+        .produce(),
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
@@ -1648,7 +1648,7 @@ class ApplicationServiceTest {
     .withProbationRegion(
       ProbationRegionEntityFactory()
         .withApArea(ApAreaEntityFactory().produce())
-        .produce()
+        .produce(),
     )
     .produce()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -77,12 +77,11 @@ class AssessmentServiceTest {
     communityApiClientMock,
     cruServiceMock,
     placementRequestServiceMock,
-    "http://frontend/applications/#id"
+    "http://frontend/applications/#id",
   )
 
   @Test
   fun `getAssessmentSummariesForUser gets all assessment summaries for workflow manager`() {
-
     val user = UserEntityFactory()
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -95,7 +94,7 @@ class AssessmentServiceTest {
       UserRoleAssignmentEntityFactory()
         .withRole(UserRole.WORKFLOW_MANAGER)
         .withUser(user)
-        .produce()
+        .produce(),
     )
 
     every { assessmentRepositoryMock.findAllAssessmentSummariesNotReallocated(any()) } returns emptyList()
@@ -107,7 +106,6 @@ class AssessmentServiceTest {
 
   @Test
   fun `getAssessmentSummariesForUser only fetches allocated assessment summaries for non-workflow user`() {
-
     val user = UserEntityFactory()
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -120,7 +118,7 @@ class AssessmentServiceTest {
       UserRoleAssignmentEntityFactory()
         .withRole(UserRole.ASSESSOR)
         .withUser(user)
-        .produce()
+        .produce(),
     )
 
     every { assessmentRepositoryMock.findAllAssessmentSummariesNotReallocated(any()) } returns emptyList()
@@ -146,7 +144,7 @@ class AssessmentServiceTest {
       UserRoleAssignmentEntityFactory()
         .withRole(UserRole.WORKFLOW_MANAGER)
         .withUser(user)
-        .produce()
+        .produce(),
     )
 
     val assessment =
@@ -159,7 +157,7 @@ class AssessmentServiceTest {
                 .withYieldedApArea { ApAreaEntityFactory().produce() }
                 .produce()
             }
-            .produce()
+            .produce(),
         )
         .withApplication(
           ApprovedPremisesApplicationEntityFactory()
@@ -170,9 +168,9 @@ class AssessmentServiceTest {
                     .withYieldedApArea { ApAreaEntityFactory().produce() }
                     .produce()
                 }
-                .produce()
+                .produce(),
             )
-            .produce()
+            .produce(),
         )
         .produce()
 
@@ -208,7 +206,7 @@ class AssessmentServiceTest {
                 .withYieldedApArea { ApAreaEntityFactory().produce() }
                 .produce()
             }
-            .produce()
+            .produce(),
         )
         .withApplication(
           ApprovedPremisesApplicationEntityFactory()
@@ -219,9 +217,9 @@ class AssessmentServiceTest {
                     .withYieldedApArea { ApAreaEntityFactory().produce() }
                     .produce()
                 }
-                .produce()
+                .produce(),
             )
-            .produce()
+            .produce(),
         )
         .produce()
 
@@ -296,9 +294,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(
         UserEntityFactory()
@@ -307,7 +305,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -334,7 +332,7 @@ class AssessmentServiceTest {
       UserRoleAssignmentEntityFactory()
         .withRole(UserRole.WORKFLOW_MANAGER)
         .withUser(user)
-        .produce()
+        .produce(),
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -348,9 +346,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(
         UserEntityFactory()
@@ -359,7 +357,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -399,9 +397,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .produce()
@@ -442,9 +440,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(
         UserEntityFactory()
@@ -453,7 +451,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -487,9 +485,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
@@ -522,7 +520,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -536,9 +534,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
@@ -572,7 +570,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -586,9 +584,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(null)
       .withDecision(null)
@@ -623,7 +621,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -637,9 +635,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .withAssessmentSchema(schema)
@@ -681,9 +679,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(
         UserEntityFactory()
@@ -692,7 +690,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -726,9 +724,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
@@ -761,7 +759,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -775,9 +773,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
@@ -811,7 +809,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -825,9 +823,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(null)
       .withDecision(null)
@@ -862,7 +860,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -876,9 +874,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .withAssessmentSchema(schema)
@@ -898,7 +896,7 @@ class AssessmentServiceTest {
     assertThat(validationResult is ValidatableActionResult.FieldValidationError)
     val fieldValidationError = (validationResult as ValidatableActionResult.FieldValidationError)
     assertThat(fieldValidationError.validationMessages).contains(
-      entry("$.data", "invalid")
+      entry("$.data", "invalid"),
     )
   }
 
@@ -913,15 +911,15 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     val assessment = AssessmentEntityFactory().withId(assessmentId).withApplication(
       ApprovedPremisesApplicationEntityFactory().withCreatedByUser(
         UserEntityFactory().withYieldedProbationRegion {
           ProbationRegionEntityFactory().withYieldedApArea { ApAreaEntityFactory().produce() }.produce()
-        }.produce()
-      ).produce()
+        }.produce(),
+      ).produce(),
     ).withAllocatedToUser(user).withAssessmentSchema(schema).withData("{\"test\": \"data\"}").produce()
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
@@ -967,7 +965,7 @@ class AssessmentServiceTest {
             data.applicationUrl == "http://frontend/applications/${assessment.application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == (assessment.application as ApprovedPremisesApplicationEntity).eventNumber &&
             data.assessedBy == ApplicationAssessedAssessedBy(
@@ -976,19 +974,19 @@ class AssessmentServiceTest {
               staffIdentifier = staffUserDetails.staffIdentifier,
               forenames = staffUserDetails.staff.forenames,
               surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username
+              username = staffUserDetails.username,
             ),
             probationArea = ProbationArea(
               code = staffUserDetails.probationArea.code,
-              name = staffUserDetails.probationArea.description
+              name = staffUserDetails.probationArea.description,
             ),
             cru = Cru(
-              name = "South West & South Central"
-            )
+              name = "South West & South Central",
+            ),
           ) &&
             data.decision == "ACCEPTED" &&
             data.decisionRationale == null
-        }
+        },
       )
     }
 
@@ -1008,15 +1006,15 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     val assessment = AssessmentEntityFactory().withId(assessmentId).withApplication(
       ApprovedPremisesApplicationEntityFactory().withCreatedByUser(
         UserEntityFactory().withYieldedProbationRegion {
           ProbationRegionEntityFactory().withYieldedApArea { ApAreaEntityFactory().produce() }.produce()
-        }.produce()
-      ).produce()
+        }.produce(),
+      ).produce(),
     ).withAllocatedToUser(user).withAssessmentSchema(schema).withData("{\"test\": \"data\"}").produce()
 
     val requirements = PlacementRequirements(
@@ -1043,7 +1041,7 @@ class AssessmentServiceTest {
         .withApplication(assessment.application as ApprovedPremisesApplicationEntity)
         .withAssessment(assessment)
         .withAllocatedToUser(user)
-        .produce()
+        .produce(),
     )
 
     val offenderDetails = OffenderDetailsSummaryFactory().produce()
@@ -1081,7 +1079,7 @@ class AssessmentServiceTest {
             data.applicationUrl == "http://frontend/applications/${assessment.application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == (assessment.application as ApprovedPremisesApplicationEntity).eventNumber &&
             data.assessedBy == ApplicationAssessedAssessedBy(
@@ -1090,19 +1088,19 @@ class AssessmentServiceTest {
               staffIdentifier = staffUserDetails.staffIdentifier,
               forenames = staffUserDetails.staff.forenames,
               surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username
+              username = staffUserDetails.username,
             ),
             probationArea = ProbationArea(
               code = staffUserDetails.probationArea.code,
-              name = staffUserDetails.probationArea.description
+              name = staffUserDetails.probationArea.description,
             ),
             cru = Cru(
-              name = "South West & South Central"
-            )
+              name = "South West & South Central",
+            ),
           ) &&
             data.decision == "ACCEPTED" &&
             data.decisionRationale == null
-        }
+        },
       )
     }
 
@@ -1122,15 +1120,15 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     val assessment = AssessmentEntityFactory().withId(assessmentId).withApplication(
       ApprovedPremisesApplicationEntityFactory().withCreatedByUser(
         UserEntityFactory().withYieldedProbationRegion {
           ProbationRegionEntityFactory().withYieldedApArea { ApAreaEntityFactory().produce() }.produce()
-        }.produce()
-      ).produce()
+        }.produce(),
+      ).produce(),
     ).withAllocatedToUser(user).withAssessmentSchema(schema).withData("{\"test\": \"data\"}").produce()
 
     val requirements = PlacementRequirements(
@@ -1192,9 +1190,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(
         UserEntityFactory()
@@ -1203,7 +1201,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -1237,9 +1235,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
@@ -1272,7 +1270,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -1286,9 +1284,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
@@ -1322,7 +1320,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -1336,9 +1334,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(null)
       .withDecision(null)
@@ -1373,7 +1371,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns AssessmentEntityFactory()
@@ -1387,9 +1385,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .withAssessmentSchema(schema)
@@ -1409,7 +1407,7 @@ class AssessmentServiceTest {
     assertThat(validationResult is ValidatableActionResult.FieldValidationError)
     val fieldValidationError = (validationResult as ValidatableActionResult.FieldValidationError)
     assertThat(fieldValidationError.validationMessages).contains(
-      entry("$.data", "invalid")
+      entry("$.data", "invalid"),
     )
   }
 
@@ -1428,7 +1426,7 @@ class AssessmentServiceTest {
     val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     val assessment = AssessmentEntityFactory()
@@ -1442,9 +1440,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .withAssessmentSchema(schema)
@@ -1495,7 +1493,7 @@ class AssessmentServiceTest {
             data.applicationUrl == "http://frontend/applications/${assessment.application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == (assessment.application as ApprovedPremisesApplicationEntity).eventNumber &&
             data.assessedBy == ApplicationAssessedAssessedBy(
@@ -1504,19 +1502,19 @@ class AssessmentServiceTest {
               staffIdentifier = staffUserDetails.staffIdentifier,
               forenames = staffUserDetails.staff.forenames,
               surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username
+              username = staffUserDetails.username,
             ),
             probationArea = ProbationArea(
               code = staffUserDetails.probationArea.code,
-              name = staffUserDetails.probationArea.description
+              name = staffUserDetails.probationArea.description,
             ),
             cru = Cru(
-              name = "South West & South Central"
-            )
+              name = "South West & South Central",
+            ),
           ) &&
             data.decision == "REJECTED" &&
             data.decisionRationale == "reasoning"
-        }
+        },
       )
     }
   }
@@ -1539,7 +1537,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -1552,7 +1550,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
@@ -1587,7 +1585,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -1600,7 +1598,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -1640,7 +1638,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .withIsPipeApplication(true)
       .produce()
@@ -1654,7 +1652,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -1699,7 +1697,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .withIsPipeApplication(true)
       .produce()
@@ -1713,7 +1711,7 @@ class AssessmentServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -1722,7 +1720,7 @@ class AssessmentServiceTest {
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     every { assessmentRepositoryMock.save(previousAssessment) } answers { it.invocation.args[0] as AssessmentEntity }
@@ -1763,7 +1761,7 @@ class AssessmentServiceTest {
       communityApiClientMock,
       cruServiceMock,
       placementRequestServiceMock,
-      "http://frontend/applications/#id"
+      "http://frontend/applications/#id",
     )
 
     private val user = UserEntityFactory()
@@ -1777,7 +1775,7 @@ class AssessmentServiceTest {
     private val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
-      schema = "{}"
+      schema = "{}",
     )
 
     private val assessment = AssessmentEntityFactory()
@@ -1790,9 +1788,9 @@ class AssessmentServiceTest {
                   .withYieldedApArea { ApAreaEntityFactory().produce() }
                   .produce()
               }
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .withAssessmentSchema(schema)
@@ -1818,7 +1816,7 @@ class AssessmentServiceTest {
       every {
         assessmentClarificationNoteRepositoryMock.findByAssessmentIdAndId(
           assessment.id,
-          assessmentClarificationNoteEntity.id
+          assessmentClarificationNoteEntity.id,
         )
       } returns assessmentClarificationNoteEntity
 
@@ -1829,7 +1827,7 @@ class AssessmentServiceTest {
         assessment.id,
         assessmentClarificationNoteEntity.id,
         "Some response",
-        LocalDate.parse("2022-03-03")
+        LocalDate.parse("2022-03-03"),
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1847,7 +1845,7 @@ class AssessmentServiceTest {
       every {
         assessmentClarificationNoteRepositoryMock.findByAssessmentIdAndId(
           assessment.id,
-          assessmentClarificationNoteEntity.id
+          assessmentClarificationNoteEntity.id,
         )
       } returns null
 
@@ -1856,7 +1854,7 @@ class AssessmentServiceTest {
         assessment.id,
         assessmentClarificationNoteEntity.id,
         "Some response",
-        LocalDate.parse("2022-03-03")
+        LocalDate.parse("2022-03-03"),
       )
 
       assertThat(result is AuthorisableActionResult.NotFound).isTrue
@@ -1868,7 +1866,7 @@ class AssessmentServiceTest {
       every {
         assessmentClarificationNoteRepositoryMock.findByAssessmentIdAndId(
           assessment.id,
-          assessmentClarificationNoteEntity.id
+          assessmentClarificationNoteEntity.id,
         )
       } returns AssessmentClarificationNoteEntityFactory()
         .withAssessment(assessment)
@@ -1881,7 +1879,7 @@ class AssessmentServiceTest {
         assessment.id,
         assessmentClarificationNoteEntity.id,
         "Some response",
-        LocalDate.parse("2022-03-03")
+        LocalDate.parse("2022-03-03"),
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1899,7 +1897,7 @@ class AssessmentServiceTest {
       every {
         assessmentClarificationNoteRepositoryMock.findByAssessmentIdAndId(
           assessment.id,
-          assessmentClarificationNoteEntity.id
+          assessmentClarificationNoteEntity.id,
         )
       } returns AssessmentClarificationNoteEntityFactory()
         .withAssessment(assessment)
@@ -1910,7 +1908,7 @@ class AssessmentServiceTest {
                 .withYieldedApArea { ApAreaEntityFactory().produce() }
                 .produce()
             }
-            .produce()
+            .produce(),
         )
         .produce()
 
@@ -1919,7 +1917,7 @@ class AssessmentServiceTest {
         assessment.id,
         assessmentClarificationNoteEntity.id,
         "Some response",
-        LocalDate.parse("2022-03-03")
+        LocalDate.parse("2022-03-03"),
       )
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -541,7 +541,7 @@ class BedSearchServiceTest {
         startDate = LocalDate.parse("2023-03-22"),
         durationInDays = 7,
         probationDeliveryUnit = "PDU-1",
-        probationRegionId = user.probationRegion.id
+        probationRegionId = user.probationRegion.id,
       )
     } returns repositorySearchResults
 
@@ -633,7 +633,7 @@ class BedSearchServiceTest {
         startDate = LocalDate.parse("2023-03-22"),
         durationInDays = 7,
         probationDeliveryUnit = "PDU-1",
-        probationRegionId = user.probationRegion.id
+        probationRegionId = user.probationRegion.id,
       )
     } returns repositorySearchResults
 
@@ -642,7 +642,7 @@ class BedSearchServiceTest {
       .withProbationRegion(user.probationRegion)
       .withLocalAuthorityArea(
         LocalAuthorityEntityFactory()
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -675,7 +675,7 @@ class BedSearchServiceTest {
       .withProbationRegion(user.probationRegion)
       .withLocalAuthorityArea(
         LocalAuthorityEntityFactory()
-          .produce()
+          .produce(),
       )
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -151,7 +151,7 @@ class BookingServiceTest {
     placementRequestRepository = mockPlacementRequestRepository,
     lostBedsRepository = mockLostBedsRepository,
     turnaroundRepository = mockTurnaroundRepository,
-    applicationUrlTemplate = "http://frontend/applications/#id"
+    applicationUrlTemplate = "http://frontend/applications/#id",
   )
 
   @Test
@@ -281,7 +281,7 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
@@ -324,12 +324,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.dateTime", "beforeBookingArrivalDate")
+      entry("$.dateTime", "beforeBookingArrivalDate"),
     )
   }
 
@@ -369,12 +369,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reasonId", "doesNotExist")
+      entry("$.reasonId", "doesNotExist"),
     )
   }
 
@@ -418,12 +418,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reasonId", "incorrectDepartureReasonServiceScope")
+      entry("$.reasonId", "incorrectDepartureReasonServiceScope"),
     )
   }
 
@@ -463,12 +463,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.moveOnCategoryId", "doesNotExist")
+      entry("$.moveOnCategoryId", "doesNotExist"),
     )
   }
 
@@ -513,12 +513,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.moveOnCategoryId", "incorrectMoveOnCategoryServiceScope")
+      entry("$.moveOnCategoryId", "incorrectMoveOnCategoryServiceScope"),
     )
   }
 
@@ -558,12 +558,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.destinationProviderId", "doesNotExist")
+      entry("$.destinationProviderId", "doesNotExist"),
     )
   }
 
@@ -602,12 +602,12 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.destinationProviderId", "empty")
+      entry("$.destinationProviderId", "empty"),
     )
   }
 
@@ -659,7 +659,7 @@ class BookingServiceTest {
       notes = "notes",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -703,9 +703,9 @@ class BookingServiceTest {
           .withCreatedByUser(
             UserEntityFactory()
               .withUnitTestControlProbationRegion()
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -740,7 +740,7 @@ class BookingServiceTest {
 
     every { mockCommunityApiClient.getStaffUserDetailsForStaffCode(keyWorker.code) } returns ClientResult.Success(
       HttpStatus.OK,
-      keyWorkerStaffUserDetails
+      keyWorkerStaffUserDetails,
     )
 
     every { mockDomainEventService.savePersonDepartedEvent(any()) } just Runs
@@ -752,7 +752,7 @@ class BookingServiceTest {
       moveOnCategoryId = moveOnCategoryId,
       destinationProviderId = destinationProviderId,
       notes = "notes",
-      user = user
+      user = user,
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -778,7 +778,7 @@ class BookingServiceTest {
             data.applicationUrl == "http://frontend/applications/${application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == application.eventNumber &&
             data.premises == Premises(
@@ -786,16 +786,16 @@ class BookingServiceTest {
             name = approvedPremises.name,
             apCode = approvedPremises.apCode,
             legacyApCode = approvedPremises.qCode,
-            localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+            localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
           ) &&
             data.departedAt == Instant.parse("2022-08-24T15:00:00+01:00") &&
             data.legacyReasonCode == reasonEntity.legacyDeliusReasonCode &&
             data.destination.destinationProvider == DestinationProvider(
             description = destinationProviderEntity.name,
-            id = destinationProviderEntity.id
+            id = destinationProviderEntity.id,
           ) &&
             data.reason == reasonEntity.name
-        }
+        },
       )
     }
   }
@@ -830,7 +830,7 @@ class BookingServiceTest {
       keyWorkerStaffCode = "123",
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
@@ -862,12 +862,12 @@ class BookingServiceTest {
       keyWorkerStaffCode = keyWorker.code,
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.expectedDepartureDate", "beforeBookingArrivalDate")
+      entry("$.expectedDepartureDate", "beforeBookingArrivalDate"),
     )
   }
 
@@ -903,7 +903,7 @@ class BookingServiceTest {
       keyWorkerStaffCode = keyWorker.code,
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -939,9 +939,9 @@ class BookingServiceTest {
           .withCreatedByUser(
             UserEntityFactory()
               .withUnitTestControlProbationRegion()
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -962,7 +962,7 @@ class BookingServiceTest {
 
     every { mockCommunityApiClient.getStaffUserDetailsForStaffCode(keyWorker.code) } returns ClientResult.Success(
       HttpStatus.OK,
-      keyWorkerStaffUserDetails
+      keyWorkerStaffUserDetails,
     )
 
     every { mockDomainEventService.savePersonArrivedEvent(any()) } just Runs
@@ -973,7 +973,7 @@ class BookingServiceTest {
       expectedDepartureDate = LocalDate.parse("2022-08-29"),
       notes = "notes",
       keyWorkerStaffCode = keyWorker.code,
-      user = user
+      user = user,
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -995,7 +995,7 @@ class BookingServiceTest {
             data.applicationUrl == "http://frontend/applications/${application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == application.eventNumber &&
             data.premises == Premises(
@@ -1003,10 +1003,10 @@ class BookingServiceTest {
             name = approvedPremises.name,
             apCode = approvedPremises.apCode,
             legacyApCode = approvedPremises.qCode,
-            localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+            localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
           ) &&
             data.applicationSubmittedOn == LocalDate.parse("2023-02-15")
-        }
+        },
       )
     }
   }
@@ -1038,7 +1038,7 @@ class BookingServiceTest {
       keyWorkerStaffCode = null,
       user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .produce()
+        .produce(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1079,7 +1079,7 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = UUID.randomUUID(),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
@@ -1113,13 +1113,13 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
       entry("$.date", "afterBookingArrivalDate"),
-      entry("$.reason", "doesNotExist")
+      entry("$.reason", "doesNotExist"),
     )
   }
 
@@ -1154,7 +1154,7 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1211,7 +1211,7 @@ class BookingServiceTest {
 
     every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
       HttpStatus.OK,
-      staffUserDetails
+      staffUserDetails,
     )
 
     every { mockDomainEventService.savePersonNotArrivedEvent(any()) } just Runs
@@ -1221,7 +1221,7 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1243,7 +1243,7 @@ class BookingServiceTest {
             data.applicationUrl == "http://frontend/applications/${application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == application.eventNumber &&
             data.premises == Premises(
@@ -1251,7 +1251,7 @@ class BookingServiceTest {
             name = approvedPremises.name,
             apCode = approvedPremises.apCode,
             legacyApCode = approvedPremises.qCode,
-            localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name
+            localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
           ) &&
             data.expectedArrivalOn == bookingEntity.originalArrivalDate &&
             data.recordedBy == StaffMember(
@@ -1259,9 +1259,9 @@ class BookingServiceTest {
             staffIdentifier = staffUserDetails.staffIdentifier,
             forenames = staffUserDetails.staff.forenames,
             surname = staffUserDetails.staff.surname,
-            username = staffUserDetails.username
+            username = staffUserDetails.username,
           )
-        }
+        },
       )
     }
   }
@@ -1292,7 +1292,7 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = UUID.randomUUID(),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
@@ -1323,12 +1323,12 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "doesNotExist")
+      entry("$.reason", "doesNotExist"),
     )
   }
 
@@ -1361,12 +1361,12 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "incorrectCancellationReasonServiceScope")
+      entry("$.reason", "incorrectCancellationReasonServiceScope"),
     )
   }
 
@@ -1396,7 +1396,7 @@ class BookingServiceTest {
       booking = bookingEntity,
       date = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1438,12 +1438,12 @@ class BookingServiceTest {
     val result = bookingService.createExtension(
       booking = bookingEntity,
       newDepartureDate = LocalDate.parse("2022-08-25"),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.newDepartureDate", "beforeExistingDepartureDate")
+      entry("$.newDepartureDate", "beforeExistingDepartureDate"),
     )
   }
 
@@ -1484,7 +1484,7 @@ class BookingServiceTest {
     val result = bookingService.createExtension(
       booking = bookingEntity,
       newDepartureDate = LocalDate.parse("2022-08-25"),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1527,12 +1527,12 @@ class BookingServiceTest {
     val result = bookingService.createExtension(
       booking = bookingEntity,
       newDepartureDate = LocalDate.parse("2022-08-25"),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.newDepartureDate", "beforeBookingArrivalDate")
+      entry("$.newDepartureDate", "beforeBookingArrivalDate"),
     )
   }
 
@@ -1572,7 +1572,7 @@ class BookingServiceTest {
     val result = bookingService.createExtension(
       booking = bookingEntity,
       newDepartureDate = LocalDate.parse("2022-08-25"),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1607,7 +1607,7 @@ class BookingServiceTest {
     val result = bookingService.createConfirmation(
       booking = bookingEntity,
       dateTime = OffsetDateTime.parse("2022-08-25T12:34:56.789Z"),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
@@ -1635,7 +1635,7 @@ class BookingServiceTest {
     val result = bookingService.createConfirmation(
       booking = bookingEntity,
       dateTime = OffsetDateTime.parse("2022-08-25T12:34:56.789Z"),
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1702,7 +1702,7 @@ class BookingServiceTest {
     assertThat(validatableResult is ValidatableActionResult.FieldValidationError)
 
     assertThat((validatableResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.departureDate", "beforeBookingArrivalDate")
+      entry("$.departureDate", "beforeBookingArrivalDate"),
     )
   }
 
@@ -1738,7 +1738,7 @@ class BookingServiceTest {
     assertThat(validatableResult is ValidatableActionResult.FieldValidationError)
 
     assertThat((validatableResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.bedId", "doesNotExist")
+      entry("$.bedId", "doesNotExist"),
     )
   }
 
@@ -1781,7 +1781,7 @@ class BookingServiceTest {
     assertThat(validatableResult is ValidatableActionResult.FieldValidationError)
 
     assertThat((validatableResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.crn", "doesNotHaveApplication")
+      entry("$.crn", "doesNotHaveApplication"),
     )
   }
 
@@ -1946,7 +1946,7 @@ class BookingServiceTest {
             it.premises == premises &&
             it.arrivalDate == arrivalDate &&
             it.departureDate == departureDate
-        }
+        },
       )
     }
 
@@ -1961,7 +1961,7 @@ class BookingServiceTest {
             data.applicationUrl == "http://frontend/applications/${existingApplication.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == existingApplication.eventNumber &&
             data.premises == Premises(
@@ -1969,10 +1969,10 @@ class BookingServiceTest {
             name = premises.name,
             apCode = premises.apCode,
             legacyApCode = premises.qCode,
-            localAuthorityAreaName = premises.localAuthorityArea!!.name
+            localAuthorityAreaName = premises.localAuthorityArea!!.name,
           ) &&
             data.arrivalOn == arrivalDate
-        }
+        },
       )
     }
   }
@@ -2028,7 +2028,7 @@ class BookingServiceTest {
             it.premises == premises &&
             it.arrivalDate == arrivalDate &&
             it.departureDate == departureDate
-        }
+        },
       )
     }
 
@@ -2066,7 +2066,7 @@ class BookingServiceTest {
     assertThat(validatableResult is ValidatableActionResult.FieldValidationError)
 
     assertThat((validatableResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.departureDate", "beforeBookingArrivalDate")
+      entry("$.departureDate", "beforeBookingArrivalDate"),
     )
   }
 
@@ -2098,7 +2098,7 @@ class BookingServiceTest {
     assertThat(validatableResult is ValidatableActionResult.FieldValidationError)
 
     assertThat((validatableResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.bedId", "doesNotExist")
+      entry("$.bedId", "doesNotExist"),
     )
   }
 
@@ -2147,7 +2147,7 @@ class BookingServiceTest {
             it.premises == premises &&
             it.arrivalDate == arrivalDate &&
             it.departureDate == departureDate
-        }
+        },
       )
     }
   }
@@ -2199,7 +2199,7 @@ class BookingServiceTest {
             it.premises == premises &&
             it.arrivalDate == arrivalDate &&
             it.departureDate == departureDate
-        }
+        },
       )
     }
 
@@ -2208,7 +2208,7 @@ class BookingServiceTest {
         match {
           it.booking == bookingSlot.captured &&
             it.workingDayCount == 0
-        }
+        },
       )
     }
   }
@@ -2260,7 +2260,7 @@ class BookingServiceTest {
             it.premises == premises &&
             it.arrivalDate == arrivalDate &&
             it.departureDate == departureDate
-        }
+        },
       )
     }
 
@@ -2269,7 +2269,7 @@ class BookingServiceTest {
         match {
           it.booking == bookingSlot.captured &&
             it.workingDayCount == premises.turnaroundWorkingDayCount
-        }
+        },
       )
     }
   }
@@ -2290,7 +2290,7 @@ class BookingServiceTest {
       placementRequestId = placementRequestId,
       bedId = bedId,
       arrivalDate = LocalDate.parse("2023-03-28"),
-      departureDate = LocalDate.parse("2023-03-30")
+      departureDate = LocalDate.parse("2023-03-30"),
     )
 
     assertThat(result is AuthorisableActionResult.NotFound).isTrue
@@ -2316,7 +2316,7 @@ class BookingServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(otherUser)
       .produce()
@@ -2330,7 +2330,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bedId,
       arrivalDate = LocalDate.parse("2023-03-28"),
-      departureDate = LocalDate.parse("2023-03-30")
+      departureDate = LocalDate.parse("2023-03-30"),
     )
 
     assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
@@ -2359,7 +2359,7 @@ class BookingServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .produce()
@@ -2387,7 +2387,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      departureDate = departureDate,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -2421,7 +2421,7 @@ class BookingServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .produce()
@@ -2447,7 +2447,7 @@ class BookingServiceTest {
         .withDepartureDate(departureDate)
         .withPremises(premises)
         .withBed(bed)
-        .produce()
+        .produce(),
     )
     every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
@@ -2458,7 +2458,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      departureDate = departureDate,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -2492,7 +2492,7 @@ class BookingServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .produce()
@@ -2520,7 +2520,7 @@ class BookingServiceTest {
         .withPremises(premises)
         .withBed(bed)
         .withYieldedReason { LostBedReasonEntityFactory().produce() }
-        .produce()
+        .produce(),
     )
 
     val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -2528,7 +2528,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      departureDate = departureDate,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -2564,7 +2564,7 @@ class BookingServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(user)
       .produce()
@@ -2608,7 +2608,7 @@ class BookingServiceTest {
       placementRequestId = placementRequest.id,
       bedId = bed.id,
       arrivalDate = arrivalDate,
-      departureDate = departureDate
+      departureDate = departureDate,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -2624,7 +2624,7 @@ class BookingServiceTest {
             it.premises == premises &&
             it.arrivalDate == arrivalDate &&
             it.departureDate == departureDate
-        }
+        },
       )
     }
 
@@ -2639,7 +2639,7 @@ class BookingServiceTest {
             data.applicationUrl == "http://frontend/applications/${placementRequest.application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == placementRequest.application.eventNumber &&
             data.premises == Premises(
@@ -2647,10 +2647,10 @@ class BookingServiceTest {
             name = premises.name,
             apCode = premises.apCode,
             legacyApCode = premises.qCode,
-            localAuthorityAreaName = premises.localAuthorityArea!!.name
+            localAuthorityAreaName = premises.localAuthorityArea!!.name,
           ) &&
             data.arrivalOn == arrivalDate
-        }
+        },
       )
     }
 
@@ -2658,7 +2658,7 @@ class BookingServiceTest {
       mockPlacementRequestRepository.save(
         match {
           it.booking == createdBooking
-        }
+        },
       )
     }
   }
@@ -2670,13 +2670,13 @@ class BookingServiceTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withLocalAuthorityArea(
         LocalAuthorityEntityFactory()
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -2703,12 +2703,12 @@ class BookingServiceTest {
 
     assertThat(negativeDaysResult).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((negativeDaysResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.workingDays", "isNotAPositiveInteger")
+      entry("$.workingDays", "isNotAPositiveInteger"),
     )
 
     assertThat(zeroDaysResult).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((zeroDaysResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.workingDays", "isNotAPositiveInteger")
+      entry("$.workingDays", "isNotAPositiveInteger"),
     )
   }
 
@@ -2719,13 +2719,13 @@ class BookingServiceTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
-          .produce()
+          .produce(),
       )
       .withLocalAuthorityArea(
         LocalAuthorityEntityFactory()
-          .produce()
+          .produce(),
       )
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -82,7 +82,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.application.submitted",
-      eventDetails = ApplicationSubmittedFactory().produce()
+      eventDetails = ApplicationSubmittedFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -101,8 +101,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -128,8 +128,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.submitted",
-        eventDetails = ApplicationSubmittedFactory().produce()
-      )
+        eventDetails = ApplicationSubmittedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -145,7 +145,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -162,7 +162,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -189,8 +189,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.submitted",
-        eventDetails = ApplicationSubmittedFactory().produce()
-      )
+        eventDetails = ApplicationSubmittedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -208,7 +208,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -237,7 +237,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.application.assessed",
-      eventDetails = ApplicationAssessedFactory().produce()
+      eventDetails = ApplicationAssessedFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -256,8 +256,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -283,8 +283,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.assessed",
-        eventDetails = ApplicationAssessedFactory().produce()
-      )
+        eventDetails = ApplicationAssessedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -300,7 +300,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -317,7 +317,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -344,8 +344,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.assessed",
-        eventDetails = ApplicationAssessedFactory().produce()
-      )
+        eventDetails = ApplicationAssessedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -363,7 +363,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -392,7 +392,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.booking.made",
-      eventDetails = BookingMadeFactory().produce()
+      eventDetails = BookingMadeFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -411,8 +411,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -438,8 +438,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.booking.made",
-        eventDetails = BookingMadeFactory().produce()
-      )
+        eventDetails = BookingMadeFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -455,7 +455,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -472,7 +472,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -499,8 +499,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.booking.made",
-        eventDetails = BookingMadeFactory().produce()
-      )
+        eventDetails = BookingMadeFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -518,7 +518,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -547,7 +547,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.person.arrived",
-      eventDetails = PersonArrivedFactory().produce()
+      eventDetails = PersonArrivedFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -566,8 +566,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -593,8 +593,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.person.arrived",
-        eventDetails = PersonArrivedFactory().produce()
-      )
+        eventDetails = PersonArrivedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -610,7 +610,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -627,7 +627,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -654,8 +654,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.person.arrived",
-        eventDetails = PersonArrivedFactory().produce()
-      )
+        eventDetails = PersonArrivedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -673,7 +673,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -702,7 +702,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.person.not-arrived",
-      eventDetails = PersonNotArrivedFactory().produce()
+      eventDetails = PersonNotArrivedFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -721,8 +721,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -748,8 +748,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.person.not-arrived",
-        eventDetails = PersonNotArrivedFactory().produce()
-      )
+        eventDetails = PersonNotArrivedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -765,7 +765,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -782,7 +782,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -809,8 +809,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.person.not-arrived",
-        eventDetails = PersonNotArrivedFactory().produce()
-      )
+        eventDetails = PersonNotArrivedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -828,7 +828,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -857,7 +857,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.person.departed",
-      eventDetails = PersonDepartedFactory().produce()
+      eventDetails = PersonDepartedFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -876,8 +876,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -903,8 +903,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.person.departed",
-        eventDetails = PersonDepartedFactory().produce()
-      )
+        eventDetails = PersonDepartedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -920,7 +920,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -937,7 +937,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -964,8 +964,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.person.departed",
-        eventDetails = PersonDepartedFactory().produce()
-      )
+        eventDetails = PersonDepartedFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -983,7 +983,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -1012,7 +1012,7 @@ class DomainEventServiceTest {
       id = id,
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.booking.not-made",
-      eventDetails = BookingNotMadeFactory().produce()
+      eventDetails = BookingNotMadeFactory().produce(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -1031,8 +1031,8 @@ class DomainEventServiceTest {
         applicationId = applicationId,
         crn = "CRN",
         occurredAt = occurredAt.toInstant(),
-        data = data
-      )
+        data = data,
+      ),
     )
   }
 
@@ -1058,8 +1058,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.booking.not-made",
-        eventDetails = BookingNotMadeFactory().produce()
-      )
+        eventDetails = BookingNotMadeFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -1075,7 +1075,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 
@@ -1092,7 +1092,7 @@ class DomainEventServiceTest {
             deserializedMessage.additionalInformation.applicationId == applicationId &&
             deserializedMessage.personReference.identifiers.any { it.type == "CRN" && it.value == domainEventToSave.data.eventDetails.personReference.crn } &&
             deserializedMessage.personReference.identifiers.any { it.type == "NOMS" && it.value == domainEventToSave.data.eventDetails.personReference.noms }
-        }
+        },
       )
     }
   }
@@ -1119,8 +1119,8 @@ class DomainEventServiceTest {
         id = id,
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.booking.not-made",
-        eventDetails = BookingNotMadeFactory().produce()
-      )
+        eventDetails = BookingNotMadeFactory().produce(),
+      ),
     )
 
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
@@ -1138,7 +1138,7 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data)
-        }
+        },
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -29,7 +29,7 @@ class JsonSchemaServiceTest {
   private val jsonSchemaService = JsonSchemaService(
     objectMapper = jacksonObjectMapper(),
     jsonSchemaRepository = mockJsonSchemaRepository,
-    applicationRepository = mockApplicationRepository
+    applicationRepository = mockApplicationRepository,
   )
 
   @Test
@@ -51,7 +51,7 @@ class JsonSchemaServiceTest {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
       )
       .produce()
 
@@ -66,7 +66,7 @@ class JsonSchemaServiceTest {
           "type": "object",
           "properties": { }
         }
-        """
+        """,
       )
       .produce()
 
@@ -90,7 +90,7 @@ class JsonSchemaServiceTest {
           {
              "thingId": 123
           }
-          """
+          """,
       )
       .produce()
 
@@ -138,7 +138,7 @@ class JsonSchemaServiceTest {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
       )
       .produce()
 
@@ -153,7 +153,7 @@ class JsonSchemaServiceTest {
           "type": "object",
           "properties": { }
         }
-        """
+        """,
       )
       .produce()
 
@@ -177,7 +177,7 @@ class JsonSchemaServiceTest {
           {
              "thingId": 123
           }
-          """
+          """,
       )
       .withProbationRegion(userEntity.probationRegion)
       .produce()
@@ -227,7 +227,7 @@ class JsonSchemaServiceTest {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
       )
       .produce()
 
@@ -253,7 +253,7 @@ class JsonSchemaServiceTest {
           },
           "required": [ "thingId" ]
         }
-        """
+        """,
       )
       .produce()
 
@@ -264,8 +264,8 @@ class JsonSchemaServiceTest {
         {
            "thingId": 123
         }
-      """
-      )
+      """,
+      ),
     ).isTrue
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -59,7 +59,7 @@ class OffenderServiceTest {
       ExcludedCategoryBindingModel().apply {
         this.category = "EXCLUDED_CATEGORY"
         this.subcategory = null
-      }
+      },
     )
   }
   private val adjudicationsConfigBindingModel = PrisonAdjudicationsConfigBindingModel().apply {
@@ -73,7 +73,7 @@ class OffenderServiceTest {
     mockCaseNotesClient,
     mockApOASysContextApiClient,
     prisonCaseNotesConfigBindingModel,
-    adjudicationsConfigBindingModel
+    adjudicationsConfigBindingModel,
   )
 
   @Test
@@ -143,7 +143,7 @@ class OffenderServiceTest {
       HttpMethod.GET,
       "/secure/crn/a-crn/user/distinguished.name/userAccess",
       HttpStatus.FORBIDDEN,
-      jacksonObjectMapper().writeValueAsString(accessBody)
+      jacksonObjectMapper().writeValueAsString(accessBody),
     )
 
     assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue
@@ -163,7 +163,7 @@ class OffenderServiceTest {
       HttpMethod.GET,
       "/secure/crn/a-crn/user/distinguished.name/userAccess",
       HttpStatus.FORBIDDEN,
-      null
+      null,
     )
 
     val exception = assertThrows<RuntimeException> { offenderService.getOffenderByCrn("a-crn", "distinguished.name") }
@@ -302,7 +302,7 @@ class OffenderServiceTest {
         withRiskPublicCommunity(RiskLevel.MEDIUM)
         withRiskKnownAdultCommunity(RiskLevel.HIGH)
         withRiskStaffCommunity(RiskLevel.VERY_HIGH)
-      }.produce()
+      }.produce(),
     )
 
     mock200Tier(
@@ -310,8 +310,8 @@ class OffenderServiceTest {
       Tier(
         tierScore = "M2",
         calculationId = UUID.randomUUID(),
-        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00")
-      )
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
     )
 
     mock200Registrations(
@@ -326,9 +326,9 @@ class OffenderServiceTest {
             .produce(),
           RegistrationClientResponseFactory()
             .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
-            .produce()
-        )
-      )
+            .produce(),
+        ),
+      ),
     )
 
     val result = offenderService.getRiskByCrn(crn, jwt, distinguishedName)
@@ -411,9 +411,9 @@ class OffenderServiceTest {
           agencyId = "AGY",
           locationId = 89,
           description = "AGENCY DESCRIPTION",
-          agencyName = "AGENCY NAME"
-        )
-      )
+          agencyName = "AGENCY NAME",
+        ),
+      ),
     )
 
     val result = offenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
@@ -427,8 +427,8 @@ class OffenderServiceTest {
         agencyId = "AGY",
         locationId = 89,
         description = "AGENCY DESCRIPTION",
-        agencyName = "AGENCY NAME"
-      )
+        agencyName = "AGENCY NAME",
+      ),
     )
   }
 
@@ -441,7 +441,7 @@ class OffenderServiceTest {
         nomsNumber = nomsNumber,
         from = LocalDate.now().minusDays(prisonCaseNotesConfigBindingModel.lookbackDays!!.toLong()),
         page = 0,
-        pageSize = 2
+        pageSize = 2,
       )
     } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/v2", HttpStatus.NOT_FOUND, null)
 
@@ -457,7 +457,7 @@ class OffenderServiceTest {
         nomsNumber = nomsNumber,
         from = LocalDate.now().minusDays(prisonCaseNotesConfigBindingModel.lookbackDays!!.toLong()),
         page = 0,
-        pageSize = 2
+        pageSize = 2,
       )
     } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/v2", HttpStatus.FORBIDDEN, null)
 
@@ -471,13 +471,13 @@ class OffenderServiceTest {
     val caseNotesPageOne = listOf(
       CaseNoteFactory().produce(),
       CaseNoteFactory().produce(),
-      CaseNoteFactory().withType("EXCLUDED_TYPE").produce()
+      CaseNoteFactory().withType("EXCLUDED_TYPE").produce(),
     )
 
     val caseNotesPageTwo = listOf(
       CaseNoteFactory().produce(),
       CaseNoteFactory().produce(),
-      CaseNoteFactory().withType("TYPE").withSubType("EXCLUDED_SUBTYPE").produce()
+      CaseNoteFactory().withType("TYPE").withSubType("EXCLUDED_SUBTYPE").produce(),
     )
 
     every {
@@ -485,7 +485,7 @@ class OffenderServiceTest {
         nomsNumber = nomsNumber,
         from = LocalDate.now().minusDays(prisonCaseNotesConfigBindingModel.lookbackDays!!.toLong()),
         page = 0,
-        pageSize = 2
+        pageSize = 2,
       )
     } returns ClientResult.Success(
       HttpStatus.OK,
@@ -493,8 +493,8 @@ class OffenderServiceTest {
         totalElements = 6,
         totalPages = 2,
         number = 1,
-        content = caseNotesPageOne
-      )
+        content = caseNotesPageOne,
+      ),
     )
 
     every {
@@ -502,7 +502,7 @@ class OffenderServiceTest {
         nomsNumber = nomsNumber,
         from = LocalDate.now().minusDays(prisonCaseNotesConfigBindingModel.lookbackDays!!.toLong()),
         page = 1,
-        pageSize = 2
+        pageSize = 2,
       )
     } returns ClientResult.Success(
       HttpStatus.OK,
@@ -510,8 +510,8 @@ class OffenderServiceTest {
         totalElements = 4,
         totalPages = 2,
         number = 2,
-        content = caseNotesPageTwo
-      )
+        content = caseNotesPageTwo,
+      ),
     )
 
     val result = offenderService.getPrisonCaseNotesByNomsNumber(nomsNumber)
@@ -529,7 +529,7 @@ class OffenderServiceTest {
       mockPrisonsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
         pageSize = 2,
-        offset = 0
+        offset = 0,
       )
     } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.NOT_FOUND, null)
 
@@ -544,7 +544,7 @@ class OffenderServiceTest {
       mockPrisonsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
         pageSize = 2,
-        offset = 0
+        offset = 0,
       )
     } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.FORBIDDEN, null)
 
@@ -559,27 +559,27 @@ class OffenderServiceTest {
       .withResults(
         listOf(
           AdjudicationFactory().withAgencyId("AGNCY1").produce(),
-          AdjudicationFactory().withAgencyId("AGNCY2").produce()
-        )
+          AdjudicationFactory().withAgencyId("AGNCY2").produce(),
+        ),
       )
       .withAgencies(
         listOf(
           AgencyFactory().withAgencyId("AGNCY1").produce(),
-          AgencyFactory().withAgencyId("AGNCY2").produce()
-        )
+          AgencyFactory().withAgencyId("AGNCY2").produce(),
+        ),
       )
       .produce()
 
     val adjudicationsPageTwo = AdjudicationsPageFactory()
       .withResults(
         listOf(
-          AdjudicationFactory().withAgencyId("AGNCY3").produce()
-        )
+          AdjudicationFactory().withAgencyId("AGNCY3").produce(),
+        ),
       )
       .withAgencies(
         listOf(
-          AgencyFactory().withAgencyId("AGNCY3").produce()
-        )
+          AgencyFactory().withAgencyId("AGNCY3").produce(),
+        ),
       )
       .produce()
 
@@ -587,22 +587,22 @@ class OffenderServiceTest {
       mockPrisonsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
         pageSize = 2,
-        offset = 0
+        offset = 0,
       )
     } returns ClientResult.Success(
       HttpStatus.OK,
-      adjudicationsPageOne
+      adjudicationsPageOne,
     )
 
     every {
       mockPrisonsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
         pageSize = 2,
-        offset = 2
+        offset = 2,
       )
     } returns ClientResult.Success(
       HttpStatus.OK,
-      adjudicationsPageTwo
+      adjudicationsPageTwo,
     )
 
     val result = offenderService.getAdjudicationsByNomsNumber(nomsNumber)
@@ -610,10 +610,10 @@ class OffenderServiceTest {
     assertThat(result is AuthorisableActionResult.Success).isTrue
     result as AuthorisableActionResult.Success
     assertThat(result.entity.results).containsAll(
-      adjudicationsPageOne.results.plus(adjudicationsPageTwo.results)
+      adjudicationsPageOne.results.plus(adjudicationsPageTwo.results),
     )
     assertThat(result.entity.agencies).containsExactlyInAnyOrder(
-      *adjudicationsPageOne.agencies.union(adjudicationsPageTwo.agencies).toTypedArray()
+      *adjudicationsPageOne.agencies.union(adjudicationsPageTwo.agencies).toTypedArray(),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -61,7 +61,7 @@ class PlacementRequestServiceTest {
     offenderService,
     communityApiClient,
     cruService,
-    "http://frontend/applications/#id"
+    "http://frontend/applications/#id",
   )
 
   private val previousUser = UserEntityFactory()
@@ -88,7 +88,7 @@ class PlacementRequestServiceTest {
             .withYieldedApArea { ApAreaEntityFactory().produce() }
             .produce()
         }
-        .produce()
+        .produce(),
     )
     .produce()
 
@@ -118,7 +118,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(assigneeUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(previousUser)
       .produce()
@@ -147,7 +147,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(assigneeUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(previousUser)
       .produce()
@@ -190,7 +190,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(assigneeUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(previousUser)
       .produce()
@@ -257,7 +257,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(requestingUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(assigneeUser)
       .produce()
@@ -285,7 +285,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(assigneeUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(requestingUser)
       .produce()
@@ -319,7 +319,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(assigneeUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(assigneeUser)
       .produce()
@@ -366,7 +366,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -397,7 +397,7 @@ class PlacementRequestServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -411,7 +411,7 @@ class PlacementRequestServiceTest {
 
     every { communityApiClient.getStaffUserDetails(requestingUser.deliusUsername) } returns ClientResult.Success(
       HttpStatus.OK,
-      staffUserDetails
+      staffUserDetails,
     )
 
     every { domainEventService.saveBookingNotMadeEvent(any()) } just Runs
@@ -442,11 +442,11 @@ class PlacementRequestServiceTest {
             data.applicationUrl == "http://frontend/applications/${application.id}" &&
             data.personReference == PersonReference(
             crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!
+            noms = offenderDetails.otherIds.nomsNumber!!,
           ) &&
             data.deliusEventNumber == application.eventNumber &&
             data.failureDescription == "some notes"
-        }
+        },
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -86,7 +86,7 @@ class PremisesServiceTest {
     assertThat(result).containsValues(
       Availability(date = startDate, 0, 0, 0, 0, 0),
       Availability(date = startDate.plusDays(1), 0, 0, 0, 0, 0),
-      Availability(date = startDate.plusDays(2), 0, 0, 0, 0, 0)
+      Availability(date = startDate.plusDays(2), 0, 0, 0, 0, 0),
     )
   }
 
@@ -114,7 +114,7 @@ class PremisesServiceTest {
               withYieldedPremises { premises }
             }.produce()
           }
-        }.produce()
+        }.produce(),
       )
       .produce()
 
@@ -130,7 +130,7 @@ class PremisesServiceTest {
               withYieldedPremises { premises }
             }.produce()
           }
-        }.produce()
+        }.produce(),
       )
       .produce()
 
@@ -186,11 +186,11 @@ class PremisesServiceTest {
       pendingBookingEntity,
       arrivedBookingEntity,
       nonArrivedBookingEntity,
-      cancelledBookingEntity
+      cancelledBookingEntity,
     )
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf(
       lostBedEntityOne,
-      lostBedEntityTwo
+      lostBedEntityTwo,
     )
 
     val result = premisesService.getAvailabilityForRange(premises, startDate, endDate)
@@ -201,7 +201,7 @@ class PremisesServiceTest {
       Availability(date = startDate.plusDays(2), pendingBookings = 1, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0),
       Availability(date = startDate.plusDays(3), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 1, cancelledBookings = 0, lostBeds = 0),
       Availability(date = startDate.plusDays(4), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 1, cancelledBookings = 1, lostBeds = 0),
-      Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 1, lostBeds = 0)
+      Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 1, lostBeds = 0),
     )
   }
 
@@ -229,7 +229,7 @@ class PremisesServiceTest {
               withYieldedPremises { premises }
             }.produce()
           }
-        }.produce()
+        }.produce(),
       )
       .produce()
 
@@ -241,7 +241,7 @@ class PremisesServiceTest {
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf()
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf(
-      lostBedEntity
+      lostBedEntity,
     )
 
     val result = premisesService.getAvailabilityForRange(premises, startDate, endDate)
@@ -252,7 +252,7 @@ class PremisesServiceTest {
       Availability(date = startDate.plusDays(2), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0),
       Availability(date = startDate.plusDays(3), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0),
       Availability(date = startDate.plusDays(4), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0),
-      Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)
+      Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0),
     )
   }
 
@@ -335,10 +335,10 @@ class PremisesServiceTest {
       pendingBookingEntity,
       arrivedBookingEntity,
       nonArrivedBookingEntity,
-      cancelledBookingEntity
+      cancelledBookingEntity,
     )
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf(
-      lostBedEntity
+      lostBedEntity,
     )
 
     val result = premisesService.getAvailabilityForRange(premises, startDate, endDate)
@@ -349,7 +349,7 @@ class PremisesServiceTest {
       Availability(date = startDate.plusDays(2), pendingBookings = 1, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0),
       Availability(date = startDate.plusDays(3), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 1, cancelledBookings = 0, lostBeds = 0),
       Availability(date = startDate.plusDays(4), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 1, cancelledBookings = 1, lostBeds = 0),
-      Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 1, lostBeds = 0)
+      Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 1, lostBeds = 0),
     )
   }
 
@@ -375,13 +375,13 @@ class PremisesServiceTest {
       reasonId = reasonId,
       referenceNumber = "12345",
       notes = "notes",
-      bedId = UUID.randomUUID()
+      bedId = UUID.randomUUID(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
       entry("$.endDate", "beforeStartDate"),
-      entry("$.reason", "doesNotExist")
+      entry("$.reason", "doesNotExist"),
     )
   }
 
@@ -409,12 +409,12 @@ class PremisesServiceTest {
       reasonId = reasonId,
       referenceNumber = "12345",
       notes = "notes",
-      bedId = UUID.randomUUID()
+      bedId = UUID.randomUUID(),
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "incorrectLostBedReasonServiceScope")
+      entry("$.reason", "incorrectLostBedReasonServiceScope"),
     )
   }
 
@@ -455,7 +455,7 @@ class PremisesServiceTest {
       reasonId = lostBedReason.id,
       referenceNumber = "12345",
       notes = "notes",
-      bedId = bed.id
+      bedId = bed.id,
     )
 
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -495,7 +495,7 @@ class PremisesServiceTest {
               withPremises(premisesEntity)
             }.produce()
           }
-        }.produce()
+        }.produce(),
       )
       .produce()
 
@@ -508,7 +508,7 @@ class PremisesServiceTest {
       endDate = LocalDate.parse("2022-08-25"),
       reasonId = reasonId,
       referenceNumber = "12345",
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
@@ -516,7 +516,7 @@ class PremisesServiceTest {
     assertThat(resultEntity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
       entry("$.endDate", "beforeStartDate"),
-      entry("$.reason", "doesNotExist")
+      entry("$.reason", "doesNotExist"),
     )
   }
 
@@ -547,7 +547,7 @@ class PremisesServiceTest {
               withPremises(premisesEntity)
             }.produce()
           }
-        }.produce()
+        }.produce(),
       )
       .produce()
 
@@ -562,14 +562,14 @@ class PremisesServiceTest {
       endDate = LocalDate.parse("2022-08-28"),
       reasonId = reasonId,
       referenceNumber = "12345",
-      notes = "notes"
+      notes = "notes",
     )
 
     assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
     val resultEntity = (result as AuthorisableActionResult.Success).entity
     assertThat(resultEntity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "incorrectLostBedReasonServiceScope")
+      entry("$.reason", "incorrectLostBedReasonServiceScope"),
     )
   }
 
@@ -602,7 +602,7 @@ class PremisesServiceTest {
               withPremises(premisesEntity)
             }.produce()
           }
-        }.produce()
+        }.produce(),
       )
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
@@ -41,7 +41,7 @@ class RoomServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.name", "empty")
+      entry("$.name", "empty"),
     )
   }
 
@@ -64,7 +64,7 @@ class RoomServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.name", "empty")
+      entry("$.name", "empty"),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -41,7 +41,7 @@ class TaskServiceTest {
     applicationRepositoryMock,
     userServiceMock,
     placementRequestServiceMock,
-    userTransformerMock
+    userTransformerMock,
   )
 
   private val requestUserWithPermission = UserEntityFactory()
@@ -109,8 +109,8 @@ class TaskServiceTest {
 
     every { assessmentServiceMock.reallocateAssessment(assigneeUser, application) } returns AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
-        assessment
-      )
+        assessment,
+      ),
     )
 
     val transformedUser = mockk<ApprovedPremisesUser>()
@@ -119,7 +119,7 @@ class TaskServiceTest {
 
     val reallocation = Reallocation(
       taskType = TaskType.assessment,
-      user = transformedUser
+      user = transformedUser,
     )
 
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUser.id, application.id)
@@ -144,15 +144,15 @@ class TaskServiceTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(assigneeUser)
-          .produce()
+          .produce(),
       )
       .withAllocatedToUser(assigneeUser)
       .produce()
 
     every { placementRequestServiceMock.reallocatePlacementRequest(assigneeUser, application) } returns AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
-        placementRequest
-      )
+        placementRequest,
+      ),
     )
 
     val transformedUser = mockk<ApprovedPremisesUser>()
@@ -161,7 +161,7 @@ class TaskServiceTest {
 
     val reallocation = Reallocation(
       taskType = TaskType.placementRequest,
-      user = transformedUser
+      user = transformedUser,
     )
 
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.placementRequest, assigneeUser.id, application.id)
@@ -198,7 +198,7 @@ class TaskServiceTest {
               .withYieldedApArea { ApAreaEntityFactory().produce() }
               .produce()
           }
-          .produce()
+          .produce(),
       )
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -35,7 +35,7 @@ class UserAccessServiceTest {
     .withId(probationRegionId)
     .withApArea(
       ApAreaEntityFactory()
-        .produce()
+        .produce(),
     )
     .produce()
 
@@ -47,7 +47,7 @@ class UserAccessServiceTest {
     .withProbationRegion(probationRegion)
     .withLocalAuthorityArea(
       LocalAuthorityEntityFactory()
-        .produce()
+        .produce(),
     )
     .produce()
 
@@ -55,7 +55,7 @@ class UserAccessServiceTest {
     .withProbationRegion(probationRegion)
     .withLocalAuthorityArea(
       LocalAuthorityEntityFactory()
-        .produce()
+        .produce(),
     )
     .produce()
 
@@ -64,13 +64,13 @@ class UserAccessServiceTest {
       ProbationRegionEntityFactory()
         .withApArea(
           ApAreaEntityFactory()
-            .produce()
+            .produce(),
         )
-        .produce()
+        .produce(),
     )
     .withLocalAuthorityArea(
       LocalAuthorityEntityFactory()
-        .produce()
+        .produce(),
     )
     .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -86,7 +86,7 @@ class UserServiceTest {
         .withForenames("Jim")
         .withSurname("Jimmerson")
         .withStaffIdentifier(5678)
-        .produce()
+        .produce(),
     )
 
     every { mockProbationRegionRepository.findByDeliusCode(any()) } returns ProbationRegionEntityFactory()
@@ -160,7 +160,7 @@ class UserServiceTest {
       every { mockUserRepository.findByIdOrNull(id) } returns user
       every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
         HttpStatus.OK,
-        deliusUser
+        deliusUser,
       )
 
       val result = userService.updateUserFromCommunityApiById(id)
@@ -192,7 +192,7 @@ class UserServiceTest {
       every { mockUserRepository.findByIdOrNull(id) } returns user
       every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
         HttpStatus.OK,
-        deliusUser
+        deliusUser,
       )
 
       val result = userService.updateUserFromCommunityApiById(id)
@@ -211,6 +211,7 @@ class UserServiceTest {
       verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
       verify(exactly = 1) { mockUserRepository.save(any()) }
     }
+
     @Test
     fun `it does not save the object if the email, telephone number and staff code are the same as Delius`() {
       val email = "foo@example.com"
@@ -235,7 +236,7 @@ class UserServiceTest {
       every { mockUserRepository.findByIdOrNull(id) } returns user
       every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Success(
         HttpStatus.OK,
-        deliusUser
+        deliusUser,
       )
 
       val result = userService.updateUserFromCommunityApiById(id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WorkingDayCountServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WorkingDayCountServiceTest.kt
@@ -30,23 +30,23 @@ class WorkingDayCountServiceTest {
     UKBankHolidays(
       englandAndWales = CountryBankHolidays(
         division = "england-and-wales",
-        events = listOf()
+        events = listOf(),
       ),
       scotland = CountryBankHolidays(
         division = "scotland",
-        events = listOf()
+        events = listOf(),
       ),
       northernIreland = CountryBankHolidays(
         division = "northern-ireland",
-        events = listOf()
-      )
-    )
+        events = listOf(),
+      ),
+    ),
   )
 
   @ParameterizedTest(name = "getWorkingDaysCount returns 0 if from and to are the same date = {0} and it is a weekend day")
   @MethodSource("weekendDayProvider")
   fun `getWorkingDaysCount returns 0 if from and to are the same date and it is a weekend day`(
-    from: LocalDate
+    from: LocalDate,
   ) {
     every {
       mockGovUKBankHolidaysApiClient.getUKBankHolidays()
@@ -57,7 +57,6 @@ class WorkingDayCountServiceTest {
 
   @Test
   fun `getWorkingDaysCount returns 0 if from and to are the same date and it is a week day bank holiday`() {
-
     val weekDayBankHoliday = LocalDate.of(2023, 4, 27).with(TemporalAdjusters.next(DayOfWeek.TUESDAY))
 
     val bankHolidays = ClientResult.Success(
@@ -70,19 +69,19 @@ class WorkingDayCountServiceTest {
               title = "sunny bank holiday",
               date = weekDayBankHoliday,
               notes = "",
-              bunting = true
-            )
-          )
+              bunting = true,
+            ),
+          ),
         ),
         scotland = CountryBankHolidays(
           division = "scotland",
-          events = listOf()
+          events = listOf(),
         ),
         northernIreland = CountryBankHolidays(
           division = "northern-ireland",
-          events = listOf()
-        )
-      )
+          events = listOf(),
+        ),
+      ),
     )
 
     every {
@@ -94,7 +93,6 @@ class WorkingDayCountServiceTest {
 
   @Test
   fun `getWorkingDaysCount returns 1 if from and to are the same date and it is not a weekend day and it is not a bank holiday`() {
-
     every {
       mockGovUKBankHolidaysApiClient.getUKBankHolidays()
     } returns emptyBankHolidays
@@ -132,25 +130,25 @@ class WorkingDayCountServiceTest {
               title = "sunny tuesday bank holiday",
               date = aTuesdayBankHoliday,
               notes = "",
-              bunting = true
+              bunting = true,
             ),
             BankHolidayEvent(
               title = "sunny thursday bank holiday",
               date = aThursdayBankHoliday,
               notes = "",
-              bunting = true
-            )
-          )
+              bunting = true,
+            ),
+          ),
         ),
         scotland = CountryBankHolidays(
           division = "scotland",
-          events = listOf()
+          events = listOf(),
         ),
         northernIreland = CountryBankHolidays(
           division = "northern-ireland",
-          events = listOf()
-        )
-      )
+          events = listOf(),
+        ),
+      ),
     )
 
     every {
@@ -195,25 +193,25 @@ class WorkingDayCountServiceTest {
               title = "Early May bank holiday",
               date = LocalDate.of(2023, 5, 1),
               notes = "",
-              bunting = true
+              bunting = true,
             ),
             BankHolidayEvent(
               title = "Bank holiday for the coronation of King Charles III",
               date = LocalDate.of(2023, 5, 8),
               notes = "",
-              bunting = true
-            )
-          )
+              bunting = true,
+            ),
+          ),
         ),
         scotland = CountryBankHolidays(
           division = "scotland",
-          events = listOf()
+          events = listOf(),
         ),
         northernIreland = CountryBankHolidays(
           division = "northern-ireland",
-          events = listOf()
-        )
-      )
+          events = listOf(),
+        ),
+      ),
     )
 
     every {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AdjudicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AdjudicationTransformerTest.kt
@@ -27,9 +27,9 @@ class AdjudicationTransformerTest {
             AdjudicationFactory()
               .withAgencyId("UNKNOWN")
               .withCharges(listOf(AdjudicationChargeFactory().produce()))
-              .produce()
-          )
-        ).produce()
+              .produce(),
+          ),
+        ).produce(),
       )
     }
 
@@ -51,18 +51,18 @@ class AdjudicationTransformerTest {
               oicChargeId = "CHARGE",
               offenceCode = "OFFENCE",
               offenceDescription = "Something, something",
-              findingCode = "QUASHED"
-            )
-          )
-        )
+              findingCode = "QUASHED",
+            ),
+          ),
+        ),
       ),
       agencies = listOf(
         Agency(
           agencyId = "PLACE",
           description = "THE PLACE",
-          agencyType = "INST"
-        )
-      )
+          agencyType = "INST",
+        ),
+      ),
     )
 
     val transformed = adjudicationTransformer.transformToApi(adjudicationsPage)
@@ -74,9 +74,9 @@ class AdjudicationTransformerTest {
           establishment = "THE PLACE",
           offenceDescription = "Something, something",
           hearingHeld = true,
-          finding = "QUASHED"
-        )
-      )
+          finding = "QUASHED",
+        ),
+      ),
     )
   }
 
@@ -95,18 +95,18 @@ class AdjudicationTransformerTest {
               oicChargeId = "CHARGE",
               offenceCode = "OFFENCE",
               offenceDescription = "Something, something",
-              findingCode = null
-            )
-          )
-        )
+              findingCode = null,
+            ),
+          ),
+        ),
       ),
       agencies = listOf(
         Agency(
           agencyId = "PLACE",
           description = "THE PLACE",
-          agencyType = "INST"
-        )
-      )
+          agencyType = "INST",
+        ),
+      ),
     )
 
     val transformed = adjudicationTransformer.transformToApi(adjudicationsPage)
@@ -118,9 +118,9 @@ class AdjudicationTransformerTest {
           establishment = "THE PLACE",
           offenceDescription = "Something, something",
           hearingHeld = false,
-          finding = null
-        )
-      )
+          finding = null,
+        ),
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -53,7 +53,7 @@ class ApplicationsTransformerTest {
   private val applicationsTransformer = ApplicationsTransformer(
     objectMapper,
     mockPersonTransformer,
-    mockRisksTransformer
+    mockRisksTransformer,
   )
 
   private val user = UserEntityFactory()
@@ -133,7 +133,7 @@ class ApplicationsTransformerTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
           .produce()
       }
@@ -163,7 +163,7 @@ class ApplicationsTransformerTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
           .produce()
       }
@@ -186,7 +186,7 @@ class ApplicationsTransformerTest {
         .produce(),
       awaitingClarificationNoteFactory
         .withAssessment(assessment)
-        .produce()
+        .produce(),
     )
 
     val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
@@ -201,7 +201,7 @@ class ApplicationsTransformerTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
           .produce()
       }
@@ -215,7 +215,7 @@ class ApplicationsTransformerTest {
         .produce(),
       awaitingClarificationNoteFactory
         .withAssessment(assessment)
-        .produce()
+        .produce(),
     )
 
     val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
@@ -231,7 +231,7 @@ class ApplicationsTransformerTest {
     assessment.clarificationNotes = mutableListOf(
       completedClarificationNoteFactory
         .withAssessment(assessment)
-        .produce()
+        .produce(),
     )
 
     application.assessments = mutableListOf(assessment)
@@ -290,7 +290,7 @@ class ApplicationsTransformerTest {
       .withAllocatedToUser(
         UserEntityFactory()
           .withUnitTestControlProbationRegion()
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -316,7 +316,7 @@ class ApplicationsTransformerTest {
       .withPremises(
         ApprovedPremisesEntityFactory()
           .withUnitTestControlTestProbationAreaAndLocalAuthority()
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -327,7 +327,7 @@ class ApplicationsTransformerTest {
       .withAllocatedToUser(
         UserEntityFactory()
           .withUnitTestControlProbationRegion()
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -345,7 +345,7 @@ class ApplicationsTransformerTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
           .produce()
       }
@@ -355,7 +355,7 @@ class ApplicationsTransformerTest {
     assessment.clarificationNotes = mutableListOf(
       completedClarificationNoteFactory
         .withAssessment(assessment)
-        .produce()
+        .produce(),
     )
 
     application.assessments = mutableListOf(assessment)
@@ -372,7 +372,7 @@ class ApplicationsTransformerTest {
         ProbationRegionEntityFactory()
           .withApArea(
             ApAreaEntityFactory()
-              .produce()
+              .produce(),
           )
           .produce()
       }
@@ -387,13 +387,13 @@ class ApplicationsTransformerTest {
     oldAssessment.clarificationNotes = mutableListOf(
       awaitingClarificationNoteFactory
         .withAssessment(oldAssessment)
-        .produce()
+        .produce(),
     )
 
     latestAssessment.clarificationNotes = mutableListOf(
       completedClarificationNoteFactory
         .withAssessment(latestAssessment)
-        .produce()
+        .produce(),
     )
 
     application.assessments = mutableListOf(oldAssessment, latestAssessment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -63,7 +63,7 @@ class AssessmentTransformerTest {
     fun assessmentDecisionPairs(): Stream<Arguments> = Stream.of(
       of("ACCEPTED", ApiAssessmentDecision.accepted),
       of("REJECTED", ApiAssessmentDecision.rejected),
-      of(null, null)
+      of(null, null),
     )
   }
 
@@ -91,8 +91,8 @@ class AssessmentTransformerTest {
       ApprovedPremisesAssessmentJsonSchemaEntity(
         id = UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"),
         addedAt = OffsetDateTime.now(),
-        schema = "{}"
-      )
+        schema = "{}",
+      ),
     )
     .withDecision(JpaAssessmentDecision.REJECTED)
     .withRejectionRationale("reasoning")
@@ -142,7 +142,7 @@ class AssessmentTransformerTest {
                 .withYieldedApArea { ApAreaEntityFactory().produce() }
                 .produce()
             }
-            .produce()
+            .produce(),
         )
         .produce(),
       AssessmentClarificationNoteEntityFactory()
@@ -154,9 +154,9 @@ class AssessmentTransformerTest {
                 .withYieldedApArea { ApAreaEntityFactory().produce() }
                 .produce()
             }
-            .produce()
+            .produce(),
         )
-        .produce()
+        .produce(),
     )
 
     assessment.clarificationNotes = clarificationNotes
@@ -227,7 +227,7 @@ class AssessmentTransformerTest {
       completed = false,
       decision = domainDecision,
       crn = randomStringMultiCaseWithNumbers(6),
-      isStarted = true
+      isStarted = true,
     )
 
     every { mockPersonTransformer.transformModelToApi(any(), any()) } returns mockk<Person>()
@@ -257,7 +257,7 @@ class AssessmentTransformerTest {
       completed = false,
       decision = "ACCEPTED",
       crn = randomStringMultiCaseWithNumbers(6),
-      isStarted = true
+      isStarted = true,
     )
 
     every { mockPersonTransformer.transformModelToApi(any(), any()) } returns mockk<Person>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingNotMadeTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingNotMadeTransformerTest.kt
@@ -34,7 +34,7 @@ class BookingNotMadeTransformerTest {
         AssessmentEntityFactory()
           .withApplication(application)
           .withAllocatedToUser(otherUser)
-          .produce()
+          .produce(),
       )
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -103,14 +103,14 @@ class BookingTransformerTest {
         id = UUID.fromString("a005f122-a0e9-4d93-b5bb-f7c5bd82a015"),
         identifier = "APA",
         name = "Ap Area",
-        probationRegions = mutableListOf()
-      )
+        probationRegions = mutableListOf(),
+      ),
     ).apply { apArea.probationRegions.add(this) },
     localAuthorityArea = LocalAuthorityAreaEntity(
       id = UUID.fromString("ee39d3bc-e9ad-4408-a21d-cf763aa1d981"),
       identifier = "AUTHORITY",
       name = "Local Authority Area",
-      premises = mutableListOf()
+      premises = mutableListOf(),
     ),
     bookings = mutableListOf(),
     lostBeds = mutableListOf(),
@@ -125,7 +125,7 @@ class BookingTransformerTest {
     characteristics = mutableListOf(),
     status = PropertyStatus.active,
     probationDeliveryUnit = null,
-    turnaroundWorkingDayCount = 2
+    turnaroundWorkingDayCount = 2,
   )
 
   private val baseBookingEntity = BookingEntity(
@@ -149,7 +149,7 @@ class BookingTransformerTest {
     application = null,
     offlineApplication = null,
     turnarounds = mutableListOf(),
-    nomsNumber = "NOMS123"
+    nomsNumber = "NOMS123",
   )
 
   private val staffMember = StaffMember(
@@ -158,8 +158,8 @@ class BookingTransformerTest {
     name = StaffMemberName(
       forename = "first",
       middleName = null,
-      surname = "last"
-    )
+      surname = "last",
+    ),
   )
 
   private val offenderDetails = OffenderDetailsSummaryFactory()
@@ -183,7 +183,7 @@ class BookingTransformerTest {
     every { mockStaffMemberTransformer.transformDomainToApi(staffMember) } returns uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
       code = "789",
       keyWorker = true,
-      name = "first last"
+      name = "first last",
     )
 
     every { mockPersonTransformer.transformModelToApi(offenderDetails, inmateDetail) } returns Person(
@@ -196,7 +196,7 @@ class BookingTransformerTest {
       nationality = "English",
       religionOrBelief = null,
       genderIdentity = null,
-      prisonName = null
+      prisonName = null,
     )
   }
 
@@ -224,7 +224,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -238,7 +238,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -264,7 +264,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -278,7 +278,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -319,7 +319,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -341,8 +341,8 @@ class BookingTransformerTest {
         departures = listOf(),
         cancellations = listOf(),
         turnarounds = listOf(),
-        effectiveEndDate = LocalDate.parse("2022-08-30")
-      )
+        effectiveEndDate = LocalDate.parse("2022-08-30"),
+      ),
     )
   }
 
@@ -382,14 +382,14 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
           code = "789",
           keyWorker = true,
-          name = "first last"
+          name = "first last",
         ),
         status = BookingStatus.arrived,
         arrival = Arrival(
@@ -408,7 +408,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -423,7 +423,7 @@ class BookingTransformerTest {
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        )
+        ),
       )
     }
 
@@ -450,7 +450,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -476,11 +476,11 @@ class BookingTransformerTest {
             reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          )
+          ),
         ),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -504,7 +504,7 @@ class BookingTransformerTest {
           notes = "Original reason chosen in error",
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-02T12:34:56.789Z"),
-        )
+        ),
       )
     }
 
@@ -545,7 +545,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -578,11 +578,11 @@ class BookingTransformerTest {
             date = LocalDate.parse("2022-08-10"),
             reason = CancellationReason(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
             createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
-          )
+          ),
         ),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -607,24 +607,24 @@ class BookingTransformerTest {
             name = "Departure Reason",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusReasonCode = "A"
+            legacyDeliusReasonCode = "A",
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
             name = "Move on Category",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT"
+            legacyDeliusCategoryCode = "CAT",
           ),
           destinationProvider = DestinationProviderEntity(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        )
+        ),
       )
     }
 
@@ -655,7 +655,7 @@ class BookingTransformerTest {
       destinationProvider = DestinationProvider(
         id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
         name = "Destination Provider",
-        isActive = true
+        isActive = true,
       ),
       notes = null,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -676,14 +676,14 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
           code = "789",
           keyWorker = true,
-          name = "first last"
+          name = "first last",
         ),
         status = BookingStatus.departed,
         arrival = Arrival(
@@ -712,7 +712,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -742,16 +742,16 @@ class BookingTransformerTest {
             destinationProvider = DestinationProvider(
               id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
               name = "Destination Provider",
-              isActive = true
+              isActive = true,
             ),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          )
+          ),
         ),
         cancellations = listOf(),
         turnarounds = listOf(),
-        effectiveEndDate = LocalDate.parse("2022-08-30")
-      )
+        effectiveEndDate = LocalDate.parse("2022-08-30"),
+      ),
     )
   }
 
@@ -776,31 +776,31 @@ class BookingTransformerTest {
             name = "Departure Reason",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusReasonCode = "A"
+            legacyDeliusReasonCode = "A",
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
             name = "Move on Category",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT"
+            legacyDeliusCategoryCode = "CAT",
           ),
           destinationProvider = DestinationProviderEntity(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        )
+        ),
       )
 
       turnarounds += TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 0,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        booking = this
+        booking = this,
       )
     }
 
@@ -831,7 +831,7 @@ class BookingTransformerTest {
       destinationProvider = DestinationProvider(
         id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
         name = "Destination Provider",
-        isActive = true
+        isActive = true,
       ),
       notes = null,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -841,7 +841,7 @@ class BookingTransformerTest {
       id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
       workingDays = 0,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-      bookingId = bookingId
+      bookingId = bookingId,
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
@@ -859,14 +859,14 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
           code = "789",
           keyWorker = true,
-          name = "first last"
+          name = "first last",
         ),
         status = BookingStatus.closed,
         arrival = Arrival(
@@ -895,7 +895,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -925,29 +925,29 @@ class BookingTransformerTest {
             destinationProvider = DestinationProvider(
               id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
               name = "Destination Provider",
-              isActive = true
+              isActive = true,
             ),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          )
+          ),
         ),
         cancellations = listOf(),
         turnaround = Turnaround(
           id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
           workingDays = 0,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          bookingId = bookingId
+          bookingId = bookingId,
         ),
         turnarounds = listOf(
           Turnaround(
             id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
             workingDays = 0,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-            bookingId = bookingId
-          )
+            bookingId = bookingId,
+          ),
         ),
-        effectiveEndDate = LocalDate.parse("2022-08-30")
-      )
+        effectiveEndDate = LocalDate.parse("2022-08-30"),
+      ),
     )
   }
 
@@ -982,31 +982,31 @@ class BookingTransformerTest {
             name = "Departure Reason",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusReasonCode = "A"
+            legacyDeliusReasonCode = "A",
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
             name = "Move on Category",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT"
+            legacyDeliusCategoryCode = "CAT",
           ),
           destinationProvider = DestinationProviderEntity(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        )
+        ),
       )
 
       turnarounds += TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 2,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        booking = this
+        booking = this,
       )
     }
 
@@ -1037,7 +1037,7 @@ class BookingTransformerTest {
       destinationProvider = DestinationProvider(
         id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
         name = "Destination Provider",
-        isActive = true
+        isActive = true,
       ),
       notes = null,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1047,7 +1047,7 @@ class BookingTransformerTest {
       id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
       workingDays = 2,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-      bookingId = bookingId
+      bookingId = bookingId,
     )
 
     every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 1) } returns departedAt.toLocalDate().plusDays(1)
@@ -1068,14 +1068,14 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = departedAt.toLocalDate(),
         keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
           code = "789",
           keyWorker = true,
-          name = "first last"
+          name = "first last",
         ),
         status = BookingStatus.departed,
         arrival = Arrival(
@@ -1104,7 +1104,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1134,30 +1134,30 @@ class BookingTransformerTest {
             destinationProvider = DestinationProvider(
               id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
               name = "Destination Provider",
-              isActive = true
+              isActive = true,
             ),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          )
+          ),
         ),
         cancellations = listOf(),
         turnaround = Turnaround(
           id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
           workingDays = 2,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          bookingId = bookingId
+          bookingId = bookingId,
         ),
         turnarounds = listOf(
           Turnaround(
             id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
             workingDays = 2,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-            bookingId = bookingId
-          )
+            bookingId = bookingId,
+          ),
         ),
         turnaroundStartDate = departedAt.toLocalDate().plusDays(1),
-        effectiveEndDate = expectedEffectiveEndDate
-      )
+        effectiveEndDate = expectedEffectiveEndDate,
+      ),
     )
   }
 
@@ -1192,31 +1192,31 @@ class BookingTransformerTest {
             name = "Departure Reason",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusReasonCode = "A"
+            legacyDeliusReasonCode = "A",
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
             name = "Move on Category",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT"
+            legacyDeliusCategoryCode = "CAT",
           ),
           destinationProvider = DestinationProviderEntity(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        )
+        ),
       )
 
       turnarounds += TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 2,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        booking = this
+        booking = this,
       )
     }
 
@@ -1247,7 +1247,7 @@ class BookingTransformerTest {
       destinationProvider = DestinationProvider(
         id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
         name = "Destination Provider",
-        isActive = true
+        isActive = true,
       ),
       notes = null,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1257,7 +1257,7 @@ class BookingTransformerTest {
       id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
       workingDays = 2,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-      bookingId = bookingId
+      bookingId = bookingId,
     )
 
     every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 1) } returns departedAt.toLocalDate().plusDays(1)
@@ -1278,14 +1278,14 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = departedAt.toLocalDate(),
         keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
           code = "789",
           keyWorker = true,
-          name = "first last"
+          name = "first last",
         ),
         status = BookingStatus.closed,
         arrival = Arrival(
@@ -1314,7 +1314,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1344,30 +1344,30 @@ class BookingTransformerTest {
             destinationProvider = DestinationProvider(
               id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
               name = "Destination Provider",
-              isActive = true
+              isActive = true,
             ),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          )
+          ),
         ),
         cancellations = listOf(),
         turnaround = Turnaround(
           id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
           workingDays = 2,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          bookingId = bookingId
+          bookingId = bookingId,
         ),
         turnarounds = listOf(
           Turnaround(
             id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
             workingDays = 2,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-            bookingId = bookingId
-          )
+            bookingId = bookingId,
+          ),
         ),
         turnaroundStartDate = departedAt.toLocalDate().plusDays(1),
-        effectiveEndDate = expectedEffectiveEndDate
-      )
+        effectiveEndDate = expectedEffectiveEndDate,
+      ),
     )
   }
 
@@ -1393,19 +1393,19 @@ class BookingTransformerTest {
             name = "Departure Reason",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusReasonCode = "A"
+            legacyDeliusReasonCode = "A",
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
             name = "Move on Category",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT"
+            legacyDeliusCategoryCode = "CAT",
           ),
           destinationProvider = DestinationProviderEntity(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           booking = this,
@@ -1419,24 +1419,24 @@ class BookingTransformerTest {
             name = "Departure Reason",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusReasonCode = "A"
+            legacyDeliusReasonCode = "A",
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("3fc011f3-81ae-46fa-a066-84de8423ab87"),
             name = "Some other category",
             isActive = true,
             serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT"
+            legacyDeliusCategoryCode = "CAT",
           ),
           destinationProvider = DestinationProviderEntity(
             id = UUID.fromString("48a5fac2-6ac6-4dad-8389-b59cc6b6112c"),
             name = "Some other destination provider",
-            isActive = true
+            isActive = true,
           ),
           notes = "Updated move-on category and destination provider after receiving new information",
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-02T12:34:56.789Z"),
-        )
+        ),
       )
     }
 
@@ -1471,7 +1471,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
             name = "Destination Provider",
-            isActive = true
+            isActive = true,
           ),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1495,7 +1495,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("48a5fac2-6ac6-4dad-8389-b59cc6b6112c"),
             name = "Some other destination provider",
-            isActive = true
+            isActive = true,
           ),
           notes = "Updated move-on category and destination provider after receiving new information",
           createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
@@ -1520,14 +1520,14 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
         keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
           code = "789",
           keyWorker = true,
-          name = "first last"
+          name = "first last",
         ),
         status = BookingStatus.closed,
         arrival = Arrival(
@@ -1556,7 +1556,7 @@ class BookingTransformerTest {
           destinationProvider = DestinationProvider(
             id = UUID.fromString("48a5fac2-6ac6-4dad-8389-b59cc6b6112c"),
             name = "Some other destination provider",
-            isActive = true
+            isActive = true,
           ),
           notes = "Updated move-on category and destination provider after receiving new information",
           createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
@@ -1586,7 +1586,7 @@ class BookingTransformerTest {
             destinationProvider = DestinationProvider(
               id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
               name = "Destination Provider",
-              isActive = true
+              isActive = true,
             ),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1610,16 +1610,16 @@ class BookingTransformerTest {
             destinationProvider = DestinationProvider(
               id = UUID.fromString("48a5fac2-6ac6-4dad-8389-b59cc6b6112c"),
               name = "Some other destination provider",
-              isActive = true
+              isActive = true,
             ),
             notes = "Updated move-on category and destination provider after receiving new information",
             createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
-          )
+          ),
         ),
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -1661,7 +1661,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -1684,7 +1684,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
-      )
+      ),
     )
   }
 
@@ -1693,7 +1693,7 @@ class BookingTransformerTest {
     val awaitingArrivalBooking = baseBookingEntity.copy(
       id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
       service = ServiceName.temporaryAccommodation.value,
-      turnarounds = mutableListOf()
+      turnarounds = mutableListOf(),
     )
 
     val turnaround1 = TurnaroundEntity(
@@ -1756,7 +1756,7 @@ class BookingTransformerTest {
           nationality = "English",
           religionOrBelief = null,
           genderIdentity = null,
-          prisonName = null
+          prisonName = null,
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
@@ -1795,8 +1795,8 @@ class BookingTransformerTest {
           ),
         ),
         turnaroundStartDate = LocalDate.parse("2022-08-31"),
-        effectiveEndDate = LocalDate.parse("2022-09-05")
-      )
+        effectiveEndDate = LocalDate.parse("2022-09-05"),
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ConvictionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ConvictionTransformerTest.kt
@@ -30,8 +30,8 @@ class ConvictionTransformerTest {
             .withMainCategoryDescription("Main Category 2")
             .withSubCategoryDescription("Sub Category 2")
             .withOffenceDate(LocalDateTime.parse("2022-12-05T00:00:00"))
-            .produce()
-        )
+            .produce(),
+        ),
       )
       .produce()
 
@@ -41,15 +41,15 @@ class ConvictionTransformerTest {
         offenceDescription = "Main Category 1 - Sub Category 1",
         offenceId = "1",
         convictionId = 12345,
-        offenceDate = LocalDate.parse("2022-12-06")
+        offenceDate = LocalDate.parse("2022-12-06"),
       ),
       ActiveOffence(
         deliusEventNumber = "5",
         offenceDescription = "Main Category 2 - Sub Category 2",
         offenceId = "2",
         convictionId = 12345,
-        offenceDate = LocalDate.parse("2022-12-05")
-      )
+        offenceDate = LocalDate.parse("2022-12-05"),
+      ),
     )
   }
 
@@ -66,7 +66,7 @@ class ConvictionTransformerTest {
             .withSubCategoryDescription("A Description")
             .withOffenceDate(LocalDateTime.parse("2022-12-06T00:00:00"))
             .produce(),
-        )
+        ),
       )
       .produce()
 
@@ -76,8 +76,8 @@ class ConvictionTransformerTest {
         offenceDescription = "A Description",
         offenceId = "1",
         convictionId = 12345,
-        offenceDate = LocalDate.parse("2022-12-06")
-      )
+        offenceDate = LocalDate.parse("2022-12-06"),
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
@@ -25,7 +25,7 @@ class DocumentTransformerTest {
           .withTypeDescription("Type 1 Description")
           .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
           .withExtendedDescription("Extended Description 1")
-          .produce()
+          .produce(),
       )
       .withConvictionLevelDocument(
         "12345",
@@ -37,7 +37,7 @@ class DocumentTransformerTest {
           .withTypeDescription("Type 2 Description")
           .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
           .withExtendedDescription("Extended Description 2")
-          .produce()
+          .produce(),
       )
       .withConvictionLevelDocument(
         "6789",
@@ -48,7 +48,7 @@ class DocumentTransformerTest {
           .withTypeDescription("Type 2 Description")
           .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
           .withExtendedDescription("Extended Description 2")
-          .produce()
+          .produce(),
       )
       .produce()
 
@@ -62,7 +62,7 @@ class DocumentTransformerTest {
         createdAt = Instant.parse("2022-12-07T11:40:00Z"),
         typeCode = "TYPE-1",
         typeDescription = "Type 1 Description",
-        description = "Extended Description 1"
+        description = "Extended Description 1",
       ),
       Document(
         id = UUID.fromString("457af8a5-82b1-449a-ad03-032b39435865").toString(),
@@ -71,8 +71,8 @@ class DocumentTransformerTest {
         createdAt = Instant.parse("2022-12-07T10:40:00Z"),
         typeCode = "TYPE-2",
         typeDescription = "Type 2 Description",
-        description = "Extended Description 2"
-      )
+        description = "Extended Description 2",
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/NeedsDetailsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/NeedsDetailsTransformerTest.kt
@@ -21,18 +21,18 @@ class NeedsDetailsTransformerTest {
       .withEducationTrainingEmploymentIssuesDetails(
         educationTrainingEmploymentIssuesDetails = null,
         linkedToHarm = null,
-        linkedToReoffending = null
+        linkedToReoffending = null,
       )
       .withAccommodationIssuesDetails(
         accommodationIssuesDetails = null,
         linkedToHarm = null,
-        linkedToReoffending = null
+        linkedToReoffending = null,
       )
       .withAttitudeIssuesDetails(attitudeIssuesDetails = null, linkedToHarm = null, linkedToReoffending = null)
       .withThinkingBehaviouralIssuesDetails(
         thinkingBehaviouralIssuesDetails = null,
         linkedToHarm = null,
-        linkedToReoffending = null
+        linkedToReoffending = null,
       )
       .produce()
 
@@ -47,7 +47,7 @@ class NeedsDetailsTransformerTest {
       OASysSection(section = 7, name = "Lifestyle", linkedToHarm = null, linkedToReOffending = null),
       OASysSection(section = 11, name = "Thinking and Behavioural", linkedToHarm = null, linkedToReOffending = null),
       OASysSection(section = 12, name = "Attitude", linkedToHarm = null, linkedToReOffending = null),
-      OASysSection(section = 13, name = "Health", linkedToHarm = null, linkedToReOffending = null)
+      OASysSection(section = 13, name = "Health", linkedToHarm = null, linkedToReOffending = null),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
@@ -77,7 +77,7 @@ class OASysSectionsTransformerTest {
       risksToTheIndividualApiResponse,
       riskManagementPlanApiResponse,
       needsDetailsApiResponse,
-      requestedOptionalSections
+      requestedOptionalSections,
     )
 
     assertThat(result.assessmentId).isEqualTo(offenceDetailsApiResponse.assessmentId)
@@ -89,39 +89,39 @@ class OASysSectionsTransformerTest {
         OASysQuestion(
           label = "Offence analysis",
           questionNumber = "2.1",
-          answer = offenceDetailsApiResponse.offence?.offenceAnalysis
+          answer = offenceDetailsApiResponse.offence?.offenceAnalysis,
         ),
         OASysQuestion(
           label = "Pattern of offending",
           questionNumber = "2.12",
-          answer = offenceDetailsApiResponse.offence?.patternOffending
+          answer = offenceDetailsApiResponse.offence?.patternOffending,
         ),
         OASysQuestion(
           label = "Victim - perpetrator relationship",
           questionNumber = "2.4.1",
-          answer = offenceDetailsApiResponse.offence?.victimPerpetratorRel
+          answer = offenceDetailsApiResponse.offence?.victimPerpetratorRel,
         ),
         OASysQuestion(
           label = "Other victim information",
           questionNumber = "2.4.2",
-          answer = offenceDetailsApiResponse.offence?.victimInfo
+          answer = offenceDetailsApiResponse.offence?.victimInfo,
         ),
         OASysQuestion(
           label = "Impact on the victim",
           questionNumber = "2.5",
-          answer = offenceDetailsApiResponse.offence?.victimImpact
+          answer = offenceDetailsApiResponse.offence?.victimImpact,
         ),
         OASysQuestion(
           label = "Motivation and triggers",
           questionNumber = "2.8.3",
-          answer = offenceDetailsApiResponse.offence?.offenceMotivation
+          answer = offenceDetailsApiResponse.offence?.offenceMotivation,
         ),
         OASysQuestion(
           label = "Issues contributing to risks",
           questionNumber = "2.98",
-          answer = offenceDetailsApiResponse.offence?.issueContributingToRisk
-        )
-      )
+          answer = offenceDetailsApiResponse.offence?.issueContributingToRisk,
+        ),
+      ),
     )
 
     assertThat(result.roshSummary).containsAll(
@@ -129,29 +129,29 @@ class OASysSectionsTransformerTest {
         OASysQuestion(
           label = "Who is at risk",
           questionNumber = "R10.1",
-          answer = roshSummaryApiResponse.roshSummary?.whoIsAtRisk
+          answer = roshSummaryApiResponse.roshSummary?.whoIsAtRisk,
         ),
         OASysQuestion(
           label = "What is the nature of the risk",
           questionNumber = "R10.2",
-          answer = roshSummaryApiResponse.roshSummary?.natureOfRisk
+          answer = roshSummaryApiResponse.roshSummary?.natureOfRisk,
         ),
         OASysQuestion(
           label = "When is the risk likely to be the greatest",
           questionNumber = "R10.3",
-          answer = roshSummaryApiResponse.roshSummary?.riskGreatest
+          answer = roshSummaryApiResponse.roshSummary?.riskGreatest,
         ),
         OASysQuestion(
           label = "What circumstances are likely to increase risk",
           questionNumber = "R10.4",
-          answer = roshSummaryApiResponse.roshSummary?.riskIncreaseLikelyTo
+          answer = roshSummaryApiResponse.roshSummary?.riskIncreaseLikelyTo,
         ),
         OASysQuestion(
           label = "What circumstances are likely to reduce the risk",
           questionNumber = "R10.5",
-          answer = roshSummaryApiResponse.roshSummary?.riskReductionLikelyTo
-        )
-      )
+          answer = roshSummaryApiResponse.roshSummary?.riskReductionLikelyTo,
+        ),
+      ),
     )
 
     assertThat(result.riskToSelf).containsAll(
@@ -159,19 +159,19 @@ class OASysSectionsTransformerTest {
         OASysQuestion(
           label = "Current concerns about self-harm or suicide",
           questionNumber = "R8.1.1",
-          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentConcernsSelfHarmSuicide
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentConcernsSelfHarmSuicide,
         ),
         OASysQuestion(
           label = "Current concerns about Coping in Custody or Hostel",
           questionNumber = "R8.2.1",
-          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentCustodyHostelCoping
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentCustodyHostelCoping,
         ),
         OASysQuestion(
           label = "Current concerns about Vulnerability",
           questionNumber = "R8.3.1",
-          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentVulnerability
-        )
-      )
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentVulnerability,
+        ),
+      ),
     )
 
     assertThat(result.riskManagementPlan).containsAll(
@@ -179,44 +179,44 @@ class OASysSectionsTransformerTest {
         OASysQuestion(
           label = "Further considerations",
           questionNumber = "RM28",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.furtherConsiderations
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.furtherConsiderations,
         ),
         OASysQuestion(
           label = "Additional comments",
           questionNumber = "RM35",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.additionalComments
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.additionalComments,
         ),
         OASysQuestion(
           label = "Contingency plans",
           questionNumber = "RM34",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.contingencyPlans
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.contingencyPlans,
         ),
         OASysQuestion(
           label = "Victim safety planning",
           questionNumber = "RM33",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.victimSafetyPlanning
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.victimSafetyPlanning,
         ),
         OASysQuestion(
           label = "Interventions and treatment",
           questionNumber = "RM32",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.interventionsAndTreatment
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.interventionsAndTreatment,
         ),
         OASysQuestion(
           label = "Monitoring and control",
           questionNumber = "RM31",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.monitoringAndControl
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.monitoringAndControl,
         ),
         OASysQuestion(
           label = "Supervision",
           questionNumber = "RM30",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.supervision
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.supervision,
         ),
         OASysQuestion(
           label = "Key information about current situation",
           questionNumber = "RM28.1",
-          answer = riskManagementPlanApiResponse.riskManagementPlan?.keyInformationAboutCurrentSituation
-        )
-      )
+          answer = riskManagementPlanApiResponse.riskManagementPlan?.keyInformationAboutCurrentSituation,
+        ),
+      ),
     )
   }
 
@@ -240,7 +240,7 @@ class OASysSectionsTransformerTest {
       risksToTheIndividualApiResponse,
       riskManagementPlanApiResponse,
       needsDetailsApiResponse,
-      requestedOptionalSections
+      requestedOptionalSections,
     )
 
     assertThat(result.supportingInformation).containsExactlyInAnyOrder(
@@ -250,7 +250,7 @@ class OASysSectionsTransformerTest {
         sectionNumber = 4,
         linkedToHarm = false,
         linkedToReOffending = false,
-        answer = "Education, Training, Employment"
+        answer = "Education, Training, Employment",
       ),
       OASysSupportingInformationQuestion(
         label = "Financial management issues contributing to risks of offending and harm",
@@ -258,7 +258,7 @@ class OASysSectionsTransformerTest {
         sectionNumber = 5,
         linkedToHarm = null,
         linkedToReOffending = null,
-        answer = null
+        answer = null,
       ),
       OASysSupportingInformationQuestion(
         label = "Issues of emotional well-being contributing to risks of offending and harm",
@@ -266,7 +266,7 @@ class OASysSectionsTransformerTest {
         sectionNumber = 10,
         linkedToHarm = true,
         linkedToReOffending = false,
-        answer = "Emotional"
+        answer = "Emotional",
       ),
       OASysSupportingInformationQuestion(
         label = "Drug misuse issues contributing to risks of offending and harm",
@@ -274,7 +274,7 @@ class OASysSectionsTransformerTest {
         sectionNumber = 8,
         linkedToHarm = needsDetailsApiResponse.linksToHarm?.drugLinkedToHarm,
         linkedToReOffending = needsDetailsApiResponse.linksToReOffending?.drugLinkedToReOffending,
-        answer = needsDetailsApiResponse.needs?.drugIssuesDetails
+        answer = needsDetailsApiResponse.needs?.drugIssuesDetails,
       ),
       OASysSupportingInformationQuestion(
         label = "Alcohol misuse issues contributing to risks of offending and harm",
@@ -282,8 +282,8 @@ class OASysSectionsTransformerTest {
         sectionNumber = 9,
         linkedToHarm = needsDetailsApiResponse.linksToHarm?.alcoholLinkedToHarm,
         linkedToReOffending = needsDetailsApiResponse.linksToReOffending?.alcoholLinkedToReOffending,
-        answer = needsDetailsApiResponse.needs?.alcoholIssuesDetails
-      )
+        answer = needsDetailsApiResponse.needs?.alcoholIssuesDetails,
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -35,7 +35,7 @@ class PersonTransformerTest {
         mostRecentPrisonNumber = null,
         niNumber = null,
         nomsNumber = "NOMS321",
-        pncNumber = null
+        pncNumber = null,
       ),
       offenderProfile = OffenderProfile(
         ethnicity = null,
@@ -47,7 +47,7 @@ class PersonTransformerTest {
           primaryLanguage = null,
           otherLanguages = listOf(),
           languageConcerns = null,
-          requiresInterpreter = null
+          requiresInterpreter = null,
         ),
         religion = "Sikh",
         sexualOrientation = null,
@@ -56,20 +56,20 @@ class PersonTransformerTest {
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = null,
-        selfDescribedGender = null
+        selfDescribedGender = null,
       ),
       softDeleted = null,
       currentDisposal = "",
       partitionArea = null,
       currentRestriction = false,
       currentExclusion = false,
-      isActiveProbationManagedSentence = false
+      isActiveProbationManagedSentence = false,
     )
 
     val inmateDetail = InmateDetail(
       offenderNo = "NOMS321",
       inOutStatus = InOutStatus.OUT,
-      assignedLivingUnit = null
+      assignedLivingUnit = null,
     )
 
     val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
@@ -85,8 +85,8 @@ class PersonTransformerTest {
         nationality = "Spanish",
         religionOrBelief = "Sikh",
         genderIdentity = null,
-        prisonName = null
-      )
+        prisonName = null,
+      ),
     )
   }
 
@@ -109,7 +109,7 @@ class PersonTransformerTest {
         mostRecentPrisonNumber = null,
         niNumber = null,
         nomsNumber = "NOMS321",
-        pncNumber = null
+        pncNumber = null,
       ),
       offenderProfile = OffenderProfile(
         ethnicity = null,
@@ -121,7 +121,7 @@ class PersonTransformerTest {
           primaryLanguage = null,
           otherLanguages = listOf(),
           languageConcerns = null,
-          requiresInterpreter = null
+          requiresInterpreter = null,
         ),
         religion = "Sikh",
         sexualOrientation = null,
@@ -130,20 +130,20 @@ class PersonTransformerTest {
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = "Female",
-        selfDescribedGender = null
+        selfDescribedGender = null,
       ),
       softDeleted = null,
       currentDisposal = "",
       partitionArea = null,
       currentRestriction = false,
       currentExclusion = false,
-      isActiveProbationManagedSentence = false
+      isActiveProbationManagedSentence = false,
     )
 
     val inmateDetail = InmateDetail(
       offenderNo = "NOMS321",
       inOutStatus = InOutStatus.OUT,
-      assignedLivingUnit = null
+      assignedLivingUnit = null,
     )
 
     val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
@@ -159,8 +159,8 @@ class PersonTransformerTest {
         nationality = "Spanish",
         religionOrBelief = "Sikh",
         genderIdentity = "Female",
-        prisonName = null
-      )
+        prisonName = null,
+      ),
     )
   }
 
@@ -183,7 +183,7 @@ class PersonTransformerTest {
         mostRecentPrisonNumber = null,
         niNumber = null,
         nomsNumber = "NOMS321",
-        pncNumber = null
+        pncNumber = null,
       ),
       offenderProfile = OffenderProfile(
         ethnicity = null,
@@ -195,7 +195,7 @@ class PersonTransformerTest {
           primaryLanguage = null,
           otherLanguages = listOf(),
           languageConcerns = null,
-          requiresInterpreter = null
+          requiresInterpreter = null,
         ),
         religion = "Sikh",
         sexualOrientation = null,
@@ -204,20 +204,20 @@ class PersonTransformerTest {
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = "Female",
-        selfDescribedGender = null
+        selfDescribedGender = null,
       ),
       softDeleted = null,
       currentDisposal = "",
       partitionArea = null,
       currentRestriction = false,
       currentExclusion = false,
-      isActiveProbationManagedSentence = false
+      isActiveProbationManagedSentence = false,
     )
 
     val inmateDetail = InmateDetail(
       offenderNo = "NOMS321",
       inOutStatus = InOutStatus.OUT,
-      assignedLivingUnit = null
+      assignedLivingUnit = null,
     )
 
     val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
@@ -233,8 +233,8 @@ class PersonTransformerTest {
         nationality = "Spanish",
         religionOrBelief = "Sikh",
         genderIdentity = "Female",
-        prisonName = null
-      )
+        prisonName = null,
+      ),
     )
   }
 
@@ -257,7 +257,7 @@ class PersonTransformerTest {
         mostRecentPrisonNumber = null,
         niNumber = null,
         nomsNumber = "NOMS321",
-        pncNumber = null
+        pncNumber = null,
       ),
       offenderProfile = OffenderProfile(
         ethnicity = null,
@@ -269,7 +269,7 @@ class PersonTransformerTest {
           primaryLanguage = null,
           otherLanguages = listOf(),
           languageConcerns = null,
-          requiresInterpreter = null
+          requiresInterpreter = null,
         ),
         religion = "Sikh",
         sexualOrientation = null,
@@ -278,14 +278,14 @@ class PersonTransformerTest {
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = null,
-        selfDescribedGender = null
+        selfDescribedGender = null,
       ),
       softDeleted = null,
       currentDisposal = "",
       partitionArea = null,
       currentRestriction = false,
       currentExclusion = false,
-      isActiveProbationManagedSentence = false
+      isActiveProbationManagedSentence = false,
     )
 
     val inmateDetail = InmateDetail(
@@ -295,8 +295,8 @@ class PersonTransformerTest {
         agencyId = "BRI",
         locationId = 5,
         description = "B-2F-004",
-        agencyName = "HMP Bristol"
-      )
+        agencyName = "HMP Bristol",
+      ),
     )
 
     val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
@@ -312,8 +312,8 @@ class PersonTransformerTest {
         nationality = "Spanish",
         religionOrBelief = "Sikh",
         genderIdentity = null,
-        prisonName = "HMP Bristol"
-      )
+        prisonName = "HMP Bristol",
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
@@ -39,7 +39,7 @@ class PremisesSummaryTransformerTest {
         pdu = "North east",
         status = PropertyStatus.active,
         bedCount = 1,
-      )
+      ),
     )
   }
 
@@ -54,7 +54,7 @@ class PremisesSummaryTransformerTest {
       postcode = "123ABC",
       status = PropertyStatus.active,
       bedCount = 1,
-      apCode = "APCODE"
+      apCode = "APCODE",
     )
 
     val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
@@ -68,8 +68,8 @@ class PremisesSummaryTransformerTest {
         postcode = "123ABC",
         status = PropertyStatus.active,
         bedCount = 1,
-        apCode = "APCODE"
-      )
+        apCode = "APCODE",
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -28,12 +28,12 @@ class JwtAuthHelper {
 
   internal fun createValidClientCredentialsJwt() = createClientCredentialsJwt(
     expiryTime = Duration.ofMinutes(2),
-    roles = listOf("ROLE_COMMUNITY")
+    roles = listOf("ROLE_COMMUNITY"),
   )
 
   internal fun createExpiredClientCredentialsJwt() = createClientCredentialsJwt(
     expiryTime = Duration.ofMinutes(-2),
-    roles = listOf("ROLE_COMMUNITY")
+    roles = listOf("ROLE_COMMUNITY"),
   )
 
   internal fun createClientCredentialsJwt(
@@ -42,7 +42,7 @@ class JwtAuthHelper {
     roles: List<String>? = listOf(),
     authSource: String = if (username == null) "none" else "delius",
     expiryTime: Duration = Duration.ofHours(1),
-    jwtId: String = UUID.randomUUID().toString()
+    jwtId: String = UUID.randomUUID().toString(),
   ): String =
     mutableMapOf<String, Any>()
       .also { it["user_name"] = username ?: "integration-test-client-id" }
@@ -64,7 +64,7 @@ class JwtAuthHelper {
   internal fun createValidAuthorizationCodeJwt(username: String = "username") = createAuthorizationCodeJwt(
     subject = username,
     authSource = "delius",
-    roles = listOf("ROLE_PROBATION")
+    roles = listOf("ROLE_PROBATION"),
   )
 
   internal fun createAuthorizationCodeJwt(
@@ -73,7 +73,7 @@ class JwtAuthHelper {
     roles: List<String>? = listOf(),
     authSource: String = "delius",
     expiryTime: Duration = Duration.ofHours(1),
-    jwtId: String = UUID.randomUUID().toString()
+    jwtId: String = UUID.randomUUID().toString(),
   ): String =
     mutableMapOf<String, Any>()
       .also { it["auth_source"] = authSource }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/LogEntry.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/LogEntry.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 data class LogEntry(
   val message: String,
   val level: String,
-  val throwable: Throwable?
+  val throwable: Throwable?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TestPropertiesInitializer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TestPropertiesInitializer.kt
@@ -41,8 +41,8 @@ class TestPropertiesInitializer : ApplicationContextInitializer<ConfigurableAppl
           "wiremock.port" to wiremockPort.toString(),
           "preemptive-cache-key-prefix" to wiremockPort.toString(),
           "hmpps.sqs.topics.domainevents.arn" to "arn:aws:sns:eu-west-2:000000000000:domainevents-int-test-${randomStringLowerCase(10)}",
-          "spring.datasource.url" to "jdbc:postgresql://localhost:5433/$databaseName"
-        ) + upstreamServiceUrlsToOverride
+          "spring.datasource.url" to "jdbc:postgresql://localhost:5433/$databaseName",
+        ) + upstreamServiceUrlsToOverride,
       ).applyTo(applicationContext)
   }
 


### PR DESCRIPTION
PR #656 updates the version of uk.gov.justice.hmpps.gradle-spring-boot to 4.8.7, which includes new rules for ktlint. These rule changes are causing the pipelines to fail. However, instead of cluttering that PR with all of the reformatted files, those changes are here.