### PR TITLE
Allow AP over-bookings when marking an Arrival

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -417,7 +417,10 @@ class PremisesController(
     val bedId = booking.bed?.id
       ?: throw InternalServerErrorProblem("No bed ID present on Booking: $bookingId")
 
-    throwIfBookingDatesConflict(body.arrivalDate, body.expectedDepartureDate, bookingId, bedId)
+    if (booking.premises !is ApprovedPremisesEntity) {
+      throwIfBookingDatesConflict(body.arrivalDate, body.expectedDepartureDate, bookingId, bedId)
+    }
+
     throwIfLostBedDatesConflict(body.arrivalDate, body.expectedDepartureDate, null, bedId)
 
     val result = bookingService.createArrival(


### PR DESCRIPTION
AP beds can now be overbooked for manual Bookings - this was missed for arrivals though