### PR TITLE
213 - Return Bookings cancelled due to an appeal to matching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -102,6 +102,8 @@ data class BookingEntity(
   @OneToMany(mappedBy = "booking")
   var turnarounds: MutableList<TurnaroundEntity>,
   var nomsNumber: String,
+  @OneToOne(mappedBy = "booking")
+  var placementRequest: PlacementRequestEntity?,
 ) {
   val departure: DepartureEntity?
     get() = departures.maxByOrNull { it.createdAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -73,6 +73,7 @@ class BookingService(
   private val applicationService: ApplicationService,
   private val workingDayCountService: WorkingDayCountService,
   private val emailNotificationService: EmailNotificationService,
+  private val placementRequestService: PlacementRequestService,
   private val communityApiClient: CommunityApiClient,
   private val bookingRepository: BookingRepository,
   private val arrivalRepository: ArrivalRepository,
@@ -113,6 +114,10 @@ class BookingService(
     }
 
     val validationResult = validated {
+      if (placementRequest.booking != null) {
+        return@validated placementRequest.booking!!.id hasConflictError "A Booking has already been made for this Placement Request"
+      }
+
       if (departureDate.isBefore(arrivalDate)) {
         "$.departureDate" hasValidationError "beforeBookingArrivalDate"
       }
@@ -162,6 +167,7 @@ class BookingService(
           offlineApplication = null,
           turnarounds = mutableListOf(),
           nomsNumber = placementRequest.application.nomsNumber,
+          placementRequest = null,
         ),
       )
 
@@ -278,6 +284,7 @@ class BookingService(
           offlineApplication = if (associateWithOfflineApplication) newestOfflineApplication else null,
           turnarounds = mutableListOf(),
           nomsNumber = nomsNumber,
+          placementRequest = null,
         ),
       )
 
@@ -440,6 +447,7 @@ class BookingService(
           application = null,
           offlineApplication = null,
           turnarounds = mutableListOf(),
+          placementRequest = null,
         ),
       )
 
@@ -709,6 +717,7 @@ class BookingService(
     return success(nonArrivalEntity)
   }
 
+  @Transactional
   fun createCancellation(
     booking: BookingEntity,
     date: LocalDate,

--- a/src/main/resources/db/migration/all/20230608133712__add_cancellation_type_for_appealed.sql
+++ b/src/main/resources/db/migration/all/20230608133712__add_cancellation_type_for_appealed.sql
@@ -1,0 +1,2 @@
+INSERT INTO cancellation_reasons (id, name, is_active, service_scope)
+VALUES ('acba3547-ab22-442d-acec-2652e49895f2', 'Booking successfully appealed', true, 'approved-premises');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
@@ -46,6 +47,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
   private var turnarounds: Yielded<MutableList<TurnaroundEntity>>? = null
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+  private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -167,6 +169,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.nomsNumber = { nomsNumber }
   }
 
+  fun withPlacementRequest(placementRequest: PlacementRequestEntity) = apply {
+    this.placementRequest = { placementRequest }
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),
@@ -189,5 +195,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     offlineApplication = this.offlineApplication(),
     turnarounds = this.turnarounds?.invoke() ?: mutableListOf(),
     nomsNumber = this.nomsNumber(),
+    placementRequest = this.placementRequest(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -150,6 +150,7 @@ class BookingTransformerTest {
     offlineApplication = null,
     turnarounds = mutableListOf(),
     nomsNumber = "NOMS123",
+    placementRequest = null,
   )
 
   private val staffMember = StaffMember(


### PR DESCRIPTION
 - Create a new Cancellation Reason "Booking successfully appealed"
 - When this is used to cancel an AP Booking which is linked to a Placement Request, create a new Placement Request with the same criteria