### PR TITLE
Change handling of errors for Preemptive caching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -33,7 +33,7 @@ class CommunityApiClient(
   private val offenderDetailCacheConfig = PreemptiveCacheConfig(
     cacheName = "offenderDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
-    failureSoftTtlSeconds = Duration.ofMinutes(30).toSeconds().toInt(),
+    failureSoftTtlBackoffSeconds = listOf(30, Duration.ofMinutes(5).toSeconds().toInt(), Duration.ofMinutes(10).toSeconds().toInt(), Duration.ofMinutes(30).toSeconds().toInt()),
     hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
@@ -21,7 +21,7 @@ class PrisonsApiClient(
   private val inmateDetailsCacheConfig = PreemptiveCacheConfig(
     cacheName = "inmateDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
-    failureSoftTtlSeconds = Duration.ofMinutes(30).toSeconds().toInt(),
+    failureSoftTtlBackoffSeconds = listOf(30, Duration.ofMinutes(5).toSeconds().toInt(), Duration.ofMinutes(10).toSeconds().toInt(), Duration.ofMinutes(30).toSeconds().toInt()),
     hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 


### PR DESCRIPTION
For non-2xx responses cache for 30 seconds, 5 minutes, 10 minutes, 30 minutes (then 30 minutes for every failed attempt thereafter) and start shipping exception to Sentry after 4 attempts.