### PR TITLE
Add PlacementRequestStatus to Tasks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -43,7 +43,7 @@ class PlacementRequestTransformer(
     )
   }
 
-  private fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
+  fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
     if (placementRequest.booking == null) {
       if (placementRequest.bookingNotMades.any()) {
         return PlacementRequestStatus.unableToMatch

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -44,6 +44,7 @@ class TaskTransformer(
     risks = risksTransformer.transformDomainToApi(placementRequest.application.riskRatings!!, placementRequest.application.crn),
     expectedArrival = placementRequest.expectedArrival,
     duration = placementRequest.duration,
+    placementRequestStatus = placementRequestTransformer.getStatus(placementRequest),
     releaseType = placementRequestTransformer.getReleaseType(placementRequest.application.releaseType)!!,
   )
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3254,10 +3254,13 @@ components:
               $ref: '#/components/schemas/PersonRisks'
             releaseType:
               $ref: '#/components/schemas/ReleaseTypeOption'
+            placementRequestStatus:
+              $ref: '#/components/schemas/PlacementRequestStatus'
           required:
             - id
             - risks
             - releaseType
+            - placementRequestStatus
     PlacementApplicationTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskStatus
@@ -238,11 +239,13 @@ class TaskTransformerTest {
     val application = placementRequest.application
     private val mockRisks = mockk<PersonRisks>()
     private val releaseType = ReleaseTypeOption.licence
+    private val placementRequestStatus = PlacementRequestStatus.notMatched
 
     @BeforeEach
     fun setup() {
       every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockRisks
       every { mockPlacementRequestTransformer.getReleaseType(application.releaseType) } returns releaseType
+      every { mockPlacementRequestTransformer.getStatus(placementRequest) } returns placementRequestStatus
     }
 
     @Test
@@ -255,6 +258,7 @@ class TaskTransformerTest {
       assertThat(result.releaseType).isEqualTo(releaseType)
       assertThat(result.expectedArrival).isEqualTo(placementRequest.expectedArrival)
       assertThat(result.duration).isEqualTo(placementRequest.duration)
+      assertThat(result.placementRequestStatus).isEqualTo(placementRequestStatus)
     }
 
     @Test
@@ -273,6 +277,8 @@ class TaskTransformerTest {
             .produce(),
         )
         .produce()
+
+      every { mockPlacementRequestTransformer.getStatus(placementRequest) } returns placementRequestStatus
 
       val result = taskTransformer.transformPlacementRequestToTask(placementRequest, mockOffenderDetailSummary, mockInmateDetail)
 


### PR DESCRIPTION
Tasks have a broad ‘Status’ of `not_started`, `in_progress` or `complete`, but we need a more fine grained status for the PlacementRequestTask.