### PR TITLE
Attempt to fix CI memory errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,9 +161,9 @@ jobs:
           paths:
             - build
   test:
-    parallelism: 4
+    parallelism: 5
     environment:
-      _JAVA_OPTIONS: "-Xmx2g"
+      _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
       POSTGRES_PORT: 5432
       SPRING_REDIS_PORT: 6379


### PR DESCRIPTION
We’re still getting intermittent failures with the message:

```
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

Even though we’ve reduced the memory usage, there’s still no room for the other processes in the container sometimes, and this causes the containers to run out of memory. This reduces the amount of RAM each Gradle process can use, as well as upping the number of containers to try and make up for the slower tests.