### PR TITLE
POST and GET CAS-2 applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -123,6 +123,7 @@ class ApplicationsController(
 
     val applicationResult = when (xServiceName ?: ServiceName.approvedPremises) {
       ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
+      ServiceName.cas2 -> applicationService.createCas2Application(body.crn, user, deliusPrincipal.token.tokenValue)
       ServiceName.temporaryAccommodation -> applicationService.createTemporaryAccommodationApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -115,6 +115,7 @@ class PremisesController(
 
         summaries.map(premisesSummaryTransformer::transformDomainToApi)
       }
+      ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
       ServiceName.temporaryAccommodation -> {
         val user = usersService.getUserForRequest()
         val summaries = premisesService.getAllTemporaryAccommodationPremisesSummaries(user.probationRegion.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -122,6 +122,22 @@ WHERE a.created_by_user_id = :userId
 
   @Query("SELECT DISTINCT(a.nomsNumber) FROM ApplicationEntity a")
   fun getDistinctNomsNumbers(): List<String>
+
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt,
+    CAST(apa.risk_ratings AS TEXT) as riskRatings
+FROM cas_2_applications apa
+LEFT JOIN applications a ON a.id = apa.id
+""",
+    nativeQuery = true,
+  )
+  fun findAllCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
@@ -42,6 +42,16 @@ class ApprovedPremisesApplicationJsonSchemaEntity(
 ) : JsonSchemaEntity(id, addedAt, schema)
 
 @Entity
+@DiscriminatorValue("CAS_2_APPLICATION")
+@Table(name = "cas_2_application_json_schemas")
+@PrimaryKeyJoinColumn(name = "json_schema_id")
+class Cas2ApplicationJsonSchemaEntity(
+  id: UUID,
+  addedAt: OffsetDateTime,
+  schema: String,
+) : JsonSchemaEntity(id, addedAt, schema)
+
+@Entity
 @DiscriminatorValue("TEMPORARY_ACCOMMODATION_APPLICATION")
 @Table(name = "temporary_accommodation_application_json_schemas")
 @PrimaryKeyJoinColumn(name = "json_schema_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ReportGenerator.kt
@@ -41,6 +41,7 @@ abstract class ReportGenerator<Input : Any, Output : Any, Properties>(private va
   protected fun checkServiceType(serviceName: ServiceName, premisesEntity: PremisesEntity) =
     when (serviceName) {
       ServiceName.approvedPremises -> premisesEntity is ApprovedPremisesEntity
+      ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
       ServiceName.temporaryAccommodation -> premisesEntity is TemporaryAccommodationPremisesEntity
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -70,7 +71,6 @@ class ApplicationService(
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationSummary> {
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
       ?: return emptyList()
-
     val userDetailsResult = communityApiClient.getStaffUserDetails(userEntity.deliusUsername)
     val userDetails = when (userDetailsResult) {
       is ClientResult.Success -> userDetailsResult.body
@@ -81,6 +81,8 @@ class ApplicationService(
       applicationRepository.findAllApprovedPremisesSummaries()
     } else if (serviceName == ServiceName.approvedPremises) {
       applicationRepository.findApprovedPremisesSummariesForManagingTeams(userDetails.teams?.map { it.code } ?: emptyList())
+    } else if (serviceName == ServiceName.cas2) {
+      applicationRepository.findAllCas2ApplicationSummaries()
     } else {
       applicationRepository.findAllTemporaryAccommodationSummariesCreatedByUser(userEntity.id)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -17,7 +17,7 @@ class UserTransformer(
   private val probationRegionTransformer: ProbationRegionTransformer,
 ) {
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {
-    ServiceName.approvedPremises -> ApprovedPremisesUser(
+    ServiceName.approvedPremises, ServiceName.cas2 -> ApprovedPremisesUser(
       id = jpa.id,
       deliusUsername = jpa.deliusUsername,
       roles = jpa.roles.map(::transformRoleToApi),

--- a/src/main/resources/db/migration/all/20230525120902__cas_2_applications.sql
+++ b/src/main/resources/db/migration/all/20230525120902__cas_2_applications.sql
@@ -1,0 +1,7 @@
+CREATE TABLE cas_2_applications (
+    id UUID NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (id) REFERENCES applications(id)
+);
+
+ALTER TABLE cas_2_applications ADD COLUMN risk_ratings JSON;

--- a/src/main/resources/db/migration/all/20230602092725__add_cas_2_application_schema.sql
+++ b/src/main/resources/db/migration/all/20230602092725__add_cas_2_application_schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE cas_2_application_json_schemas (
+    json_schema_id UUID NOT NULL,
+    PRIMARY KEY (json_schema_id),
+    FOREIGN KEY (json_schema_id) REFERENCES json_schemas(id)
+);
+
+INSERT INTO json_schemas (id, added_at, "schema") VALUES  ('20c06750-27d3-4dc6-8ac6-948c8f0a0210', NOW(), '{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "title": "Application Placeholder Schema",
+ "description": "An application schema that requires no properties",
+ "type": "object",
+ "properties": {},
+ "required": []
+}');
+
+INSERT INTO cas_2_application_json_schemas (json_schema_id) VALUES
+    ('20c06750-27d3-4dc6-8ac6-948c8f0a0210');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4184,6 +4184,7 @@ components:
         mapping:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
+          CAS2: '#/components/schemas/Cas2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - id
@@ -4204,6 +4205,38 @@ components:
               type: boolean
             isPipeApplication:
               type: boolean
+            arrivalDate:
+              type: string
+              format: date-time
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            submittedAt:
+              type: string
+              format: date-time
+          required:
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
+            - status
+    Cas2Application:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
             arrivalDate:
               type: string
               format: date-time
@@ -4279,6 +4312,7 @@ components:
         mapping:
           Offline: '#/components/schemas/OfflineApplicationSummary'
           CAS1: '#/components/schemas/ApprovedPremisesApplicationSummary'
+          CAS2: '#/components/schemas/Cas2ApplicationSummary'
           CAS3: '#/components/schemas/TemporaryAccommodationApplicationSummary'
       required:
         - id
@@ -4327,6 +4361,18 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2ApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+          required:
+            - createdByUserId
     ApplicationStatus:
       type: string
       enum:
@@ -4811,9 +4857,11 @@ components:
       type: string
       enum:
         - approved-premises
+        - cas2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
+        - cas2
         - temporaryAccommodation
     NewRoom:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -39,7 +39,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var confirmation: Yielded<ConfirmationEntity>? = null
   private var extensions: Yielded<MutableList<ExtensionEntity>>? = null
   private var premises: Yielded<PremisesEntity>? = null
-  private var serviceName: Yielded<ServiceName> = { randomOf(ServiceName.values().asList()) }
+  private var serviceName: Yielded<ServiceName> = { randomOf(listOf(ServiceName.approvedPremises, ServiceName.temporaryAccommodation)) }
   private var bed: Yielded<BedEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
   private var application: Yielded<ApplicationEntity?> = { null }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var createdByUser: Yielded<UserEntity>? = null
+  private var data: Yielded<String?> = { "{}" }
+  private var document: Yielded<String?> = { "{}" }
+  private var applicationSchema: Yielded<JsonSchemaEntity> = {
+    ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
+  }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var submittedAt: Yielded<OffsetDateTime?> = { null }
+  private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf<AssessmentEntity>() }
+  private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
+  private var riskRatings: Yielded<PersonRisks> = { PersonRisksFactory().produce() }
+  private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withCreatedByUser(createdByUser: UserEntity) = apply {
+    this.createdByUser = { createdByUser }
+  }
+
+  fun withYieldedCreatedByUser(createdByUser: Yielded<UserEntity>) = apply {
+    this.createdByUser = createdByUser
+  }
+
+  fun withData(data: String?) = apply {
+    this.data = { data }
+  }
+
+  fun withDocument(document: String?) = apply {
+    this.document = { document }
+  }
+
+  fun withApplicationSchema(applicationSchema: JsonSchemaEntity) = apply {
+    this.applicationSchema = { applicationSchema }
+  }
+
+  fun withYieldedApplicationSchema(applicationSchema: Yielded<JsonSchemaEntity>) = apply {
+    this.applicationSchema = applicationSchema
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withSubmittedAt(submittedAt: OffsetDateTime?) = apply {
+    this.submittedAt = { submittedAt }
+  }
+
+  fun withEventNumber(eventNumber: String) = apply {
+    this.eventNumber = { eventNumber }
+  }
+
+  override fun produce(): Cas2ApplicationEntity = Cas2ApplicationEntity(
+    id = this.id(),
+    crn = this.crn(),
+    createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
+    data = this.data(),
+    document = this.document(),
+    schemaVersion = this.applicationSchema(),
+    createdAt = this.createdAt(),
+    submittedAt = this.submittedAt(),
+    schemaUpToDate = false,
+    assessments = this.assessments(),
+    riskRatings = this.riskRatings(),
+    nomsNumber = this.nomsNumber(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationJsonSchemaEntityFactory.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2ApplicationJsonSchemaEntityFactory : Factory<Cas2ApplicationJsonSchemaEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var addedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var schema: Yielded<String> = { "{}" }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAddedAt(addedAt: OffsetDateTime) = apply {
+    this.addedAt = { addedAt }
+  }
+
+  fun withSchema(schema: String) = apply {
+    this.schema = { schema }
+  }
+
+  fun withPermissiveSchema() = apply {
+    withSchema(
+      """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """,
+    )
+  }
+
+  override fun produce(): Cas2ApplicationJsonSchemaEntity = Cas2ApplicationJsonSchemaEntity(
+    id = this.id(),
+    addedAt = this.addedAt(),
+    schema = this.schema(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -38,6 +38,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingNotMadeEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
@@ -85,6 +87,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
@@ -142,6 +146,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingNotMad
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
@@ -318,6 +324,9 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesApplicationRepository: ApprovedPremisesApplicationTestRepository
 
   @Autowired
+  lateinit var cas2ApplicationRepository: Cas2ApplicationTestRepository
+
+  @Autowired
   lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationApplicationTestRepository
 
   @Autowired
@@ -325,6 +334,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var approvedPremisesApplicationJsonSchemaRepository: ApprovedPremisesApplicationJsonSchemaTestRepository
+
+  @Autowired
+  lateinit var cas2ApplicationJsonSchemaRepository: Cas2ApplicationJsonSchemaTestRepository
 
   @Autowired
   lateinit var temporaryAccommodationApplicationJsonSchemaRepository: TemporaryAccommodationApplicationJsonSchemaTestRepository
@@ -410,9 +422,11 @@ abstract class IntegrationTestBase {
   lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
   lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
+  lateinit var cas2ApplicationEntityFactory: PersistedFactory<Cas2ApplicationEntity, UUID, Cas2ApplicationEntityFactory>
   lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
   lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
+  lateinit var cas2ApplicationJsonSchemaEntityFactory: PersistedFactory<Cas2ApplicationJsonSchemaEntity, UUID, Cas2ApplicationJsonSchemaEntityFactory>
   lateinit var temporaryAccommodationApplicationJsonSchemaEntityFactory: PersistedFactory<TemporaryAccommodationApplicationJsonSchemaEntity, UUID, TemporaryAccommodationApplicationJsonSchemaEntityFactory>
   lateinit var approvedPremisesPlacementApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesPlacementApplicationJsonSchemaEntity, UUID, ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory>
   lateinit var approvedPremisesAssessmentJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesAssessmentJsonSchemaEntity, UUID, ApprovedPremisesAssessmentJsonSchemaEntityFactory>
@@ -483,9 +497,11 @@ abstract class IntegrationTestBase {
     extensionEntityFactory = PersistedFactory({ ExtensionEntityFactory() }, extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory({ NonArrivalReasonEntityFactory() }, nonArrivalReasonRepository)
     approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)
+    cas2ApplicationEntityFactory = PersistedFactory({ Cas2ApplicationEntityFactory() }, cas2ApplicationRepository)
     temporaryAccommodationApplicationEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationEntityFactory() }, temporaryAccommodationApplicationRepository)
     offlineApplicationEntityFactory = PersistedFactory({ OfflineApplicationEntityFactory() }, offlineApplicationRepository)
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesApplicationJsonSchemaEntityFactory() }, approvedPremisesApplicationJsonSchemaRepository)
+    cas2ApplicationJsonSchemaEntityFactory = PersistedFactory({ Cas2ApplicationJsonSchemaEntityFactory() }, cas2ApplicationJsonSchemaRepository)
     temporaryAccommodationApplicationJsonSchemaEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationJsonSchemaEntityFactory() }, temporaryAccommodationApplicationJsonSchemaRepository)
     approvedPremisesAssessmentJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesAssessmentJsonSchemaEntityFactory() }, approvedPremisesAssessmentJsonSchemaRepository)
     approvedPremisesPlacementApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory() }, approvedPremisesPlacementApplicationJsonSchemaRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -70,6 +70,19 @@ class PremisesSummaryTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get all Premises throws error with incorrect service name`() {
+    `Given a User` { _, jwt ->
+      webTestClient.get()
+        .uri("/premises/summary")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "service-name")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+    }
+  }
+
+  @Test
   fun `Get all CAS1 Premises returns OK with correct body`() {
     `Given a User` { _, jwt ->
       val uuid = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
@@ -3,11 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import java.util.UUID
 
 @Repository
 interface ApprovedPremisesApplicationTestRepository : JpaRepository<ApprovedPremisesApplicationEntity, UUID>
+
+@Repository
+interface Cas2ApplicationTestRepository : JpaRepository<Cas2ApplicationEntity, UUID>
 
 @Repository
 interface TemporaryAccommodationApplicationTestRepository : JpaRepository<TemporaryAccommodationApplicationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/JsonSchemaTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/JsonSchemaTestRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import java.util.UUID
 
@@ -13,6 +14,9 @@ interface ApprovedPremisesApplicationJsonSchemaTestRepository : JpaRepository<Ap
 
 @Repository
 interface TemporaryAccommodationApplicationJsonSchemaTestRepository : JpaRepository<TemporaryAccommodationApplicationJsonSchemaEntity, UUID>
+
+@Repository
+interface Cas2ApplicationJsonSchemaTestRepository : JpaRepository<Cas2ApplicationJsonSchemaEntity, UUID>
 
 @Repository
 interface ApprovedPremisesAssessmentJsonSchemaTestRepository : JpaRepository<ApprovedPremisesAssessmentJsonSchemaEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationJsonSchemaEntityFactory
@@ -16,6 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
@@ -104,6 +108,93 @@ class JsonSchemaServiceTest {
 
     every { mockJsonSchemaRepository.getSchemasForType(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns listOf(newestJsonSchema)
     every { mockApplicationRepository.findAllByCreatedByUser_Id(userId, ApprovedPremisesApplicationEntity::class.java) } returns applicationEntities
+    every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+
+    assertThat(jsonSchemaService.checkSchemaOutdated(upToDateApplication)).matches {
+      it.id == upToDateApplication.id &&
+        it.schemaVersion == newestJsonSchema &&
+        it.schemaUpToDate
+    }
+
+    assertThat(jsonSchemaService.checkSchemaOutdated(outdatedApplication)).matches {
+      it.id == outdatedApplication.id &&
+        it.schemaVersion == olderJsonSchema &&
+        !it.schemaUpToDate
+    }
+  }
+
+  @Test
+  fun `checkSchemaOutdated marks outdated correctly for CAS2 applications`() {
+    val newestJsonSchema = Cas2ApplicationJsonSchemaEntityFactory()
+      .withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": {
+            "thingId": {
+              "description": "The unique identifier for a thing",
+              "type": "integer"
+            }
+          },
+          "required": [ "thingId" ]
+        }
+        """,
+      )
+      .produce()
+
+    val olderJsonSchema = Cas2ApplicationJsonSchemaEntityFactory()
+      .withSchema(
+        """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """,
+      )
+      .produce()
+
+    val userId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
+    val distinguishedName = "SOMEPERSON"
+    val userEntity = UserEntityFactory()
+      .withId(userId)
+      .withDeliusUsername(distinguishedName)
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    val upToDateApplication = Cas2ApplicationEntityFactory()
+      .withCreatedByUser(userEntity)
+      .withApplicationSchema(newestJsonSchema)
+      .withData(
+        """
+          {
+             "thingId": 123
+          }
+          """,
+      )
+      .produce()
+
+    val outdatedApplication = Cas2ApplicationEntityFactory()
+      .withCreatedByUser(userEntity)
+      .withApplicationSchema(olderJsonSchema)
+      .withData("{}")
+      .produce()
+
+    val applicationEntities = listOf(upToDateApplication, outdatedApplication)
+
+    every { mockJsonSchemaRepository.getSchemasForType(Cas2ApplicationJsonSchemaEntity::class.java) } returns listOf(newestJsonSchema)
+    every { mockApplicationRepository.findAllByCreatedByUser_Id(userId, Cas2ApplicationEntity::class.java) } returns applicationEntities
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     assertThat(jsonSchemaService.checkSchemaOutdated(upToDateApplication)).matches {


### PR DESCRIPTION
# Context

[Trello card](https://trello.com/c/gYeRYOSP/214-save-an-application)
As part of our work on CAS-2, we need to be able to create and retrieve blank applications in a CAS-2 specific manner.

# Changes in this PR

We are mostly following the [pattern already set out by CAS-3](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/641). When POSTing to `/applications` we check the `ServiceName` and diverge to saving our own application. When GETing applications we check the service name in the `ApplicationService`.

### feedback/questions

* naming: the CAS-2 repo is currently called `supported-accommodation` but this name has now been rejected - it looks like we will be using CAS-2 as a primary name for users, with a second name TBA. After chatting with other devs it seems like there is a future plan to bring everything under the CAS umbrella, so we feel _ok_ using CAS2 going forward  in code, although it doesn't feel great sitting next to `temporaryAccommodation`/`approvedPremises` and [maybe doesn't fit with moj naming guidelines](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-things.html#principles). Any feedback or suggestions welcome. 
* We are not familiar with Kotlin best practices at all, so please feedback on whether we can cut down on any repetition or tidy the code in any way. 
* Have we added everything necessary in `api.yml`?
* We are currently re-using the `TemporaryAccommodation` JSON schema, as we have not got to the stage of saving our own application form, is that ok for now?
* There were a couple of things we weren't sure how to test in `ApplicationService` -> `createCas2Application` , which we copied from the CAS3 method
  * what is the `validationErrors.any()` check doing? is that if there are any errors on the `ApplicationEntity`, based on what fields?
  * there is a check for `offenderDetails.otherIds.nomsNumber == null` - how would we recreate that in a unit test?


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->

