### PR TITLE
(173) Show Placement Applications as tasks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -9,10 +9,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapAndTransformAssessments
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapAndTransformPlacementApplications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapAndTransformPlacementRequests
 
 @Service
@@ -22,6 +24,7 @@ class TasksController(
   private val placementRequestService: PlacementRequestService,
   private val taskTransformer: TaskTransformer,
   private val offenderService: OffenderService,
+  private val placementApplicationService: PlacementApplicationService,
 ) : TasksApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -45,7 +48,15 @@ class TasksController(
         taskTransformer::transformPlacementRequestToTask,
       )
 
-      return ResponseEntity.ok(placementRequests + assessments)
+      val placementApplications = mapAndTransformPlacementApplications(
+        log,
+        placementApplicationService.getAllReallocatable(),
+        user.deliusUsername,
+        this.offenderService,
+        taskTransformer::transformPlacementApplicationToTask,
+      )
+
+      return ResponseEntity.ok(placementRequests + assessments + placementApplications)
     } else {
       throw ForbiddenProblem()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -14,7 +14,9 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
-interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEntity, UUID>
+interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEntity, UUID> {
+  fun findAllByReallocatedAtNullAndDecisionNull(): List<PlacementApplicationEntity>
+}
 
 @Entity
 @Table(name = "placement_applications")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -16,6 +17,9 @@ import javax.persistence.Table
 @Repository
 interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEntity, UUID> {
   fun findAllByReallocatedAtNullAndDecisionNull(): List<PlacementApplicationEntity>
+
+  @Query("SELECT a FROM PlacementApplicationEntity a WHERE a.application.id = :id")
+  fun findByApplicationId(id: UUID): PlacementApplicationEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -20,6 +20,8 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   @Query("SELECT a FROM PlacementApplicationEntity a WHERE a.application.id = :id")
   fun findByApplicationId(id: UUID): PlacementApplicationEntity?
+
+  fun findByApplication_IdAndReallocatedAtNull(id: UUID): PlacementApplicationEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -55,11 +55,14 @@ class PlacementApplicationService(
 
   fun getApplication(id: UUID): AuthorisableActionResult<PlacementApplicationEntity> {
     val placementApplication = placementApplicationRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
-    val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java)
 
-    placementApplication.schemaUpToDate = placementApplication.schemaVersion.id == latestSchema.id
+    return AuthorisableActionResult.Success(setSchemaUpToDate(placementApplication))
+  }
 
-    return AuthorisableActionResult.Success(placementApplication)
+  fun getPlacementApplicationForApplicationId(applicationId: UUID): AuthorisableActionResult<PlacementApplicationEntity> {
+    val placementApplication = placementApplicationRepository.findByApplicationId(applicationId) ?: return AuthorisableActionResult.NotFound()
+
+    return AuthorisableActionResult.Success(setSchemaUpToDate(placementApplication))
   }
 
   fun updateApplication(id: UUID, data: String): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
@@ -126,6 +129,14 @@ class PlacementApplicationService(
 
   fun getAllReallocatable(): List<PlacementApplicationEntity> {
     return placementApplicationRepository.findAllByReallocatedAtNullAndDecisionNull()
+  }
+
+  private fun setSchemaUpToDate(placementApplicationEntity: PlacementApplicationEntity): PlacementApplicationEntity {
+    val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java)
+
+    placementApplicationEntity.schemaUpToDate = placementApplicationEntity.schemaVersion.id == latestSchema.id
+
+    return placementApplicationEntity
   }
 
   private fun getApplicationForUpdateOrSubmit(id: UUID): AuthorisableActionResult<PlacementApplicationEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -121,6 +122,10 @@ class PlacementApplicationService(
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(savedApplication),
     )
+  }
+
+  fun getAllReallocatable(): List<PlacementApplicationEntity> {
+    return placementApplicationRepository.findAllByReallocatedAtNullAndDecisionNull()
   }
 
   private fun getApplicationForUpdateOrSubmit(id: UUID): AuthorisableActionResult<PlacementApplicationEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -63,6 +65,44 @@ class PlacementApplicationService(
     val placementApplication = placementApplicationRepository.findByApplicationId(applicationId) ?: return AuthorisableActionResult.NotFound()
 
     return AuthorisableActionResult.Success(setSchemaUpToDate(placementApplication))
+  }
+
+  fun reallocateApplication(assigneeUser: UserEntity, application: ApprovedPremisesApplicationEntity): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
+    val currentPlacementApplication = placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id)
+      ?: return AuthorisableActionResult.NotFound()
+
+    if (currentPlacementApplication.decision != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("This placement application has already been completed"),
+      )
+    }
+
+    if (!assigneeUser.hasRole(UserRole.ASSESSOR)) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingAssessorRole" }),
+      )
+    }
+
+    currentPlacementApplication.reallocatedAt = OffsetDateTime.now()
+    placementApplicationRepository.save(currentPlacementApplication)
+
+    // Make the timestamp precision less precise, so we don't have any issues with microsecond resolution in tests
+    val dateTimeNow = OffsetDateTime.now().withNano(0)
+
+    val newPlacementApplication = placementApplicationRepository.save(
+      currentPlacementApplication.copy(
+        id = UUID.randomUUID(),
+        reallocatedAt = null,
+        allocatedToUser = assigneeUser,
+        createdAt = dateTimeNow,
+      ),
+    )
+
+    return AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(
+        newPlacementApplication,
+      ),
+    )
   }
 
   fun updateApplication(id: UUID, data: String): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -25,6 +26,7 @@ class TaskService(
   private val userService: UserService,
   private val placementRequestService: PlacementRequestService,
   private val userTransformer: UserTransformer,
+  private val placementApplicationService: PlacementApplicationService,
 ) {
   fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, applicationId: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
     if (!requestUser.hasRole(UserRole.WORKFLOW_MANAGER)) {
@@ -49,6 +51,9 @@ class TaskService(
       }
       TaskType.placementRequest -> {
         placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+      }
+      TaskType.placementApplication -> {
+        placementApplicationService.reallocateApplication(assigneeUser, application)
       }
       else -> {
         throw NotAllowedProblem(detail = "The Task Type $taskType is not currently supported")
@@ -77,6 +82,7 @@ class TaskService(
     val allocatedToUser = when (entity) {
       is PlacementRequestEntity -> entity.allocatedToUser
       is AssessmentEntity -> entity.allocatedToUser
+      is PlacementApplicationEntity -> entity.allocatedToUser!!
       else -> throw RuntimeException("Unexpected type")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PlacementApplicationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PlacementApplicationUtils.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.slf4j.Logger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+
+fun <T> mapAndTransformPlacementApplications(
+  log: Logger,
+  placementApplications: List<PlacementApplicationEntity>,
+  deliusUsername: String,
+  offenderService: OffenderService,
+  transformer: (PlacementApplicationEntity, OffenderDetailSummary, InmateDetail) -> T,
+): List<T> {
+  return placementApplications.mapNotNull {
+    val placementApplication = transformPlacementApplication<T>(log, it, deliusUsername, offenderService, transformer)
+      ?: return@mapNotNull null
+
+    placementApplication
+  }
+}
+
+fun <T> transformPlacementApplication(
+  log: Logger,
+  placementApplication: PlacementApplicationEntity,
+  deliusUsername: String,
+  offenderService: OffenderService,
+  transformer: (PlacementApplicationEntity, OffenderDetailSummary, InmateDetail) -> T,
+): T {
+  val (offenderDetailSummary, inmateDetail) = getPersonDetailsForCrn(log, placementApplication.application.crn, deliusUsername, offenderService)
+    ?: throw NotFoundProblem(placementApplication.application.crn, "Offender")
+
+  return transformer(placementApplication, offenderDetailSummary, inmateDetail)
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3213,7 +3213,7 @@ components:
       enum:
         - Assessment
         - PlacementRequest
-        - PlacementRequestReview
+        - PlacementApplication
         - BookingAppeal
     LocalAuthorityArea:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -13,6 +14,7 @@ import java.util.UUID
 class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var createdByUser: Yielded<UserEntity>? = null
+  private var allocatedToUser: Yielded<UserEntity?> = { null }
   private var application: Yielded<ApplicationEntity>? = null
   private var schemaVersion: Yielded<JsonSchemaEntity> = {
     ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory().produce()
@@ -21,6 +23,8 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var document: Yielded<String?> = { "{}" }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
+  private var decision: Yielded<PlacementApplicationDecision?> = { null }
+  private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -28,6 +32,10 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
 
   fun withCreatedByUser(createdByUser: UserEntity) = apply {
     this.createdByUser = { createdByUser }
+  }
+
+  fun withAllocatedToUser(allocatedToUser: UserEntity?) = apply {
+    this.allocatedToUser = { allocatedToUser }
   }
 
   fun withData(data: String?) = apply {
@@ -54,6 +62,14 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.application = { applicationEntity }
   }
 
+  fun withDecision(decision: PlacementApplicationDecision?) = apply {
+    this.decision = { decision }
+  }
+
+  fun withReallocatedAt(reallocatedAt: OffsetDateTime?) = apply {
+    this.reallocatedAt = { reallocatedAt }
+  }
+
   override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
     id = this.id(),
     createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
@@ -64,9 +80,9 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
     schemaUpToDate = false,
-    allocatedToUser = null,
+    allocatedToUser = this.allocatedToUser(),
     allocatedAt = null,
-    reallocatedAt = null,
-    decision = null,
+    reallocatedAt = this.reallocatedAt(),
+    decision = this.decision(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -3,19 +3,27 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
 fun IntegrationTestBase.`Given a Placement Application`(
   assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
   createdByUser: UserEntity,
   schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity,
+  crn: String = randomStringMultiCaseWithNumbers(8),
+  allocatedToUser: UserEntity? = null,
   submittedAt: OffsetDateTime? = null,
+  decision: PlacementApplicationDecision? = null,
+  reallocated: Boolean = false,
   block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
 ) {
   `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
+    submittedAt = OffsetDateTime.now(),
+    crn = crn,
     allocatedToUser = userEntityFactory.produceAndPersist {
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist {
@@ -33,9 +41,14 @@ fun IntegrationTestBase.`Given a Placement Application`(
   ) { _, application ->
     val placementApplicationEntity = placementApplicationFactory.produceAndPersist {
       withCreatedByUser(createdByUser)
+      withAllocatedToUser(allocatedToUser)
       withApplication(application)
       withSchemaVersion(schema)
       withSubmittedAt(submittedAt)
+      withDecision(decision)
+      if (reallocated) {
+        withReallocatedAt(OffsetDateTime.now())
+      }
     }
 
     block(placementApplicationEntity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -16,6 +16,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   reallocated: Boolean = false,
   data: String? = "{ \"some\": \"data\"}",
   decision: AssessmentDecision? = null,
+  submittedAt: OffsetDateTime? = null,
   block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit,
 ) {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -39,6 +40,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withAssessmentSchema(assessmentSchema)
     withData(data)
     withDecision(decision)
+    withSubmittedAt(submittedAt)
     if (reallocated) {
       withReallocatedAt(OffsetDateTime.now())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -1,0 +1,149 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class PlacementApplicationServiceTest {
+  private val placementApplicationRepository = mockk<PlacementApplicationRepository>()
+  private val jsonSchemaService = mockk<JsonSchemaService>()
+  private val userService = mockk<UserService>()
+
+  private val placementApplicationService = PlacementApplicationService(
+    placementApplicationRepository,
+    jsonSchemaService,
+    userService,
+  )
+
+  @Nested
+  inner class ReallocateApplicationTest {
+    private val previousUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    private val assigneeUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    private val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce(),
+      )
+      .produce()
+
+    private val previousPlacementApplication = PlacementApplicationEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(assigneeUser)
+      .withDecision(null)
+      .withCreatedByUser(
+        UserEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .produce(),
+      )
+      .produce()
+
+    @Test
+    fun `Reallocating an application returns successfully`() {
+      assigneeUser.apply {
+        roles += UserRoleAssignmentEntityFactory()
+          .withUser(this)
+          .withRole(UserRole.ASSESSOR)
+          .produce()
+      }
+
+      every { placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementApplication
+
+      every { placementApplicationRepository.save(previousPlacementApplication) } answers { it.invocation.args[0] as PlacementApplicationEntity }
+      every { placementApplicationRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementApplicationEntity }
+
+      val result = placementApplicationService.reallocateApplication(assigneeUser, application)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(validationResult is ValidatableActionResult.Success).isTrue
+      validationResult as ValidatableActionResult.Success
+
+      assertThat(previousPlacementApplication.reallocatedAt).isNotNull
+
+      verify { placementApplicationRepository.save(match { it.allocatedToUser == assigneeUser }) }
+
+      val newPlacementApplication = validationResult.entity
+
+      assertThat(newPlacementApplication.application).isEqualTo(application)
+      assertThat(newPlacementApplication.allocatedToUser).isEqualTo(assigneeUser)
+      assertThat(newPlacementApplication.createdByUser).isEqualTo(newPlacementApplication.createdByUser)
+      assertThat(newPlacementApplication.data).isEqualTo(newPlacementApplication.data)
+      assertThat(newPlacementApplication.document).isEqualTo(newPlacementApplication.document)
+      assertThat(newPlacementApplication.schemaVersion).isEqualTo(newPlacementApplication.schemaVersion)
+    }
+
+    @Test
+    fun `Reallocating a placement application with a decision returns a General Validation Error`() {
+      previousPlacementApplication.apply {
+        decision = PlacementApplicationDecision.ACCEPTED
+      }
+
+      every { placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementApplication
+
+      val result = placementApplicationService.reallocateApplication(assigneeUser, application)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(validationResult is ValidatableActionResult.GeneralValidationError).isTrue
+      validationResult as ValidatableActionResult.GeneralValidationError
+      assertThat(validationResult.message).isEqualTo("This placement application has already been completed")
+    }
+
+    @Test
+    fun `Reallocating a placement application when user to assign to is not an ASSESSOR returns a field validation error`() {
+      every { placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementApplication
+
+      val result = placementApplicationService.reallocateApplication(assigneeUser, application)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(validationResult is ValidatableActionResult.FieldValidationError).isTrue
+      validationResult as ValidatableActionResult.FieldValidationError
+      assertThat(validationResult.validationMessages).containsEntry("$.userId", "lackingAssessorRole")
+    }
+  }
+}


### PR DESCRIPTION
This allows Placement Applications to show up as tasks and be reallocated, in a similar way to assessments and placement requests. These were originally going to be called `PlacementRequestReview`s, but the thinking has evolved, so I've renamed them to `PlacementApplications`