### PR TITLE
Create CAS3_ASSESSOR and CAS3_REFERRER roles and assign to dev/test users

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,7 +28,7 @@ generic-service:
     PREEMPTIVE-CACHE-LOGGING-ENABLED: true
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
-    SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test
+    SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -26,7 +26,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_EMIT-ENABLED: false
     SEED_AUTO_ENABLED: true
-    SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test
+    SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -116,6 +116,8 @@ enum class UserRole {
   CAS1_WORKFLOW_MANAGER,
   CAS1_APPLICANT,
   CAS1_ADMIN,
+  CAS3_ASSESSOR,
+  CAS3_REFERRER,
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -20,7 +20,7 @@ class UserTransformer(
     ServiceName.approvedPremises, ServiceName.cas2 -> ApprovedPremisesUser(
       id = jpa.id,
       deliusUsername = jpa.deliusUsername,
-      roles = jpa.roles.map(::transformRoleToApi),
+      roles = jpa.roles.mapNotNull(::transformRoleToApi),
       email = jpa.email,
       name = jpa.name,
       telephoneNumber = jpa.telephoneNumber,
@@ -30,19 +30,20 @@ class UserTransformer(
     )
     ServiceName.temporaryAccommodation -> TemporaryAccommodationUser(
       id = jpa.id,
-      roles = jpa.roles.map(::transformRoleToApi),
+      roles = jpa.roles.mapNotNull(::transformRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       service = ServiceName.temporaryAccommodation.value,
     )
   }
 
-  private fun transformRoleToApi(userRole: UserRoleAssignmentEntity): ApiUserRole = when (userRole.role) {
+  private fun transformRoleToApi(userRole: UserRoleAssignmentEntity): ApiUserRole? = when (userRole.role) {
     UserRole.CAS1_ADMIN -> ApiUserRole.roleAdmin
     UserRole.CAS1_ASSESSOR -> ApiUserRole.assessor
     UserRole.CAS1_MATCHER -> ApiUserRole.matcher
     UserRole.CAS1_MANAGER -> ApiUserRole.manager
     UserRole.CAS1_WORKFLOW_MANAGER -> ApiUserRole.workflowManager
     UserRole.CAS1_APPLICANT -> ApiUserRole.applicant
+    else -> null
   }
 
   private fun transformQualificationToApi(userQualification: UserQualificationAssignmentEntity): ApiUserQualification = when (userQualification.qualification) {

--- a/src/main/resources/db/seed/dev+test/user.csv
+++ b/src/main/resources/db/seed/dev+test/user.csv
@@ -1,0 +1,4 @@
+deliusUsername,roles,qualifications
+temporary-accommodation-training-1,CAS3_REFERRER,
+temporary-accommodation-training-2,CAS3_ASSESSOR,
+temporary-accommodation-e2e-tester,CAS3_ASSESSOR,


### PR DESCRIPTION
> See [ticket #1135 on the CAS3 Trello board](https://trello.com/c/HUFggb7I/1135-add-new-cas3-roles-to-dev-and-test).

This PR is the second part of the work to introduce user roles to the Temporary Accommodation service. It adds the CAS3_ASSESSOR and CAS3_REFERRER roles and assigns these roles to the `temporary-accommodation-*` users in the dev and test environments.

This PR does not expose these new roles in API responses as this will be implemented in [ticket #1136](https://trello.com/c/DxTBacWv/1136-extend-profile-endpoint-to-return-the-cas3-user-roles).