### PR TITLE
Hide cancelled lost beds and bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CalendarService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.GetBookingForPremisesResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LostBedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
@@ -96,6 +97,7 @@ class PremisesController(
   private val premisesService: PremisesService,
   private val offenderService: OffenderService,
   private val bookingService: BookingService,
+  private val lostBedsService: LostBedService,
   private val bedService: BedService,
   private val calendarService: CalendarService,
   private val premisesTransformer: PremisesTransformer,
@@ -646,11 +648,13 @@ class PremisesController(
     val premises = premisesService.getPremises(premisesId)
       ?: throw NotFoundProblem(premisesId, "Premises")
 
+    val lostBeds = lostBedsService.getActiveLostBedsForPremisesId(premisesId)
+
     if (!userAccessService.currentUserCanManagePremisesLostBeds(premises)) {
       throw ForbiddenProblem()
     }
 
-    return ResponseEntity.ok(premises.lostBeds.map(lostBedsTransformer::transformJpaToApi))
+    return ResponseEntity.ok(lostBeds.map(lostBedsTransformer::transformJpaToApi))
   }
 
   override fun premisesPremisesIdLostBedsLostBedIdGet(premisesId: UUID, lostBedId: UUID): ResponseEntity<LostBed> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -34,16 +34,22 @@ const val bedSummaryQuery =
       (
         select count(booking.id)
         from bookings booking
+          left join cancellations cancellation
+            on booking.id = cancellation.booking_id
         where booking.bed_id = b.id
           and booking.arrival_date <= CURRENT_DATE
           and booking.departure_date >= CURRENT_DATE
+          and cancellation IS NULL
       ) > 0 as bedBooked,
       (
         select count(lost_bed.id)
         from lost_beds lost_bed
+          left join lost_bed_cancellations cancellation
+            on lost_bed.id = cancellation.lost_bed_id
         where lost_bed.bed_id = b.id
           and lost_bed.start_date <= CURRENT_DATE
           and lost_bed.end_date >= CURRENT_DATE
+          and cancellation IS NULL
       ) > 0 as bedOutOfService
       from beds b
            join rooms r on b.room_id = r.id 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedsEntity.kt
@@ -40,6 +40,9 @@ interface LostBedsRepository : JpaRepository<LostBedsEntity, UUID> {
 
   @Query("SELECT lb FROM LostBedsEntity lb WHERE lb.startDate <= :endDate AND lb.endDate >= :startDate AND lb.bed = :bed")
   fun findAllByOverlappingDateForBed(startDate: LocalDate, endDate: LocalDate, bed: BedEntity): List<LostBedsEntity>
+
+  @Query("SELECT lb FROM LostBedsEntity lb LEFT JOIN lb.cancellation c WHERE lb.premises.id = :premisesId AND c is NULL")
+  fun findAllActiveForPremisesId(premisesId: UUID): List<LostBedsEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/LostBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/LostBedService.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
+import java.util.UUID
+
+@Service
+class LostBedService(
+  private val lostBedsRepository: LostBedsRepository,
+) {
+  fun getActiveLostBedsForPremisesId(premisesId: UUID) = lostBedsRepository.findAllActiveForPremisesId(premisesId)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -69,7 +69,7 @@ class LostBedsTest : IntegrationTestBase() {
         }
       }
 
-      val lostBeds = lostBedsEntityFactory.produceAndPersist {
+      val lostBed = lostBedsEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
@@ -77,7 +77,19 @@ class LostBedsTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val expectedJson = objectMapper.writeValueAsString(listOf(lostBedsTransformer.transformJpaToApi(lostBeds)))
+      val cancelledLostBed = lostBedsEntityFactory.produceAndPersist() {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withBed(bed)
+        withPremises(premises)
+      }
+
+      lostBedCancellationEntityFactory.produceAndPersist() {
+        withLostBed(cancelledLostBed)
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(listOf(lostBedsTransformer.transformJpaToApi(lostBed)))
 
       webTestClient.get()
         .uri("/premises/${premises.id}/lost-beds")


### PR DESCRIPTION
After introucing lost bed cancellation in the frontend, I noticed that cancelled lost beds were still showing in some places. This filters cancelled lost beds in the lost bed listing, as well as altering the status of beds with cancelled bookings / lost beds in the bed listing, and removing cancelled lost beds / bookings in the calendar view.