### PR TITLE
Include generated .trivyignore file in `trivy_latest_scan` CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,10 @@ workflows:
           context:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:
+          pre-steps:
+            - attach_workspace:
+                at: ~/trivyetc
+          additional_args: --ignorefile ~/trivyetc/.trivyignore
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars


### PR DESCRIPTION
> See [ticket #1157 on the CAS3 Trello board](https://trello.com/c/0IlKERvZ/1157-patch-4-critical-vulnerabilities-identified-by-trivy).

As part of #656, a change was made to the `security` CircleCI workflow to generate the `.trivyignore` file for the `trivy_latest_scan` job. However, this file was not being used, unlike in the `trivy_pipeline_scan` job in the `security-branch` workflow.

It can be seen by comparing the steps executed by [`trivy_latest_scan`](https://github.com/ministryofjustice/hmpps-circleci-orb/blob/main/src/jobs/trivy_latest_scan.yml#L34-L83) and by [`trivy_pipeline_scan`](https://github.com/ministryofjustice/hmpps-circleci-orb/blob/main/src/jobs/trivy_pipeline_scan.yml#L24-L53) that the latter has a step called [`recall_container_image`](https://github.com/ministryofjustice/hmpps-circleci-orb/blob/main/src/commands/recall_container_image.yml#L10-L11), the definition for which contains the `attach_workspace` step. This allowed it to retrieve the `.trivyignore` file where the `trivy_latest_scan` job did not.

CircleCI provides a [`pre-steps` and `post-steps` configuration for jobs](https://circleci.com/docs/reusing-config/#using-pre-and-post-steps), which can be used to attach the workspace (and thus, the `.trivyignore` file) before the job runs, allowing Trivy to detect the file and report correctly.