### PR TITLE
Correct recipient of deallocated emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -505,10 +505,10 @@ class AssessmentService(
       )
 
       emailNotificationService.sendEmail(
-        user = assigneeUser,
+        user = currentAssessment.allocatedToUser,
         templateId = notifyConfig.templates.assessmentDeallocated,
         personalisation = mapOf(
-          "name" to assigneeUser.name,
+          "name" to currentAssessment.allocatedToUser.name,
           "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
           "crn" to application.crn,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1248,7 +1248,7 @@ class AssessmentServiceTest {
     verify { assessmentRepositoryMock.save(match { it.allocatedToUser == assigneeUser }) }
     verify(exactly = 1) {
       emailNotificationServiceMock.sendEmail(
-        any(),
+        match { it.id == assigneeUser.id },
         "f3d78814-383f-4b5f-a681-9bd3ab912888",
         match {
           it["name"] == assigneeUser.name &&
@@ -1258,10 +1258,10 @@ class AssessmentServiceTest {
     }
     verify(exactly = 1) {
       emailNotificationServiceMock.sendEmail(
-        any(),
+        match { it.id == previousAssessment.allocatedToUser.id },
         "331ce452-ea83-4f0c-aec0-5eafe85094f2",
         match {
-          it["name"] == assigneeUser.name &&
+          it["name"] == previousAssessment.allocatedToUser.name &&
             (it["assessmentUrl"] as String).matches(Regex("http://frontend/assessments/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
         },
       )


### PR DESCRIPTION
These should go to the person from whom the Assessment was deallocated, not the new assignee