### PR TITLE
Prevent `ClassCastException` for JWT with only a single authority claim

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -118,7 +118,11 @@ class AuthAwareTokenConverter() : Converter<Jwt, AbstractAuthenticationToken> {
     val authorities = mutableListOf<GrantedAuthority>().apply { addAll(jwtGrantedAuthoritiesConverter.convert(jwt)!!) }
     if (jwt.claims.containsKey(CLAIM_AUTHORITY)) {
       @Suppress("UNCHECKED_CAST")
-      val claimAuthorities = (jwt.claims[CLAIM_AUTHORITY] as Collection<String>).toList()
+      val claimAuthorities = when (val claims = jwt.claims[CLAIM_AUTHORITY]) {
+        is String -> listOf(claims)
+        is Collection<*> -> (claims as Collection<String>).toList()
+        else -> emptyList()
+      }
       authorities.addAll(claimAuthorities.map(::SimpleGrantedAuthority))
     }
     return authorities.toSet()


### PR DESCRIPTION
It is possible for HMPPS Auth to issue a JWT with only a single authority claim. When this happens, this single claim is encoded as a string rather than array of strings with a single element. When the API tries to extract the authorities in the JWT, the attempt to cast the string to a `Collection<String>` fails and a `ClassCastException` occurs.

This PR introduces explicit handling for the case of a single authority claim. Additionally, unexpected data will result in a an empty list of authority claims, meaning that a JWT that is malformed in this way will result in a more appropriate 401/403 response instead of a 500.