### PR TITLE
(271) Add arrival time

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.Objects
@@ -21,6 +22,7 @@ data class ArrivalEntity(
   @Id
   val id: UUID,
   val arrivalDate: LocalDate,
+  val arrivalDateTime: Instant,
   val expectedDepartureDate: LocalDate,
   val notes: String?,
   val createdAt: OffsetDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ArrivalTransformer.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 @Component
 class ArrivalTransformer() {
@@ -10,6 +12,7 @@ class ArrivalTransformer() {
     Arrival(
       bookingId = jpa.booking.id,
       arrivalDate = jpa.arrivalDate,
+      arrivalTime = DateTimeFormatter.ISO_LOCAL_TIME.format(jpa.arrivalDateTime.atZone(ZoneOffset.UTC)),
       expectedDepartureDate = jpa.expectedDepartureDate,
       notes = jpa.notes,
       createdAt = jpa.createdAt.toInstant(),

--- a/src/main/resources/db/migration/all/20230628104650__add_arrival_date_time_to_arrivals.sql
+++ b/src/main/resources/db/migration/all/20230628104650__add_arrival_date_time_to_arrivals.sql
@@ -1,0 +1,3 @@
+ALTER TABLE arrivals ADD COLUMN arrival_date_time TIMESTAMP WITH TIME ZONE;
+
+UPDATE arrivals SET arrival_date_time = cast(arrival_date as timestamp) at time zone 'utc';

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3692,34 +3692,11 @@ components:
         - dateOfBirth
         - sex
         - status
-    Arrival:
-      type: object
-      properties:
-        bookingId:
-          type: string
-          format: uuid
-        arrivalDate:
-          type: string
-          format: date
-        expectedDepartureDate:
-          type: string
-          format: date
-        notes:
-          type: string
-        createdAt:
-          type: string
-          format: date-time
-      required:
-        - bookingId
-        - arrivalDate
-        - expectedDepartureDate
-        - createdAt
     NewArrival:
       type: object
       properties:
-        arrivalDate:
+        type:
           type: string
-          format: date
         expectedDepartureDate:
           type: string
           format: date
@@ -3728,8 +3705,73 @@ components:
         keyWorkerStaffCode:
           type: string
       required:
-        - arrivalDate
+        - type
         - expectedDepartureDate
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/NewCas1Arrival'
+          CAS2: '#/components/schemas/NewCas2Arrival'
+          CAS3: '#/components/schemas/NewCas3Arrival'
+    NewCas1Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDateTime:
+              type: string
+              format: date-time
+          required:
+            - arrivalDateTime
+    NewCas2Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+          required:
+            - arrivalDate
+    NewCas3Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+          required:
+            - arrivalDate
+    Arrival:
+      type: object
+      properties:
+        expectedDepartureDate:
+          type: string
+          format: date
+        arrivalDate:
+          type: string
+          format: date
+        arrivalTime:
+          type: string
+          format: time
+        notes:
+          type: string
+        keyWorkerStaffCode:
+          type: string
+        bookingId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - type
+        - bookingId
+        - expectedDepartureDate
+        - createdAt
+        - arrivalDate
+        - arrivalTime
     Nonarrival:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -15,6 +16,7 @@ import java.util.UUID
 class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var arrivalDateTime: Yielded<Instant> = { Instant.now().randomDateTimeBefore() }
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
@@ -26,6 +28,10 @@ class ArrivalEntityFactory : Factory<ArrivalEntity> {
 
   fun withArrivalDate(arrivalDate: LocalDate) = apply {
     this.arrivalDate = { arrivalDate }
+  }
+
+  fun withArrivalDateTime(arrivalDateTime: Instant) = apply {
+    this.arrivalDateTime = { arrivalDateTime }
   }
 
   fun withExpectedDepartureDate(expectedDepartureDate: LocalDate) = apply {
@@ -51,6 +57,7 @@ class ArrivalEntityFactory : Factory<ArrivalEntity> {
   override fun produce(): ArrivalEntity = ArrivalEntity(
     id = this.id(),
     arrivalDate = this.arrivalDate(),
+    arrivalDateTime = this.arrivalDateTime(),
     expectedDepartureDate = this.expectedDepartureDate(),
     notes = this.notes(),
     booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -8,9 +8,10 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.reactive.server.expectBodyList
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1Arrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas3Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewDeparture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
@@ -996,7 +997,8 @@ class BookingTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises/e0f03aa2-1468-441c-aa98-0b98d86b67f9/bookings/1617e729-13f3-4158-bd88-c59affdb8a45/arrivals")
       .bodyValue(
-        NewArrival(
+        NewCas3Arrival(
+          type = "CAS3",
           arrivalDate = LocalDate.parse("2022-08-12"),
           expectedDepartureDate = LocalDate.parse("2022-08-14"),
           notes = null,
@@ -1053,7 +1055,8 @@ class BookingTest : IntegrationTestBase() {
           .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
-            NewArrival(
+            NewCas3Arrival(
+              type = "CAS3",
               arrivalDate = LocalDate.parse("2022-06-16"),
               expectedDepartureDate = LocalDate.parse("2022-07-16"),
               notes = "Moved in late due to sickness",
@@ -1113,7 +1116,8 @@ class BookingTest : IntegrationTestBase() {
           .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
-            NewArrival(
+            NewCas3Arrival(
+              type = "CAS3",
               arrivalDate = LocalDate.parse("2022-06-16"),
               expectedDepartureDate = LocalDate.parse("2022-07-16"),
               notes = "Moved in late due to sickness",
@@ -1165,8 +1169,9 @@ class BookingTest : IntegrationTestBase() {
         .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
-          NewArrival(
-            arrivalDate = LocalDate.parse("2022-08-12"),
+          NewCas1Arrival(
+            type = "CAS1",
+            arrivalDateTime = Instant.parse("2022-08-12T15:30:00Z"),
             expectedDepartureDate = LocalDate.parse("2022-08-14"),
             notes = "Hello",
             keyWorkerStaffCode = keyWorker.code,
@@ -1178,6 +1183,7 @@ class BookingTest : IntegrationTestBase() {
         .expectBody()
         .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
         .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
+        .jsonPath("$.arrivalTime").isEqualTo("15:30:00")
         .jsonPath("$.expectedDepartureDate").isEqualTo("2022-08-14")
         .jsonPath("$.notes").isEqualTo("Hello")
         .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
@@ -1227,8 +1233,9 @@ class BookingTest : IntegrationTestBase() {
         .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
-          NewArrival(
-            arrivalDate = LocalDate.parse("2023-05-20"),
+          NewCas1Arrival(
+            type = "CAS1",
+            arrivalDateTime = Instant.parse("2023-05-20T15:00:00Z"),
             expectedDepartureDate = LocalDate.parse("2023-06-05"),
             notes = "Hello",
             keyWorkerStaffCode = keyWorker.code,
@@ -1284,7 +1291,8 @@ class BookingTest : IntegrationTestBase() {
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
-            NewArrival(
+            NewCas3Arrival(
+              type = "CAS3",
               arrivalDate = LocalDate.parse("2022-08-12"),
               expectedDepartureDate = LocalDate.parse("2022-08-14"),
               notes = "Hello",
@@ -1346,7 +1354,8 @@ class BookingTest : IntegrationTestBase() {
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
-            NewArrival(
+            NewCas3Arrival(
+              type = "CAS3",
               arrivalDate = LocalDate.parse("2022-08-12"),
               expectedDepartureDate = LocalDate.parse("2022-08-14"),
               notes = "Hello",
@@ -1410,7 +1419,8 @@ class BookingTest : IntegrationTestBase() {
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
-            NewArrival(
+            NewCas3Arrival(
+              type = "CAS3",
               arrivalDate = LocalDate.parse("2022-08-12"),
               expectedDepartureDate = LocalDate.parse("2022-08-14"),
               notes = "Hello",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -353,6 +353,7 @@ class BookingTransformerTest {
       arrival = ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
+        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
         expectedDepartureDate = LocalDate.parse("2022-08-16"),
         notes = null,
         booking = this,
@@ -363,6 +364,7 @@ class BookingTransformerTest {
     every { mockArrivalTransformer.transformJpaToApi(arrivalBooking.arrival) } returns Arrival(
       bookingId = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
       arrivalDate = LocalDate.parse("2022-08-10"),
+      arrivalTime = "00:00:00",
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
       notes = null,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -396,6 +398,7 @@ class BookingTransformerTest {
         arrival = Arrival(
           bookingId = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
           arrivalDate = LocalDate.parse("2022-08-10"),
+          arrivalTime = "00:00:00",
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null,
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -602,6 +605,7 @@ class BookingTransformerTest {
       arrival = ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
+        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
         expectedDepartureDate = LocalDate.parse("2022-08-16"),
         notes = null,
         booking = this,
@@ -642,6 +646,7 @@ class BookingTransformerTest {
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
       notes = null,
+      arrivalTime = "00:00:00",
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
@@ -700,6 +705,7 @@ class BookingTransformerTest {
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null,
+          arrivalTime = "00:00:00",
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         departure = Departure(
@@ -771,6 +777,7 @@ class BookingTransformerTest {
       arrival = ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
+        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
         expectedDepartureDate = LocalDate.parse("2022-08-16"),
         notes = null,
         booking = this,
@@ -818,6 +825,7 @@ class BookingTransformerTest {
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
       notes = null,
+      arrivalTime = "00:00:00",
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
@@ -883,6 +891,7 @@ class BookingTransformerTest {
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null,
+          arrivalTime = "00:00:00",
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         departure = Departure(
@@ -977,6 +986,7 @@ class BookingTransformerTest {
       arrival = ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
+        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
         expectedDepartureDate = departedAt.toLocalDate(),
         notes = null,
         booking = this,
@@ -1024,6 +1034,7 @@ class BookingTransformerTest {
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
       notes = null,
+      arrivalTime = "00:00:00",
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
@@ -1092,6 +1103,7 @@ class BookingTransformerTest {
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null,
+          arrivalTime = "00:00:00",
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         departure = Departure(
@@ -1187,6 +1199,7 @@ class BookingTransformerTest {
       arrival = ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
+        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
         expectedDepartureDate = departedAt.toLocalDate(),
         notes = null,
         booking = this,
@@ -1234,6 +1247,7 @@ class BookingTransformerTest {
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
       notes = null,
+      arrivalTime = "00:00:00",
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
@@ -1302,6 +1316,7 @@ class BookingTransformerTest {
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null,
+          arrivalTime = "00:00:00",
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         departure = Departure(
@@ -1388,6 +1403,7 @@ class BookingTransformerTest {
       arrival = ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
+        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
         expectedDepartureDate = LocalDate.parse("2022-08-16"),
         notes = null,
         booking = this,
@@ -1454,6 +1470,7 @@ class BookingTransformerTest {
       arrivalDate = LocalDate.parse("2022-08-10"),
       expectedDepartureDate = LocalDate.parse("2022-08-16"),
       notes = null,
+      arrivalTime = "00:00:00",
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
@@ -1544,6 +1561,7 @@ class BookingTransformerTest {
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null,
+          arrivalTime = "00:00:00",
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         departure = Departure(


### PR DESCRIPTION
This adds the functionality to add an Arrival Time in  DateTime format for CAS1 premises. There's been a bit of jiggery pokery to ensure compatibility with CAS3, but hopefully this is all sensible enough.