### PR TITLE
Handle multiple authority claims in the JWT being provided as a comma-separated string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -119,7 +119,7 @@ class AuthAwareTokenConverter() : Converter<Jwt, AbstractAuthenticationToken> {
     if (jwt.claims.containsKey(CLAIM_AUTHORITY)) {
       @Suppress("UNCHECKED_CAST")
       val claimAuthorities = when (val claims = jwt.claims[CLAIM_AUTHORITY]) {
-        is String -> listOf(claims)
+        is String -> claims.split(',')
         is Collection<*> -> (claims as Collection<String>).toList()
         else -> emptyList()
       }


### PR DESCRIPTION
HMPPS Auth, in some situations, generates a JWT where the authority claims are represented as a comma-separated string, despite [the README implying that this should be an array of strings](https://github.com/ministryofjustice/hmpps-auth/tree/b3fd501ab7ef1c0b0dbbc51a65a5895b81361ce0#get-a-jwt-token). This causes a JWT with the `ROLE_PROBATION` authority to be incorrectly considered invalid if it appears in such a list. For example, generating a JWT in the test environment yields the following payload:

```
{
  "jti": "94851966-5c4a-4e6b-b094-ca409bff9010",
  "sub": "TEMPORARY-ACCOMMODATION-E2E-TESTER",
  "authorities": "ROLE_WORKLOAD_MEASUREMENT,ROLE_PROBATION",
  "name": "Temporary Accommodation E2E Tester",
  "auth_source": "delius",
  "user_id": "2500430111",
  "passed_mfa": false,
  "exp": 1687573444
}
```

Which should authenticate given the appearance of `ROLE_PROBATION`.