### PR TITLE
Remove other lost bed reason for AP

### DIFF
--- a/src/main/resources/db/migration/all/20230605134546__remove_other_lost_bed_reason_for_approved_premises.sql
+++ b/src/main/resources/db/migration/all/20230605134546__remove_other_lost_bed_reason_for_approved_premises.sql
@@ -1,0 +1,3 @@
+UPDATE lost_bed_reasons
+SET service_scope = 'temporary-accommodation'
+WHERE "name" = 'Other';


### PR DESCRIPTION
This is still in use for TA, so we’ll just update the scope