### PR TITLE
Fix for PostGIS Point missing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -125,7 +125,7 @@ class ApprovedPremisesEntity(
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
   status: PropertyStatus,
-  val point: Point?, // TODO: Make not-null once Premises have had point added in all environments
+  var point: Point?, // TODO: Make not-null once Premises have had point added in all environments
 ) : PremisesEntity(
   id,
   name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesSeedJob.kt
@@ -61,6 +61,7 @@ class ApprovedPremisesSeedJob(
   ),
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
+  private val geometryFactory = GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), 4326)
 
   override fun deserializeRow(columns: Map<String, String>) = ApprovedPremisesSeedCsvRow(
     name = columns["name"]!!,
@@ -157,8 +158,6 @@ class ApprovedPremisesSeedJob(
   ) {
     log.info("Creating new Approved Premises: ${row.apCode} ${row.name}")
 
-    val geometryFactory = GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), 4326)
-
     val approvedPremises = premisesRepository.save(
       ApprovedPremisesEntity(
         id = UUID.randomUUID(),
@@ -224,6 +223,7 @@ class ApprovedPremisesSeedJob(
       this.probationRegion = probationRegion
       this.localAuthorityArea = localAuthorityArea
       this.status = row.status
+      this.point = if (row.longitude != null && row.latitude != null) geometryFactory.createPoint(Coordinate(row.latitude, row.longitude)) else null
     }
 
     characteristics.forEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedApprovedPremisesTest.kt
@@ -6,6 +6,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesSeedCsvRow
@@ -299,6 +302,8 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       .withApCode(existingApprovedPremises.apCode)
       .withProbationRegion(updatedProbationRegion.name)
       .withLocalAuthorityArea(updatedLocalAuthorityArea.name)
+      .withLatitude(12.5)
+      .withLongitude(30.1)
       .produce()
 
     withCsv(
@@ -324,6 +329,12 @@ class SeedApprovedPremisesTest : SeedTestBase() {
     assertThat(persistedApprovedPremises.localAuthorityArea!!.name).isEqualTo(csvRow.localAuthorityArea)
     assertThat(persistedApprovedPremises.characteristics.map { it.name }).isEqualTo(csvRow.characteristics)
     assertThat(persistedApprovedPremises.status).isEqualTo(csvRow.status)
+    assertThat(persistedApprovedPremises.latitude).isEqualTo(csvRow.latitude!!)
+    assertThat(persistedApprovedPremises.longitude).isEqualTo(csvRow.longitude!!)
+    assertThat(persistedApprovedPremises.point).isEqualTo(
+      GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), 4326)
+        .createPoint(Coordinate(csvRow.latitude!!, csvRow.longitude!!)),
+    )
   }
 
   private fun approvedPremisesSeedCsvRowsToCsv(rows: List<ApprovedPremisesSeedCsvRow>): String {


### PR DESCRIPTION
This fixes an issue where updating an existing Approved Premises via seeding did not update the `latitude`, `longtitude` and `point` properties