### PR TITLE
Add request information to MDC

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.HandlerMapping
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class MDCHandlerInterceptor(
+  private val userService: UserService,
+) : HandlerInterceptor {
+  override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+    appendRequestDiagnosticsToMDC(request)
+
+    return super.preHandle(request, response, handler)
+  }
+
+  private fun appendRequestDiagnosticsToMDC(request: HttpServletRequest) {
+    MDC.put("request.id", UUID.randomUUID().toString())
+    MDC.put("request.uri", request.requestURI)
+    MDC.put("request.method", request.method)
+    MDC.put("request.pathPattern", request.getPathPattern())
+    request.getPathParams().entries.forEach {
+      MDC.put("request.params.${it.key}", it.value.toString())
+    }
+    request.parameterMap.entries.forEach {
+      MDC.put("request.params.${it.key}", it.value.joinToString(","))
+    }
+    MDC.put("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified")
+    MDC.put("request.user", userService.getUserForRequestOrNull()?.deliusUsername ?: "Anonymous")
+  }
+
+  private fun HttpServletRequest.getPathPattern() =
+    this.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE) as String
+  private fun HttpServletRequest.getPathParams() =
+    this.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE) as Map<*, *>
+}
+
+@Component
+class MDCHandlerInterceptorConfig(
+  private val interceptor: MDCHandlerInterceptor,
+) : WebMvcConfigurer {
+  override fun addInterceptors(registry: InterceptorRegistry) {
+    registry.addInterceptor(interceptor)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/HttpAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/HttpAuthService.kt
@@ -16,4 +16,14 @@ class HttpAuthService {
 
     return principal
   }
+
+  fun getDeliusPrincipalOrNull(): AuthAwareAuthenticationToken? {
+    val principal = SecurityContextHolder.getContext().authentication as? AuthAwareAuthenticationToken ?: return null
+
+    if (principal.token.claims["auth_source"] != "delius") {
+      return null
+    }
+
+    return principal
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -45,6 +45,13 @@ class UserService(
     return getUserForUsername(username)
   }
 
+  fun getUserForRequestOrNull(): UserEntity? {
+    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrNull() ?: return null
+    val username = deliusPrincipal.name
+
+    return userRepository.findByDeliusUsername(username.uppercase())
+  }
+
   fun getUsersWithQualificationsAndRoles(qualifications: List<UserQualification>?, roles: List<UserRole>?) =
     userRepository.findAll(hasQualificationsAndRoles(qualifications, roles), Sort.by(Sort.Direction.ASC, "name"))
 


### PR DESCRIPTION
This adds the following to the MDC for a given request:
- `request.id`: a random per-request UUID that can be used to group all log messages for a given request.
- `request.uri`: the requested URI, e.g. `/premises/a93602aa-4787-4aa4-a488-a22ba01149fb`.
- `request.method`: the request method, e.g. `GET`.
- `request.pathPattern`: the path pattern that best matches the requested URI in the format that developers talk about it, e.g. `/premises/{premisesId}`.
- `request.params`: all path parameters and query parameters are added as subkeys. For example, the above value of `request.uri` would have a corresponding `request.params.premisesId` MDC key with a value of `a93602aa-4787-4aa4-a488-a22ba01149fb`.
- `request.serviceName`: the service the request is for, derived from the `X-Service-Name` header. If this header does not have a value, it will have a value of `Not specified`.
- `request.user`: the Delius username of the user making the request, e.g. `JIMSNOWLDAP`. If the user could not be retrieved, this will have a value of `Anonymous`.

These values in the MDC will be captured by Application Insights and stored as custom dimensions for log messages.