### PR TITLE
Rename CAS1 user roles

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -275,7 +275,7 @@ class ApplicationsController(
           taskTransformer::transformAssessmentToTask,
         )
 
-        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRoles(assessment.application.getRequiredQualifications(), listOf(UserRole.ASSESSOR))
+        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRoles(assessment.application.getRequiredQualifications(), listOf(UserRole.CAS1_ASSESSOR))
           .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
       }
       TaskType.placementRequest -> {
@@ -296,7 +296,7 @@ class ApplicationsController(
           taskTransformer.transformPlacementRequestToTask(placementRequest, personDetail.first, personDetail.second)
 
         transformedAllocatableUsers =
-          userService.getUsersWithQualificationsAndRoles(emptyList(), listOf(UserRole.MATCHER))
+          userService.getUsersWithQualificationsAndRoles(emptyList(), listOf(UserRole.CAS1_MATCHER))
             .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
       }
       TaskType.placementApplication -> {
@@ -314,7 +314,7 @@ class ApplicationsController(
 
         transformedTask = taskTransformer.transformPlacementApplicationToTask(placementApplication, personDetail.first, personDetail.second)
 
-        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRoles(placementApplication.application.getRequiredQualifications(), listOf(UserRole.ASSESSOR))
+        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRoles(placementApplication.application.getRequiredQualifications(), listOf(UserRole.CAS1_ASSESSOR))
           .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
       } else -> {
         throw NotAllowedProblem(detail = "The Task Type $taskType is not currently supported")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -605,7 +605,7 @@ class PremisesController(
 
     val user = usersService.getUserForRequest()
 
-    if (premises is ApprovedPremisesEntity && !user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)) {
+    if (premises is ApprovedPremisesEntity && !user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -31,7 +31,7 @@ class TasksController(
   override fun tasksGet(): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
-    if (user.hasRole(UserRole.WORKFLOW_MANAGER)) {
+    if (user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       val assessments = mapAndTransformAssessments(
         log,
         assessmentService.getAllReallocatable(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -34,7 +34,7 @@ class UsersController(
 
   override fun usersGet(xServiceName: ServiceName, roles: List<UserRole>?, qualifications: List<UserQualification>?): ResponseEntity<List<User>> {
     val user = userService.getUserForRequest()
-    if (!user.hasAnyRole(JpaUserRole.ROLE_ADMIN, JpaUserRole.WORKFLOW_MANAGER)) {
+    if (!user.hasAnyRole(JpaUserRole.CAS1_ADMIN, JpaUserRole.CAS1_WORKFLOW_MANAGER)) {
       throw ForbiddenProblem()
     }
 
@@ -48,13 +48,13 @@ class UsersController(
   }
 
   private fun transformApiRole(apiRole: UserRole): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole = when (apiRole) {
-    UserRole.roleAdmin -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.ROLE_ADMIN
-    UserRole.applicant -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.APPLICANT
-    UserRole.assessor -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.ASSESSOR
-    UserRole.manager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.MANAGER
-    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.MATCHER
-    UserRole.workflowManager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.WORKFLOW_MANAGER
-    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.MATCHER
+    UserRole.roleAdmin -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ADMIN
+    UserRole.applicant -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_APPLICANT
+    UserRole.assessor -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ASSESSOR
+    UserRole.manager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MANAGER
+    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MATCHER
+    UserRole.workflowManager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_WORKFLOW_MANAGER
+    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MATCHER
   }
 
   private fun transformApiQualification(apiQualification: uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification = when (apiQualification) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -25,7 +25,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
     FROM "users"  u
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
-    WHERE ura.role = 'ASSESSOR' AND 
+    WHERE ura.role = 'CAS1_ASSESSOR' AND 
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications 
     ORDER BY 
       (SELECT COUNT(1) FROM assessments a WHERE a.allocated_to_user_id = u.id AND a.submitted_at IS NULL) ASC 
@@ -43,7 +43,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
         users
         LEFT JOIN user_role_assignments AS ura ON ura.user_id = users.id
       WHERE
-        role = 'MATCHER'
+        role = 'CAS1_MATCHER'
       OFFSET
         floor(
           random() * (
@@ -53,7 +53,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
               users
               LEFT JOIN user_role_assignments AS ura ON ura.user_id = users.id
             WHERE
-              role = 'MATCHER'
+              role = 'CAS1_MATCHER'
           )
         )
       LIMIT
@@ -110,12 +110,12 @@ data class UserRoleAssignmentEntity(
 }
 
 enum class UserRole {
-  ASSESSOR,
-  MATCHER,
-  MANAGER,
-  WORKFLOW_MANAGER,
-  APPLICANT,
-  ROLE_ADMIN,
+  CAS1_ASSESSOR,
+  CAS1_MATCHER,
+  CAS1_MANAGER,
+  CAS1_WORKFLOW_MANAGER,
+  CAS1_APPLICANT,
+  CAS1_ADMIN,
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -31,7 +31,7 @@ class UsersSeedJob(
 
     val roles = roleNames.mapNotNull {
       try {
-        UserRole.valueOf(it)
+        parseUserRole(it)
       } catch (_: Exception) {
         unknownRoles += it
         null
@@ -81,6 +81,16 @@ class UsersSeedJob(
     row.qualifications.forEach {
       userService.addQualificationToUser(user, it)
     }
+  }
+
+  private fun parseUserRole(value: String) = when (value) {
+    "APPLICANT" -> UserRole.CAS1_APPLICANT
+    "ASSESSOR" -> UserRole.CAS1_ASSESSOR
+    "MANAGER" -> UserRole.CAS1_MANAGER
+    "MATCHER" -> UserRole.CAS1_MATCHER
+    "ROLE_ADMIN" -> UserRole.CAS1_ADMIN
+    "WORKFLOW_MANAGER" -> UserRole.CAS1_WORKFLOW_MANAGER
+    else -> UserRole.valueOf(value)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -77,7 +77,7 @@ class ApplicationService(
       is ClientResult.Failure -> userDetailsResult.throwException()
     }
 
-    val applicationSummaries = if (serviceName == ServiceName.approvedPremises && userEntity.hasAnyRole(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER)) {
+    val applicationSummaries = if (serviceName == ServiceName.approvedPremises && userEntity.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER)) {
       applicationRepository.findAllApprovedPremisesSummaries()
     } else if (serviceName == ServiceName.approvedPremises) {
       applicationRepository.findApprovedPremisesSummariesForManagingTeams(userDetails.teams?.map { it.code } ?: emptyList())
@@ -95,7 +95,7 @@ class ApplicationService(
     val userEntity = userRepository.findByDeliusUsername(deliusUsername)
       ?: return emptyList()
 
-    val applications = if (userEntity.hasAnyRole(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER)) {
+    val applications = if (userEntity.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER)) {
       offlineApplicationRepository.findAllByService(serviceName.value)
     } else {
       emptyList()
@@ -114,7 +114,7 @@ class ApplicationService(
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
       ?: throw RuntimeException("Could not get user")
 
-    if (userEntity.id == applicationEntity.createdByUser.id || userEntity.hasAnyRole(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER)) {
+    if (userEntity.id == applicationEntity.createdByUser.id || userEntity.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER)) {
       return AuthorisableActionResult.Success(jsonSchemaService.checkSchemaOutdated(applicationEntity))
     }
 
@@ -140,7 +140,7 @@ class ApplicationService(
     val userEntity = userRepository.findByDeliusUsername(deliusUsername)
       ?: throw RuntimeException("Could not get user")
 
-    if (userEntity.hasAnyRole(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER) &&
+    if (userEntity.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER) &&
       offenderService.canAccessOffender(deliusUsername, applicationEntity.crn)
     ) {
       return AuthorisableActionResult.Success(applicationEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -55,7 +55,7 @@ class AssessmentService(
 ) {
   fun getVisibleAssessmentSummariesForUser(user: UserEntity): List<DomainAssessmentSummary> =
     assessmentRepository.findAllAssessmentSummariesNotReallocated(
-      if (user.hasRole(UserRole.WORKFLOW_MANAGER)) {
+      if (user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
         null
       } else {
         user.id.toString()
@@ -81,7 +81,7 @@ class AssessmentService(
     val assessment = assessmentRepository.findByIdOrNull(assessmentId)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (!user.hasRole(UserRole.WORKFLOW_MANAGER) && assessment.allocatedToUser != user) {
+    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && assessment.allocatedToUser != user) {
       return AuthorisableActionResult.Unauthorised()
     }
 
@@ -96,7 +96,7 @@ class AssessmentService(
     val assessment = assessmentRepository.findByApplication_IdAndReallocatedAtNull(applicationID)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (!user.hasRole(UserRole.WORKFLOW_MANAGER) && assessment.allocatedToUser != user) {
+    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && assessment.allocatedToUser != user) {
       return AuthorisableActionResult.Unauthorised()
     }
 
@@ -447,7 +447,7 @@ class AssessmentService(
 
     val requiredQualifications = application.getRequiredQualifications()
 
-    if (!assigneeUser.hasRole(UserRole.ASSESSOR)) {
+    if (!assigneeUser.hasRole(UserRole.CAS1_ASSESSOR)) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingAssessorRole" }),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -32,7 +32,7 @@ class BedSearchService(
     durationInDays: Int,
     requiredCharacteristics: List<PlacementCriteria>,
   ): AuthorisableActionResult<ValidatableActionResult<List<ApprovedPremisesBedSearchResult>>> {
-    if (!user.hasRole(UserRole.MATCHER)) {
+    if (!user.hasRole(UserRole.CAS1_MATCHER)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -202,7 +202,7 @@ class BookingService(
     departureDate: LocalDate,
     bedId: UUID,
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
-    if (!user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)) {
+    if (!user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -77,7 +77,7 @@ class PlacementApplicationService(
       )
     }
 
-    if (!assigneeUser.hasRole(UserRole.ASSESSOR)) {
+    if (!assigneeUser.hasRole(UserRole.CAS1_ASSESSOR)) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingAssessorRole" }),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -53,7 +53,7 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (placementRequest.allocatedToUser.id != user.id && !user.hasRole(UserRole.WORKFLOW_MANAGER)) {
+    if (placementRequest.allocatedToUser.id != user.id && !user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       return AuthorisableActionResult.Unauthorised()
     }
 
@@ -64,7 +64,7 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByApplication_IdAndReallocatedAtNull(applicationID)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (!user.hasRole(UserRole.WORKFLOW_MANAGER) && placementRequest.allocatedToUser != user) {
+    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.allocatedToUser != user) {
       return AuthorisableActionResult.Unauthorised()
     }
 
@@ -81,7 +81,7 @@ class PlacementRequestService(
       )
     }
 
-    if (!assigneeUser.hasRole(UserRole.MATCHER)) {
+    if (!assigneeUser.hasRole(UserRole.CAS1_MATCHER)) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingMatcherRole" }),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -29,7 +29,7 @@ class TaskService(
   private val placementApplicationService: PlacementApplicationService,
 ) {
   fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, applicationId: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
-    if (!requestUser.hasRole(UserRole.WORKFLOW_MANAGER)) {
+    if (!requestUser.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -53,7 +53,7 @@ class UserAccessService(
     userCanManagePremisesBookings(userService.getUserForRequest(), premises)
 
   fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
     else -> false
   }
@@ -62,7 +62,7 @@ class UserAccessService(
     userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)
 
   fun userCanManagePremisesLostBeds(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
     else -> false
   }
@@ -71,7 +71,7 @@ class UserAccessService(
     userCanViewPremisesCapacity(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesCapacity(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
     else -> false
   }
@@ -80,7 +80,7 @@ class UserAccessService(
     userCanViewPremisesStaff(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesStaff(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.MANAGER, UserRole.MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
     else -> false
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -37,12 +37,12 @@ class UserTransformer(
   }
 
   private fun transformRoleToApi(userRole: UserRoleAssignmentEntity): ApiUserRole = when (userRole.role) {
-    UserRole.ROLE_ADMIN -> ApiUserRole.roleAdmin
-    UserRole.ASSESSOR -> ApiUserRole.assessor
-    UserRole.MATCHER -> ApiUserRole.matcher
-    UserRole.MANAGER -> ApiUserRole.manager
-    UserRole.WORKFLOW_MANAGER -> ApiUserRole.workflowManager
-    UserRole.APPLICANT -> ApiUserRole.applicant
+    UserRole.CAS1_ADMIN -> ApiUserRole.roleAdmin
+    UserRole.CAS1_ASSESSOR -> ApiUserRole.assessor
+    UserRole.CAS1_MATCHER -> ApiUserRole.matcher
+    UserRole.CAS1_MANAGER -> ApiUserRole.manager
+    UserRole.CAS1_WORKFLOW_MANAGER -> ApiUserRole.workflowManager
+    UserRole.CAS1_APPLICANT -> ApiUserRole.applicant
   }
 
   private fun transformQualificationToApi(userQualification: UserQualificationAssignmentEntity): ApiUserQualification = when (userQualification.qualification) {

--- a/src/main/resources/db/migration/all/20230601152046__rename_user_roles_for_cas1.sql
+++ b/src/main/resources/db/migration/all/20230601152046__rename_user_roles_for_cas1.sql
@@ -1,0 +1,23 @@
+UPDATE user_role_assignments
+SET role = 'CAS1_APPLICANT'
+WHERE role = 'APPLICANT';
+
+UPDATE user_role_assignments
+SET role = 'CAS1_ASSESSOR'
+WHERE role = 'ASSESSOR';
+
+UPDATE user_role_assignments
+SET role = 'CAS1_MANAGER'
+WHERE role = 'MANAGER';
+
+UPDATE user_role_assignments
+SET role = 'CAS1_MATCHER'
+WHERE role = 'MATCHER';
+
+UPDATE user_role_assignments
+SET role = 'CAS1_ADMIN'
+WHERE role = 'ROLE_ADMIN';
+
+UPDATE user_role_assignments
+SET role = 'CAS1_WORKFLOW_MANAGER'
+WHERE role = 'WORKFLOW_MANAGER';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserRoleAssignmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserRoleAssignmentEntityFactory.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 class UserRoleAssignmentEntityFactory : Factory<UserRoleAssignmentEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var user: Yielded<UserEntity>? = null
-  private var role: Yielded<UserRole> = { UserRole.APPLICANT }
+  private var role: Yielded<UserRole> = { UserRole.CAS1_APPLICANT }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -49,7 +49,7 @@ class AllocationQueryTest : IntegrationTestBase() {
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
-      withRole(UserRole.ASSESSOR)
+      withRole(UserRole.CAS1_ASSESSOR)
     }
 
     return user
@@ -67,7 +67,7 @@ class AllocationQueryTest : IntegrationTestBase() {
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
-      withRole(UserRole.ASSESSOR)
+      withRole(UserRole.CAS1_ASSESSOR)
     }
 
     userQualificationAssignmentEntityFactory.produceAndPersist {
@@ -107,7 +107,7 @@ class AllocationQueryTest : IntegrationTestBase() {
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(user)
-      withRole(UserRole.ASSESSOR)
+      withRole(UserRole.CAS1_ASSESSOR)
     }
 
     userQualificationAssignmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -221,7 +221,7 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["WORKFLOW_MANAGER", "ASSESSOR", "MATCHER", "MANAGER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
   fun `Get all applications returns 200 with correct body - when user has one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER returns all applications`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       `Given a User` { otherUser, _ ->
@@ -692,7 +692,7 @@ class ApplicationTest : IntegrationTestBase() {
 
   @Test
   fun `Get single offline application returns 200 with correct body`() {
-    `Given a User`(roles = listOf(UserRole.MANAGER)) { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val offlineApplicationEntity = offlineApplicationEntityFactory.produceAndPersist {
           withCrn(offenderDetails.otherIds.crn)
@@ -1028,7 +1028,7 @@ class ApplicationTest : IntegrationTestBase() {
   @Test
   fun `Update existing AP application returns 200 with correct body`() {
     `Given a User` { submittingUser, jwt ->
-      `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE)) { assessorUser, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR), qualifications = listOf(UserQualification.PIPE)) { assessorUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
@@ -1098,7 +1098,7 @@ class ApplicationTest : IntegrationTestBase() {
         )
       },
     ) { submittingUser, jwt ->
-      `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
@@ -1228,7 +1228,7 @@ class ApplicationTest : IntegrationTestBase() {
         )
       },
     ) { submittingUser, jwt ->
-      `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
@@ -1438,9 +1438,9 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get assessment for application returns an application's assessment when the requesting user is a workflow manager`() {
-      `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { requestUser, jwt ->
-        `Given a User`(roles = listOf(UserRole.ASSESSOR)) { applicant, _ ->
-          `Given a User`(roles = listOf(UserRole.ASSESSOR)) { assignee, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { requestUser, jwt ->
+        `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR)) { applicant, _ ->
+          `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR)) { assignee, _ ->
             `Given an Offender` { offenderDetails, inmateDetails ->
               val (application, assessment) = produceAndPersistApplicationAndAssessment(
                 applicant,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -224,8 +224,8 @@ class AssessmentTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
-      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher1, _ ->
-        `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher2, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher1, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher2, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
               withPermissiveSchema()
@@ -321,8 +321,8 @@ class AssessmentTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
-      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher1, _ ->
-        `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher2, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher1, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher2, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
               withPermissiveSchema()
@@ -407,8 +407,8 @@ class AssessmentTest : IntegrationTestBase() {
     `Given a User`(
       staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
     ) { userEntity, jwt ->
-      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher1, _ ->
-        `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher2, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher1, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher2, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
               withPermissiveSchema()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -62,7 +62,7 @@ class BedSearchTest : IntegrationTestBase() {
   @Test
   fun `Searching for an Approved Premises Bed returns 200 with correct body`() {
     `Given a User`(
-      roles = listOf(UserRole.MATCHER),
+      roles = listOf(UserRole.CAS1_MATCHER),
     ) { _, jwt ->
       val postCodeDistrictLatLong = LatLong(50.1044, -2.3992)
       val tenMilesFromPostcodeDistrict = postCodeDistrictLatLong.plusLatitudeMiles(10)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -52,7 +52,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get a booking for an Approved Premises returns OK with the correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
@@ -195,7 +195,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get all Bookings on Premises without any Bookings returns empty list when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -215,7 +215,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get all Bookings returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
@@ -359,7 +359,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Approved Premises Booking returns Bad Request when no application exists for CRN`() {
     `Given a User`(
-      roles = listOf(UserRole.MATCHER),
+      roles = listOf(UserRole.CAS1_MATCHER),
     ) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -400,7 +400,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Approved Premises Booking returns OK with correct body emits domain event`() {
-    `Given a User`(roles = listOf(UserRole.MATCHER)) { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1174,7 +1174,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Arrival on Approved Premises Booking returns 200 with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
@@ -1228,7 +1228,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival updates arrival and departure date for an Approved Premises booking`() {
-    `Given a User`(roles = listOf(UserRole.MANAGER)) { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val keyWorker = ContextStaffMemberFactory().produce()
         APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, "QCODE")
@@ -1405,7 +1405,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Departure on Approved Premises Booking returns 200 with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
@@ -1463,7 +1463,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Departure updates departure date for an Approved Premises booking`() {
-    `Given a User`(roles = listOf(UserRole.MANAGER)) { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val keyWorker = ContextStaffMemberFactory().produce()
         APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, "QCODE")
@@ -1537,7 +1537,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Departure on Approved Premises Booking when a departure already exists returns 400 Bad Request`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
@@ -1785,7 +1785,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Cancellation on Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
@@ -1828,7 +1828,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Cancellation on Approved Premises Booking when a cancellation already exists returns 400 Bad Request`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
@@ -2227,7 +2227,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Extension on Approved Premises Booking returns OK with expected body, updates departureDate on Booking entity when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
@@ -2334,7 +2334,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
@@ -2403,7 +2403,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Non Arrival on Approved Premises Booking returns 200 with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 class CacheClearTest : IntegrationTestBase() {
   @Test
   fun `Clearing a regular cache results in upstream calls being made again`() {
-    `Given a User`(roles = listOf(UserRole.MANAGER)) { _, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
       val premisesId = UUID.fromString("d687f947-ff80-431e-9c72-75f704730978")
       val qCode = "FOUND"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -43,7 +43,7 @@ class CapacityTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Capacity with no bookings or lost beds on Approved Premises returns OK with empty list body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -68,7 +68,7 @@ class CapacityTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Capacity for Approved Premises with booking in past returns OK with empty list body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -100,7 +100,7 @@ class CapacityTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Capacity for Approved Premises with booking in future returns OK with list entry for each day until the booking ends when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -51,7 +51,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `List Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -213,7 +213,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Lost Bed for non-existent lost bed returns 404`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -233,7 +233,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Lost Bed on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -427,7 +427,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Create Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -589,7 +589,7 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds on Approved Premises for current day does not break GET all Premises endpoint`() {
-    `Given a User`(roles = listOf(UserRole.MANAGER)) { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withTotalBeds(3)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -730,7 +730,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Update Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -986,7 +986,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Cancel Lost Bed on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -469,7 +469,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
 
     @Test
     fun `submitting an in-progress placement request application returns successfully and updates the application`() {
-      `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR), qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS)) { assessorUser, _ ->
         `Given a User` { user, jwt ->
           `Given a Placement Application`(
             createdByUser = user,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -1351,7 +1351,7 @@ class PremisesTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Approved Premises Staff where delius team cannot be found returns 500 when use has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val qCode = "NOTFOUND"
@@ -1427,7 +1427,7 @@ class PremisesTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Approved Premises Staff for Approved Premises returns 200 with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val qCode = "FOUND"
@@ -1480,7 +1480,7 @@ class PremisesTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Approved Premises Staff caches response when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val qCode = "FOUND"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -64,7 +64,7 @@ class ProfileTest : IntegrationTestBase() {
 
     `Given a User`(
       id = id,
-      roles = listOf(UserRole.ASSESSOR),
+      roles = listOf(UserRole.CAS1_ASSESSOR),
       qualifications = listOf(UserQualification.PIPE),
       staffUserDetailsConfigBlock = {
         withUsername(deliusUsername)
@@ -126,7 +126,7 @@ class ProfileTest : IntegrationTestBase() {
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(userEntity)
-      withRole(UserRole.ASSESSOR)
+      withRole(UserRole.CAS1_ASSESSOR)
     }
 
     userQualificationAssignmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -15,9 +15,9 @@ class ReallocationAtomicTest : IntegrationTestBase() {
 
   @Test
   fun `Database exception after setting reallocated on original Assessment results in that change being rolled back`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { requestUser, jwt ->
-      `Given a User`(roles = listOf(UserRole.ASSESSOR)) { otherUser, _ ->
-        `Given a User`(roles = listOf(UserRole.ASSESSOR)) { assigneeUser, _ ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { requestUser, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR)) { otherUser, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR)) { assigneeUser, _ ->
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
           val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedScaffoldingTest.kt
@@ -85,7 +85,7 @@ class SeedScaffoldingTest : SeedTestBase() {
       "malformed",
       """
 deliusUsername,roles,qualifications
-RogerSmith,MANAGER,
+RogerSmith,CAS1_MANAGER,
 ,
       """.trimIndent(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUsersTest.kt
@@ -65,7 +65,7 @@ class SeedUsersTest : SeedTestBase() {
         listOf(
           UserRoleAssignmentsSeedCsvRowFactory()
             .withDeliusUsername("unknown-user")
-            .withTypedRoles(listOf(UserRole.ASSESSOR, UserRole.WORKFLOW_MANAGER))
+            .withTypedRoles(listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_WORKFLOW_MANAGER))
             .withTypedQualifications(listOf(UserQualification.PIPE))
             .produce(),
         ),
@@ -79,8 +79,8 @@ class SeedUsersTest : SeedTestBase() {
     assertThat(persistedUser).isNotNull
     assertThat(persistedUser!!.deliusStaffIdentifier).isEqualTo(6789)
     assertThat(persistedUser.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
-      UserRole.ASSESSOR,
-      UserRole.WORKFLOW_MANAGER,
+      UserRole.CAS1_ASSESSOR,
+      UserRole.CAS1_WORKFLOW_MANAGER,
     )
     assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification)).containsExactlyInAnyOrder(
       UserQualification.PIPE,
@@ -104,7 +104,7 @@ class SeedUsersTest : SeedTestBase() {
         listOf(
           UserRoleAssignmentsSeedCsvRowFactory()
             .withDeliusUsername("KNOWN-USER")
-            .withTypedRoles(listOf(UserRole.ASSESSOR, UserRole.WORKFLOW_MANAGER))
+            .withTypedRoles(listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_WORKFLOW_MANAGER))
             .withTypedQualifications(listOf(UserQualification.PIPE))
             .produce(),
         ),
@@ -117,8 +117,8 @@ class SeedUsersTest : SeedTestBase() {
 
     assertThat(persistedUser).isNotNull
     assertThat(persistedUser!!.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
-      UserRole.ASSESSOR,
-      UserRole.WORKFLOW_MANAGER,
+      UserRole.CAS1_ASSESSOR,
+      UserRole.CAS1_WORKFLOW_MANAGER,
     )
     assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification)).containsExactlyInAnyOrder(
       UserQualification.PIPE,
@@ -217,7 +217,7 @@ class SeedUsersTest : SeedTestBase() {
 
 class UserRoleAssignmentsSeedCsvRowFactory : Factory<UsersSeedUntypedEnumsCsvRow> {
   private var deliusUsername: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
-  private var roles: Yielded<List<String>> = { listOf(UserRole.ASSESSOR.name) }
+  private var roles: Yielded<List<String>> = { listOf(UserRole.CAS1_ASSESSOR.name) }
   private var qualifications: Yielded<List<String>> = { listOf(UserQualification.PIPE.name) }
 
   fun withDeliusUsername(deliusUsername: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -52,7 +52,7 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Get all tasks returns 200 with correct body`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
       `Given a User` { otherUser, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->
           `Given an Assessment for Approved Premises`(
@@ -144,7 +144,7 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Get an unknown task type for an application returns 404`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         `Given an Assessment for Approved Premises`(
           allocatedToUser = user,
@@ -164,10 +164,10 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Get an assessment task for an application returns 200 with correct body`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User` { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.ASSESSOR),
+          roles = listOf(UserRole.CAS1_ASSESSOR),
         ) { allocatableUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             `Given an Assessment for Approved Premises`(
@@ -199,10 +199,10 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Get a Placement Request Task for an application returns 200`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User` { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.MATCHER),
+          roles = listOf(UserRole.CAS1_MATCHER),
         ) { allocatableUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             `Given a Placement Request`(
@@ -235,10 +235,10 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Get a Placement Application Task for an application returns 200`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User` { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.ASSESSOR),
+          roles = listOf(UserRole.CAS1_ASSESSOR),
         ) { allocatableUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             `Given a Placement Application`(
@@ -273,7 +273,7 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Get an non-implemented task type for an application returns 405`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         `Given an Assessment for Approved Premises`(
           allocatedToUser = user,
@@ -324,10 +324,10 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Reallocate assessment to different assessor returns 201, creates new assessment, deallocates old one`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
-      `Given a User`(roles = listOf(UserRole.ASSESSOR)) { user, _ ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR)) { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.ASSESSOR),
+          roles = listOf(UserRole.CAS1_ASSESSOR),
         ) { assigneeUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
             `Given an Assessment for Approved Premises`(
@@ -371,9 +371,9 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Reallocating a placement request to different assessor returns 201, creates new placement request, deallocates old one`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
       `Given a User`(
-        roles = listOf(UserRole.MATCHER),
+        roles = listOf(UserRole.CAS1_MATCHER),
       ) { assigneeUser, _ ->
         `Given an Offender` { offenderDetails, _ ->
           `Given a Placement Request`(
@@ -422,10 +422,10 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Reallocating a placement application to different assessor returns 201, creates new placement application, deallocates old one`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { _, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
       `Given a User` { user, _ ->
         `Given a User`(
-          roles = listOf(UserRole.ASSESSOR),
+          roles = listOf(UserRole.CAS1_ASSESSOR),
         ) { assigneeUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
             `Given a Placement Application`(
@@ -471,7 +471,7 @@ class TasksTest : IntegrationTestBase() {
 
   @Test
   fun `Reallocating a booking appeal returns a NotAllowedProblem`() {
-    `Given a User`(roles = listOf(UserRole.WORKFLOW_MANAGER)) { user, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
       `Given a User` { userToReallocate, _ ->
         `Given an Application`(createdByUser = user) { application ->
           webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -225,7 +225,7 @@ class UsersTest : IntegrationTestBase() {
   @Nested
   inner class GetUsers {
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
     fun `GET to users with a role other than ROLE_ADMIN or WORKFLOW_MANAGER is forbidden`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         webTestClient.get()
@@ -252,10 +252,10 @@ class UsersTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
     fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER returns full list ordered by name`(role: UserRole) {
-      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher, _ ->
-        `Given a User`(roles = listOf(UserRole.MANAGER)) { manager, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
               webTestClient.get()
@@ -280,10 +280,10 @@ class UsersTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
     fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by roles`(role: UserRole) {
-      `Given a User`(roles = listOf(UserRole.MATCHER)) { matcher, _ ->
-        `Given a User`(roles = listOf(UserRole.MANAGER)) { manager, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { _, _ ->
             `Given a User`(roles = listOf(role)) { _, jwt ->
               webTestClient.get()
@@ -308,7 +308,7 @@ class UsersTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
     fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by qualifications`(role: UserRole) {
       `Given a User`(qualifications = listOf(UserQualification.WOMENS)) { womensUser, _ ->
         `Given a User`(qualifications = listOf(UserQualification.PIPE)) { _, _ ->
@@ -336,11 +336,11 @@ class UsersTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["ROLE_ADMIN", "WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
     fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by role and qualifications`(role: UserRole) {
-      `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.WOMENS)) { womensAssessor1, _ ->
-        `Given a User`(roles = listOf(UserRole.ASSESSOR), qualifications = listOf(UserQualification.WOMENS)) { womensAssessor2, _ ->
-          `Given a User`(roles = listOf(UserRole.ASSESSOR)) { _, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR), qualifications = listOf(UserQualification.WOMENS)) { womensAssessor1, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR), qualifications = listOf(UserQualification.WOMENS)) { womensAssessor2, _ ->
+          `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR)) { _, _ ->
             `Given a User` { _, _ ->
               `Given a User`(roles = listOf(role)) { _, jwt ->
                 webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -340,7 +340,7 @@ class ApplicationServiceTest {
 
   @Test
   fun `getApplicationForUsername where application not created by caller but user has any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER returns Success result with entity from db`() {
-    listOf(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER).forEach { role ->
+    listOf(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER).forEach { role ->
       val distinguishedName = "SOMEPERSON"
       val userId = UUID.fromString("239b5e41-f83e-409e-8fc0-8f1e058d417e")
       val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
@@ -1520,7 +1520,7 @@ class ApplicationServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["WORKFLOW_MANAGER", "ASSESSOR", "MATCHER", "MANAGER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
   fun `Get all offline applications where Probation Officer exists returns repository results for user with any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER`(role: UserRole) {
     val userId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
     val distinguishedName = "SOMEPERSON"
@@ -1587,7 +1587,7 @@ class ApplicationServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["WORKFLOW_MANAGER", "ASSESSOR", "MATCHER", "MANAGER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
   fun `getOfflineApplicationForUsername where user has one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER but does not pass LAO check returns Unauthorised result`(role: UserRole) {
     val distinguishedName = "SOMEPERSON"
     val userId = UUID.fromString("239b5e41-f83e-409e-8fc0-8f1e058d417e")
@@ -1623,7 +1623,7 @@ class ApplicationServiceTest {
 
   @Test
   fun `getOfflineApplicationForUsername where user has any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER and passes LAO check returns Success result with entity from db`() {
-    listOf(UserRole.WORKFLOW_MANAGER, UserRole.ASSESSOR, UserRole.MATCHER, UserRole.MANAGER).forEach { role ->
+    listOf(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER).forEach { role ->
       val distinguishedName = "SOMEPERSON"
       val userId = UUID.fromString("239b5e41-f83e-409e-8fc0-8f1e058d417e")
       val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -97,7 +97,7 @@ class AssessmentServiceTest {
 
     user.roles.add(
       UserRoleAssignmentEntityFactory()
-        .withRole(UserRole.WORKFLOW_MANAGER)
+        .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
         .withUser(user)
         .produce(),
     )
@@ -121,7 +121,7 @@ class AssessmentServiceTest {
 
     user.roles.add(
       UserRoleAssignmentEntityFactory()
-        .withRole(UserRole.ASSESSOR)
+        .withRole(UserRole.CAS1_ASSESSOR)
         .withUser(user)
         .produce(),
     )
@@ -147,7 +147,7 @@ class AssessmentServiceTest {
 
     user.roles.add(
       UserRoleAssignmentEntityFactory()
-        .withRole(UserRole.WORKFLOW_MANAGER)
+        .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
         .withUser(user)
         .produce(),
     )
@@ -335,7 +335,7 @@ class AssessmentServiceTest {
 
     user.roles.add(
       UserRoleAssignmentEntityFactory()
-        .withRole(UserRole.WORKFLOW_MANAGER)
+        .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
         .withUser(user)
         .produce(),
     )
@@ -1133,7 +1133,7 @@ class AssessmentServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.ASSESSOR)
+          .withRole(UserRole.CAS1_ASSESSOR)
           .produce()
       }
 
@@ -1187,7 +1187,7 @@ class AssessmentServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.ASSESSOR)
+          .withRole(UserRole.CAS1_ASSESSOR)
           .produce()
 
         qualifications += UserQualificationAssignmentEntityFactory()
@@ -1470,7 +1470,7 @@ class AssessmentServiceTest {
         .apply {
           roles += UserRoleAssignmentEntityFactory()
             .withUser(this)
-            .withRole(UserRole.ASSESSOR)
+            .withRole(UserRole.CAS1_ASSESSOR)
             .produce()
 
           qualifications += UserQualificationAssignmentEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -71,7 +71,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -115,7 +115,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -163,7 +163,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -207,7 +207,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -255,7 +255,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -305,7 +305,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -353,7 +353,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -401,7 +401,7 @@ class BedSearchServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1667,7 +1667,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking returns FieldValidationError if Departure Date is before Arrival Date`(role: UserRole) {
     val crn = "CRN123"
     val arrivalDate = LocalDate.parse("2023-02-23")
@@ -1714,7 +1714,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking returns FieldValidationError if Bed does not exist`(role: UserRole) {
     val crn = "CRN123"
     val bedId = UUID.fromString("5c0d77ff-3ec8-45e1-9e1f-a68e73bf45ec")
@@ -1750,7 +1750,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking returns FieldValidationError if there are no existing Applications for the CRN`(role: UserRole) {
     val crn = "CRN123"
     val arrivalDate = LocalDate.parse("2023-02-22")
@@ -1793,7 +1793,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking throws if unable to get Offender Details`(role: UserRole) {
     val arrivalDate = LocalDate.parse("2023-02-22")
     val departureDate = LocalDate.parse("2023-02-23")
@@ -1840,7 +1840,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking throws if unable to get Staff Details`(role: UserRole) {
     val crn = "CRN123"
     val arrivalDate = LocalDate.parse("2023-02-22")
@@ -1891,7 +1891,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking saves Booking and creates Domain Event when associated Application is an Online Application`(role: UserRole) {
     val crn = "CRN123"
     val arrivalDate = LocalDate.parse("2023-02-22")
@@ -2000,7 +2000,7 @@ class BookingServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["MANAGER", "MATCHER"])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesBooking saves Booking but does not create Domain Event when associated Application is an Offline Application as Event Number is not present`(role: UserRole) {
     val crn = "CRN123"
     val arrivalDate = LocalDate.parse("2023-02-22")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -83,7 +83,7 @@ class PlacementApplicationServiceTest {
       assigneeUser.apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.ASSESSOR)
+          .withRole(UserRole.CAS1_ASSESSOR)
           .produce()
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -183,7 +183,7 @@ class PlacementRequestServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.MATCHER)
+          .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
@@ -330,7 +330,7 @@ class PlacementRequestServiceTest {
       .apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.WORKFLOW_MANAGER)
+          .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
           .produce()
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -58,7 +58,7 @@ class TaskServiceTest {
     .produce()
     .apply {
       roles += UserRoleAssignmentEntityFactory()
-        .withRole(UserRole.WORKFLOW_MANAGER)
+        .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
         .withUser(this)
         .produce()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -256,7 +256,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `userCanManagePremisesBookings returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -287,7 +287,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `currentUserCanManagePremisesBookings returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -318,7 +318,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `userCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -349,7 +349,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `currentUserCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -380,7 +380,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `userCanViewPremisesCapacity returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -411,7 +411,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `currentUserCanViewPremisesCapacity returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -442,7 +442,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `userCanViewPremisesStaff returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -473,7 +473,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "MANAGER", "MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `currentUserCanViewPremisesStaff returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 


### PR DESCRIPTION
> See [ticket #1154 on the CAS3 Trello board](https://trello.com/c/VtlF4Phc/1134-rename-existing-cas1-roles-with-a-cas1-prefix).

This PR is the first part of the work to introduce user roles to the Temporary Accommodation service. It renames the existing user roles to indicate that they are scoped to the Approved Premises service, allowing CAS3-specific roles to be created without conflict or confusion regarding names.

To ensure backwards compatibility, the user seeding job has also been updated to recognise the old names of the user roles and translate them to the new ones.