### PR TITLE
Fix missing role on 'temporary-accommodation-e2e-tester' user

### DIFF
--- a/src/main/resources/db/seed/dev+test/user.csv
+++ b/src/main/resources/db/seed/dev+test/user.csv
@@ -1,4 +1,4 @@
 deliusUsername,roles,qualifications
-temporary-accommodation-training-1,CAS3_REFERRER,
-temporary-accommodation-training-2,CAS3_ASSESSOR,
-temporary-accommodation-e2e-tester,CAS3_ASSESSOR,
+temporary-accommodation-training-1,"CAS3_REFERRER",""
+temporary-accommodation-training-2,"CAS3_ASSESSOR",""
+temporary-accommodation-e2e-tester,"CAS3_ASSESSOR,CAS3_REFERRER",""


### PR DESCRIPTION
Without the `CAS3_REFERRER` role, the E2E tests for creating an application will fail due to the `403 Forbidden` response.