### PR TITLE
Update total booked days/occupancy rate calculation on bed utilisation report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
@@ -75,7 +75,7 @@ class BedUtilisationReportGenerator(
       voidDays += daysOfVoidInMonth
     }
 
-    val totalBookedDays = bookedDaysActiveAndClosed + confirmedDays + provisionalDays + effectiveTurnaroundDays + voidDays
+    val totalBookedDays = bookedDaysActiveAndClosed
     val daysInMonth = YearMonth.of(properties.year, properties.month).lengthOfMonth()
 
     listOf(


### PR DESCRIPTION
> See [ticket #1124 on the CAS3 Trello board](https://trello.com/c/zln7bteP/1124-amend-the-calculation-of-total-booked-days-in-occupancy-report).

The bed utilisation report has been identified as having an incorrect calculation for the number of booked days (and therefore the occupancy rate). Currently, the total number of booked days is calculated as the sum of booked days for closed, active, confirmed, and provisional bookings, as well as the number of effective turnaround days (i.e. not including weekends or bank holidays) and void days. This leads to a misleadingly high occupancy rate.

This PR alters the calculation to just the sum of booked days for closed and active bookings. This has been confirmed to be the expected calculation by users of the report and leads to a more accurate understanding of the amount of time a room is actually occupied.