### PR TITLE
Return CAS3 user roles in API responses returning `TemporaryAccommodationUser`s

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -4,10 +4,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.UsersApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -32,9 +32,9 @@ class UsersController(
     return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)
   }
 
-  override fun usersGet(xServiceName: ServiceName, roles: List<UserRole>?, qualifications: List<UserQualification>?): ResponseEntity<List<User>> {
+  override fun usersGet(xServiceName: ServiceName, roles: List<ApprovedPremisesUserRole>?, qualifications: List<UserQualification>?): ResponseEntity<List<User>> {
     val user = userService.getUserForRequest()
-    if (!user.hasAnyRole(JpaUserRole.CAS1_ADMIN, JpaUserRole.CAS1_WORKFLOW_MANAGER)) {
+    if (xServiceName != ServiceName.approvedPremises || !user.hasAnyRole(JpaUserRole.CAS1_ADMIN, JpaUserRole.CAS1_WORKFLOW_MANAGER)) {
       throw ForbiddenProblem()
     }
 
@@ -47,14 +47,13 @@ class UsersController(
     )
   }
 
-  private fun transformApiRole(apiRole: UserRole): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole = when (apiRole) {
-    UserRole.roleAdmin -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ADMIN
-    UserRole.applicant -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_APPLICANT
-    UserRole.assessor -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ASSESSOR
-    UserRole.manager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MANAGER
-    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MATCHER
-    UserRole.workflowManager -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_WORKFLOW_MANAGER
-    UserRole.matcher -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MATCHER
+  private fun transformApiRole(apiRole: ApprovedPremisesUserRole): JpaUserRole = when (apiRole) {
+    ApprovedPremisesUserRole.roleAdmin -> JpaUserRole.CAS1_ADMIN
+    ApprovedPremisesUserRole.applicant -> JpaUserRole.CAS1_APPLICANT
+    ApprovedPremisesUserRole.assessor -> JpaUserRole.CAS1_ASSESSOR
+    ApprovedPremisesUserRole.manager -> JpaUserRole.CAS1_MANAGER
+    ApprovedPremisesUserRole.matcher -> JpaUserRole.CAS1_MATCHER
+    ApprovedPremisesUserRole.workflowManager -> JpaUserRole.CAS1_WORKFLOW_MANAGER
   }
 
   private fun transformApiQualification(apiQualification: uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification = when (apiQualification) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -2,15 +2,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as ApiUserQualification
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRole as ApiUserRole
 
 @Component
 class UserTransformer(
@@ -20,7 +21,7 @@ class UserTransformer(
     ServiceName.approvedPremises, ServiceName.cas2 -> ApprovedPremisesUser(
       id = jpa.id,
       deliusUsername = jpa.deliusUsername,
-      roles = jpa.roles.mapNotNull(::transformRoleToApi),
+      roles = jpa.roles.mapNotNull(::transformApprovedPremisesRoleToApi),
       email = jpa.email,
       name = jpa.name,
       telephoneNumber = jpa.telephoneNumber,
@@ -30,19 +31,25 @@ class UserTransformer(
     )
     ServiceName.temporaryAccommodation -> TemporaryAccommodationUser(
       id = jpa.id,
-      roles = jpa.roles.mapNotNull(::transformRoleToApi),
+      roles = jpa.roles.mapNotNull(::transformTemporaryAccommodationRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       service = ServiceName.temporaryAccommodation.value,
     )
   }
 
-  private fun transformRoleToApi(userRole: UserRoleAssignmentEntity): ApiUserRole? = when (userRole.role) {
-    UserRole.CAS1_ADMIN -> ApiUserRole.roleAdmin
-    UserRole.CAS1_ASSESSOR -> ApiUserRole.assessor
-    UserRole.CAS1_MATCHER -> ApiUserRole.matcher
-    UserRole.CAS1_MANAGER -> ApiUserRole.manager
-    UserRole.CAS1_WORKFLOW_MANAGER -> ApiUserRole.workflowManager
-    UserRole.CAS1_APPLICANT -> ApiUserRole.applicant
+  private fun transformApprovedPremisesRoleToApi(userRole: UserRoleAssignmentEntity): ApprovedPremisesUserRole? = when (userRole.role) {
+    UserRole.CAS1_ADMIN -> ApprovedPremisesUserRole.roleAdmin
+    UserRole.CAS1_ASSESSOR -> ApprovedPremisesUserRole.assessor
+    UserRole.CAS1_MATCHER -> ApprovedPremisesUserRole.matcher
+    UserRole.CAS1_MANAGER -> ApprovedPremisesUserRole.manager
+    UserRole.CAS1_WORKFLOW_MANAGER -> ApprovedPremisesUserRole.workflowManager
+    UserRole.CAS1_APPLICANT -> ApprovedPremisesUserRole.applicant
+    else -> null
+  }
+
+  private fun transformTemporaryAccommodationRoleToApi(userRole: UserRoleAssignmentEntity): TemporaryAccommodationUserRole? = when (userRole.role) {
+    UserRole.CAS3_ASSESSOR -> TemporaryAccommodationUserRole.assessor
+    UserRole.CAS3_REFERRER -> TemporaryAccommodationUserRole.referrer
     else -> null
   }
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2792,7 +2792,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/UserRole'
+              $ref: '#/components/schemas/ApprovedPremisesUserRole'
         - in: query
           name: qualifications
           required: false
@@ -4915,10 +4915,6 @@ components:
           format: uuid
         region:
           $ref: '#/components/schemas/ProbationRegion'
-        roles:
-          type: array
-          items:
-            $ref: '#/components/schemas/UserRole'
         service:
           type: string
           example: CAS1
@@ -4930,7 +4926,6 @@ components:
       required:
         - id
         - region
-        - roles
         - service
     ApprovedPremisesUser:
       allOf:
@@ -4949,16 +4944,27 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/UserQualification'
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/ApprovedPremisesUserRole'
           required:
             - name
             - deliusUsername
             - qualifications
+            - roles
     TemporaryAccommodationUser:
       allOf:
         - $ref: '#/components/schemas/User'
         - type: object
-          properties: {}
-    UserRole:
+          properties:
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemporaryAccommodationUserRole'
+          required:
+            - roles
+    ApprovedPremisesUserRole:
       type: string
       enum:
         - assessor
@@ -4967,6 +4973,11 @@ components:
         - workflow_manager
         - applicant
         - role_admin
+    TemporaryAccommodationUserRole:
+      type: string
+      enum:
+        - assessor
+        - referrer
     UserQualification:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -2,14 +2,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRole as ApiUserRole
 
 class ProfileTest : IntegrationTestBase() {
   @Test
@@ -90,7 +91,7 @@ class ProfileTest : IntegrationTestBase() {
               email = email,
               name = userEntity.name,
               telephoneNumber = telephoneNumber,
-              roles = listOf(ApiUserRole.assessor),
+              roles = listOf(ApprovedPremisesUserRole.assessor),
               qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
               service = ServiceName.approvedPremises.value,
             ),
@@ -126,7 +127,7 @@ class ProfileTest : IntegrationTestBase() {
 
     userRoleAssignmentEntityFactory.produceAndPersist {
       withUser(userEntity)
-      withRole(UserRole.CAS1_ASSESSOR)
+      withRole(UserRole.CAS3_ASSESSOR)
     }
 
     userQualificationAssignmentEntityFactory.produceAndPersist {
@@ -147,7 +148,7 @@ class ProfileTest : IntegrationTestBase() {
           TemporaryAccommodationUser(
             id = id,
             region = ProbationRegion(region.id, region.name),
-            roles = listOf(ApiUserRole.assessor),
+            roles = listOf(TemporaryAccommodationUserRole.assessor),
             service = ServiceName.temporaryAccommodation.value,
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -225,6 +225,20 @@ class UsersTest : IntegrationTestBase() {
   @Nested
   inner class GetUsers {
     @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
+    fun `GET to users with X-Service-Name other than approved-premises is forbidden`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        webTestClient.get()
+          .uri("/users")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
     fun `GET to users with a role other than ROLE_ADMIN or WORKFLOW_MANAGER is forbidden`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->


### PR DESCRIPTION
> See [ticket #1136 on the CAS3 Trello board](https://trello.com/c/DxTBacWv/1136-extend-profile-endpoint-to-return-the-cas3-user-roles).

This PR is the third part of the work to introduce user roles to the Temporary Accommodation service. It allows endpoints that return a `TemporaryAccommodationUser` (such as `GET /users/{id}` or `/profile`) to return roles specific to the Temporary Accommodation service.

To do this, the `UserRole` enum has been split into service-specific enums, `ApprovedPremisesUserRole` and `TemporaryAccommodationUserRole`, and the `User.roles` property has been moved into the service-specific schemas.

As a consequence, the `roles` query parameter on the `GET /users` endpoint can now only accept `ApprovedPremisesUserRole`s. However, as the Temporary Accommodation service does not use this endpoint and does not plan to in the near future, the controller method for this endpoint has been modified to return a `403 Forbidden` response if the `X-Service-Name` header is not `approved-premises`, avoiding incorrect semantics or giving up type safety of the controller method signature.