### PR TITLE
(172) Add CRUD endpoints to placement requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PlacementApplicationsApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
@@ -53,6 +54,20 @@ class PlacementApplicationsController(
     val serializedData = objectMapper.writeValueAsString(updatePlacementApplication.data)
 
     val result = placementApplicationService.updateApplication(id, serializedData)
+
+    val validationResult = extractEntityFromAuthorisableActionResult(result, id.toString(), "Placement Application")
+    val placementApplication = extractEntityFromValidatableActionResult(validationResult)
+
+    return ResponseEntity.ok(placementApplicationTransformer.transformJpaToApi(placementApplication))
+  }
+
+  override fun placementApplicationsIdSubmissionPost(
+    id: UUID,
+    submitPlacementApplication: SubmitPlacementApplication,
+  ): ResponseEntity<PlacementApplication> {
+    val serializedData = objectMapper.writeValueAsString(submitPlacementApplication.translatedDocument)
+
+    val result = placementApplicationService.submitApplication(id, serializedData)
 
     val validationResult = extractEntityFromAuthorisableActionResult(result, id.toString(), "Placement Application")
     val placementApplication = extractEntityFromValidatableActionResult(validationResult)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
+import java.util.UUID
 
 @Service
 class PlacementApplicationsController(
@@ -31,6 +32,13 @@ class PlacementApplicationsController(
     val placementApplication = extractEntityFromValidatableActionResult(
       placementApplicationService.createApplication(application, user),
     )
+
+    return ResponseEntity.ok(placementApplicationTransformer.transformJpaToApi(placementApplication))
+  }
+
+  override fun placementApplicationsIdGet(id: UUID): ResponseEntity<PlacementApplication> {
+    val result = placementApplicationService.getApplication(id)
+    val placementApplication = extractEntityFromAuthorisableActionResult(result, id.toString(), "Application")
 
     return ResponseEntity.ok(placementApplicationTransformer.transformJpaToApi(placementApplication))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
@@ -60,3 +60,13 @@ class ApprovedPremisesAssessmentJsonSchemaEntity(
   addedAt: OffsetDateTime,
   schema: String,
 ) : JsonSchemaEntity(id, addedAt, schema)
+
+@Entity
+@DiscriminatorValue("APPROVED_PREMISES_PLACEMENT_APPLICATION")
+@Table(name = "approved_premises_placement_application_json_schemas")
+@PrimaryKeyJoinColumn(name = "json_schema_id")
+class ApprovedPremisesPlacementApplicationJsonSchemaEntity(
+  id: UUID,
+  addedAt: OffsetDateTime,
+  schema: String,
+) : JsonSchemaEntity(id, addedAt, schema)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.hibernate.annotations.Type
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEntity, UUID>
+
+@Entity
+@Table(name = "placement_applications")
+data class PlacementApplicationEntity(
+  @Id
+  val id: UUID,
+
+  @ManyToOne
+  @JoinColumn(name = "application_id")
+  val application: ApplicationEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdByUser: UserEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "schema_version")
+  var schemaVersion: JsonSchemaEntity,
+
+  @Transient
+  var schemaUpToDate: Boolean,
+
+  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
+  var data: String?,
+
+  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
+  var document: String?,
+
+  val createdAt: OffsetDateTime,
+
+  var submittedAt: OffsetDateTime?,
+
+  @ManyToOne
+  @JoinColumn(name = "allocated_to_user_id")
+  var allocatedToUser: UserEntity?,
+
+  var allocatedAt: OffsetDateTime?,
+  var reallocatedAt: OffsetDateTime?,
+
+  @Enumerated(value = EnumType.STRING)
+  var decision: PlacementApplicationDecision?,
+)
+
+enum class PlacementApplicationDecision {
+  ACCEPTED,
+  REJECTED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -43,5 +45,14 @@ class PlacementApplicationService(
     )
 
     return success(createdApplication.apply { schemaUpToDate = true })
+  }
+
+  fun getApplication(id: UUID): AuthorisableActionResult<PlacementApplicationEntity> {
+    val placementApplication = placementApplicationRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
+    val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java)
+
+    placementApplication.schemaUpToDate = placementApplication.schemaVersion.id == latestSchema.id
+
+    return AuthorisableActionResult.Success(placementApplication)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class PlacementApplicationService(
+  private val placementApplicationRepository: PlacementApplicationRepository,
+  private val jsonSchemaService: JsonSchemaService,
+) {
+
+  fun createApplication(
+    application: ApplicationEntity,
+    user: UserEntity,
+  ) = validated<PlacementApplicationEntity> {
+    val assessment = application.getLatestAssessment()
+
+    if (assessment?.decision !== AssessmentDecision.ACCEPTED) {
+      return generalError("You cannot request a placement request for an application that has not been approved")
+    }
+
+    val createdApplication = placementApplicationRepository.save(
+      PlacementApplicationEntity(
+        id = UUID.randomUUID(),
+        application = application,
+        createdByUser = user,
+        data = null,
+        document = null,
+        schemaVersion = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java),
+        createdAt = OffsetDateTime.now(),
+        submittedAt = null,
+        schemaUpToDate = true,
+        allocatedToUser = null,
+        decision = null,
+        allocatedAt = null,
+        reallocatedAt = null,
+      ),
+    )
+
+    return success(createdApplication.apply { schemaUpToDate = true })
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -45,6 +45,8 @@ class UserService(
     return userRepository.findAll(hasQualificationsAndRoles(qualifications, roles), Sort.by(Sort.Direction.ASC, "name"))
   }
 
+  fun getUserForAllocation(qualifications: List<UserQualification>): UserEntity? = userRepository.findQualifiedAssessorWithLeastPendingAllocations(qualifications.map(UserQualification::toString), qualifications.size.toLong())
+
   fun updateUserFromCommunityApiById(id: UUID): AuthorisableActionResult<UserEntity> {
     var user = userRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
     val staffUserDetailsResponse = communityApiClient.getStaffUserDetails(user.deliusUsername)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+
+@Component
+class PlacementApplicationTransformer(
+  private val objectMapper: ObjectMapper,
+) {
+  fun transformJpaToApi(jpa: PlacementApplicationEntity): PlacementApplication = PlacementApplication(
+    id = jpa.id,
+    applicationId = jpa.application.id,
+    createdByUserId = jpa.createdByUser.id,
+    schemaVersion = jpa.schemaVersion.id,
+    createdAt = jpa.createdAt.toInstant(),
+    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+    document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
+    outdatedSchema = !jpa.schemaUpToDate,
+    submittedAt = jpa.submittedAt?.toInstant(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+
+fun <EntityType> extractEntityFromAuthorisableActionResult(result: AuthorisableActionResult<EntityType>, id: String, entityType: String) = when (result) {
+  is AuthorisableActionResult.Success -> result.entity
+  is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, entityType)
+  is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+}
+
+fun <EntityType> extractEntityFromValidatableActionResult(result: ValidatableActionResult<EntityType>) = when (result) {
+  is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
+  is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages)
+  is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)
+  is ValidatableActionResult.Success -> result.entity
+}

--- a/src/main/resources/db/migration/all/20230530130559__create_placement_applications.sql
+++ b/src/main/resources/db/migration/all/20230530130559__create_placement_applications.sql
@@ -1,0 +1,25 @@
+CREATE TABLE placement_applications (
+    id uuid NOT NULL,
+    application_id uuid NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    data json NULL,
+    document json NULL,
+    schema_version uuid NULL,
+    created_at timestamp NOT NULL,
+    submitted_at timestamp NULL,
+    allocated_to_user_id uuid NULL,
+    allocated_at timestamp NULL,
+    reallocated_at timestamp NULL,
+    decision TEXT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (application_id) REFERENCES applications(id),
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id),
+    FOREIGN KEY (allocated_to_user_id) REFERENCES users(id),
+    FOREIGN KEY (schema_version) REFERENCES json_schemas(id)
+);
+
+CREATE TABLE approved_premises_placement_application_json_schemas (
+    json_schema_id UUID NOT NULL,
+    PRIMARY KEY (json_schema_id),
+    FOREIGN KEY (json_schema_id) REFERENCES json_schemas(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2364,6 +2364,31 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /placement-applications:
+    post:
+      tags:
+        - Placement applications
+      summary: Creates an application for a placement
+      requestBody:
+        description: Details about the application
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewPlacementApplication'
+        required: true
+      responses:
+        200:
+          description: successfully recorded that a placement application has been made
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/PlacementApplication'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -5179,6 +5204,14 @@ components:
             - schemaVersion
             - outdatedScheme
             - createdAt
+    NewPlacementApplication:
+      type: object
+      properties:
+        applicationId:
+          type: string
+          format: uuid
+      required:
+        - applicationId
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2389,6 +2389,32 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /placement-applications/{id}:
+    get:
+      tags:
+        - Placement applications
+      summary: Retrieves an application for a placement request
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the application
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successfully retrieved placement request application
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/PlacementApplication'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5147,6 +5147,38 @@ components:
         - radius
         - essentialCriteria
         - desirableCriteria
+    PlacementApplication:
+      allOf:
+        - $ref: '#/components/schemas/NewPlacementApplication'
+        - type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            createdAt:
+              type: string
+              format: date-time
+            submittedAt:
+              type: string
+              format: date-time
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+          required:
+            - id
+            - createdByUserId
+            - schemaVersion
+            - outdatedScheme
+            - createdAt
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2415,6 +2415,38 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+    put:
+      tags:
+        - Placement applications
+      summary: Updates an application for a placement request
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the application
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Details about the application
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdatePlacementApplication'
+        required: true
+      responses:
+        200:
+          description: successfully retrieved placement request application
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/PlacementApplication'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -5238,6 +5270,15 @@ components:
           format: uuid
       required:
         - applicationId
+    UpdatePlacementApplication:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AnyValue'
+      required:
+        - data
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2447,6 +2447,45 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /placement-applications/{id}/submission:
+    post:
+      tags:
+        - Placement applications
+      summary: Submits an application for a placement request
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the application
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information needed to submit a placement application
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SubmitPlacementApplication'
+        required: true
+      responses:
+        200:
+          description: successfully submitted the placement application
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/PlacementApplication'
+        400:
+          description: placement application has already been submitted
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -5279,6 +5318,13 @@ components:
             $ref: '#/components/schemas/AnyValue'
       required:
         - data
+    SubmitPlacementApplication:
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+      required:
+        - translatedDocument
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory : Factory<ApprovedPremisesPlacementApplicationJsonSchemaEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var addedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var schema: Yielded<String> = { "{}" }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAddedAt(addedAt: OffsetDateTime) = apply {
+    this.addedAt = { addedAt }
+  }
+
+  fun withSchema(schema: String) = apply {
+    this.schema = { schema }
+  }
+
+  fun withPermissiveSchema() = apply {
+    withSchema(
+      """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": { }
+        }
+        """,
+    )
+  }
+
+  override fun produce(): ApprovedPremisesPlacementApplicationJsonSchemaEntity = ApprovedPremisesPlacementApplicationJsonSchemaEntity(
+    id = this.id(),
+    addedAt = this.addedAt(),
+    schema = this.schema(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdByUser: Yielded<UserEntity>? = null
+  private var application: Yielded<ApplicationEntity>? = null
+  private var schemaVersion: Yielded<JsonSchemaEntity> = {
+    ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory().produce()
+  }
+  private var data: Yielded<String?> = { "{}" }
+  private var document: Yielded<String?> = { "{}" }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var submittedAt: Yielded<OffsetDateTime?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCreatedByUser(createdByUser: UserEntity) = apply {
+    this.createdByUser = { createdByUser }
+  }
+
+  fun withData(data: String?) = apply {
+    this.data = { data }
+  }
+
+  fun withDocument(document: String?) = apply {
+    this.document = { document }
+  }
+
+  fun withSchemaVersion(schemaVersion: JsonSchemaEntity) = apply {
+    this.schemaVersion = { schemaVersion }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withSubmittedAt(submittedAt: OffsetDateTime?) = apply {
+    this.submittedAt = { submittedAt }
+  }
+
+  fun withApplication(applicationEntity: ApplicationEntity) = apply {
+    this.application = { applicationEntity }
+  }
+
+  override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
+    id = this.id(),
+    createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
+    application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
+    schemaVersion = this.schemaVersion(),
+    data = this.data(),
+    document = this.document(),
+    createdAt = this.createdAt(),
+    submittedAt = this.submittedAt(),
+    schemaUpToDate = false,
+    allocatedToUser = null,
+    allocatedAt = null,
+    reallocatedAt = null,
+    decision = null,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
@@ -53,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PostCodeDistrictEntityFactory
@@ -72,6 +74,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
@@ -97,6 +100,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
@@ -125,6 +130,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesAssessmentJsonSchemaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesPlacementApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentClarificationNoteTestRepository
@@ -324,6 +330,9 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesAssessmentJsonSchemaRepository: ApprovedPremisesAssessmentJsonSchemaTestRepository
 
   @Autowired
+  lateinit var approvedPremisesPlacementApplicationJsonSchemaRepository: ApprovedPremisesPlacementApplicationJsonSchemaTestRepository
+
+  @Autowired
   lateinit var userRepository: UserTestRepository
 
   @Autowired
@@ -363,6 +372,9 @@ abstract class IntegrationTestBase {
   lateinit var placementRequirementsRepository: PlacementRequirementsRepository
 
   @Autowired
+  lateinit var placementApplicationRepository: PlacementApplicationRepository
+
+  @Autowired
   lateinit var bookingNotMadeRepository: BookingNotMadeTestRepository
 
   @Autowired
@@ -396,6 +408,7 @@ abstract class IntegrationTestBase {
   lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
   lateinit var temporaryAccommodationApplicationJsonSchemaEntityFactory: PersistedFactory<TemporaryAccommodationApplicationJsonSchemaEntity, UUID, TemporaryAccommodationApplicationJsonSchemaEntityFactory>
+  lateinit var approvedPremisesPlacementApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesPlacementApplicationJsonSchemaEntity, UUID, ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory>
   lateinit var approvedPremisesAssessmentJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesAssessmentJsonSchemaEntity, UUID, ApprovedPremisesAssessmentJsonSchemaEntityFactory>
   lateinit var userEntityFactory: PersistedFactory<UserEntity, UUID, UserEntityFactory>
   lateinit var userRoleAssignmentEntityFactory: PersistedFactory<UserRoleAssignmentEntity, UUID, UserRoleAssignmentEntityFactory>
@@ -413,6 +426,7 @@ abstract class IntegrationTestBase {
   lateinit var probationDeliveryUnitFactory: PersistedFactory<ProbationDeliveryUnitEntity, UUID, ProbationDeliveryUnitEntityFactory>
   lateinit var applicationTeamCodeFactory: PersistedFactory<ApplicationTeamCodeEntity, UUID, ApplicationTeamCodeEntityFactory>
   lateinit var turnaroundFactory: PersistedFactory<TurnaroundEntity, UUID, TurnaroundEntityFactory>
+  lateinit var placementApplicationFactory: PersistedFactory<PlacementApplicationEntity, UUID, PlacementApplicationEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -467,6 +481,7 @@ abstract class IntegrationTestBase {
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesApplicationJsonSchemaEntityFactory() }, approvedPremisesApplicationJsonSchemaRepository)
     temporaryAccommodationApplicationJsonSchemaEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationJsonSchemaEntityFactory() }, temporaryAccommodationApplicationJsonSchemaRepository)
     approvedPremisesAssessmentJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesAssessmentJsonSchemaEntityFactory() }, approvedPremisesAssessmentJsonSchemaRepository)
+    approvedPremisesPlacementApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory() }, approvedPremisesPlacementApplicationJsonSchemaRepository)
     userEntityFactory = PersistedFactory({ UserEntityFactory() }, userRepository)
     userRoleAssignmentEntityFactory = PersistedFactory({ UserRoleAssignmentEntityFactory() }, userRoleAssignmentRepository)
     userQualificationAssignmentEntityFactory = PersistedFactory({ UserQualificationAssignmentEntityFactory() }, userQualificationAssignmentRepository)
@@ -483,6 +498,7 @@ abstract class IntegrationTestBase {
     probationDeliveryUnitFactory = PersistedFactory({ ProbationDeliveryUnitEntityFactory() }, probationDeliveryUnitRepository)
     applicationTeamCodeFactory = PersistedFactory({ ApplicationTeamCodeEntityFactory() }, applicationTeamCodeRepository)
     turnaroundFactory = PersistedFactory({ TurnaroundEntityFactory() }, turnaroundRepository)
+    placementApplicationFactory = PersistedFactory({ PlacementApplicationEntityFactory() }, placementApplicationRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1,0 +1,147 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import java.util.UUID
+
+class PlacementApplicationsTest : IntegrationTestBase() {
+
+  @Nested
+  inner class CreatePlacementApplicationTest {
+    @Test
+    fun `creating a placement application JWT returns 401`() {
+      webTestClient.post()
+        .uri("/placement-applications")
+        .bodyValue(
+          NewPlacementApplication(
+            applicationId = UUID.randomUUID(),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `creating a placement application when the application does not exist returns 404`() {
+      `Given a User` { _, jwt ->
+        webTestClient.post()
+          .uri("/placement-applications")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewPlacementApplication(
+              applicationId = UUID.randomUUID(),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isNotFound()
+      }
+    }
+
+    @Test
+    fun `creating a placement application when the application does not belong to the user returns 401`() {
+      `Given a User` { _, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Application`(createdByUser = otherUser) { application ->
+            webTestClient.post()
+              .uri("/placement-applications")
+              .header("Authorization", "Bearer $jwt")
+              .bodyValue(
+                NewPlacementApplication(
+                  applicationId = application.id,
+                ),
+              )
+              .exchange()
+              .expectStatus()
+              .isForbidden()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `creating a placement application when the application does not have an assessment returns an error`() {
+      `Given a User` { user, jwt ->
+        `Given an Application`(createdByUser = user) { application ->
+          webTestClient.post()
+            .uri("/placement-applications")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewPlacementApplication(
+                applicationId = application.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isBadRequest()
+        }
+      }
+    }
+
+    @Test
+    fun `creating a placement application when the assessment has been rejected returns an error`() {
+      `Given a User` { user, jwt ->
+        `Given an Assessment for Approved Premises`(decision = AssessmentDecision.REJECTED, allocatedToUser = user, createdByUser = user) { _, application ->
+          approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          }
+
+          webTestClient.post()
+            .uri("/placement-applications")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewPlacementApplication(
+                applicationId = application.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isBadRequest()
+        }
+      }
+    }
+
+    @Test
+    fun `creating a placement application when the application belongs to the user returns successfully`() {
+      `Given a User` { user, jwt ->
+        `Given an Assessment for Approved Premises`(decision = AssessmentDecision.ACCEPTED, allocatedToUser = user, createdByUser = user) { _, application ->
+          val schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          }
+
+          val rawResult = webTestClient.post()
+            .uri("/placement-applications")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewPlacementApplication(
+                applicationId = application.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .returnResult<String>()
+            .responseBody
+            .blockFirst()
+
+          val body = objectMapper.readValue(rawResult, PlacementApplication::class.java)
+
+          assertThat(body.applicationId).isEqualTo(application.id)
+          assertThat(body.applicationId).isEqualTo(application.id)
+          assertThat(body.outdatedSchema).isEqualTo(false)
+          assertThat(body.createdAt).isNotNull()
+          assertThat(body.schemaVersion).isEqualTo(schema.id)
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.time.OffsetDateTime
+
+fun IntegrationTestBase.`Given a Placement Application`(
+  assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
+  createdByUser: UserEntity,
+  schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity,
+  submittedAt: OffsetDateTime? = null,
+  block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
+) {
+  `Given an Assessment for Approved Premises`(
+    decision = assessmentDecision,
+    allocatedToUser = userEntityFactory.produceAndPersist {
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    },
+    createdByUser = userEntityFactory.produceAndPersist {
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    },
+  ) { _, application ->
+    val placementApplicationEntity = placementApplicationFactory.produceAndPersist {
+      withCreatedByUser(createdByUser)
+      withApplication(application)
+      withSchemaVersion(schema)
+      withSubmittedAt(submittedAt)
+    }
+
+    block(placementApplicationEntity)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -14,6 +15,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
   data: String? = "{ \"some\": \"data\"}",
+  decision: AssessmentDecision? = null,
   block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit,
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -36,6 +38,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withApplication(application)
     withAssessmentSchema(assessmentSchema)
     withData(data)
+    withDecision(decision)
     if (reallocated) {
       withReallocatedAt(OffsetDateTime.now())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/JsonSchemaTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/JsonSchemaTestRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import java.util.UUID
 
@@ -15,3 +16,6 @@ interface TemporaryAccommodationApplicationJsonSchemaTestRepository : JpaReposit
 
 @Repository
 interface ApprovedPremisesAssessmentJsonSchemaTestRepository : JpaRepository<ApprovedPremisesAssessmentJsonSchemaEntity, UUID>
+
+@Repository
+interface ApprovedPremisesPlacementApplicationJsonSchemaTestRepository : JpaRepository<ApprovedPremisesPlacementApplicationJsonSchemaEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
+
+class PlacementApplicationTransformerTest {
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+  private val placementApplicationTransformer = PlacementApplicationTransformer(objectMapper)
+
+  private var user = UserEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .produce()
+
+  private var application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .produce()
+
+  @Test
+  fun `transformJpaToApi converts correctly when there is no data or document`() {
+    val placementApplication = PlacementApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withApplication(application)
+      .withData(null)
+      .withDocument(null)
+      .produce()
+
+    val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
+
+    assertThat(result.id).isEqualTo(placementApplication.id)
+    assertThat(result.applicationId).isEqualTo(placementApplication.application.id)
+    assertThat(result.createdByUserId).isEqualTo(placementApplication.createdByUser.id)
+    assertThat(result.schemaVersion).isEqualTo(placementApplication.schemaVersion.id)
+    assertThat(result.createdAt).isEqualTo(placementApplication.createdAt.toInstant())
+    assertThat(result.data).isNull()
+    assertThat(result.document).isNull()
+    assertThat(result.outdatedSchema).isEqualTo(true)
+    assertThat(result.submittedAt).isNull()
+  }
+
+  @Test
+  fun `transformJpaToApi converts correctly when there is data and a document`() {
+    val data = "{\"data\": \"something\"}"
+    val document = "{\"document\": \"something\"}"
+    val placementApplication = PlacementApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withApplication(application)
+      .withData(data)
+      .withDocument(document)
+      .produce()
+
+    val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
+
+    assertThat(result.id).isEqualTo(placementApplication.id)
+    assertThat(result.data).isEqualTo(objectMapper.readTree(data))
+    assertThat(result.document).isEqualTo(objectMapper.readTree(document))
+  }
+}


### PR DESCRIPTION
This adds a new Placement Application model, which acts like a mini-application with the same kind of data and document fields. This can then be assigned to an Assessor, who will be able to approve/reject the application without having to have a seperate Assessment object.