### PR TITLE
Introduce Gatling performance tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   kotlin("plugin.spring") version "1.8.22"
   id("org.openapi.generator") version "5.4.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.8.22"
+  id("io.gatling.gradle") version "3.9.5"
 }
 
 configurations {
@@ -201,3 +202,9 @@ tasks {
 }
 
 tasks.getByName("runKtlintCheckOverMainSourceSet").dependsOn("openApiGenerate", "openApiGenerateDomainEvents")
+
+gatling {
+  // WARNING: options below only work when logback config file isn't provided
+  logLevel = "WARN" // logback root level
+  logHttp = io.gatling.gradle.LogHttp.NONE // set to 'ALL' for all HTTP traffic in TRACE, 'FAILURES' for failed HTTP traffic in DEBUG
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.3.0")
 
   implementation("uk.gov.service.notify:notifications-java-client:4.1.0-RELEASE")
+
+  gatlingImplementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 java {

--- a/doc/how-to/run_performance_tests.md
+++ b/doc/how-to/run_performance_tests.md
@@ -1,0 +1,26 @@
+# How to run performance tests
+Performance tests use [Gatling](https://gatling.io), which provides a Gradle plugin.
+This bundles up Gatling in a convenient way so that no additional tools need to be downloaded.
+
+## Running against a local instance
+This requires the [ap-tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools)
+utility to be running.
+
+Once the API has started locally, just run:
+```shell
+./gradlew gatlingRun
+```
+
+## Running against a remote environment
+This requires some configuration, which can be done through environment variables:
+```shell
+GATLING_BASE_URL="https://approved-premises-api-{env}.hmpps.service.justice.gov.uk" \
+GATLING_USERNAME="{your username}" \
+GATLING_PASSWORD="{your password}" \
+GATLING_HMPPS_AUTH_BASE_URL="https://sign-in-{env}.hmpps.service.justice.gov.uk" \
+./gradlew gatlingRun
+```
+
+## Results
+Once Gatling has finished, it will output reports into the `build/reports/gatling` folder.
+It will also provide a link in the terminal to open the report directly in the browser.

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
+
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.exec
+import io.gatling.javaapi.core.CoreDsl.jsonPath
+import io.gatling.javaapi.core.CoreDsl.repeat
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.CoreDsl.stressPeakUsers
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class ApplyJourneyStressSimulation : Simulation() {
+  private val createTemporaryAccommodationApplication = exec(
+    http("Create Application")
+      .post("/applications")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+      .body(
+        toJson(
+          NewApplication(
+            crn = "X320741",
+            convictionId = 0L,
+            deliusEventNumber = "",
+            offenceId = "",
+          ),
+        ),
+      )
+      .check(status().`is`(201))
+      .check(jsonPath("$.id").saveAs("application_id")),
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val updateTemporaryAccommodationApplication = repeat({ randomInt(1, 20) }, "n").on(
+    exec(
+      http("Update Application")
+        .put("/applications/#{application_id}")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .body(
+          toJson(
+            UpdateTemporaryAccommodationApplication(
+              type = "CAS3",
+              data = mapOf(),
+            ),
+          ),
+        ),
+    ).pause(5.seconds.toJavaDuration()),
+  )
+
+  private val submitTemporaryAccommodationApplication = exec(
+    http("Submit Application")
+      .post("/applications/#{application_id}/submission")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+      .body(
+        toJson(
+          SubmitTemporaryAccommodationApplication(
+            type = "CAS3",
+            translatedDocument = "{}",
+          ),
+        ),
+      ),
+  ).pause(10.seconds.toJavaDuration())
+
+  private val temporaryAccommodationApplyJourney = scenario("Apply journey for Temporary Accommodation")
+    .exec(
+      authorizeUser(),
+      createTemporaryAccommodationApplication,
+      updateTemporaryAccommodationApplication,
+      submitTemporaryAccommodationApplication,
+    )
+
+  init {
+    setUp(
+      temporaryAccommodationApplyJourney.injectOpen(
+        constantUsersPerSec(50.0).during(2.minutes.toJavaDuration()).randomized(),
+        stressPeakUsers(5000).during(1.minutes.toJavaDuration()),
+      ),
+    ).withAuthorizedUserHttpProtocol()
+  }
+}

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
+
+import io.gatling.javaapi.core.ChainBuilder
+import io.gatling.javaapi.core.CoreDsl.exec
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
+import java.net.URLEncoder
+import java.nio.charset.Charset
+
+fun authorizeUser(): ChainBuilder {
+  val jwt = getJwt()
+
+  return exec { session ->
+    session.set("access_token", jwt)
+  }
+}
+
+fun Simulation.SetUp.withAuthorizedUserHttpProtocol() = apply {
+  val protocol = http
+    .baseUrl(BASE_URL)
+    .acceptHeader("application/json")
+    .contentTypeHeader("application/json")
+    .authorizationHeader("Bearer #{access_token}")
+
+  this.protocols(protocol)
+}
+
+private fun getJwt(): String {
+  println("Setting up auth ($HMPPS_AUTH_BASE_URL)...")
+  val webClient = WebClient.create()
+
+  val savedRequestCookie = webClient.get()
+    .uri("$HMPPS_AUTH_BASE_URL/auth/oauth/authorize?response_type=code&state=gatling&client_id=gatling&redirect_uri=http://example.org")
+    .exchangeToMono {
+      it.printIfError("authorize")
+      Mono.justOrEmpty(it.cookies()["savedrequest"]?.get(0))
+    }
+    .block()
+
+  val jwtCookie = webClient.post()
+    .uri("$HMPPS_AUTH_BASE_URL/auth/sign-in")
+    .apply {
+      if (savedRequestCookie != null) {
+        this.cookie("savedrequest", savedRequestCookie.value)
+      }
+    }
+    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+    .bodyValue(
+      "redirect_url=${URLEncoder.encode("http://example.org", Charset.defaultCharset())}" +
+        "&username=${URLEncoder.encode(USERNAME, Charset.defaultCharset())}" +
+        "&password=${URLEncoder.encode(PASSWORD, Charset.defaultCharset())}",
+    )
+    .exchangeToMono {
+      it.printIfError("sign in")
+      Mono.justOrEmpty(it.cookies()["jwtSession"]?.get(0))
+    }
+    .block()
+
+  return jwtCookie?.value ?: throw RuntimeException("Could not get JWT successfully")
+}
+
+private fun ClientResponse.printIfError(name: String) {
+  if (this.statusCode().isError) {
+    println("Could not call '$name' endpoint: ${this.statusCode().value()} ${this.statusCode().reasonPhrase}")
+    println()
+    println(this.bodyToMono<String>().block())
+  }
+}

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Environment.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Environment.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
+
+val BASE_URL = System.getenv("GATLING_BASE_URL") ?: "http://localhost:8080"
+val USERNAME = System.getenv("GATLING_USERNAME") ?: "JimSnowLdap"
+val PASSWORD = System.getenv("GATLING_PASSWORD") ?: "secret"
+val HMPPS_AUTH_BASE_URL = System.getenv("GATLING_HMPPS_AUTH_BASE_URL") ?: "http://localhost:9091"

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.gatling.javaapi.core.CoreDsl.StringBody
+
+fun toJson(value: Any) = StringBody(ObjectMapper().writeValueAsString(value))


### PR DESCRIPTION
> See [ticket #1244 on the CAS3 Trello board](https://trello.com/c/RVHj2JFc/1244-can-we-spare-1-day-to-set-up-some-load-testing-on-apply-to-de-risk-go-live-for-both-us-and-cas1).

This PR provides a prototype for using Gatling as a tool to run performance tests against the API.
This will help us to identify parts of our application that regress in performance or are vulnerable to high load, which will give us confidence that it will be able to handle the increased traffic from onboarding new groups of users.

Specifically, this PR runs a simulation of the Apply journey in Temporary Accommodation. Each simulated user will perform the following steps:
1. Create a new application.
2. Update the application a random number of times.
3. Submit the application.

Between each step is a pause to simulate user thinking/typing time, although this has been deliberately made small to emulate adverse conditions.

Similarly, the user populations have been chosen to represent adverse conditions:
- For the first two minutes, users begin the simulation at random intervals, at an overall rate of 50 users per second.
- For an additional minute, the number of users added ramps up to a peak value of 5000 concurrent users.