### PR TITLE
Set CAS2 application type in json schemas table

### DIFF
--- a/src/main/resources/db/migration/all/20230605160742__use_correct_type_for_cas_2_application_json_schema.sql
+++ b/src/main/resources/db/migration/all/20230605160742__use_correct_type_for_cas_2_application_json_schema.sql
@@ -1,0 +1,3 @@
+UPDATE json_schemas
+SET type = 'CAS_2_APPLICATION'
+WHERE id = '20c06750-27d3-4dc6-8ac6-948c8f0a0210';


### PR DESCRIPTION
Fixes an accidental omission from PR #670 in which we failed to set the type of the json schema we created for CAS2 applications. This was causing POST requests for CAS2 applications to fail.