### PR TITLE
Acct Alert comments can be null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/Alert.kt
@@ -10,7 +10,7 @@ data class Alert(
   val alertTypeDescription: String,
   val alertCode: String,
   val alertCodeDescription: String,
-  val comment: String,
+  val comment: String?,
   val dateCreated: LocalDate,
   val dateExpires: LocalDate?,
   val expired: Boolean,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4394,7 +4394,6 @@ components:
           type: boolean
       required:
         - alertId
-        - comment
         - dateCreated
         - expired
         - active

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AlertFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AlertFactory.kt
@@ -13,7 +13,7 @@ class AlertFactory : Factory<Alert> {
   private var alertId: Yielded<Long> = { randomInt(0, 1000).toLong() }
   private var bookingId: Yielded<Long> = { randomInt(0, 1000).toLong() }
   private var offenderNo: Yielded<String> = { randomStringUpperCase(6) }
-  private var comment: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var comment: Yielded<String?> = { randomStringMultiCaseWithNumbers(10) }
   private var dateCreated: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(10) }
   private var dateExpires: Yielded<LocalDate?> = { null }
   private var active: Yielded<Boolean> = { true }
@@ -30,7 +30,7 @@ class AlertFactory : Factory<Alert> {
     this.offenderNo = { offenderNo }
   }
 
-  fun withComment(comment: String) = apply {
+  fun withComment(comment: String?) = apply {
     this.comment = { comment }
   }
 


### PR DESCRIPTION
This fixes a deserialization error caused by us incorrectly typing comment as not-null