### PR TITLE
66 - Seed offline applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -21,6 +21,5 @@ data class OfflineApplicationEntity(
   val id: UUID,
   val crn: String,
   val service: String,
-  val submittedAt: OffsetDateTime,
   val createdAt: OffsetDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesOfflineApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesOfflineApplicationsSeedJob.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApprovedPremisesOfflineApplicationsSeedJob(
+  fileName: String,
+  private val offlineApplicationRepository: OfflineApplicationRepository,
+) : SeedJob<OfflineApplicationsSeedCsvRow>(
+  fileName = fileName,
+  requiredColumns = 12,
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun verifyPresenceOfRequiredHeaders(headers: Set<String>) {
+    val missingHeaders = requiredHeaders() - headers
+
+    if (missingHeaders.any()) {
+      throw RuntimeException("required headers: $missingHeaders")
+    }
+  }
+
+  override fun deserializeRow(columns: Map<String, String>) = OfflineApplicationsSeedCsvRow(
+    crn = columns["crn"]!!,
+  )
+
+  override fun processRow(row: OfflineApplicationsSeedCsvRow) {
+    val existingOfflineApplications = offlineApplicationRepository.findAllByServiceAndCrn(ServiceName.approvedPremises.value, row.crn)
+
+    if (existingOfflineApplications.none()) {
+      offlineApplicationRepository.save(
+        OfflineApplicationEntity(
+          id = UUID.randomUUID(),
+          crn = row.crn,
+          service = ServiceName.approvedPremises.value,
+          createdAt = OffsetDateTime.now(),
+        ),
+      )
+    }
+  }
+}
+
+private fun requiredHeaders(): Set<String> {
+  return setOf(
+    "crn",
+  )
+}
+
+data class OfflineApplicationsSeedCsvRow(
+  val crn: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -230,7 +230,7 @@ class BookingService(
         .filter { it.submittedAt != null }
         .maxByOrNull { it.submittedAt!! }
       val newestOfflineApplication = applicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises)
-        .maxByOrNull { it.submittedAt }
+        .maxByOrNull { it.createdAt }
 
       if (newestSubmittedOnlineApplication == null && newestOfflineApplication == null) {
         validationErrors["$.crn"] = "doesNotHaveApplication"
@@ -241,7 +241,7 @@ class BookingService(
       }
 
       val associateWithOfflineApplication = (newestOfflineApplication != null && newestSubmittedOnlineApplication == null) ||
-        (newestOfflineApplication != null && newestSubmittedOnlineApplication != null && newestOfflineApplication.submittedAt > newestSubmittedOnlineApplication.submittedAt)
+        (newestOfflineApplication != null && newestSubmittedOnlineApplication != null && newestOfflineApplication.createdAt > newestSubmittedOnlineApplication.submittedAt)
 
       val associateWithOnlineApplication = newestSubmittedOnlineApplication != null && !associateWithOfflineApplication
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -13,10 +13,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesOfflineApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CharacteristicsSeedJob
@@ -121,6 +123,11 @@ class SeedService(
           applicationContext.getBean(PremisesRepository::class.java),
           applicationContext.getBean(CharacteristicService::class.java),
           applicationContext.getBean(RoomService::class.java),
+        )
+
+        SeedFileType.approvedPremisesOfflineApplications -> ApprovedPremisesOfflineApplicationsSeedJob(
+          filename,
+          applicationContext.getBean(OfflineApplicationRepository::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -103,14 +103,12 @@ class ApplicationsTransformer(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),
-    submittedAt = jpa.submittedAt.toInstant(),
   )
 
   fun transformJpaToApiSummary(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplicationSummary(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),
-    submittedAt = jpa.submittedAt.toInstant(),
   )
 
   private fun getStatus(entity: ApplicationEntity): ApplicationStatus {

--- a/src/main/resources/db/migration/all/20230601094346__remove_submitted_date_from_offline_applications.sql
+++ b/src/main/resources/db/migration/all/20230601094346__remove_submitted_date_from_offline_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE offline_applications DROP COLUMN submitted_at;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5223,6 +5223,7 @@ components:
         - temporary_accommodation_bedspace
         - user
         - characteristics
+        - approved_premises_offline_applications
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4179,9 +4179,6 @@ components:
         createdAt:
           type: string
           format: date-time
-        submittedAt:
-          type: string
-          format: date-time
       discriminator:
         propertyName: type
         mapping:
@@ -4226,6 +4223,9 @@ components:
               $ref: '#/components/schemas/AnyValue'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            submittedAt:
+              type: string
+              format: date-time
           required:
             - createdByUserId
             - schemaVersion
@@ -4252,6 +4252,9 @@ components:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            submittedAt:
+              type: string
+              format: date-time
           required:
             - createdByUserId
             - schemaVersion

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
@@ -12,7 +12,6 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var service: Yielded<String> = { "approved-premises" }
-  private var submittedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
 
   fun withId(id: UUID) = apply {
@@ -27,10 +26,6 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
     this.service = { service }
   }
 
-  fun withSubmittedAt(submittedAt: OffsetDateTime) = apply {
-    this.submittedAt = { submittedAt }
-  }
-
   fun withCreatedAt(createdAt: OffsetDateTime) = apply {
     this.createdAt = { createdAt }
   }
@@ -39,7 +34,6 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
     id = this.id(),
     crn = this.crn(),
     service = this.service(),
-    submittedAt = this.submittedAt(),
     createdAt = this.createdAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -715,8 +715,7 @@ class ApplicationTest : IntegrationTestBase() {
         assertThat(responseBody).matches {
           offlineApplicationEntity.id == it.id &&
             offlineApplicationEntity.crn == it.person.crn &&
-            offlineApplicationEntity.createdAt.toInstant() == it.createdAt &&
-            offlineApplicationEntity.submittedAt.toInstant() == it.submittedAt
+            offlineApplicationEntity.createdAt.toInstant() == it.createdAt
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesOfflineApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesOfflineApplicationsTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.OfflineApplicationsSeedCsvRow
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedApprovedPremisesOfflineApplicationsTest : SeedTestBase() {
+  @Test
+  fun `An Offline Application is created for a CRN that doesn't currently have any Offline Applications`() {
+    withCsv(
+      "offline-applications",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          OfflineApplicationsSeedCsvRow("NEWCRN"),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesOfflineApplications, "offline-applications")
+
+    assertThat(offlineApplicationRepository.findAll()).anyMatch {
+      it.crn == "NEWCRN"
+    }
+  }
+
+  @Test
+  fun `An Offline Application is not created for a CRN that already has an Offline Application`() {
+    offlineApplicationEntityFactory.produceAndPersist {
+      withCrn("EXISTINGCRN")
+      withService(ServiceName.approvedPremises.value)
+    }
+
+    withCsv(
+      "offline-applications",
+      approvedPremisesSeedCsvRowsToCsv(
+        listOf(
+          OfflineApplicationsSeedCsvRow("EXISTINGCRN"),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesOfflineApplications, "offline-applications")
+
+    val matchingOfflineApplications = offlineApplicationRepository.findAll().filter {
+      it.crn == "EXISTINGCRN"
+    }
+
+    assertThat(matchingOfflineApplications.size).isEqualTo(1)
+  }
+
+  private fun approvedPremisesSeedCsvRowsToCsv(rows: List<OfflineApplicationsSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "crn",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.crn)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2026,7 +2026,7 @@ class BookingServiceTest {
 
     val existingApplication = OfflineApplicationEntityFactory()
       .withCrn(crn)
-      .withSubmittedAt(OffsetDateTime.now())
+      .withCreatedAt(OffsetDateTime.now())
       .produce()
 
     every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()


### PR DESCRIPTION
- Remove `submittedAt` from OfflineApplications as we won't actually have this data for legacy applications
- Add a Seed Job that creates an Offline Application for each CRN in a CSV