### PR TITLE
Use entire 2 minutes during Preemptive Cache Refresh

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
@@ -14,7 +14,8 @@ class InmateDetailsCacheRefreshWorker(
   private val loggingEnabled: Boolean,
   private val delayMs: Long,
   redLock: RedLock,
-) : CacheRefreshWorker(redLock, "inmateDetails") {
+  lockDurationMs: Int,
+) : CacheRefreshWorker(redLock, "inmateDetails", lockDurationMs) {
   override fun work(checkShouldStop: () -> Boolean) {
     val distinctNomsNumbers = (applicationRepository.getDistinctNomsNumbers() + bookingRepository.getDistinctNomsNumbers()).distinct()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
@@ -14,7 +14,8 @@ class OffenderDetailsCacheRefreshWorker(
   private val loggingEnabled: Boolean,
   private val delayMs: Long,
   redLock: RedLock,
-) : CacheRefreshWorker(redLock, "offenderDetails") {
+  lockDurationMs: Int,
+) : CacheRefreshWorker(redLock, "offenderDetails", lockDurationMs) {
   override fun work(checkShouldStop: () -> Boolean) {
     val distinctCrns = (applicationRepository.getDistinctCrns() + bookingRepository.getDistinctCrns()).distinct()
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -189,3 +189,4 @@ url-templates:
 preemptive-cache-key-prefix: ""
 preemptive-cache-logging-enabled: false
 preemptive-cache-delay-ms: 10000
+preemptive-cache-lock-duration-ms: 120000

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
@@ -27,6 +27,7 @@ class InmateDetailsCacheRefreshWorkerTest {
     false,
     0,
     mockRedLock,
+    10000,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/OffenderDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/OffenderDetailsCacheRefreshWorkerTest.kt
@@ -27,6 +27,7 @@ class OffenderDetailsCacheRefreshWorkerTest {
     false,
     0,
     mockRedLock,
+    10000,
   )
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -120,3 +120,4 @@ url-templates:
     booking: http://frontend/premises/{premisesId}/bookings/{bookingId}
 
 preemptive-cache-delay-ms: 250
+preemptive-cache-lock-duration-ms: 10000


### PR DESCRIPTION
If work is finished earlier than the 2 minutes then sleep until it is over.  This should bring down the noise level in the logs as the lock is currently bouncing between instances constantly and printing the Got Lock/Released Lock messages every time.