### PR TITLE
Update seeding process to output root exception message too where available

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationBedspaceSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findRootCause
 import java.io.File
 import java.io.IOException
 import javax.annotation.PostConstruct
@@ -184,7 +185,8 @@ class SeedService(
           try {
             job.processRow(deserializedRow)
           } catch (exception: RuntimeException) {
-            errors.add("Error on row $rowNumber: ${exception.message}")
+            val rootCauseException = findRootCause(exception)
+            errors.add("Error on row $rowNumber: ${exception.message} ${if (rootCauseException != null) rootCauseException.message else "no exception cause"}")
             seedLogger.error("Error on row $rowNumber:", exception)
           }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ThrowableUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ThrowableUtils.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+fun findRootCause(throwable: Throwable, topMost: Boolean = true): Throwable? {
+  if (throwable.cause == null && !topMost) return throwable
+  if (throwable.cause == null && topMost) return null
+
+  return findRootCause(throwable.cause!!, false)
+}


### PR DESCRIPTION
Whilst the full exceptions are logged too it's not practical to go through hundreds of entries in AppInsights.  The particular example here is seeding users - the exception message doesn't identify why we failed to retrieve a user but the root exception does (e.g. a 404 vs a failure to map probation region).