### PR TITLE
Add bed and room name to lost bed response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
@@ -20,6 +20,8 @@ class LostBedsTransformer(
     status = determineStatus(jpa),
     cancellation = jpa.cancellation?.let { lostBedCancellationTransformer.transformJpaToApi(it) },
     bedId = jpa.bed.id,
+    bedName = jpa.bed.name,
+    roomName = jpa.bed.room.name,
   )
 
   private fun determineStatus(jpa: LostBedsEntity) = when {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3948,6 +3948,10 @@ components:
         bedId:
           type: string
           format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
         reason:
           $ref: '#/components/schemas/LostBedReason'
         referenceNumber:
@@ -3965,6 +3969,8 @@ components:
         - startDate
         - endDate
         - bedId
+        - bedName
+        - roomName
         - reason
         - status
     NewLostBed:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/LostBedsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/LostBedsTransformerTest.kt
@@ -27,40 +27,40 @@ class LostBedsTransformerTest {
 
   private val lostBedsTransformer = LostBedsTransformer(lostBedReasonTransformer, lostBedCancellationTransformer)
 
+  val premises = TemporaryAccommodationPremisesEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea {
+          ApAreaEntityFactory()
+            .produce()
+        }
+        .produce()
+    }
+    .withYieldedLocalAuthorityArea {
+      LocalAuthorityEntityFactory()
+        .produce()
+    }
+    .produce()
+
+  val room = RoomEntityFactory()
+    .withYieldedPremises { premises }
+    .produce()
+
+  val bed = BedEntityFactory()
+    .withYieldedRoom { room }
+    .produce()
+
+  private val lostBed = LostBedsEntityFactory()
+    .withYieldedReason {
+      LostBedReasonEntityFactory()
+        .produce()
+    }
+    .withYieldedPremises { premises }
+    .withYieldedBed { bed }
+    .produce()
+
   @Test
   fun `Lost Bed entity is correctly transformed`() {
-    val premises = TemporaryAccommodationPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea {
-            ApAreaEntityFactory()
-              .produce()
-          }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea {
-        LocalAuthorityEntityFactory()
-          .produce()
-      }
-      .produce()
-
-    val lostBed = LostBedsEntityFactory()
-      .withYieldedReason {
-        LostBedReasonEntityFactory()
-          .produce()
-      }
-      .withYieldedPremises { premises }
-      .withYieldedBed {
-        BedEntityFactory()
-          .withYieldedRoom {
-            RoomEntityFactory()
-              .withYieldedPremises { premises }
-              .produce()
-          }
-          .produce()
-      }
-      .produce()
-
     every { lostBedReasonTransformer.transformJpaToApi(lostBed.reason) } returns LostBedReason(
       id = lostBed.reason.id,
       name = lostBed.reason.name,
@@ -78,43 +78,13 @@ class LostBedsTransformerTest {
     assertThat(result.referenceNumber).isEqualTo(lostBed.referenceNumber)
     assertThat(result.status).isEqualTo(LostBedStatus.active)
     assertThat(result.cancellation).isNull()
-    assertThat(result.bedId).isEqualTo(lostBed.bed.id)
+    assertThat(result.bedId).isEqualTo(bed.id)
+    assertThat(result.bedName).isEqualTo(bed.name)
+    assertThat(result.roomName).isEqualTo(room.name)
   }
 
   @Test
   fun `A cancelled lost bed entity is correctly transformed`() {
-    val premises = TemporaryAccommodationPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea {
-            ApAreaEntityFactory()
-              .produce()
-          }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea {
-        LocalAuthorityEntityFactory()
-          .produce()
-      }
-      .produce()
-
-    val lostBed = LostBedsEntityFactory()
-      .withYieldedReason {
-        LostBedReasonEntityFactory()
-          .produce()
-      }
-      .withYieldedPremises { premises }
-      .withYieldedBed {
-        BedEntityFactory()
-          .withYieldedRoom {
-            RoomEntityFactory()
-              .withYieldedPremises { premises }
-              .produce()
-          }
-          .produce()
-      }
-      .produce()
-
     val lostBedCancellation = LostBedCancellationEntityFactory()
       .withYieldedLostBed { lostBed }
       .produce()
@@ -148,6 +118,8 @@ class LostBedsTransformerTest {
     assertThat(result.cancellation!!.id).isEqualTo(lostBed.cancellation!!.id)
     assertThat(result.cancellation!!.createdAt).isEqualTo(now)
     assertThat(result.cancellation!!.notes).isEqualTo("Some notes")
-    assertThat(result.bedId).isEqualTo(lostBed.bed.id)
+    assertThat(result.bedId).isEqualTo(bed.id)
+    assertThat(result.bedName).isEqualTo(bed.name)
+    assertThat(result.roomName).isEqualTo(room.name)
   }
 }


### PR DESCRIPTION
This adds a couple of extra attributes to the API response for lost beds.