### PR TITLE
(174) Add first class entities to placement applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -67,7 +67,7 @@ class PlacementApplicationsController(
   ): ResponseEntity<PlacementApplication> {
     val serializedData = objectMapper.writeValueAsString(submitPlacementApplication.translatedDocument)
 
-    val result = placementApplicationService.submitApplication(id, serializedData)
+    val result = placementApplicationService.submitApplication(id, serializedData, submitPlacementApplication.placementType, submitPlacementApplication.placementDates)
 
     val validationResult = extractEntityFromAuthorisableActionResult(result, id.toString(), "Placement Application")
     val placementApplication = extractEntityFromValidatableActionResult(validationResult)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -12,6 +12,7 @@ import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
@@ -64,7 +65,18 @@ data class PlacementApplicationEntity(
 
   @Enumerated(value = EnumType.STRING)
   var decision: PlacementApplicationDecision?,
+
+  var placementType: PlacementType?,
+
+  @OneToMany(mappedBy = "placementApplication")
+  var placementDates: MutableList<PlacementDateEntity>,
 )
+
+enum class PlacementType {
+  ROTL,
+  RELEASE_FOLLOWING_DECISION,
+  ADDITIONAL_PLACEMENT,
+}
 
 enum class PlacementApplicationDecision {
   ACCEPTED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Repository
+interface PlacementDateRepository : JpaRepository<PlacementDateEntity, UUID> {
+
+  @Query("SELECT p FROM PlacementDateEntity p WHERE p.placementApplication = placementApplication")
+  fun findAllByPlacementApplication(placementApplication: PlacementApplicationEntity): List<PlacementDateEntity>
+}
+
+@Entity
+@Table(name = "placement_application_dates")
+data class PlacementDateEntity(
+  @Id
+  val id: UUID,
+
+  val createdAt: OffsetDateTime,
+
+  @OneToOne
+  @JoinColumn(name = "placement_application_id")
+  val placementApplication: PlacementApplicationEntity,
+
+  val expectedArrival: LocalDate,
+
+  val duration: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -106,6 +106,20 @@ class PlacementApplicationService(
       ),
     )
 
+    val newPlacementDates = placementDateRepository.saveAll(
+      currentPlacementApplication.placementDates.map {
+        PlacementDateEntity(
+          id = UUID.randomUUID(),
+          expectedArrival = it.expectedArrival,
+          duration = it.duration,
+          placementApplication = newPlacementApplication,
+          createdAt = dateTimeNow,
+        )
+      },
+    )
+
+    newPlacementApplication.placementDates = newPlacementDates
+
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
         newPlacementApplication,

--- a/src/main/resources/db/migration/all/20230602111949__add_first_class_fields_to_placement_applications.sql
+++ b/src/main/resources/db/migration/all/20230602111949__add_first_class_fields_to_placement_applications.sql
@@ -1,0 +1,14 @@
+ALTER TABLE
+  placement_applications
+ADD
+  COLUMN "placement_type" text NULL;
+
+create table
+  placement_application_dates (
+    "id" UUID primary key,
+    "created_at" timestamp not null,
+    "placement_application_id" UUID not null,
+    "expected_arrival" DATE not null,
+    "duration" INT4 not null,
+    FOREIGN KEY (placement_application_id) REFERENCES placement_applications(id)
+  )

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5327,8 +5327,22 @@ components:
       properties:
         translatedDocument:
           $ref: '#/components/schemas/AnyValue'
+        placementType:
+          $ref: '#/components/schemas/PlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
       required:
         - translatedDocument
+        - placementType
+        - placementDates
+    PlacementType:
+      type: string
+      enum:
+        - rotl
+        - release_following_decision
+        - additional_placement
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
@@ -25,6 +26,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var decision: Yielded<PlacementApplicationDecision?> = { null }
   private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
+  private var placementDates: Yielded<MutableList<PlacementDateEntity>?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -70,6 +72,10 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.reallocatedAt = { reallocatedAt }
   }
 
+  fun withPlacementDates(placementDates: MutableList<PlacementDateEntity>) = apply {
+    this.placementDates = { placementDates }
+  }
+
   override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
     id = this.id(),
     createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
@@ -85,6 +91,6 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     reallocatedAt = this.reallocatedAt(),
     decision = this.decision(),
     placementType = null,
-    placementDates = mutableListOf(),
+    placementDates = this.placementDates() ?: mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -84,5 +84,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     allocatedAt = null,
     reallocatedAt = this.reallocatedAt(),
     decision = this.decision(),
+    placementType = null,
+    placementDates = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementDateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementDateEntityFactory.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class PlacementDateEntityFactory : Factory<PlacementDateEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var placementApplication: Yielded<PlacementApplicationEntity?> = { null }
+  private var expectedArrival: Yielded<LocalDate> = { LocalDate.now() }
+  private var duration: Yielded<Int> = { 12 }
+
+  fun withPlacementApplication(placementApplication: PlacementApplicationEntity) = apply {
+    this.placementApplication = { placementApplication }
+  }
+
+  override fun produce(): PlacementDateEntity = PlacementDateEntity(
+    id = this.id(),
+    createdAt = this.createdAt(),
+    placementApplication = this.placementApplication() ?: throw RuntimeException("Must provide a placementApplication"),
+    expectedArrival = this.expectedArrival(),
+    duration = this.duration(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -55,6 +55,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PostCodeDistrictEntityFactory
@@ -102,6 +103,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
@@ -431,6 +433,7 @@ abstract class IntegrationTestBase {
   lateinit var applicationTeamCodeFactory: PersistedFactory<ApplicationTeamCodeEntity, UUID, ApplicationTeamCodeEntityFactory>
   lateinit var turnaroundFactory: PersistedFactory<TurnaroundEntity, UUID, TurnaroundEntityFactory>
   lateinit var placementApplicationFactory: PersistedFactory<PlacementApplicationEntity, UUID, PlacementApplicationEntityFactory>
+  lateinit var placementDateFactory: PersistedFactory<PlacementDateEntity, UUID, PlacementDateEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -503,6 +506,7 @@ abstract class IntegrationTestBase {
     applicationTeamCodeFactory = PersistedFactory({ ApplicationTeamCodeEntityFactory() }, applicationTeamCodeRepository)
     turnaroundFactory = PersistedFactory({ TurnaroundEntityFactory() }, turnaroundRepository)
     placementApplicationFactory = PersistedFactory({ PlacementApplicationEntityFactory() }, placementApplicationRepository)
+    placementDateFactory = PersistedFactory({ PlacementDateEntityFactory() }, placementDateRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -102,6 +102,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
@@ -373,6 +374,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var placementApplicationRepository: PlacementApplicationRepository
+
+  @Autowired
+  lateinit var placementDateRepository: PlacementDateRepository
 
   @Autowired
   lateinit var bookingNotMadeRepository: BookingNotMadeTestRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -9,6 +9,8 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
@@ -18,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -375,6 +378,13 @@ class PlacementApplicationsTest : IntegrationTestBase() {
         .bodyValue(
           SubmitPlacementApplication(
             translatedDocument = mapOf("thingId" to 123),
+            placementType = PlacementType.additionalPlacement,
+            placementDates = listOf(
+              PlacementDates(
+                expectedArrival = LocalDate.now(),
+                duration = 12,
+              ),
+            ),
           ),
         )
         .exchange()
@@ -398,6 +408,13 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
+                placementType = PlacementType.additionalPlacement,
+                placementDates = listOf(
+                  PlacementDates(
+                    expectedArrival = LocalDate.now(),
+                    duration = 12,
+                  ),
+                ),
               ),
             )
             .exchange()
@@ -429,6 +446,13 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
+                placementType = PlacementType.additionalPlacement,
+                placementDates = listOf(
+                  PlacementDates(
+                    expectedArrival = LocalDate.now(),
+                    duration = 12,
+                  ),
+                ),
               ),
             )
             .exchange()
@@ -458,6 +482,13 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
+                placementType = PlacementType.additionalPlacement,
+                placementDates = listOf(
+                  PlacementDates(
+                    expectedArrival = LocalDate.now(),
+                    duration = 12,
+                  ),
+                ),
               ),
             )
             .exchange()
@@ -477,12 +508,20 @@ class PlacementApplicationsTest : IntegrationTestBase() {
               withPermissiveSchema()
             },
           ) { placementApplicationEntity ->
+            val placementDates = listOf(
+              PlacementDates(
+                expectedArrival = LocalDate.now(),
+                duration = 12,
+              ),
+            )
             val rawResult = webTestClient.post()
               .uri("/placement-applications/${placementApplicationEntity.id}/submission")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
                 SubmitPlacementApplication(
                   translatedDocument = mapOf("thingId" to 123),
+                  placementType = PlacementType.additionalPlacement,
+                  placementDates = placementDates,
                 ),
               )
               .exchange()
@@ -514,6 +553,14 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             assertThat(updatedPlacementApplication.submittedAt).isNotNull()
             assertThat(updatedPlacementApplication.allocatedToUser!!.id).isEqualTo(assessorUser.id)
             assertThat(updatedPlacementApplication.allocatedAt).isNotNull()
+
+            val createdPlacementDates = placementDateRepository.findAllByPlacementApplication(placementApplicationEntity)
+
+            assertThat(createdPlacementDates.size).isEqualTo(1)
+
+            assertThat(createdPlacementDates[0].placementApplication.id).isEqualTo(placementApplicationEntity.id)
+            assertThat(createdPlacementDates[0].duration).isEqualTo(placementDates[0].duration)
+            assertThat(createdPlacementDates[0].expectedArrival).isEqualTo(placementDates[0].expectedArrival)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -436,6 +436,10 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
             ) { placementApplication ->
+              val placementDate = placementDateFactory.produceAndPersist {
+                withPlacementApplication(placementApplication)
+              }
+
               webTestClient.post()
                 .uri("/applications/${placementApplication.application.id}/tasks/placement-application/allocations")
                 .header("Authorization", "Bearer $jwt")
@@ -462,6 +466,12 @@ class TasksTest : IntegrationTestBase() {
 
               Assertions.assertThat(placementApplications.first { it.id == placementApplication.id }.reallocatedAt).isNotNull
               Assertions.assertThat(allocatedPlacementApplication).isNotNull
+
+              val placementDates = allocatedPlacementApplication!!.placementDates
+
+              Assertions.assertThat(placementDates.size).isEqualTo(1)
+              Assertions.assertThat(placementDates[0].expectedArrival).isEqualTo(placementDate.expectedArrival)
+              Assertions.assertThat(placementDates[0].duration).isEqualTo(placementDate.duration)
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -26,11 +27,13 @@ class PlacementApplicationServiceTest {
   private val placementApplicationRepository = mockk<PlacementApplicationRepository>()
   private val jsonSchemaService = mockk<JsonSchemaService>()
   private val userService = mockk<UserService>()
+  private val placementDateRepository = mockk<PlacementDateRepository>()
 
   private val placementApplicationService = PlacementApplicationService(
     placementApplicationRepository,
     jsonSchemaService,
     userService,
+    placementDateRepository,
   )
 
   @Nested


### PR DESCRIPTION
This adds some first-class entities to placement applications, so they are easier to fetch when listing / viewing / using to create a placement request. The first is a placement type, and the second is a many to one relation of PlacementDates. This will give us the flexibility for PPs to request mutliple placements as shown in the Figma design here:

![V3_ Add another date](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/109774/38bf4175-72f9-46a9-8349-8d7e1da5f484)
