### PR TITLE
Set Withdrawn by Approved Premises to inactive

### DIFF
--- a/src/main/resources/db/migration/all/20230614133851__remove_cancellation_reason.sql
+++ b/src/main/resources/db/migration/all/20230614133851__remove_cancellation_reason.sql
@@ -1,0 +1,1 @@
+UPDATE cancellation_reasons SET is_active = false WHERE name = 'Withdrawn by Approved Premises';


### PR DESCRIPTION
This is no longer needed. For safety’s sake, we’ll set this to inactive