### PR TITLE
(3) API endpoint to move beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Extension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBedMove
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
@@ -77,6 +78,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTran
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RoomTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -435,6 +438,23 @@ class PremisesController(
     val arrival = extractResultEntityOrThrow(result)
 
     return ResponseEntity.ok(arrivalTransformer.transformJpaToApi(arrival))
+  }
+
+  override fun premisesPremisesIdBookingsBookingIdMovesPost(
+    premisesId: UUID,
+    bookingId: UUID,
+    body: NewBedMove,
+  ): ResponseEntity<Unit> {
+    val user = usersService.getUserForRequest()
+    val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
+
+    extractEntityFromValidatableActionResult(
+      extractEntityFromAuthorisableActionResult(
+        bookingService.moveBooking(booking, body.bedId, body.notes, user),
+      ),
+    )
+
+    return ResponseEntity.ok(Unit)
   }
 
   override fun premisesPremisesIdBookingsBookingIdNonArrivalsPost(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedMoveEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedMoveEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -11,7 +12,10 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Repository
-interface BedMoveRepository : JpaRepository<BedMoveEntity, UUID>
+interface BedMoveRepository : JpaRepository<BedMoveEntity, UUID> {
+  @Query("SELECT b FROM BedMoveEntity b WHERE b.booking.id = :bookingId")
+  fun findByBooking_IdOrNull(bookingId: UUID): BedMoveEntity?
+}
 
 @Entity
 @Table(name = "bed_moves")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedMoveEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedMoveEntity.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Repository
+interface BedMoveRepository : JpaRepository<BedMoveEntity, UUID>
+
+@Entity
+@Table(name = "bed_moves")
+data class BedMoveEntity(
+  @Id
+  val id: UUID,
+
+  @OneToOne
+  @JoinColumn(name = "booking_id")
+  val booking: BookingEntity,
+
+  @OneToOne
+  @JoinColumn(name = "previous_bed_id")
+  val previousBed: BedEntity,
+
+  @OneToOne
+  @JoinColumn(name = "new_bed_id")
+  val newBed: BedEntity,
+
+  var createdAt: OffsetDateTime,
+
+  val notes: String?,
+) {
+
+  override fun toString() = "BedMovesEntity: $id"
+}

--- a/src/main/resources/db/migration/all/20230619112523__add_bed_moves_table.sql
+++ b/src/main/resources/db/migration/all/20230619112523__add_bed_moves_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE bed_moves (
+    id uuid NOT NULL,
+    booking_id uuid NOT NULL,
+    previous_bed_id uuid NOT NULL,
+    new_bed_id uuid NOT NULL,
+    notes TEXT NULL,
+    created_at timestamp NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (booking_id) REFERENCES bookings(id),
+    FOREIGN KEY (previous_bed_id) REFERENCES beds(id),
+    FOREIGN KEY (new_bed_id) REFERENCES beds(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -447,6 +447,55 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/bookings/{bookingId}/moves:
+    post:
+      tags:
+        - Operations on bookings
+      summary: Moves a booking to a new bed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the booking is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bookingId
+          in: path
+          description: ID of the booking
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the bed move
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewBedMove'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/arrivals:
     post:
       tags:
@@ -6046,6 +6095,16 @@ components:
         - premisesName
         - arrivalDate
         - departureDate
+    NewBedMove:
+      type: object
+      properties:
+        bedId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+      required:
+        - bedId
     NewBookingNotMade:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -82,6 +82,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
@@ -277,6 +278,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var bookingRepository: BookingTestRepository
+
+  @Autowired
+  lateinit var bedMoveRepository: BedMoveRepository
 
   @Autowired
   lateinit var arrivalRepository: ArrivalTestRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MoveBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MoveBookingTest.kt
@@ -1,0 +1,149 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBedMove
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import java.util.UUID
+
+class MoveBookingTest : IntegrationTestBase() {
+
+  lateinit var premises: PremisesEntity
+  lateinit var booking: BookingEntity
+
+  @BeforeEach
+  fun setup() {
+    premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      }
+    }
+
+    booking = bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(
+        bedEntityFactory.produceAndPersist {
+          withRoom(
+            roomEntityFactory.produceAndPersist {
+              withPremises(premises)
+            },
+          )
+        },
+      )
+    }
+  }
+
+  @Test
+  fun `Move Bookings without a JWT returns 401 `() {
+    webTestClient.post()
+      .uri("/premises/${premises.id}/bookings/${booking.id}/moves")
+      .bodyValue(
+        NewBedMove(
+          bedId = UUID.randomUUID(),
+          notes = "Some Notes",
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Move Bookings when premises does not exist returns 404`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/premises/${UUID.randomUUID()}/bookings/${booking.id}/moves")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewBedMove(
+            bedId = UUID.randomUUID(),
+            notes = "Some Notes",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Move Bookings when booking does not exist returns 404`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/premises/${premises.id}/bookings/${UUID.randomUUID()}/moves")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewBedMove(
+            bedId = UUID.randomUUID(),
+            notes = "Some Notes",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Move Bookings when bed does not exist returns 404`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/premises/${premises.id}/bookings/${booking.id}/moves")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewBedMove(
+            bedId = UUID.randomUUID(),
+            notes = "Some Notes",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Move Bookings moves a booking to a new bed`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      val newRoom = roomEntityFactory.produceAndPersist {
+        withPremises(premises)
+      }
+
+      val newBed = bedEntityFactory.produceAndPersist {
+        withRoom(newRoom)
+      }
+
+      val previousBed = booking.bed!!
+
+      webTestClient.post()
+        .uri("/premises/${premises.id}/bookings/${booking.id}/moves")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewBedMove(
+            bedId = newBed.id,
+            notes = "Some Notes",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .is2xxSuccessful
+
+      val updatedBookingEntity = bookingRepository.findByIdOrNull(booking.id)!!
+
+      assertThat(updatedBookingEntity.bed!!.id).isEqualTo(newBed.id)
+
+      val createdBedMoveEntity = bedMoveRepository.findByBooking_IdOrNull(booking.id)!!
+
+      assertThat(createdBedMoveEntity.booking.id).isEqualTo(booking.id)
+      assertThat(createdBedMoveEntity.previousBed.id).isEqualTo(previousBed.id)
+      assertThat(createdBedMoveEntity.newBed.id).isEqualTo(newBed.id)
+      assertThat(createdBedMoveEntity.notes).isEqualTo("Some Notes")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -8,6 +8,8 @@ import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -62,6 +64,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
@@ -134,6 +138,7 @@ class BookingServiceTest {
   private val mockPlacementRequestRepository = mockk<PlacementRequestRepository>()
   private val mockLostBedsRepository = mockk<LostBedsRepository>()
   private val mockTurnaroundRepository = mockk<TurnaroundRepository>()
+  private val mockBedMoveRepository = mockk<BedMoveRepository>()
 
   private val bookingService = BookingService(
     premisesService = mockPremisesService,
@@ -162,6 +167,7 @@ class BookingServiceTest {
     placementRequestRepository = mockPlacementRequestRepository,
     lostBedsRepository = mockLostBedsRepository,
     turnaroundRepository = mockTurnaroundRepository,
+    bedMoveRepository = mockBedMoveRepository,
     notifyConfig = NotifyConfig(),
     applicationUrlTemplate = "http://frontend/applications/#id",
     bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
@@ -3276,5 +3282,206 @@ class BookingServiceTest {
     result as ValidatableActionResult.Success
     assertThat(result.entity.booking).isEqualTo(booking)
     assertThat(result.entity.workingDayCount).isEqualTo(2)
+  }
+
+  @Nested
+  inner class MoveBooking {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+      .addRoleForUnitTest(UserRole.CAS1_MANAGER)
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withProbationRegion(
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory()
+              .produce(),
+          )
+          .produce(),
+      )
+      .withLocalAuthorityArea(
+        LocalAuthorityEntityFactory()
+          .produce(),
+      )
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val bed = BedEntityFactory()
+      .withRoom(room)
+      .produce()
+
+    private val newRoom = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    private val newBed = BedEntityFactory()
+      .withRoom(newRoom)
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withPremises(premises)
+      .withBed(bed)
+      .produce()
+
+    @BeforeEach
+    fun setup() {
+      every { mockBedRepository.findByIdOrNull(newBed.id) } answers { newBed }
+      every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
+      every { mockBedMoveRepository.save(any()) } answers { it.invocation.args[0] as BedMoveEntity }
+    }
+
+    @Test
+    fun `it returns unauthorised when the user is does not have a CAS1_MANAGER role`() {
+      val result = bookingService.moveBooking(
+        booking,
+        newBed.id,
+        "Some Notes",
+        UserEntityFactory()
+          .withUnitTestControlProbationRegion()
+          .produce(),
+      )
+
+      assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+    }
+
+    @Test
+    fun `it returns NotFound when the bed cannot be found`() {
+      every { mockBedRepository.findByIdOrNull(any()) } answers { null }
+
+      val result = bookingService.moveBooking(
+        booking,
+        newBed.id,
+        "Some Notes",
+        user,
+      )
+
+      assertThat(result is AuthorisableActionResult.NotFound).isTrue
+    }
+
+    @Test
+    fun `it returns a validation error when the bed does not belong to the same premises`() {
+      every { mockBedRepository.findByIdOrNull(any()) } answers {
+        val premises = ApprovedPremisesEntityFactory()
+          .withProbationRegion(
+            ProbationRegionEntityFactory()
+              .withApArea(
+                ApAreaEntityFactory()
+                  .produce(),
+              )
+              .produce(),
+          )
+          .withLocalAuthorityArea(
+            LocalAuthorityEntityFactory()
+              .produce(),
+          )
+          .produce()
+
+        val room = RoomEntityFactory()
+          .withPremises(premises)
+          .produce()
+
+        BedEntityFactory()
+          .withRoom(room)
+          .produce()
+      }
+
+      val result = bookingService.moveBooking(
+        booking,
+        newBed.id,
+        "Some Notes",
+        user,
+      )
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity is ValidatableActionResult.FieldValidationError).isTrue
+      val validationError = result.entity as ValidatableActionResult.FieldValidationError
+
+      assertThat(validationError.validationMessages["$.bedId"]).isEqualTo("mustBelongToTheSamePremises")
+    }
+
+    @Test
+    fun `it returns a validation error when the bed does not belong to an approved premises`() {
+      every { mockBedRepository.findByIdOrNull(any()) } answers {
+        val premises = TemporaryAccommodationPremisesEntityFactory()
+          .withProbationRegion(
+            ProbationRegionEntityFactory()
+              .withApArea(
+                ApAreaEntityFactory()
+                  .produce(),
+              )
+              .produce(),
+          )
+          .withLocalAuthorityArea(
+            LocalAuthorityEntityFactory()
+              .produce(),
+          )
+          .produce()
+
+        val room = RoomEntityFactory()
+          .withPremises(premises)
+          .produce()
+
+        BedEntityFactory()
+          .withRoom(room)
+          .produce()
+      }
+
+      val result = bookingService.moveBooking(
+        booking,
+        newBed.id,
+        "Some Notes",
+        user,
+      )
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity is ValidatableActionResult.FieldValidationError).isTrue
+      val validationError = result.entity as ValidatableActionResult.FieldValidationError
+
+      assertThat(validationError.validationMessages["$.bedId"]).isEqualTo("mustBelongToApprovedPremises")
+    }
+
+    @Test
+    fun `updates the booking and creates a new BedMoveEntity`() {
+      val result = bookingService.moveBooking(
+        booking,
+        newBed.id,
+        "Some Notes",
+        user,
+      )
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      result as AuthorisableActionResult.Success
+
+      val validatableActionResult = result.entity as ValidatableActionResult.Success
+      val updatedBookingEntity = validatableActionResult.entity
+
+      assertThat(updatedBookingEntity.bed).isEqualTo(newBed)
+
+      verify(exactly = 1) {
+        mockBookingRepository.save(
+          match {
+            it.id == booking.id &&
+              it.bed!!.id == newBed.id
+          },
+        )
+      }
+
+      verify(exactly = 1) {
+        mockBedMoveRepository.save(
+          match {
+            it.booking.id == booking.id &&
+              it.previousBed.id == bed.id &&
+              it.newBed.id == newBed.id &&
+              it.notes == "Some Notes"
+          },
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
This adds an endpoint to move a booking from one bed to another, together with any notes. On submit, the booking's bed is changed, as well as creating a new `BedMoveEntity` to record the change. We don't do anything with this entity yet, but we may do in future.