### PR TITLE
Fix 'unable to start the daemon process' in 'Update OWASP Dependency-Check Database' CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,8 +220,6 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
-          requires:
-            - build_docker
       - hmpps/trivy_pipeline_scan:
           context:
             - hmpps-common-vars

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xms512M -Xmx4g -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvm.options="-Xmx1g"
+org.gradle.jvmargs=-Xms256M -Xmx4g -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvm.options="-Xmx1g"


### PR DESCRIPTION
> See [ticket #1160 on the CAS3 Trello board](https://trello.com/c/C1mkETas/1160-fix-gradle-owasp-job-so-it-scans-for-security-vulnerabilities-in-the-api).

Calling `./gradlew dependencyCheckUpdate` in the CircleCI `security` workflow  fails with the following message:
```
Initial heap size set to a larger value than the maximum heap size
```

Reducing the initial heap size fixes this error, but retains the configured maximum as introduced in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/386, which should prevent the recurrence of the OutOfMemoryError that was resolved by that change.