### PR TITLE
Use correct URL for `script/clear_cache`

### DIFF
--- a/script/clear_cache
+++ b/script/clear_cache
@@ -6,6 +6,6 @@
 
 set -e
 
-curl --location --request DELETE 'http://127.0.0.1:8080/cache/'$1'/clear'
+curl --location --request DELETE "http://127.0.0.1:8080/cache/$1"
 
 echo "Requested cache clear - check the application logs for status"


### PR DESCRIPTION
Clearing a cache is done by calling `DELETE /cache/{cacheName}` from within the container running the API. However, the `clear_cache` script incorrectly sends the request to `DELETE /cache/{cacheName}/clear`, which causes the following misleading response:
```
{
  "title":"Unauthenticated",
  "status":401,
  "detail":"A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint"
}
```