### PR TITLE
(214) Return cancellations when requesting a placement request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -13,7 +14,17 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
-interface CancellationRepository : JpaRepository<CancellationEntity, UUID>
+interface CancellationRepository : JpaRepository<CancellationEntity, UUID> {
+
+  @Query(
+    """
+      select c from CancellationEntity c WHERE c.booking.id IN (
+        select id from BookingEntity b where b.application.id = :applicationId
+      )
+    """,
+  )
+  fun getCancellationsForApplicationId(applicationId: UUID): List<CancellationEntity>
+}
 
 @Entity
 @Table(name = "cancellations")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationTransformer.kt
@@ -14,6 +14,7 @@ class CancellationTransformer(private val cancellationReasonTransformer: Cancell
       reason = cancellationReasonTransformer.transformJpaToApi(jpa.reason),
       notes = jpa.notes,
       createdAt = jpa.createdAt.toInstant(),
+      premisesName = jpa.booking.premises.name,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+
+@Component
+class PlacementRequestDetailTransformer(
+  private val placementRequestTransformer: PlacementRequestTransformer,
+  private val cancellationTransformer: CancellationTransformer,
+) {
+  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail, cancellations: List<CancellationEntity>): PlacementRequestDetail {
+    val placementRequest = placementRequestTransformer.transformJpaToApi(jpa, offenderDetailSummary, inmateDetail)
+
+    return PlacementRequestDetail(
+      id = placementRequest.id,
+      gender = placementRequest.gender,
+      type = placementRequest.type,
+      expectedArrival = placementRequest.expectedArrival,
+      duration = placementRequest.duration,
+      location = placementRequest.location,
+      radius = placementRequest.radius,
+      essentialCriteria = placementRequest.essentialCriteria,
+      desirableCriteria = placementRequest.desirableCriteria,
+      person = placementRequest.person,
+      risks = placementRequest.risks,
+      applicationId = placementRequest.applicationId,
+      assessmentId = placementRequest.assessmentId,
+      releaseType = placementRequest.releaseType,
+      status = placementRequest.status,
+      assessmentDecision = placementRequest.assessmentDecision,
+      assessmentDate = placementRequest.assessmentDate,
+      assessor = placementRequest.assessor,
+      notes = placementRequest.notes,
+      cancellations = cancellations.mapNotNull { cancellationTransformer.transformJpaToApi(it) },
+    )
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5668,6 +5668,17 @@ components:
             - assessmentDecision
             - assessmentDate
             - assessor
+    PlacementRequestDetail:
+      allOf:
+        - $ref: '#/components/schemas/PlacementRequest'
+        - type: object
+          properties:
+            cancellations:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cancellation'
+          required:
+            - cancellations
     PlacementRequestStatus:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3753,11 +3753,14 @@ components:
         createdAt:
           type: string
           format: date-time
+        premisesName:
+          type: string
       required:
         - bookingId
         - date
         - reason
         - createdAt
+        - premisesName
     Extension:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2359,7 +2359,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/PlacementRequest'
+                $ref: '#/components/schemas/PlacementRequestDetail'
         401:
           $ref: '#/components/responses/401Response'
         403:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CancellationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CancellationQueryTest.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
+
+class CancellationQueryTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realCancellationRepository: CancellationRepository
+
+  @Test
+  fun `Get cancellations for application returns all the relevant cancellations`() {
+    `Given a User` { user, _ ->
+      `Given an Application`(createdByUser = user) { application ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(
+            probationRegionEntityFactory.produceAndPersist {
+              withApArea(apAreaEntityFactory.produceAndPersist())
+            },
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val cancellationsForApplication = listOf(
+          cancellationEntityFactory.produceAndPersist {
+            withBooking(
+              bookingEntityFactory.produceAndPersist {
+                withApplication(application)
+                withPremises(premises)
+              },
+            )
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          },
+          cancellationEntityFactory.produceAndPersist {
+            withBooking(
+              bookingEntityFactory.produceAndPersist {
+                withApplication(application)
+                withPremises(premises)
+              },
+            )
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          },
+        )
+
+        val otherCancellations = listOf(
+          cancellationEntityFactory.produceAndPersist {
+            withBooking(
+              bookingEntityFactory.produceAndPersist {
+                withPremises(premises)
+              },
+            )
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          },
+          cancellationEntityFactory.produceAndPersist {
+            withBooking(
+              bookingEntityFactory.produceAndPersist {
+                withPremises(premises)
+              },
+            )
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          },
+        )
+
+        val result = realCancellationRepository.getCancellationsForApplicationId(application.id)
+
+        assertThat(result).isEqualTo(cancellationsForApplication)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBookingNotMade
@@ -9,7 +10,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingNotMadeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -20,171 +20,174 @@ class PlacementRequestsTest : IntegrationTestBase() {
   @Autowired
   lateinit var placementRequestTransformer: PlacementRequestTransformer
 
-  @Autowired
-  lateinit var bookingNotMadeTransformer: BookingNotMadeTransformer
+  @Nested
+  inner class AllPlacementRequests {
+    @Test
+    fun `Get all placement requests without JWT returns 401`() {
+      webTestClient.get()
+        .uri("/placement-requests")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
 
-  @Test
-  fun `Get all placement requests without JWT returns 401`() {
-    webTestClient.get()
-      .uri("/placement-requests")
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
+    @Test
+    fun `It returns all the placement requests for a user`() {
+      `Given a User` { user, jwt ->
+        `Given an Offender` { offenderDetails1, inmateDetails1 ->
+          `Given an Offender` { offenderDetails2, _ ->
+            val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withPermissiveSchema()
+            }
 
-  @Test
-  fun `It returns all the placement requests for a user`() {
-    `Given a User` { user, jwt ->
-      `Given an Offender` { offenderDetails1, inmateDetails1 ->
-        `Given an Offender` { offenderDetails2, _ ->
-          val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
-            withPermissiveSchema()
-          }
+            val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+              withPermissiveSchema()
+            }
 
-          val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
-            withPermissiveSchema()
-          }
+            val application1 = approvedPremisesApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails1.otherIds.crn)
+              withCreatedByUser(user)
+              withApplicationSchema(applicationSchema)
+              withReleaseType("licence")
+            }
 
-          val application1 = approvedPremisesApplicationEntityFactory.produceAndPersist {
-            withCrn(offenderDetails1.otherIds.crn)
-            withCreatedByUser(user)
-            withApplicationSchema(applicationSchema)
-            withReleaseType("licence")
-          }
+            val assessment1 = assessmentEntityFactory.produceAndPersist {
+              withAssessmentSchema(assessmentSchema)
+              withApplication(application1)
+              withSubmittedAt(OffsetDateTime.now())
+              withAllocatedToUser(user)
+              withDecision(AssessmentDecision.ACCEPTED)
+            }
 
-          val assessment1 = assessmentEntityFactory.produceAndPersist {
-            withAssessmentSchema(assessmentSchema)
-            withApplication(application1)
-            withSubmittedAt(OffsetDateTime.now())
-            withAllocatedToUser(user)
-            withDecision(AssessmentDecision.ACCEPTED)
-          }
+            val application2 = approvedPremisesApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails2.otherIds.crn)
+              withCreatedByUser(user)
+              withApplicationSchema(applicationSchema)
+              withReleaseType("licence")
+            }
 
-          val application2 = approvedPremisesApplicationEntityFactory.produceAndPersist {
-            withCrn(offenderDetails2.otherIds.crn)
-            withCreatedByUser(user)
-            withApplicationSchema(applicationSchema)
-            withReleaseType("licence")
-          }
+            val assessment2 = assessmentEntityFactory.produceAndPersist {
+              withAssessmentSchema(assessmentSchema)
+              withApplication(application2)
+              withSubmittedAt(OffsetDateTime.now())
+              withAllocatedToUser(user)
+              withDecision(AssessmentDecision.ACCEPTED)
+            }
 
-          val assessment2 = assessmentEntityFactory.produceAndPersist {
-            withAssessmentSchema(assessmentSchema)
-            withApplication(application2)
-            withSubmittedAt(OffsetDateTime.now())
-            withAllocatedToUser(user)
-            withDecision(AssessmentDecision.ACCEPTED)
-          }
+            val placementRequirements = placementRequirementsFactory.produceAndPersist {
+              withApplication(application1)
+              withAssessment(assessment1)
+              withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
+              withDesirableCriteria(
+                characteristicEntityFactory.produceAndPersistMultiple(5),
+              )
+              withEssentialCriteria(
+                characteristicEntityFactory.produceAndPersistMultiple(3),
+              )
+            }
 
-          val placementRequirements = placementRequirementsFactory.produceAndPersist {
-            withApplication(application1)
-            withAssessment(assessment1)
-            withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
-            withDesirableCriteria(
-              characteristicEntityFactory.produceAndPersistMultiple(5),
-            )
-            withEssentialCriteria(
-              characteristicEntityFactory.produceAndPersistMultiple(3),
-            )
-          }
+            val postcodeDistrict = postCodeDistrictRepository.findAll()[0]
 
-          val postcodeDistrict = postCodeDistrictRepository.findAll()[0]
+            val placementRequest = placementRequestFactory.produceAndPersist {
+              withAllocatedToUser(user)
+              withApplication(application1)
+              withAssessment(assessment1)
+              withPlacementRequirements(placementRequirements)
+            }
 
-          val placementRequest = placementRequestFactory.produceAndPersist {
-            withAllocatedToUser(user)
-            withApplication(application1)
-            withAssessment(assessment1)
-            withPlacementRequirements(placementRequirements)
-          }
+            placementRequestFactory.produceAndPersistMultiple(2) {
+              withAllocatedToUser(user)
+              withReallocatedAt(OffsetDateTime.now())
+              withApplication(application2)
+              withAssessment(assessment2)
+              withPlacementRequirements(placementRequirements)
+            }
 
-          placementRequestFactory.produceAndPersistMultiple(2) {
-            withAllocatedToUser(user)
-            withReallocatedAt(OffsetDateTime.now())
-            withApplication(application2)
-            withAssessment(assessment2)
-            withPlacementRequirements(placementRequirements)
-          }
-
-          webTestClient.get()
-            .uri("/placement-requests")
-            .header("Authorization", "Bearer $jwt")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .json(
-              objectMapper.writeValueAsString(
-                listOf(
-                  placementRequestTransformer.transformJpaToApi(placementRequest, offenderDetails1, inmateDetails1),
+            webTestClient.get()
+              .uri("/placement-requests")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    placementRequestTransformer.transformJpaToApi(placementRequest, offenderDetails1, inmateDetails1),
+                  ),
                 ),
-              ),
-            )
-        }
-      }
-    }
-  }
-
-  @Test
-  fun `Get single Placement Request without a JWT returns 401`() {
-    webTestClient.get()
-      .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f")
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
-
-  @Test
-  fun `Get single Placement Request that is not allocated to calling User and without WORKFLOW_MANAGER role returns 403`() {
-    `Given a User` { user, jwt ->
-      `Given a User` { otherUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Application`(createdByUser = otherUser) {
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = otherUser,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            ) { placementRequest, _ ->
-              webTestClient.get()
-                .uri("/placement-requests/${placementRequest.id}")
-                .header("Authorization", "Bearer $jwt")
-                .exchange()
-                .expectStatus()
-                .isForbidden
-            }
+              )
           }
         }
       }
     }
   }
 
-  @Test
-  fun `Get single Placement Request that is allocated to calling User returns 200`() {
-    `Given a User` { user, jwt ->
-      `Given a User` { otherUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Application`(createdByUser = otherUser) {
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            ) { placementRequest, _ ->
-              webTestClient.get()
-                .uri("/placement-requests/${placementRequest.id}")
-                .header("Authorization", "Bearer $jwt")
-                .exchange()
-                .expectStatus()
-                .isOk
-                .expectBody()
-                .json(
-                  objectMapper.writeValueAsString(
-                    placementRequestTransformer.transformJpaToApi(
-                      placementRequest,
-                      offenderDetails,
-                      inmateDetails,
+  @Nested
+  inner class SinglePlacementRequest {
+    @Test
+    fun `Get single Placement Request without a JWT returns 401`() {
+      webTestClient.get()
+        .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get single Placement Request that is not allocated to calling User and without WORKFLOW_MANAGER role returns 403`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                webTestClient.get()
+                  .uri("/placement-requests/${placementRequest.id}")
+                  .header("Authorization", "Bearer $jwt")
+                  .exchange()
+                  .expectStatus()
+                  .isForbidden
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get single Placement Request that is allocated to calling User returns 200`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = user,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                webTestClient.get()
+                  .uri("/placement-requests/${placementRequest.id}")
+                  .header("Authorization", "Bearer $jwt")
+                  .exchange()
+                  .expectStatus()
+                  .isOk
+                  .expectBody()
+                  .json(
+                    objectMapper.writeValueAsString(
+                      placementRequestTransformer.transformJpaToApi(
+                        placementRequest,
+                        offenderDetails,
+                        inmateDetails,
+                      ),
                     ),
-                  ),
-                )
+                  )
+              }
             }
           }
         }
@@ -192,94 +195,97 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Create a Booking from a Placement Request without a JWT returns 401`() {
-    webTestClient.post()
-      .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f/booking")
-      .bodyValue(
-        NewPlacementRequestBooking(
-          arrivalDate = LocalDate.parse("2023-03-29"),
-          departureDate = LocalDate.parse("2023-04-01"),
-          bedId = UUID.fromString("d5dfd808-b8f4-4cc0-a0ac-fdce7144126e"),
-        ),
-      )
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
+  @Nested
+  inner class CreateBookingFromPlacementRequest {
+    @Test
+    fun `Create a Booking from a Placement Request without a JWT returns 401`() {
+      webTestClient.post()
+        .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f/booking")
+        .bodyValue(
+          NewPlacementRequestBooking(
+            arrivalDate = LocalDate.parse("2023-03-29"),
+            departureDate = LocalDate.parse("2023-04-01"),
+            bedId = UUID.fromString("d5dfd808-b8f4-4cc0-a0ac-fdce7144126e"),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
 
-  @Test
-  fun `Creating a Booking from a Placement Request that is not allocated to the User returns a 403`() {
-    `Given a User` { user, jwt ->
-      `Given a User` { otherUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Application`(createdByUser = otherUser) {
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = otherUser,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            ) { placementRequest, _ ->
-              webTestClient.post()
-                .uri("/placement-requests/${placementRequest.id}/booking")
-                .header("Authorization", "Bearer $jwt")
-                .bodyValue(
-                  NewPlacementRequestBooking(
-                    arrivalDate = LocalDate.parse("2023-03-29"),
-                    departureDate = LocalDate.parse("2023-04-01"),
-                    bedId = UUID.fromString("d5dfd808-b8f4-4cc0-a0ac-fdce7144126e"),
-                  ),
-                )
-                .exchange()
-                .expectStatus()
-                .isForbidden
+    @Test
+    fun `Creating a Booking from a Placement Request that is not allocated to the User returns a 403`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                webTestClient.post()
+                  .uri("/placement-requests/${placementRequest.id}/booking")
+                  .header("Authorization", "Bearer $jwt")
+                  .bodyValue(
+                    NewPlacementRequestBooking(
+                      arrivalDate = LocalDate.parse("2023-03-29"),
+                      departureDate = LocalDate.parse("2023-04-01"),
+                      bedId = UUID.fromString("d5dfd808-b8f4-4cc0-a0ac-fdce7144126e"),
+                    ),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isForbidden
+              }
             }
           }
         }
       }
     }
-  }
 
-  @Test
-  fun `Creating a Booking from a Placement Request that is allocated to the User returns a 200`() {
-    `Given a User` { user, jwt ->
-      `Given a User` { otherUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Application`(createdByUser = otherUser) {
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            ) { placementRequest, _ ->
-              val premises = approvedPremisesEntityFactory.produceAndPersist {
-                withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                withYieldedProbationRegion {
-                  probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    @Test
+    fun `Creating a Booking from a Placement Request that is allocated to the User returns a 200`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = user,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                val premises = approvedPremisesEntityFactory.produceAndPersist {
+                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+                  withYieldedProbationRegion {
+                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                  }
                 }
-              }
 
-              val room = roomEntityFactory.produceAndPersist {
-                withPremises(premises)
-              }
+                val room = roomEntityFactory.produceAndPersist {
+                  withPremises(premises)
+                }
 
-              val bed = bedEntityFactory.produceAndPersist {
-                withRoom(room)
-              }
+                val bed = bedEntityFactory.produceAndPersist {
+                  withRoom(room)
+                }
 
-              webTestClient.post()
-                .uri("/placement-requests/${placementRequest.id}/booking")
-                .header("Authorization", "Bearer $jwt")
-                .bodyValue(
-                  NewPlacementRequestBooking(
-                    arrivalDate = LocalDate.parse("2023-03-29"),
-                    departureDate = LocalDate.parse("2023-04-01"),
-                    bedId = bed.id,
-                  ),
-                )
-                .exchange()
-                .expectStatus()
-                .isOk
+                webTestClient.post()
+                  .uri("/placement-requests/${placementRequest.id}/booking")
+                  .header("Authorization", "Bearer $jwt")
+                  .bodyValue(
+                    NewPlacementRequestBooking(
+                      arrivalDate = LocalDate.parse("2023-03-29"),
+                      departureDate = LocalDate.parse("2023-04-01"),
+                      bedId = bed.id,
+                    ),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isOk
+              }
             }
           }
         }
@@ -287,76 +293,79 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Create a Booking Not Made from a Placement Request without a JWT returns 401`() {
-    webTestClient.post()
-      .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f/booking-not-made")
-      .bodyValue(
-        NewBookingNotMade(
-          notes = "some notes",
-        ),
-      )
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
+  @Nested
+  inner class CreateBookingNotMadeFromPlacementRequest {
+    @Test
+    fun `Create a Booking Not Made from a Placement Request without a JWT returns 401`() {
+      webTestClient.post()
+        .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f/booking-not-made")
+        .bodyValue(
+          NewBookingNotMade(
+            notes = "some notes",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
 
-  @Test
-  fun `Create a Booking Not Made from a Placement Request that is not allocated to the user returns 403`() {
-    `Given a User` { user, jwt ->
-      `Given a User` { otherUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Application`(createdByUser = otherUser) {
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = otherUser,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            ) { placementRequest, _ ->
-              webTestClient.post()
-                .uri("/placement-requests/${placementRequest.id}/booking-not-made")
-                .header("Authorization", "Bearer $jwt")
-                .bodyValue(
-                  NewBookingNotMade(
-                    notes = "some notes",
-                  ),
-                )
-                .exchange()
-                .expectStatus()
-                .isForbidden
+    @Test
+    fun `Create a Booking Not Made from a Placement Request that is not allocated to the user returns 403`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                webTestClient.post()
+                  .uri("/placement-requests/${placementRequest.id}/booking-not-made")
+                  .header("Authorization", "Bearer $jwt")
+                  .bodyValue(
+                    NewBookingNotMade(
+                      notes = "some notes",
+                    ),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isForbidden
+              }
             }
           }
         }
       }
     }
-  }
 
-  @Test
-  fun `Create a Booking Not Made from a Placement Request returns 200`() {
-    `Given a User` { user, jwt ->
-      `Given a User` { otherUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          `Given an Application`(createdByUser = otherUser) {
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            ) { placementRequest, _ ->
-              webTestClient.post()
-                .uri("/placement-requests/${placementRequest.id}/booking-not-made")
-                .header("Authorization", "Bearer $jwt")
-                .bodyValue(
-                  NewBookingNotMade(
-                    notes = "some notes",
-                  ),
-                )
-                .exchange()
-                .expectStatus()
-                .isOk
-                .expectBody()
-                .jsonPath("$.placementRequestId").isEqualTo(placementRequest.id.toString())
-                .jsonPath("$.notes").isEqualTo("some notes")
+    @Test
+    fun `Create a Booking Not Made from a Placement Request returns 200`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = user,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                webTestClient.post()
+                  .uri("/placement-requests/${placementRequest.id}/booking-not-made")
+                  .header("Authorization", "Bearer $jwt")
+                  .bodyValue(
+                    NewBookingNotMade(
+                      notes = "some notes",
+                    ),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isOk
+                  .expectBody()
+                  .jsonPath("$.placementRequestId").isEqualTo(placementRequest.id.toString())
+                  .jsonPath("$.notes").isEqualTo("some notes")
+              }
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -434,6 +434,7 @@ class BookingTransformerTest {
       date = LocalDate.parse("2022-08-10"),
       reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+      premisesName = premisesEntity.name,
     )
 
     val transformedBooking = bookingTransformer.transformJpaToApi(cancellationBooking, offenderDetails, inmateDetail, null)
@@ -463,6 +464,7 @@ class BookingTransformerTest {
           reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+          premisesName = premisesEntity.name,
         ),
         extensions = listOf(),
         serviceName = ServiceName.approvedPremises,
@@ -477,6 +479,7 @@ class BookingTransformerTest {
             reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
             notes = null,
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+            premisesName = premisesEntity.name,
           ),
         ),
         turnarounds = listOf(),
@@ -519,6 +522,7 @@ class BookingTransformerTest {
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+          premisesName = premisesEntity.name,
         )
         UUID.fromString("d34415c3-d128-45a0-9950-b84491ab8d11") -> Cancellation(
           bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
@@ -526,6 +530,7 @@ class BookingTransformerTest {
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReason(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
           createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
+          premisesName = premisesEntity.name,
         )
         else -> null
       }
@@ -558,6 +563,7 @@ class BookingTransformerTest {
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReason(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
           createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
+          premisesName = premisesEntity.name,
         ),
         extensions = listOf(),
         serviceName = ServiceName.temporaryAccommodation,
@@ -572,6 +578,7 @@ class BookingTransformerTest {
             date = LocalDate.parse("2022-08-10"),
             reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
             createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
+            premisesName = premisesEntity.name,
           ),
           Cancellation(
             bookingId = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
@@ -579,6 +586,7 @@ class BookingTransformerTest {
             date = LocalDate.parse("2022-08-10"),
             reason = CancellationReason(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
             createdAt = Instant.parse("2022-07-02T12:34:56.789Z"),
+            premisesName = premisesEntity.name,
           ),
         ),
         turnarounds = listOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
@@ -1,0 +1,156 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import java.time.OffsetDateTime
+
+class PlacementRequestDetailTransformerTest {
+  private val mockPlacementRequestTransformer = mockk<PlacementRequestTransformer>()
+  private val mockCancellationTransformer = mockk<CancellationTransformer>()
+
+  private val placementRequestDetailTransformer = PlacementRequestDetailTransformer(
+    mockPlacementRequestTransformer,
+    mockCancellationTransformer,
+  )
+
+  private val mockCancellation = mockk<Cancellation>()
+
+  private val mockPlacementRequestEntity = mockk<PlacementRequestEntity>()
+  private val mockOffenderDetailSummary = mockk<OffenderDetailSummary>()
+  private val mockInmateDetail = mockk<InmateDetail>()
+  private val mockCancellationEntities = listOf(
+    mockk<CancellationEntity>(),
+    mockk<CancellationEntity>(),
+  )
+
+  private val transformedPlacementRequest = getTransformedPlacementRequest()
+
+  @BeforeEach
+  fun setup() {
+    every { mockCancellationTransformer.transformJpaToApi(any<CancellationEntity>()) } returns mockCancellation
+    every { mockPlacementRequestTransformer.transformJpaToApi(mockPlacementRequestEntity, mockOffenderDetailSummary, mockInmateDetail) } returns transformedPlacementRequest
+  }
+
+  @Test
+  fun `it returns a PlacementRequestDetail object`() {
+    val result = placementRequestDetailTransformer.transformJpaToApi(mockPlacementRequestEntity, mockOffenderDetailSummary, mockInmateDetail, mockCancellationEntities)
+
+    assertThat(result.id).isEqualTo(transformedPlacementRequest.id)
+    assertThat(result.gender).isEqualTo(transformedPlacementRequest.gender)
+    assertThat(result.type).isEqualTo(transformedPlacementRequest.type)
+    assertThat(result.expectedArrival).isEqualTo(transformedPlacementRequest.expectedArrival)
+    assertThat(result.duration).isEqualTo(transformedPlacementRequest.duration)
+    assertThat(result.location).isEqualTo(transformedPlacementRequest.location)
+    assertThat(result.radius).isEqualTo(transformedPlacementRequest.radius)
+    assertThat(result.essentialCriteria).isEqualTo(transformedPlacementRequest.essentialCriteria)
+    assertThat(result.desirableCriteria).isEqualTo(transformedPlacementRequest.desirableCriteria)
+    assertThat(result.person).isEqualTo(transformedPlacementRequest.person)
+    assertThat(result.risks).isEqualTo(transformedPlacementRequest.risks)
+    assertThat(result.applicationId).isEqualTo(transformedPlacementRequest.applicationId)
+    assertThat(result.assessmentId).isEqualTo(transformedPlacementRequest.assessmentId)
+    assertThat(result.releaseType).isEqualTo(transformedPlacementRequest.releaseType)
+    assertThat(result.status).isEqualTo(transformedPlacementRequest.status)
+    assertThat(result.assessmentDecision).isEqualTo(transformedPlacementRequest.assessmentDecision)
+    assertThat(result.assessmentDate).isEqualTo(transformedPlacementRequest.assessmentDate)
+    assertThat(result.assessor).isEqualTo(transformedPlacementRequest.assessor)
+    assertThat(result.notes).isEqualTo(transformedPlacementRequest.notes)
+    assertThat(result.cancellations).isEqualTo(listOf(mockCancellation, mockCancellation))
+
+    verify(exactly = 1) {
+      mockPlacementRequestTransformer.transformJpaToApi(mockPlacementRequestEntity, mockOffenderDetailSummary, mockInmateDetail)
+    }
+
+    mockCancellationEntities.forEach {
+      verify(exactly = 1) {
+        mockCancellationTransformer.transformJpaToApi(it)
+      }
+    }
+  }
+  private fun getTransformedPlacementRequest(): PlacementRequest {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withReleaseType("licence")
+      .withCreatedByUser(user)
+      .produce()
+
+    val submittedAt = OffsetDateTime.now()
+
+    val assessment = AssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .withSubmittedAt(submittedAt)
+      .produce()
+
+    val placementRequirementsEntity = PlacementRequirementsEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withEssentialCriteria(
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("isSemiSpecialistMentalHealth").produce(),
+        ),
+      )
+      .withDesirableCriteria(
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("isWheelchairDesignated").produce(),
+        ),
+      )
+      .produce()
+
+    val placementRequestEntity = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withAllocatedToUser(user)
+      .withPlacementRequirements(placementRequirementsEntity)
+      .produce()
+
+    val mockAssessmentTransformer = mockk<AssessmentTransformer>()
+    val mockPersonTransformer = mockk<PersonTransformer>()
+    val mockRisksTransformer = mockk<RisksTransformer>()
+    val mockUserTransformer = mockk<UserTransformer>()
+
+    val realPlacementRequestTransformer = PlacementRequestTransformer(
+      mockPersonTransformer,
+      mockRisksTransformer,
+      mockAssessmentTransformer,
+      mockUserTransformer,
+    )
+
+    every { mockAssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns AssessmentDecision.accepted
+    every { mockPersonTransformer.transformModelToApi(mockOffenderDetailSummary, mockInmateDetail) } returns mockk<Person>()
+    every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockk<PersonRisks>()
+    every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockk<ApprovedPremisesUser>()
+
+    return realPlacementRequestTransformer.transformJpaToApi(placementRequestEntity, mockOffenderDetailSummary, mockInmateDetail)
+  }
+}


### PR DESCRIPTION
This allows us to fetch any previous cancellations for a placement request's application, so matchers can be made aware of any previous cancellations that have happened, together with the reasoning.