### PR TITLE
Return 500s when no NOMS Number or OASys present during Application creation

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ValidationError
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
@@ -41,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockOffenderUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
@@ -1299,6 +1301,11 @@ class ApplicationTest : IntegrationTestBase() {
           ),
         )
 
+        APOASysContext_mockSuccessfulNeedsDetailsCall(
+          offenderDetails.otherIds.crn,
+          NeedsDetailsFactory().produce(),
+        )
+
         val result = webTestClient.post()
           .uri("/applications")
           .header("Authorization", "Bearer $jwt")
@@ -1342,6 +1349,11 @@ class ApplicationTest : IntegrationTestBase() {
           ManagingTeamsResponse(
             teamCodes = listOf("TEAM1"),
           ),
+        )
+
+        APOASysContext_mockSuccessfulNeedsDetailsCall(
+          offenderDetails.otherIds.crn,
+          NeedsDetailsFactory().produce(),
         )
 
         val result = webTestClient.post()


### PR DESCRIPTION
Return a 500 with detail of `No nomsNumber present for CRN` or `No OASys present for CRN` to be consistent with other endpoints to allow frontend to handle more elegantly