### PR TITLE
Format project with incoming ktlint rules

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -139,8 +139,8 @@ class WebClientConfiguration {
           HttpClient
             .create()
             .responseTimeout(Duration.ofSeconds(10))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofSeconds(10).toMillis().toInt())
-        )
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofSeconds(10).toMillis().toInt()),
+        ),
       )
       .build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -49,13 +49,13 @@ class ExceptionHandling(
 
     if (throwable is MissingServletRequestParameterException) {
       return BadRequestProblem(
-        errorDetail = "Missing required query parameter ${throwable.parameterName}"
+        errorDetail = "Missing required query parameter ${throwable.parameterName}",
       )
     }
 
     if (throwable is MethodArgumentTypeMismatchException) {
       return BadRequestProblem(
-        errorDetail = "Invalid type for query parameter ${throwable.parameter.parameterName} expected ${throwable.parameter.parameterType.name}"
+        errorDetail = "Invalid type for query parameter ${throwable.parameter.parameterName} expected ${throwable.parameter.parameterType.name}",
       )
     }
 


### PR DESCRIPTION
PR #656 updates the version of uk.gov.justice.hmpps.gradle-spring-boot to 4.8.7, which includes new rules for ktlint. Most of the breaking changes have already been resolved by #662 and #664, however #620 and #633 have introduced some additional changes which don't currently fail ktlint but violate the incoming rules.