### PR TITLE
256 - Make oays requests concurrently

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ val springDocVersion = "1.7.0"
 val sentryVersion = "6.23.0"
 
 dependencies {
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.vladmihalcea:hibernate-types-55:2.21.1")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -117,9 +117,10 @@ class WebClientConfiguration {
   fun apOASysContextApiWebClient(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
+    authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.ap-oasys-context-api.base-url}") apOASysContextApiBaseUrl: String,
   ): WebClient {
-    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("ap-oasys-context")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
@@ -26,6 +26,12 @@ fun IntegrationTestBase.APOASysContext_mockSuccessfulRiskToTheIndividualCall(crn
     responseBody = response,
   )
 
+fun IntegrationTestBase.APOASysContext_mockNotFoundRiskToTheIndividualCall(crn: String) =
+  mockUnsuccessfulGetCall(
+    url = "/risk-to-the-individual/$crn",
+    responseStatus = 404,
+  )
+
 fun IntegrationTestBase.APOASysContext_mockSuccessfulRiskManagementPlanCall(crn: String, response: RiskManagementPlan) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/risk-management-plan/$crn",


### PR DESCRIPTION
The eventual upstream (OASys) can be slow to respond, to reduce the risk of bumping into the 10s timeout between our frontend and API we can fetch the sections concurrently.  We're using coroutines dispatched to a blocking IO thread pool to do this to avoid refactoring the entire client layer to be async.