### PR TITLE
(174) Allow a matcher to see in review placement applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -32,6 +33,10 @@ class PlacementApplicationsController(
       newPlacementApplication.applicationId.toString(),
       "Placement Application",
     )
+
+    if (application !is ApprovedPremisesApplicationEntity) {
+      throw RuntimeException("Only CAS1 Applications are currently supported")
+    }
 
     val placementApplication = extractEntityFromValidatableActionResult(
       placementApplicationService.createApplication(application, user),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -23,6 +23,8 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
   fun findByApplicationId(id: UUID): PlacementApplicationEntity?
 
   fun findByApplication_IdAndReallocatedAtNull(id: UUID): PlacementApplicationEntity?
+
+  fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<PlacementApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -33,7 +33,7 @@ data class PlacementApplicationEntity(
 
   @ManyToOne
   @JoinColumn(name = "application_id")
-  val application: ApplicationEntity,
+  val application: ApprovedPremisesApplicationEntity,
 
   @ManyToOne
   @JoinColumn(name = "created_by_user_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -31,7 +30,7 @@ class PlacementApplicationService(
 ) {
 
   fun createApplication(
-    application: ApplicationEntity,
+    application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
   ) = validated<PlacementApplicationEntity> {
     val assessment = application.getLatestAssessment()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -29,6 +29,10 @@ class PlacementApplicationService(
   private val placementDateRepository: PlacementDateRepository,
 ) {
 
+  fun getVisiblePlacementApplicationsForUser(user: UserEntity): List<PlacementApplicationEntity> {
+    return placementApplicationRepository.findAllByAllocatedToUser_IdAndReallocatedAtNull(user.id)
+  }
+
   fun createApplication(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -63,7 +63,7 @@ class PlacementRequestTransformer(
     }
   }
 
-  private fun getReleaseType(releaseType: String?): ReleaseTypeOption? = when (releaseType) {
+  fun getReleaseType(releaseType: String?): ReleaseTypeOption? = when (releaseType) {
     "licence" -> ReleaseTypeOption.licence
     "rotl" -> ReleaseTypeOption.rotl
     "hdc" -> ReleaseTypeOption.hdc

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -18,6 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 class TaskTransformer(
   private val personTransformer: PersonTransformer,
   private val userTransformer: UserTransformer,
+  private val risksTransformer: RisksTransformer,
+  private val placementRequestTransformer: PlacementRequestTransformer,
 ) {
   fun transformAssessmentToTask(assessment: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = AssessmentTask(
     applicationId = assessment.application.id,
@@ -29,12 +31,17 @@ class TaskTransformer(
   )
 
   fun transformPlacementRequestToTask(placementRequest: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = PlacementRequestTask(
+    id = placementRequest.id,
     applicationId = placementRequest.application.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     dueDate = placementRequest.createdAt.plusDays(10).toLocalDate(),
     allocatedToStaffMember = userTransformer.transformJpaToApi(placementRequest.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
     status = getPlacementRequestStatus(placementRequest),
     taskType = TaskType.placementRequest,
+    risks = risksTransformer.transformDomainToApi(placementRequest.application.riskRatings!!, placementRequest.application.crn),
+    expectedArrival = placementRequest.expectedArrival,
+    duration = placementRequest.duration,
+    releaseType = placementRequestTransformer.getReleaseType(placementRequest.application.releaseType)!!,
   )
 
   fun transformPlacementApplicationToTask(placementApplication: PlacementApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = PlacementApplicationTask(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -2,9 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentTask
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationTask
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.Status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
@@ -17,7 +19,7 @@ class TaskTransformer(
   private val personTransformer: PersonTransformer,
   private val userTransformer: UserTransformer,
 ) {
-  fun transformAssessmentToTask(assessment: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Task(
+  fun transformAssessmentToTask(assessment: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = AssessmentTask(
     applicationId = assessment.application.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     dueDate = assessment.createdAt.plusDays(10).toLocalDate(),
@@ -26,7 +28,7 @@ class TaskTransformer(
     taskType = TaskType.assessment,
   )
 
-  fun transformPlacementRequestToTask(placementRequest: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Task(
+  fun transformPlacementRequestToTask(placementRequest: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = PlacementRequestTask(
     applicationId = placementRequest.application.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     dueDate = placementRequest.createdAt.plusDays(10).toLocalDate(),
@@ -35,7 +37,7 @@ class TaskTransformer(
     taskType = TaskType.placementRequest,
   )
 
-  fun transformPlacementApplicationToTask(placementApplication: PlacementApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Task(
+  fun transformPlacementApplicationToTask(placementApplication: PlacementApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = PlacementApplicationTask(
     applicationId = placementApplication.application.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     dueDate = placementApplication.createdAt.plusDays(10).toLocalDate(),
@@ -44,20 +46,20 @@ class TaskTransformer(
     taskType = TaskType.placementApplication,
   )
 
-  private fun getPlacementApplicationStatus(entity: PlacementApplicationEntity): Status = when {
-    entity.data.isNullOrEmpty() -> Status.notStarted
-    entity.decision !== null -> Status.complete
-    else -> Status.inProgress
+  private fun getPlacementApplicationStatus(entity: PlacementApplicationEntity): TaskStatus = when {
+    entity.data.isNullOrEmpty() -> TaskStatus.notStarted
+    entity.decision !== null -> TaskStatus.complete
+    else -> TaskStatus.inProgress
   }
 
-  private fun getAssessmentStatus(entity: AssessmentEntity): Status = when {
-    entity.data.isNullOrEmpty() -> Status.notStarted
-    entity.decision !== null -> Status.complete
-    else -> Status.inProgress
+  private fun getAssessmentStatus(entity: AssessmentEntity): TaskStatus = when {
+    entity.data.isNullOrEmpty() -> TaskStatus.notStarted
+    entity.decision !== null -> TaskStatus.complete
+    else -> TaskStatus.inProgress
   }
 
-  private fun getPlacementRequestStatus(entity: PlacementRequestEntity): Status = when {
-    entity.booking !== null -> Status.complete
-    else -> Status.notStarted
+  private fun getPlacementRequestStatus(entity: PlacementRequestEntity): TaskStatus = when {
+    entity.booking !== null -> TaskStatus.complete
+    else -> TaskStatus.notStarted
   }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2252,6 +2252,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /tasks/reallocatable:
+    get:
+      tags:
+        - Task data
+      summary: List all reallocatable tasks
+      responses:
+        200:
+          description: successfully retrieved tasks
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Task'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /placement-requests:
     get:
       tags:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3241,6 +3241,27 @@ components:
     PlacementApplicationTask:
       allOf:
         - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+              example: 6abb5fa3-e93f-4445-887b-30d081688f44
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            placementType:
+              $ref: '#/components/schemas/PlacementType'
+            placementDates:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlacementDates'
+          required:
+            - id
+            - risks
+            - releaseType
+            - placementType
     BookingAppealTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3194,13 +3194,16 @@ components:
         allocatedToStaffMember:
           $ref: '#/components/schemas/ApprovedPremisesUser'
         status:
-          type: string
-          enum:
-            - not_started
-            - in_progress
-            - complete
+          $ref: '#/components/schemas/TaskStatus'
         taskType:
           $ref: '#/components/schemas/TaskType'
+      discriminator:
+        propertyName: taskType
+        mapping:
+          Assessment: '#/components/schemas/AssessmentTask'
+          PlacementRequest: '#/components/schemas/PlacementRequestTask'
+          PlacementApplication: '#/components/schemas/PlacementApplicationTask'
+          BookingAppeal: '#/components/schemas/BookingAppealTask'
       required: 
         - applicationId
         - person
@@ -3208,6 +3211,24 @@ components:
         - allocatedToStaffMember
         - status
         - taskType
+    TaskStatus:
+      type: string
+      enum:
+        - not_started
+        - in_progress
+        - complete
+    AssessmentTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+    PlacementRequestTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+    PlacementApplicationTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+    BookingAppealTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
     TaskType:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3223,6 +3223,21 @@ components:
     PlacementRequestTask:
       allOf:
         - $ref: '#/components/schemas/Task'
+        - $ref: '#/components/schemas/PlacementDates'
+        - type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+              example: 6abb5fa3-e93f-4445-887b-30d081688f44
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+          required:
+            - id
+            - risks
+            - releaseType
     PlacementApplicationTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -2,11 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
@@ -16,7 +17,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var createdByUser: Yielded<UserEntity>? = null
   private var allocatedToUser: Yielded<UserEntity?> = { null }
-  private var application: Yielded<ApplicationEntity>? = null
+  private var application: Yielded<ApprovedPremisesApplicationEntity>? = null
   private var schemaVersion: Yielded<JsonSchemaEntity> = {
     ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory().produce()
   }
@@ -27,6 +28,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var decision: Yielded<PlacementApplicationDecision?> = { null }
   private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
   private var placementDates: Yielded<MutableList<PlacementDateEntity>?> = { null }
+  private var placementType: Yielded<PlacementType?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -60,7 +62,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.submittedAt = { submittedAt }
   }
 
-  fun withApplication(applicationEntity: ApplicationEntity) = apply {
+  fun withApplication(applicationEntity: ApprovedPremisesApplicationEntity) = apply {
     this.application = { applicationEntity }
   }
 
@@ -74,6 +76,10 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
 
   fun withPlacementDates(placementDates: MutableList<PlacementDateEntity>) = apply {
     this.placementDates = { placementDates }
+  }
+
+  fun withPlacementType(placementType: PlacementType) = apply {
+    this.placementType = { placementType }
   }
 
   override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
@@ -90,7 +96,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     allocatedAt = null,
     reallocatedAt = this.reallocatedAt(),
     decision = this.decision(),
-    placementType = null,
+    placementType = this.placementType(),
     placementDates = this.placementDates() ?: mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -19,9 +19,8 @@ fun IntegrationTestBase.`Given a Placement Application`(
   submittedAt: OffsetDateTime? = null,
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
-  block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
-) {
-  `Given an Assessment for Approved Premises`(
+): PlacementApplicationEntity {
+  val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
     submittedAt = OffsetDateTime.now(),
     crn = crn,
@@ -39,20 +38,43 @@ fun IntegrationTestBase.`Given a Placement Application`(
         }
       }
     },
-  ) { _, application ->
-    val placementApplicationEntity = placementApplicationFactory.produceAndPersist {
-      withCreatedByUser(createdByUser)
-      withAllocatedToUser(allocatedToUser)
-      withApplication(application)
-      withSchemaVersion(schema)
-      withSubmittedAt(submittedAt)
-      withDecision(decision)
-      withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
-      if (reallocated) {
-        withReallocatedAt(OffsetDateTime.now())
-      }
-    }
+  )
 
-    block(placementApplicationEntity)
+  return placementApplicationFactory.produceAndPersist {
+    withCreatedByUser(createdByUser)
+    withAllocatedToUser(allocatedToUser)
+    withApplication(application)
+    withSchemaVersion(schema)
+    withSubmittedAt(submittedAt)
+    withDecision(decision)
+    withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
+    if (reallocated) {
+      withReallocatedAt(OffsetDateTime.now())
+    }
   }
+}
+
+fun IntegrationTestBase.`Given a Placement Application`(
+  assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
+  createdByUser: UserEntity,
+  schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity,
+  crn: String = randomStringMultiCaseWithNumbers(8),
+  allocatedToUser: UserEntity? = null,
+  submittedAt: OffsetDateTime? = null,
+  decision: PlacementApplicationDecision? = null,
+  reallocated: Boolean = false,
+  block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
+) {
+  block(
+    `Given a Placement Application`(
+      assessmentDecision,
+      createdByUser,
+      schema,
+      crn,
+      allocatedToUser,
+      submittedAt,
+      decision,
+      reallocated,
+    ),
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
@@ -46,6 +47,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
       withSchemaVersion(schema)
       withSubmittedAt(submittedAt)
       withDecision(decision)
+      withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
       if (reallocated) {
         withReallocatedAt(OffsetDateTime.now())
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -14,8 +14,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
-  block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit,
-) {
+): Pair<PlacementRequestEntity, ApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
   }
@@ -63,5 +62,24 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withPlacementRequirements(placementRequirements)
   }
 
-  block(placementRequest, application)
+  return Pair(placementRequest, application)
+}
+
+fun IntegrationTestBase.`Given a Placement Request`(
+  placementRequestAllocatedTo: UserEntity,
+  assessmentAllocatedTo: UserEntity,
+  createdByUser: UserEntity,
+  crn: String = randomStringMultiCaseWithNumbers(8),
+  reallocated: Boolean = false,
+  block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit,
+) {
+  val result = `Given a Placement Request`(
+    placementRequestAllocatedTo,
+    assessmentAllocatedTo,
+    createdByUser,
+    crn,
+    reallocated,
+  )
+
+  block(result.first, result.second)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -17,8 +17,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   data: String? = "{ \"some\": \"data\"}",
   decision: AssessmentDecision? = null,
   submittedAt: OffsetDateTime? = null,
-  block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit,
-) {
+): Pair<AssessmentEntity, ApprovedPremisesApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
   }
@@ -48,6 +47,29 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   }
 
   assessment.schemaUpToDate = true
+
+  return Pair(assessment, application)
+}
+
+fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
+  allocatedToUser: UserEntity,
+  createdByUser: UserEntity,
+  crn: String = randomStringMultiCaseWithNumbers(8),
+  reallocated: Boolean = false,
+  data: String? = "{ \"some\": \"data\"}",
+  decision: AssessmentDecision? = null,
+  submittedAt: OffsetDateTime? = null,
+  block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit,
+) {
+  val (assessment, application) = `Given an Assessment for Approved Premises`(
+    allocatedToUser,
+    createdByUser,
+    crn,
+    reallocated,
+    data,
+    decision,
+    submittedAt,
+  )
 
   block(assessment, application)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -32,6 +32,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withCrn(crn)
     withCreatedByUser(createdByUser)
     withApplicationSchema(applicationSchema)
+    withReleaseType("licence")
   }
 
   val assessment = assessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -4,21 +4,31 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import java.time.LocalDate
@@ -27,6 +37,8 @@ import java.time.OffsetDateTime
 class TaskTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockUserTransformer = mockk<UserTransformer>()
+  private val mockRisksTransformer = mockk<RisksTransformer>()
+  private val mockPlacementRequestTransformer = mockk<PlacementRequestTransformer>()
 
   private val mockPerson = mockk<Person>()
   private val mockUser = mockk<ApprovedPremisesUser>()
@@ -50,7 +62,23 @@ class TaskTransformerTest {
     .withAllocatedToUser(user)
     .withCreatedAt(OffsetDateTime.parse("2022-12-07T10:40:00Z"))
 
-  private val taskTransformer = TaskTransformer(mockPersonTransformer, mockUserTransformer)
+  private val placementRequestFactory = PlacementRequestEntityFactory()
+    .withPlacementRequirements(
+      PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessmentFactory.produce())
+        .produce(),
+    )
+    .withApplication(application)
+    .withAssessment(assessmentFactory.produce())
+    .withAllocatedToUser(user)
+
+  private val taskTransformer = TaskTransformer(
+    mockPersonTransformer,
+    mockUserTransformer,
+    mockRisksTransformer,
+    mockPlacementRequestTransformer,
+  )
 
   @BeforeEach
   fun setup() {
@@ -58,43 +86,95 @@ class TaskTransformerTest {
     every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockUser
   }
 
-  @Test
-  fun `Not started assessment is correctly transformed`() {
-    var assessment = assessmentFactory.produce()
+  @Nested
+  inner class TransformAssessmentsTest {
+    @Test
+    fun `Not started assessment is correctly transformed`() {
+      var assessment = assessmentFactory.produce()
 
-    assessment.data = null
+      assessment.data = null
 
-    var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+      var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
 
-    assertThat(result.status).isEqualTo(TaskStatus.notStarted)
-    assertThat(result.taskType).isEqualTo(TaskType.assessment)
-    assertThat(result.applicationId).isEqualTo(application.id)
-    assertThat(result.dueDate).isEqualTo(LocalDate.parse("2022-12-17"))
-    assertThat(result.person).isEqualTo(mockPerson)
-    assertThat(result.allocatedToStaffMember).isEqualTo(mockUser)
+      assertThat(result.status).isEqualTo(TaskStatus.notStarted)
+      assertThat(result.taskType).isEqualTo(TaskType.assessment)
+      assertThat(result.applicationId).isEqualTo(application.id)
+      assertThat(result.dueDate).isEqualTo(LocalDate.parse("2022-12-17"))
+      assertThat(result.person).isEqualTo(mockPerson)
+      assertThat(result.allocatedToStaffMember).isEqualTo(mockUser)
+    }
+
+    @Test
+    fun `In Progress assessment is correctly transformed`() {
+      var assessment = assessmentFactory
+        .withDecision(null)
+        .withData("{\"test\": \"data\"}")
+        .produce()
+
+      var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+
+      assertThat(result.status).isEqualTo(TaskStatus.inProgress)
+    }
+
+    @Test
+    fun `Complete assessment is correctly transformed`() {
+      var assessment = assessmentFactory
+        .withDecision(AssessmentDecision.ACCEPTED)
+        .withData("{\"test\": \"data\"}")
+        .produce()
+
+      var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+
+      assertThat(result.status).isEqualTo(TaskStatus.complete)
+    }
   }
 
-  @Test
-  fun `In Progress assessment is correctly transformed`() {
-    var assessment = assessmentFactory
-      .withDecision(null)
-      .withData("{\"test\": \"data\"}")
-      .produce()
+  @Nested
+  inner class TransformPlacementRequestsTest {
 
-    var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+    val placementRequest = placementRequestFactory.produce()
+    val application = placementRequest.application
+    private val mockRisks = mockk<PersonRisks>()
+    private val releaseType = ReleaseTypeOption.licence
 
-    assertThat(result.status).isEqualTo(TaskStatus.inProgress)
-  }
+    @BeforeEach
+    fun setup() {
+      every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockRisks
+      every { mockPlacementRequestTransformer.getReleaseType(application.releaseType) } returns releaseType
+    }
 
-  @Test
-  fun `Complete assessment is correctly transformed`() {
-    var assessment = assessmentFactory
-      .withDecision(AssessmentDecision.ACCEPTED)
-      .withData("{\"test\": \"data\"}")
-      .produce()
+    @Test
+    fun `Placement request is correctly transformed`() {
+      val result = taskTransformer.transformPlacementRequestToTask(placementRequest, mockOffenderDetailSummary, mockInmateDetail)
 
-    var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
+      assertThat(result.status).isEqualTo(TaskStatus.notStarted)
+      assertThat(result.id).isEqualTo(placementRequest.id)
+      assertThat(result.risks).isEqualTo(mockRisks)
+      assertThat(result.releaseType).isEqualTo(releaseType)
+      assertThat(result.expectedArrival).isEqualTo(placementRequest.expectedArrival)
+      assertThat(result.duration).isEqualTo(placementRequest.duration)
+    }
 
-    assertThat(result.status).isEqualTo(TaskStatus.complete)
+    @Test
+    fun `Complete placement request is correctly transformed`() {
+      val placementRequest = placementRequestFactory
+        .withBooking(
+          BookingEntityFactory()
+            .withPremises(
+              ApprovedPremisesEntityFactory()
+                .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+                .withYieldedProbationRegion {
+                  ProbationRegionEntityFactory().withYieldedApArea { ApAreaEntityFactory().produce() }.produce()
+                }
+                .produce(),
+            )
+            .produce(),
+        )
+        .produce()
+
+      val result = taskTransformer.transformPlacementRequestToTask(placementRequest, mockOffenderDetailSummary, mockInmateDetail)
+
+      assertThat(result.status).isEqualTo(TaskStatus.complete)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task.Status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
@@ -66,7 +66,7 @@ class TaskTransformerTest {
 
     var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
 
-    assertThat(result.status).isEqualTo(Status.notStarted)
+    assertThat(result.status).isEqualTo(TaskStatus.notStarted)
     assertThat(result.taskType).isEqualTo(TaskType.assessment)
     assertThat(result.applicationId).isEqualTo(application.id)
     assertThat(result.dueDate).isEqualTo(LocalDate.parse("2022-12-17"))
@@ -83,7 +83,7 @@ class TaskTransformerTest {
 
     var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
 
-    assertThat(result.status).isEqualTo(Status.inProgress)
+    assertThat(result.status).isEqualTo(TaskStatus.inProgress)
   }
 
   @Test
@@ -95,6 +95,6 @@ class TaskTransformerTest {
 
     var result = taskTransformer.transformAssessmentToTask(assessment, mockOffenderDetailSummary, mockInmateDetail)
 
-    assertThat(result.status).isEqualTo(Status.complete)
+    assertThat(result.status).isEqualTo(TaskStatus.complete)
   }
 }


### PR DESCRIPTION
This updates the Tasks to return different values depending on the task type. It also updates the `/tasks` endpoint to return tasks that are allocated to the logged-in user. At the moment, this only works for matchers, but we can easily  extend this to return assessments, and any other type of tasks we choose to add in the future.

The existing `/tasks` endpoint has been moved to `/tasks/reallocatable`, which fetches all reallocatable tasks for a workflow manager. We'll need to update the UI to call this endpoint when this work is in.