### PR TITLE
(268) Fix placement application bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -1,23 +1,46 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.TasksApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentTask
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationTask
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestTask
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Task
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskWrapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromOffenderDetailSummaryResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.kebabCaseToPascalCase
+import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
 class TasksController(
@@ -27,6 +50,9 @@ class TasksController(
   private val taskTransformer: TaskTransformer,
   private val offenderService: OffenderService,
   private val placementApplicationService: PlacementApplicationService,
+  private val enumConverterFactory: EnumConverterFactory,
+  private val userTransformer: UserTransformer,
+  private val taskService: TaskService,
 ) : TasksApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -57,30 +83,121 @@ class TasksController(
     return ResponseEntity.ok(tasks)
   }
 
+  override fun tasksTaskTypeIdGet(id: UUID, taskType: String): ResponseEntity<TaskWrapper> {
+    val user = userService.getUserForRequest()
+    val taskType = enumConverterFactory.getConverter(TaskType::class.java).convert(
+      taskType.kebabCaseToPascalCase(),
+    ) ?: throw NotFoundProblem(taskType, "TaskType")
+
+    val transformedTask: Task
+    var transformedAllocatableUsers: List<User>
+
+    when (taskType) {
+      TaskType.assessment -> {
+        val assessment = extractEntityFromAuthorisableActionResult(
+          assessmentService.getAssessmentForUserAndApplication(user, id),
+        )
+
+        transformedTask = getAssessmentTask(assessment, user)
+
+        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRolesPassingLAO(assessment.application.crn, assessment.application.getRequiredQualifications(), listOf(UserRole.CAS1_ASSESSOR))
+          .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
+      }
+      TaskType.placementRequest -> {
+        val placementRequest = extractEntityFromAuthorisableActionResult(
+          placementRequestService.getPlacementRequestForUserAndApplication(user, id),
+        )
+
+        transformedTask = getPlacementRequestTask(placementRequest, user)
+
+        transformedAllocatableUsers =
+          userService.getUsersWithQualificationsAndRolesPassingLAO(placementRequest.application.crn, emptyList(), listOf(UserRole.CAS1_MATCHER))
+            .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
+      }
+      TaskType.placementApplication -> {
+        val placementApplication = extractEntityFromAuthorisableActionResult(
+          placementApplicationService.getPlacementApplicationForApplicationId(id),
+        )
+
+        transformedTask = getPlacementApplicationTask(placementApplication, user)
+
+        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRolesPassingLAO(placementApplication.application.crn, placementApplication.application.getRequiredQualifications(), listOf(UserRole.CAS1_ASSESSOR))
+          .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
+      } else -> {
+        throw NotAllowedProblem(detail = "The Task Type $taskType is not currently supported")
+      }
+    }
+
+    return ResponseEntity.ok(
+      TaskWrapper(
+        task = transformedTask,
+        users = transformedAllocatableUsers,
+      ),
+    )
+  }
+
+  @Transactional
+  override fun tasksTaskTypeIdAllocationsPost(
+    id: UUID,
+    taskType: String,
+    body: NewReallocation,
+  ): ResponseEntity<Reallocation> {
+    val user = userService.getUserForRequest()
+
+    val taskType = enumConverterFactory.getConverter(TaskType::class.java).convert(
+      taskType.kebabCaseToPascalCase(),
+    ) ?: throw NotFoundProblem(taskType, "TaskType")
+
+    val validationResult = when (val authorisationResult = taskService.reallocateTask(user, taskType, body.userId, id)) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, taskType.toString())
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> authorisationResult.entity
+    }
+
+    val reallocatedTask = when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.Success -> validationResult.entity
+    }
+
+    return ResponseEntity(reallocatedTask, HttpStatus.CREATED)
+  }
+
+  private fun getAssessmentTask(assessment: AssessmentEntity, user: UserEntity): AssessmentTask {
+    val offenderDetailsResult = offenderService.getOffenderByCrn(assessment.application.crn, user.deliusUsername)
+
+    return taskTransformer.transformAssessmentToTask(
+      assessment = assessment,
+      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
+    )
+  }
+
+  private fun getPlacementRequestTask(placementRequest: PlacementRequestEntity, user: UserEntity): PlacementRequestTask {
+    val offenderDetailsResult = offenderService.getOffenderByCrn(placementRequest.application.crn, user.deliusUsername)
+
+    return taskTransformer.transformPlacementRequestToTask(
+      placementRequest = placementRequest,
+      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
+    )
+  }
+
+  private fun getPlacementApplicationTask(placementApplication: PlacementApplicationEntity, user: UserEntity): PlacementApplicationTask {
+    val offenderDetailsResult = offenderService.getOffenderByCrn(placementApplication.application.crn, user.deliusUsername)
+
+    return taskTransformer.transformPlacementApplicationToTask(
+      placementApplication = placementApplication,
+      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
+    )
+  }
+
   private fun getAssessmentTasks(assessments: List<AssessmentEntity>, user: UserEntity) = assessments.map {
-    val offenderDetailsResult = offenderService.getOffenderByCrn(it.application.crn, user.deliusUsername)
-
-    taskTransformer.transformAssessmentToTask(
-      assessment = it,
-      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
-    )
+    getAssessmentTask(it, user)
   }
 
-  private fun getPlacementRequestTasks(placementRequests: List<PlacementRequestEntity>, user: UserEntity) = placementRequests.map {
-    val offenderDetailsResult = offenderService.getOffenderByCrn(it.application.crn, user.deliusUsername)
-
-    taskTransformer.transformPlacementRequestToTask(
-      placementRequest = it,
-      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
-    )
-  }
+  private fun getPlacementRequestTasks(placementRequests: List<PlacementRequestEntity>, user: UserEntity) = placementRequests.map { getPlacementRequestTask(it, user) }
 
   private fun getPlacementApplicationTasks(placementApplications: List<PlacementApplicationEntity>, user: UserEntity) = placementApplications.map {
-    val offenderDetailsResult = offenderService.getOffenderByCrn(it.application.crn, user.deliusUsername)
-
-    taskTransformer.transformPlacementApplicationToTask(
-      placementApplication = it,
-      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
-    )
+    getPlacementApplicationTask(it, user)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -95,7 +95,7 @@ class TasksController(
     when (taskType) {
       TaskType.assessment -> {
         val assessment = extractEntityFromAuthorisableActionResult(
-          assessmentService.getAssessmentForUserAndApplication(user, id),
+          assessmentService.getAssessmentForUser(user, id),
         )
 
         transformedTask = getAssessmentTask(assessment, user)
@@ -104,8 +104,8 @@ class TasksController(
           .map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
       }
       TaskType.placementRequest -> {
-        val placementRequest = extractEntityFromAuthorisableActionResult(
-          placementRequestService.getPlacementRequestForUserAndApplication(user, id),
+        val (placementRequest) = extractEntityFromAuthorisableActionResult(
+          placementRequestService.getPlacementRequestForUser(user, id),
         )
 
         transformedTask = getPlacementRequestTask(placementRequest, user)
@@ -116,7 +116,7 @@ class TasksController(
       }
       TaskType.placementApplication -> {
         val placementApplication = extractEntityFromAuthorisableActionResult(
-          placementApplicationService.getPlacementApplicationForApplicationId(id),
+          placementApplicationService.getApplication(id),
         )
 
         transformedTask = getPlacementApplicationTask(placementApplication, user)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -18,11 +17,6 @@ import javax.persistence.Table
 @Repository
 interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEntity, UUID> {
   fun findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNull(): List<PlacementApplicationEntity>
-
-  @Query("SELECT a FROM PlacementApplicationEntity a WHERE a.application.id = :id")
-  fun findByApplicationId(id: UUID): PlacementApplicationEntity?
-
-  fun findByApplication_IdAndReallocatedAtNull(id: UUID): PlacementApplicationEntity?
 
   fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<PlacementApplicationEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -21,8 +21,6 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
   fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<PlacementRequestEntity>
 
   fun findAllByReallocatedAtNullAndBooking_IdNull(): List<PlacementRequestEntity>
-
-  fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): PlacementRequestEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -436,8 +436,8 @@ class AssessmentService(
     )
   }
 
-  fun reallocateAssessment(assigneeUser: UserEntity, application: ApprovedPremisesApplicationEntity): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
-    val currentAssessment = assessmentRepository.findByApplication_IdAndReallocatedAtNull(application.id)
+  fun reallocateAssessment(assigneeUser: UserEntity, id: UUID): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
+    val currentAssessment = assessmentRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
     if (currentAssessment.submittedAt != null) {
@@ -446,6 +446,7 @@ class AssessmentService(
       )
     }
 
+    val application = currentAssessment.application
     val requiredQualifications = application.getRequiredQualifications()
 
     if (!assigneeUser.hasRole(UserRole.CAS1_ASSESSOR)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -77,14 +77,8 @@ class PlacementApplicationService(
     return AuthorisableActionResult.Success(setSchemaUpToDate(placementApplication))
   }
 
-  fun getPlacementApplicationForApplicationId(applicationId: UUID): AuthorisableActionResult<PlacementApplicationEntity> {
-    val placementApplication = placementApplicationRepository.findByApplicationId(applicationId) ?: return AuthorisableActionResult.NotFound()
-
-    return AuthorisableActionResult.Success(setSchemaUpToDate(placementApplication))
-  }
-
-  fun reallocateApplication(assigneeUser: UserEntity, application: ApprovedPremisesApplicationEntity): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
-    val currentPlacementApplication = placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id)
+  fun reallocateApplication(assigneeUser: UserEntity, id: UUID): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
+    val currentPlacementApplication = placementApplicationRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
     if (currentPlacementApplication.decision != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
@@ -70,19 +69,8 @@ class PlacementRequestService(
     return AuthorisableActionResult.Success(Pair(placementRequest, cancellations))
   }
 
-  fun getPlacementRequestForUserAndApplication(user: UserEntity, applicationID: UUID): AuthorisableActionResult<PlacementRequestEntity> {
-    val placementRequest = placementRequestRepository.findByApplication_IdAndReallocatedAtNull(applicationID)
-      ?: return AuthorisableActionResult.NotFound()
-
-    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.allocatedToUser != user) {
-      return AuthorisableActionResult.Unauthorised()
-    }
-
-    return AuthorisableActionResult.Success(placementRequest)
-  }
-
-  fun reallocatePlacementRequest(assigneeUser: UserEntity, application: ApprovedPremisesApplicationEntity): AuthorisableActionResult<ValidatableActionResult<PlacementRequestEntity>> {
-    val currentPlacementRequest = placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id)
+  fun reallocatePlacementRequest(assigneeUser: UserEntity, id: UUID): AuthorisableActionResult<ValidatableActionResult<PlacementRequestEntity>> {
+    val currentPlacementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
     if (currentPlacementRequest.booking != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -22,6 +22,7 @@ class TaskTransformer(
   private val placementRequestTransformer: PlacementRequestTransformer,
 ) {
   fun transformAssessmentToTask(assessment: AssessmentEntity, personName: String) = AssessmentTask(
+    id = assessment.id,
     applicationId = assessment.application.id,
     personName = personName,
     crn = assessment.application.crn,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3343,6 +3343,10 @@ components:
       properties:
         taskType:
           $ref: '#/components/schemas/TaskType'
+        id:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
         applicationId:
           type: string
           format: uuid
@@ -3366,6 +3370,7 @@ components:
           PlacementApplication: '#/components/schemas/PlacementApplicationTask'
           BookingAppeal: '#/components/schemas/BookingAppealTask'
       required:
+        - id
         - taskType
         - applicationId
         - personName
@@ -3388,10 +3393,6 @@ components:
         - $ref: '#/components/schemas/PlacementDates'
         - type: object
           properties:
-            id:
-              type: string
-              format: uuid
-              example: 6abb5fa3-e93f-4445-887b-30d081688f44
             tier:
               $ref: '#/components/schemas/RiskTierEnvelope'
             releaseType:
@@ -3399,7 +3400,6 @@ components:
             placementRequestStatus:
               $ref: '#/components/schemas/PlacementRequestStatus'
           required:
-            - id
             - tier
             - releaseType
             - placementRequestStatus
@@ -3408,10 +3408,6 @@ components:
         - $ref: '#/components/schemas/Task'
         - type: object
           properties:
-            id:
-              type: string
-              format: uuid
-              example: 6abb5fa3-e93f-4445-887b-30d081688f44
             tier:
               $ref: '#/components/schemas/RiskTierEnvelope'
             releaseType:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1830,83 +1830,6 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
-  /applications/{applicationId}/tasks/{taskType}:
-    get:
-      tags:
-        - Application data
-      summary: Gets a task for an application
-      parameters:
-        - in: path
-          name: applicationId
-          required: true
-          description: ID of the application
-          schema:
-            type: string
-            format: uuid
-        - in: path
-          name: taskType
-          required: true
-          description: Task type
-          schema:
-            type: string
-      responses:
-        200:
-          description: successfully retrieved task
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/TaskWrapper'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
-  /applications/{applicationId}/tasks/{taskType}/allocations:
-    post:
-      tags:
-        - Operations on applications
-      summary: Reallocates a task for an application
-      parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - in: path
-          name: taskType
-          required: true
-          description: Task type
-          schema:
-            type: string
-      requestBody:
-        content:
-          'application/json':
-            schema:
-              $ref: '#/components/schemas/NewReallocation'
-        required: true
-      responses:
-        201:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/Reallocation'
-        400:
-          description: invalid params
-          content:
-            'application/problem+json':
-              schema:
-                $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
-      x-codegen-request-body-name: body
   /applications/{applicationId}/assessment:
     get:
       tags:
@@ -2369,6 +2292,83 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /tasks/{taskType}/{id}:
+    get:
+      tags:
+        - Application data
+      summary: Gets a task for an application
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the task
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: taskType
+          required: true
+          description: Task type
+          schema:
+            type: string
+      responses:
+        200:
+          description: successfully retrieved task
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/TaskWrapper'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /tasks/{taskType}/{id}/allocations:
+    post:
+      tags:
+        - Operations on applications
+      summary: Reallocates a task for an application
+      parameters:
+        - name: id
+          in: path
+          description: ID of the task
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: taskType
+          required: true
+          description: Task type
+          schema:
+            type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewReallocation'
+        required: true
+      responses:
+        201:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Reallocation'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /placement-requests:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -35,7 +35,7 @@ class ReallocationAtomicTest : IntegrationTestBase() {
           every { realAssessmentRepository.save(match { it.id != existingAssessment.id }) } throws RuntimeException("I am a database error")
 
           webTestClient.post()
-            .uri("/applications/${application.id}/tasks/assessment/allocations")
+            .uri("/tasks/assessment/${existingAssessment.id}/allocations")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewReallocation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -247,7 +247,7 @@ class TasksTest : IntegrationTestBase() {
     @Test
     fun `Get a Task for an application without JWT returns 401`() {
       webTestClient.get()
-        .uri("/applications/f601ff2d-b1e0-4878-8731-ccfa19a2ce84/tasks/assessment")
+        .uri("/tasks/assessment/f601ff2d-b1e0-4878-8731-ccfa19a2ce84")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -263,7 +263,7 @@ class TasksTest : IntegrationTestBase() {
             crn = offenderDetails.otherIds.crn,
           ) { _, application ->
             webTestClient.get()
-              .uri("/applications/${application.id}/tasks/unknown-task")
+              .uri("/tasks/unknown-task/${application.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -287,7 +287,7 @@ class TasksTest : IntegrationTestBase() {
                 crn = offenderDetails.otherIds.crn,
               ) { assessment, application ->
                 webTestClient.get()
-                  .uri("/applications/${application.id}/tasks/assessment")
+                  .uri("/tasks/assessment/${application.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -323,7 +323,7 @@ class TasksTest : IntegrationTestBase() {
                 crn = offenderDetails.otherIds.crn,
               ) { placementRequest, application ->
                 webTestClient.get()
-                  .uri("/applications/${application.id}/tasks/placement-request")
+                  .uri("/tasks/placement-request/${application.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -361,7 +361,7 @@ class TasksTest : IntegrationTestBase() {
                 crn = offenderDetails.otherIds.crn,
               ) { placementApplication ->
                 webTestClient.get()
-                  .uri("/applications/${placementApplication.application.id}/tasks/placement-application")
+                  .uri("/tasks/placement-application/${placementApplication.application.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -392,7 +392,7 @@ class TasksTest : IntegrationTestBase() {
             crn = offenderDetails.otherIds.crn,
           ) { _, application ->
             webTestClient.get()
-              .uri("/applications/${application.id}/tasks/booking-appeal")
+              .uri("/tasks/booking-appeal/${application.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -408,7 +408,7 @@ class TasksTest : IntegrationTestBase() {
     @Test
     fun `Reallocate application to different assessor without JWT returns 401`() {
       webTestClient.post()
-        .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/assessment/allocations")
+        .uri("/tasks/assessment/9c7abdf6-fd39-4670-9704-98a5bbfec95e/allocations")
         .bodyValue(
           NewReallocation(
             userId = UUID.randomUUID(),
@@ -423,7 +423,7 @@ class TasksTest : IntegrationTestBase() {
     fun `Reallocate application to different assessor without WORKFLOW_MANAGER role returns 403`() {
       `Given a User` { _, jwt ->
         webTestClient.post()
-          .uri("/applications/9c7abdf6-fd39-4670-9704-98a5bbfec95e/tasks/assessment/allocations")
+          .uri("/tasks/assessment/9c7abdf6-fd39-4670-9704-98a5bbfec95e/allocations")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             NewReallocation(
@@ -451,7 +451,7 @@ class TasksTest : IntegrationTestBase() {
               ) { existingAssessment, application ->
 
                 webTestClient.post()
-                  .uri("/applications/${application.id}/tasks/assessment/allocations")
+                  .uri("/tasks/assessment/${application.id}/allocations")
                   .header("Authorization", "Bearer $jwt")
                   .bodyValue(
                     NewReallocation(
@@ -497,7 +497,7 @@ class TasksTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
             ) { existingPlacementRequest, application ->
               webTestClient.post()
-                .uri("/applications/${application.id}/tasks/placement-request/allocations")
+                .uri("/tasks/placement-request/${application.id}/allocations")
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   NewReallocation(
@@ -555,7 +555,7 @@ class TasksTest : IntegrationTestBase() {
                 }
 
                 webTestClient.post()
-                  .uri("/applications/${placementApplication.application.id}/tasks/placement-application/allocations")
+                  .uri("/tasks/placement-application/${placementApplication.application.id}/allocations")
                   .header("Authorization", "Bearer $jwt")
                   .bodyValue(
                     NewReallocation(
@@ -599,7 +599,7 @@ class TasksTest : IntegrationTestBase() {
         `Given a User` { userToReallocate, _ ->
           `Given an Application`(createdByUser = user) { application ->
             webTestClient.post()
-              .uri("/applications/${application.id}/tasks/booking-appeal/allocations")
+              .uri("/tasks/booking-appeal/${application.id}/allocations")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
                 NewReallocation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -285,9 +285,9 @@ class TasksTest : IntegrationTestBase() {
                 allocatedToUser = user,
                 createdByUser = user,
                 crn = offenderDetails.otherIds.crn,
-              ) { assessment, application ->
+              ) { assessment, _ ->
                 webTestClient.get()
-                  .uri("/tasks/assessment/${application.id}")
+                  .uri("/tasks/assessment/${assessment.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -321,9 +321,9 @@ class TasksTest : IntegrationTestBase() {
                 assessmentAllocatedTo = user,
                 createdByUser = user,
                 crn = offenderDetails.otherIds.crn,
-              ) { placementRequest, application ->
+              ) { placementRequest, _ ->
                 webTestClient.get()
-                  .uri("/tasks/placement-request/${application.id}")
+                  .uri("/tasks/placement-request/${placementRequest.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -361,7 +361,7 @@ class TasksTest : IntegrationTestBase() {
                 crn = offenderDetails.otherIds.crn,
               ) { placementApplication ->
                 webTestClient.get()
-                  .uri("/tasks/placement-application/${placementApplication.application.id}")
+                  .uri("/tasks/placement-application/${placementApplication.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -451,7 +451,7 @@ class TasksTest : IntegrationTestBase() {
               ) { existingAssessment, application ->
 
                 webTestClient.post()
-                  .uri("/tasks/assessment/${application.id}/allocations")
+                  .uri("/tasks/assessment/${existingAssessment.id}/allocations")
                   .header("Authorization", "Bearer $jwt")
                   .bodyValue(
                     NewReallocation(
@@ -495,9 +495,9 @@ class TasksTest : IntegrationTestBase() {
               placementRequestAllocatedTo = user,
               assessmentAllocatedTo = user,
               crn = offenderDetails.otherIds.crn,
-            ) { existingPlacementRequest, application ->
+            ) { existingPlacementRequest, _ ->
               webTestClient.post()
-                .uri("/tasks/placement-request/${application.id}/allocations")
+                .uri("/tasks/placement-request/${existingPlacementRequest.id}/allocations")
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   NewReallocation(
@@ -555,7 +555,7 @@ class TasksTest : IntegrationTestBase() {
                 }
 
                 webTestClient.post()
-                  .uri("/tasks/placement-application/${placementApplication.application.id}/allocations")
+                  .uri("/tasks/placement-application/${placementApplication.id}/allocations")
                   .header("Authorization", "Bearer $jwt")
                   .bodyValue(
                     NewReallocation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1170,9 +1170,9 @@ class AssessmentServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousAssessment
+    every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-    val result = assessmentService.reallocateAssessment(assigneeUser, application)
+    val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1217,9 +1217,9 @@ class AssessmentServiceTest {
       )
       .produce()
 
-    every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousAssessment
+    every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-    val result = assessmentService.reallocateAssessment(assigneeUser, application)
+    val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1271,9 +1271,9 @@ class AssessmentServiceTest {
       )
       .produce()
 
-    every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousAssessment
+    every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-    val result = assessmentService.reallocateAssessment(assigneeUser, application)
+    val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1330,7 +1330,7 @@ class AssessmentServiceTest {
       )
       .produce()
 
-    every { assessmentRepositoryMock.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousAssessment
+    every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
@@ -1343,7 +1343,7 @@ class AssessmentServiceTest {
 
     every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
 
-    val result = assessmentService.reallocateAssessment(assigneeUser, application)
+    val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
@@ -119,7 +120,7 @@ class PlacementApplicationServiceTest {
         ),
       )
 
-      every { placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementApplication
+      every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
       every { placementApplicationRepository.save(previousPlacementApplication) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { placementApplicationRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementApplicationEntity }
@@ -129,7 +130,7 @@ class PlacementApplicationServiceTest {
         )
       } answers { newPlacementDates }
 
-      val result = placementApplicationService.reallocateApplication(assigneeUser, application)
+      val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -159,9 +160,9 @@ class PlacementApplicationServiceTest {
         decision = PlacementApplicationDecision.ACCEPTED
       }
 
-      every { placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementApplication
+      every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
-      val result = placementApplicationService.reallocateApplication(assigneeUser, application)
+      val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -173,9 +174,9 @@ class PlacementApplicationServiceTest {
 
     @Test
     fun `Reallocating a placement application when user to assign to is not a MATCHER returns a field validation error`() {
-      every { placementApplicationRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementApplication
+      every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
-      val result = placementApplicationService.reallocateApplication(assigneeUser, application)
+      val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -134,9 +134,9 @@ class PlacementRequestServiceTest {
       .withAllocatedToUser(previousUser)
       .produce()
 
-    every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
+    every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
 
-    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -169,9 +169,9 @@ class PlacementRequestServiceTest {
       .withAllocatedToUser(previousUser)
       .produce()
 
-    every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
+    every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
 
-    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -218,12 +218,12 @@ class PlacementRequestServiceTest {
       .withAllocatedToUser(previousUser)
       .produce()
 
-    every { placementRequestRepository.findByApplication_IdAndReallocatedAtNull(application.id) } returns previousPlacementRequest
+    every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
 
     every { placementRequestRepository.save(previousPlacementRequest) } answers { it.invocation.args[0] as PlacementRequestEntity }
     every { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementRequestEntity }
 
-    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, application)
+    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -126,6 +126,7 @@ class TaskTransformerTest {
 
       var result = taskTransformer.transformAssessmentToTask(assessment, "First Last")
 
+      assertThat(result.id).isEqualTo(assessment.id)
       assertThat(result.status).isEqualTo(TaskStatus.notStarted)
       assertThat(result.taskType).isEqualTo(TaskType.assessment)
       assertThat(result.applicationId).isEqualTo(application.id)


### PR DESCRIPTION
Reallocating a task according to the application ID caused some issues, because applications can have multiple “active” placement applications, so this was raising an error. Rather than have a special case for placement applications, it makes sense to have all tasks act on their own IDs, rather than relying on the applicationID being present. This also involves so changes to the URLs that the UI causes, so this is a breaking UI change, but I'll be working on this in parallel.