### PR TITLE
Restrict access to Temporary Accommodation applications by region/role

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -117,6 +117,28 @@ WHERE a.created_by_user_id = :userId
   )
   fun findAllTemporaryAccommodationSummariesCreatedByUser(userId: UUID): List<TemporaryAccommodationApplicationSummary>
 
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt,
+    ass.submitted_at as latestAssessmentSubmittedAt,
+    ass.decision as latestAssessmentDecision,
+    (SELECT COUNT(1) FROM assessment_clarification_notes acn WHERE acn.assessment_id = ass.id AND acn.response IS NULL) > 0 as latestAssessmentHasClarificationNotesWithoutResponse,
+    (SELECT COUNT(1) FROM bookings b WHERE b.application_id = taa.id) > 0 as hasBooking,
+    CAST(taa.risk_ratings AS TEXT) as riskRatings
+FROM temporary_accommodation_applications taa 
+LEFT JOIN applications a ON a.id = taa.id 
+LEFT JOIN assessments ass ON ass.application_id = taa.id AND ass.reallocated_at IS NULL 
+WHERE taa.probation_region_id = :probationRegionId AND a.submitted_at IS NOT NULL
+    """,
+    nativeQuery = true,
+  )
+  fun findAllSubmittedTemporaryAccommodationSummariesByRegion(probationRegionId: UUID): List<TemporaryAccommodationApplicationSummary>
+
   @Query("SELECT DISTINCT(a.crn) FROM ApplicationEntity a")
   fun getDistinctCrns(): List<String>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -84,4 +84,32 @@ class UserAccessService(
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id)
     else -> false
   }
+
+  fun getApprovedPremisesApplicationAccessLevelForCurrentUser(): ApprovedPremisesApplicationAccessLevel =
+    getApprovedPremisesApplicationAccessLevelForUser(userService.getUserForRequest())
+
+  fun getApprovedPremisesApplicationAccessLevelForUser(user: UserEntity): ApprovedPremisesApplicationAccessLevel = when {
+    user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER) -> ApprovedPremisesApplicationAccessLevel.ALL
+    else -> ApprovedPremisesApplicationAccessLevel.TEAM
+  }
+
+  fun getTemporaryAccommodationApplicationAccessLevelForCurrentUser(): TemporaryAccommodationApplicationAccessLevel =
+    getTemporaryAccommodationApplicationAccessLevelForUser(userService.getUserForRequest())
+
+  fun getTemporaryAccommodationApplicationAccessLevelForUser(user: UserEntity): TemporaryAccommodationApplicationAccessLevel = when {
+    user.hasRole(UserRole.CAS3_ASSESSOR) -> TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION
+    user.hasRole(UserRole.CAS3_REFERRER) -> TemporaryAccommodationApplicationAccessLevel.SELF
+    else -> TemporaryAccommodationApplicationAccessLevel.NONE
+  }
+}
+
+enum class ApprovedPremisesApplicationAccessLevel {
+  ALL,
+  TEAM,
+}
+
+enum class TemporaryAccommodationApplicationAccessLevel {
+  SUBMITTED_IN_REGION,
+  SELF,
+  NONE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -114,6 +115,7 @@ class UserAccessService(
 
     return when (application) {
       is ApprovedPremisesApplicationEntity -> userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application)
+      is TemporaryAccommodationApplicationEntity -> userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(user, application)
       else -> false
     }
   }
@@ -132,6 +134,15 @@ class UserAccessService(
     }
 
     return application.hasAnyTeamCode(userDetails.teams?.map { it.code } ?: emptyList())
+  }
+
+  private fun userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(
+    user: UserEntity,
+    application: TemporaryAccommodationApplicationEntity,
+  ): Boolean {
+    return userCanAccessRegion(user, application.probationRegion.id) &&
+      user.hasRole(UserRole.CAS3_ASSESSOR) &&
+      application.submittedAt != null
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -428,7 +428,7 @@ class ApplicationTest : IntegrationTestBase() {
             val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
               withApplicationSchema(applicationSchema)
               withCreatedByUser(otherUser)
-              withSubmittedAt(OffsetDateTime.now())
+              withSubmittedAt(OffsetDateTime.parse("2023-06-01T12:34:56.789+01:00"))
               withCrn(offenderDetails.otherIds.crn)
               withData("{}")
               withProbationRegion(probationRegion)
@@ -446,6 +446,7 @@ class ApplicationTest : IntegrationTestBase() {
             val notInRegionApplication = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
               withApplicationSchema(applicationSchema)
               withCreatedByUser(otherUser)
+              withSubmittedAt(OffsetDateTime.parse("2023-06-01T12:34:56.789+01:00"))
               withCrn(offenderDetails.otherIds.crn)
               withData("{}")
               withYieldedProbationRegion {
@@ -953,7 +954,7 @@ class ApplicationTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(createdByUser)
             withProbationRegion(createdByUser.probationRegion)
-            withSubmittedAt(OffsetDateTime.now())
+            withSubmittedAt(OffsetDateTime.parse("2023-06-01T12:34:56.789+01:00"))
             withData(
               """
               {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1181,8 +1181,31 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Create new application for Temporary Accommodation returns 403 Forbidden when user doesn't have CAS3_REFERRER role`() {
+    `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        webTestClient.post()
+          .uri("/applications")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .bodyValue(
+            NewApplication(
+              crn = offenderDetails.otherIds.crn,
+              convictionId = 123,
+              deliusEventNumber = "1",
+              offenceId = "789",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+  }
+
+  @Test
   fun `Create new application for Temporary Accommodation returns 201 with correct body and Location header`() {
-    `Given a User` { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS3_REFERRER)) { _, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
           withAddedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAProbationRegion.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAProbationRegion.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import java.util.UUID
+
+fun IntegrationTestBase.`Given a Probation Region`(
+  id: UUID = UUID.randomUUID(),
+  name: String? = null,
+  apArea: ApAreaEntity? = null,
+  deliusCode: String? = null,
+  block: (probationRegion: ProbationRegionEntity) -> Unit,
+) {
+  val probationRegion = probationRegionEntityFactory.produceAndPersist {
+    withId(id)
+    if (name != null) {
+      withName(name)
+    }
+    if (apArea != null) {
+      withApArea(apArea)
+    } else {
+      withYieldedApArea {
+        apAreaEntityFactory.produceAndPersist()
+      }
+    }
+    if (deliusCode != null) {
+      withDeliusCode(deliusCode)
+    }
+  }
+
+  block(probationRegion)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -69,11 +69,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Mana
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApprovedPremisesApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.sql.Timestamp
 import java.time.Instant
@@ -94,6 +96,7 @@ class ApplicationServiceTest {
   private val mockCommunityApiClient = mockk<CommunityApiClient>()
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockApplicationTeamCodeRepository = mockk<ApplicationTeamCodeRepository>()
+  private val mockUserAccessService = mockk<UserAccessService>()
   private val mockEmailNotificationService = mockk<EmailNotificationService>()
   private val mockObjectMapper = mockk<ObjectMapper>()
 
@@ -110,6 +113,7 @@ class ApplicationServiceTest {
     mockApDeliusContextApiClient,
     mockApplicationTeamCodeRepository,
     mockEmailNotificationService,
+    mockUserAccessService,
     NotifyConfig(),
     mockObjectMapper,
     "http://frontend/applications/#id",
@@ -174,6 +178,7 @@ class ApplicationServiceTest {
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
+    every { mockUserAccessService.getApprovedPremisesApplicationAccessLevelForUser(userEntity) } returns ApprovedPremisesApplicationAccessLevel.TEAM
     every { mockApplicationRepository.findApprovedPremisesSummariesForManagingTeams(listOf("TEAM1")) } returns applicationSummaries
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -15,6 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApprovedPremisesApplicationAccessLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TemporaryAccommodationApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
@@ -501,5 +503,69 @@ class UserAccessServiceTest {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
+  fun `getApprovedPremisesApplicationAccessLevelForUser returns ALL if the user has one of the CAS1_WORKFLOW_MANAGER, CAS1_ASSESSOR, CAS1_MATCHER, or CAS1_MANAGER roles`(role: UserRole) {
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForUser(user)).isEqualTo(ApprovedPremisesApplicationAccessLevel.ALL)
+  }
+
+  @Test
+  fun `getApprovedPremisesApplicationAccessLevelForUser returns TEAM if the user has no suitable role`() {
+    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForUser(user)).isEqualTo(ApprovedPremisesApplicationAccessLevel.TEAM)
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
+  fun `getApprovedPremisesApplicationAccessLevelForCurrentUser returns ALL if the user has one of the CAS1_WORKFLOW_MANAGER, CAS1_ASSESSOR, CAS1_MATCHER, or CAS1_MANAGER roles`(role: UserRole) {
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForCurrentUser()).isEqualTo(ApprovedPremisesApplicationAccessLevel.ALL)
+  }
+
+  @Test
+  fun `getApprovedPremisesApplicationAccessLevelForCurrentUser returns TEAM if the user has no suitable role`() {
+    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForCurrentUser()).isEqualTo(ApprovedPremisesApplicationAccessLevel.TEAM)
+  }
+
+  @Test
+  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns SUBMITTED_IN_REGION if the user has the CAS3_ASSESSOR role`() {
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION)
+  }
+
+  @Test
+  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns SELF if the user has the CAS3_REFERRER role`() {
+    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
+
+    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SELF)
+  }
+
+  @Test
+  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns NONE if the user has no suitable role`() {
+    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.NONE)
+  }
+
+  @Test
+  fun `getTemporaryAccommodationApplicationAccessLevelForCurrentUser returns SUBMITTED_IN_REGION if the user has the CAS3_ASSESSOR role`() {
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForCurrentUser()).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION)
+  }
+
+  @Test
+  fun `getTemporaryAccommodationApplicationAccessLevelForCurrentUser returns SELF if the user has the CAS3_REFERRER role`() {
+    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
+
+    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForCurrentUser()).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SELF)
+  }
+
+  @Test
+  fun `getTemporaryAccommodationApplicationAccessLevelForCurrentUser returns NONE if the user has no suitable role`() {
+    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForCurrentUser()).isEqualTo(TemporaryAccommodationApplicationAccessLevel.NONE)
   }
 }


### PR DESCRIPTION
> See [ticket #1106 on the CAS3 Trello board](https://trello.com/c/rQD1dKfI/1106-a-user-cannot-create-edit-submit-a-temporary-accommodation-application-for-a-crn-that-is-not-in-the-users-region).

This PR is the fourth part of the work to introduce user roles to the Temporary Accommodation service. It implements restrictions for viewing and manipulating applications based on the user's role and probation region.

Specifically, it introduces the following restrictions:
- A request to the `POST /applications` endpoint to create a new Temporary Accommodation application can only be performed by a user with the `CAS3_REFERRER` role.
- A request to the `GET /applications` endpoint to list Temporary Accommodation applications will:
  - For a user with the `CAS3_ASSESSOR` role, list all submitted applications in their region.
  - For a user with the `CAS3_REFERRER` role, list all applications created by them, regardless of their state.
  - Return an empty list otherwise.
- A request to the `GET /applications/{applicationId}` endpoint to get a specific application will:
  - For a user with the `CAS3_ASSESSOR` role, return a `200 OK` response with the application information if it has been submitted and exists in their region.
  - For any other user, return a `200 OK` response if they are the creator of the application.
  - Return a `403 Forbidden` response otherwise.

The API already restricts updating or submitting an application to only allow the creator to perform those actions, so no additional work is required for those endpoints.