### PR TITLE
Notify content changes

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -29,6 +29,7 @@ generic-service:
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
+    NOTIFY_MODE: TEST_AND_GUEST_LIST
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -535,6 +535,16 @@ class ApplicationService(
 
     createApplicationSubmittedEvent(application, submitApplication, username, jwt)
 
+    emailNotificationService.sendEmail(
+      user = user,
+      templateId = notifyConfig.templates.applicationSubmitted,
+      personalisation = mapOf(
+        "name" to user.name,
+        "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
+        "crn" to application.crn,
+      ),
+    )
+
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(application),
     )
@@ -598,15 +608,6 @@ class ApplicationService(
     }
 
     application = applicationRepository.save(application)
-
-    emailNotificationService.sendEmail(
-      user = user,
-      templateId = notifyConfig.templates.applicationSubmitted,
-      personalisation = mapOf(
-        "name" to user.name,
-        "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
-      ),
-    )
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(application),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -490,23 +490,27 @@ class AssessmentService(
       ),
     )
 
-    emailNotificationService.sendEmail(
-      user = assigneeUser,
-      templateId = notifyConfig.templates.assessmentAllocated,
-      personalisation = mapOf(
-        "name" to assigneeUser.name,
-        "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
-      ),
-    )
+    if (application is ApprovedPremisesApplicationEntity) {
+      emailNotificationService.sendEmail(
+        user = assigneeUser,
+        templateId = notifyConfig.templates.assessmentAllocated,
+        personalisation = mapOf(
+          "name" to assigneeUser.name,
+          "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
+          "crn" to application.crn,
+        ),
+      )
 
-    emailNotificationService.sendEmail(
-      user = assigneeUser,
-      templateId = notifyConfig.templates.assessmentDeallocated,
-      personalisation = mapOf(
-        "name" to assigneeUser.name,
-        "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
-      ),
-    )
+      emailNotificationService.sendEmail(
+        user = assigneeUser,
+        templateId = notifyConfig.templates.assessmentDeallocated,
+        personalisation = mapOf(
+          "name" to assigneeUser.name,
+          "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
+          "crn" to application.crn,
+        ),
+      )
+    }
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -384,57 +384,60 @@ class AssessmentService(
       is ClientResult.Failure -> staffDetailsResult.throwException()
     }
 
-    domainEventService.saveApplicationAssessedDomainEvent(
-      DomainEvent(
-        id = domainEventId,
-        applicationId = application.id,
-        crn = application.crn,
-        occurredAt = rejectedAt.toInstant(),
-        data = ApplicationAssessedEnvelope(
+    if (application is ApprovedPremisesApplicationEntity) {
+      domainEventService.saveApplicationAssessedDomainEvent(
+        DomainEvent(
           id = domainEventId,
-          timestamp = rejectedAt.toInstant(),
-          eventType = "approved-premises.application.assessed",
-          eventDetails = ApplicationAssessed(
-            applicationId = application.id,
-            applicationUrl = applicationUrlTemplate
-              .replace("#id", application.id.toString()),
-            personReference = PersonReference(
-              crn = offenderDetails.otherIds.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!,
+          applicationId = application.id,
+          crn = application.crn,
+          occurredAt = rejectedAt.toInstant(),
+          data = ApplicationAssessedEnvelope(
+            id = domainEventId,
+            timestamp = rejectedAt.toInstant(),
+            eventType = "approved-premises.application.assessed",
+            eventDetails = ApplicationAssessed(
+              applicationId = application.id,
+              applicationUrl = applicationUrlTemplate
+                .replace("#id", application.id.toString()),
+              personReference = PersonReference(
+                crn = offenderDetails.otherIds.crn,
+                noms = offenderDetails.otherIds.nomsNumber!!,
+              ),
+              deliusEventNumber = (application as ApprovedPremisesApplicationEntity).eventNumber,
+              assessedAt = rejectedAt.toInstant(),
+              assessedBy = ApplicationAssessedAssessedBy(
+                staffMember = StaffMember(
+                  staffCode = staffDetails.staffCode,
+                  staffIdentifier = staffDetails.staffIdentifier,
+                  forenames = staffDetails.staff.forenames,
+                  surname = staffDetails.staff.surname,
+                  username = staffDetails.username,
+                ),
+                probationArea = ProbationArea(
+                  code = staffDetails.probationArea.code,
+                  name = staffDetails.probationArea.description,
+                ),
+                cru = Cru(
+                  name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
+                ),
+              ),
+              decision = assessment.decision.toString(),
+              decisionRationale = assessment.rejectionRationale,
             ),
-            deliusEventNumber = (application as ApprovedPremisesApplicationEntity).eventNumber,
-            assessedAt = rejectedAt.toInstant(),
-            assessedBy = ApplicationAssessedAssessedBy(
-              staffMember = StaffMember(
-                staffCode = staffDetails.staffCode,
-                staffIdentifier = staffDetails.staffIdentifier,
-                forenames = staffDetails.staff.forenames,
-                surname = staffDetails.staff.surname,
-                username = staffDetails.username,
-              ),
-              probationArea = ProbationArea(
-                code = staffDetails.probationArea.code,
-                name = staffDetails.probationArea.description,
-              ),
-              cru = Cru(
-                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
-              ),
-            ),
-            decision = assessment.decision.toString(),
-            decisionRationale = assessment.rejectionRationale,
           ),
         ),
-      ),
-    )
+      )
 
-    emailNotificationService.sendEmail(
-      user = application.createdByUser,
-      templateId = notifyConfig.templates.assessmentRejected,
-      personalisation = mapOf(
-        "name" to application.createdByUser.name,
-        "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
-      ),
-    )
+      emailNotificationService.sendEmail(
+        user = application.createdByUser,
+        templateId = notifyConfig.templates.assessmentRejected,
+        personalisation = mapOf(
+          "name" to application.createdByUser.name,
+          "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
+          "crn" to application.crn,
+        ),
+      )
+    }
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(savedAssessment),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -134,14 +134,17 @@ class AssessmentService(
       ),
     )
 
-    emailNotificationService.sendEmail(
-      user = allocatedUser,
-      templateId = notifyConfig.templates.assessmentAllocated,
-      personalisation = mapOf(
-        "name" to allocatedUser.name,
-        "assessmentUrl" to assessmentUrlTemplate.replace("#id", assessment.id.toString()),
-      ),
-    )
+    if (application is ApprovedPremisesApplicationEntity) {
+      emailNotificationService.sendEmail(
+        user = allocatedUser,
+        templateId = notifyConfig.templates.assessmentAllocated,
+        personalisation = mapOf(
+          "name" to allocatedUser.name,
+          "assessmentUrl" to assessmentUrlTemplate.replace("#id", assessment.id.toString()),
+          "crn" to application.crn,
+        ),
+      )
+    }
 
     return assessment
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -185,6 +186,10 @@ class BookingService(
 
       val applicationSubmittedByUser = placementRequest.application.createdByUser
 
+      val lengthOfStayDays = arrivalDate.getDaysUntilInclusive(departureDate).size
+      val lengthOfStayWeeks = lengthOfStayDays.toDouble() / 7
+      val lengthOfStayWeeksWholeNumber = (lengthOfStayDays.toDouble() % 7) == 0.0
+
       emailNotificationService.sendEmail(
         user = applicationSubmittedByUser,
         templateId = notifyConfig.templates.bookingMade,
@@ -194,6 +199,11 @@ class BookingService(
           "applicationUrl" to applicationUrlTemplate.replace("#id", placementRequest.application.id.toString()),
           "bookingUrl" to bookingUrlTemplate.replace("#premisesId", booking.premises.id.toString())
             .replace("#bookingId", booking.id.toString()),
+          "crn" to placementRequest.application.crn,
+          "startDate" to arrivalDate.toString(),
+          "endDate" to departureDate.toString(),
+          "lengthStay" to if (lengthOfStayWeeksWholeNumber) lengthOfStayWeeks else lengthOfStayDays,
+          "lengthStayUnit" to if (lengthOfStayWeeksWholeNumber) "weeks" else "days",
         ),
       )
 
@@ -300,6 +310,10 @@ class BookingService(
 
         val applicationSubmittedByUser = newestSubmittedOnlineApplication!!.createdByUser
 
+        val lengthOfStayDays = arrivalDate.getDaysUntilInclusive(departureDate).size
+        val lengthOfStayWeeks = lengthOfStayDays.toDouble() / 7
+        val lengthOfStayWeeksWholeNumber = (lengthOfStayDays.toDouble() % 7) == 0.0
+
         emailNotificationService.sendEmail(
           user = applicationSubmittedByUser,
           templateId = notifyConfig.templates.bookingMade,
@@ -309,6 +323,11 @@ class BookingService(
             "applicationUrl" to applicationUrlTemplate.replace("#id", newestSubmittedOnlineApplication.id.toString()),
             "bookingUrl" to bookingUrlTemplate.replace("#premisesId", booking.premises.id.toString())
               .replace("#bookingId", booking.id.toString()),
+            "crn" to crn,
+            "startDate" to arrivalDate.toString(),
+            "endDate" to departureDate.toString(),
+            "lengthStay" to if (lengthOfStayWeeksWholeNumber) lengthOfStayWeeks.toInt() else lengthOfStayDays,
+            "lengthStayUnit" to if (lengthOfStayWeeksWholeNumber) "weeks" else "days",
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1346,7 +1346,7 @@ class ApplicationServiceTest {
     }
 
     @Test
-    fun `submitApprovedPremisesApplication returns Success, creates assessment and stores event`() {
+    fun `submitApprovedPremisesApplication returns Success, creates assessment and stores event, sends confirmation email`() {
       val newestSchema = ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
 
       val application = ApprovedPremisesApplicationEntityFactory()
@@ -1411,6 +1411,7 @@ class ApplicationServiceTest {
       val schema = application.schemaVersion as ApprovedPremisesApplicationJsonSchemaEntity
 
       every { mockDomainEventService.saveApplicationSubmittedDomainEvent(any()) } just Runs
+      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
 
       val result = applicationService.submitApprovedPremisesApplication(applicationId, submitApprovedPremisesApplication, username, "jwt")
 
@@ -1473,6 +1474,17 @@ class ApplicationServiceTest {
               data.mappa == risks.mappa.value!!.level &&
               data.sentenceLengthInMonths == null &&
               data.offenceId == application.offenceId
+          },
+        )
+      }
+
+      verify(exactly = 1) {
+        mockEmailNotificationService.sendEmail(
+          any(),
+          "c9944bd8-63c4-473c-8dce-b3636e47d3dd",
+          match {
+            it["name"] == user.name &&
+              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
           },
         )
       }
@@ -1576,7 +1588,7 @@ class ApplicationServiceTest {
     }
 
     @Test
-    fun `submitTemporaryAccommodationApplication returns Success, sends confirmation email`() {
+    fun `submitTemporaryAccommodationApplication returns Success`() {
       val newestSchema = TemporaryAccommodationApplicationJsonSchemaEntityFactory().produce()
 
       val application = TemporaryAccommodationApplicationEntityFactory()
@@ -1596,8 +1608,6 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
-      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
-
       val result = applicationService.submitTemporaryAccommodationApplication(applicationId, submitTemporaryAccommodationApplication)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1608,16 +1618,6 @@ class ApplicationServiceTest {
       verify { mockApplicationRepository.save(any()) }
       verify { mockAssessmentService wasNot called }
       verify { mockDomainEventService wasNot called }
-      verify(exactly = 1) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          "c9944bd8-63c4-473c-8dce-b3636e47d3dd",
-          match {
-            it["name"] == user.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-          },
-        )
-      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2171,6 +2171,152 @@ class BookingServiceTest {
     }
   }
 
+  @Test
+  fun `createApprovedPremisesAdHocBooking uses days in Booking length for email when not whole number of weeks`() {
+    val crn = "CRN123"
+    val arrivalDate = LocalDate.parse("2023-02-22")
+    val departureDate = LocalDate.parse("2023-02-27")
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+      .addRoleForUnitTest(UserRole.CAS1_MATCHER)
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withUnitTestControlTestProbationAreaAndLocalAuthority()
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val bed = BedEntityFactory()
+      .withRoom(room)
+      .produce()
+
+    every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
+    every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+
+    val existingApplication = ApprovedPremisesApplicationEntityFactory()
+      .withCrn(crn)
+      .withCreatedByUser(user)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(existingApplication)
+    every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .produce()
+
+    val staffUserDetails = StaffUserDetailsFactory()
+      .withUsername(user.deliusUsername)
+      .produce()
+
+    every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
+    every { mockOffenderService.getOffenderByCrn(crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
+    every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
+    every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
+    every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
+
+    every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
+    assertThat(authorisableResult is AuthorisableActionResult.Success)
+    val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
+    assertThat(validatableResult is ValidatableActionResult.Success)
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        any(),
+        "1e3d2ee2-250e-4755-af38-80d24cdc3480",
+        match {
+          it["name"] == user.name &&
+            (it["apName"] as String) == premises.name &&
+            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
+            (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
+            (it["lengthStay"] as Int) == 6 &&
+            (it["lengthStayUnit"] as String) == "days"
+        },
+      )
+    }
+  }
+
+  @Test
+  fun `createApprovedPremisesAdHocBooking uses weeks in Booking length for email when whole number of weeks`() {
+    val crn = "CRN123"
+    val arrivalDate = LocalDate.parse("2023-02-01")
+    val departureDate = LocalDate.parse("2023-02-14")
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+      .addRoleForUnitTest(UserRole.CAS1_MATCHER)
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withUnitTestControlTestProbationAreaAndLocalAuthority()
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val bed = BedEntityFactory()
+      .withRoom(room)
+      .produce()
+
+    every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
+    every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
+    every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+
+    val existingApplication = ApprovedPremisesApplicationEntityFactory()
+      .withCrn(crn)
+      .withCreatedByUser(user)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(existingApplication)
+    every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()
+
+    val offenderDetails = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .produce()
+
+    val staffUserDetails = StaffUserDetailsFactory()
+      .withUsername(user.deliusUsername)
+      .produce()
+
+    every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
+    every { mockOffenderService.getOffenderByCrn(crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
+    every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
+    every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
+    every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
+
+    every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+
+    val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)
+    assertThat(authorisableResult is AuthorisableActionResult.Success)
+    val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
+    assertThat(validatableResult is ValidatableActionResult.Success)
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        any(),
+        "1e3d2ee2-250e-4755-af38-80d24cdc3480",
+        match {
+          it["name"] == user.name &&
+            (it["apName"] as String) == premises.name &&
+            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
+            (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
+            (it["lengthStay"] as Int) == 2 &&
+            (it["lengthStayUnit"] as String) == "weeks"
+        },
+      )
+    }
+  }
+
   @ParameterizedTest
   @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `createApprovedPremisesAdHocBooking saves Booking but does not create Domain Event when associated Application is an Offline Application as Event Number is not present`(role: UserRole) {


### PR DESCRIPTION
**Add variables to existing templates:**

- crn for all templates
- startDate/endDate for Booking Made template

**Add redundant CAS1-only checks around sending emails because copy is AP specific.**

Most of these are at call-sites that can only currently be hit for AP Applications but this will add another layer of protection against future changes to allow CAS2/3 to use these inadvertedly sending AP-specific emails to CAS2/3 users.

**Enable Notify in dev**

Using the `TEST_AND_GUEST_LIST` will send real emails to people on the Notify Guest List (and in the `notify_guest_list_users` table our side) otherwise it will not send.