### PR TITLE
Handle missing NOMIS and OASys data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -110,7 +110,7 @@ class ApplicationsController(
     val (offender, inmate) = getPersonDetail(body.crn, true)
 
     val applicationResult = when (xServiceName ?: ServiceName.approvedPremises) {
-      ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
+      ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(offender, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
       ServiceName.cas2 -> applicationService.createCas2Application(body.crn, user, deliusPrincipal.token.tokenValue)
       ServiceName.temporaryAccommodation -> {
         when (val actionResult = applicationService.createTemporaryAccommodationApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -49,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromOffenderDetailSummaryResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
 import java.net.URI
 import java.util.UUID
 import javax.transaction.Transactional
@@ -243,7 +244,7 @@ class ApplicationsController(
     return ResponseEntity.ok(assessmentTransformer.transformJpaToApi(assessment, offender, inmate))
   }
 
-  private fun getPersonDetail(crn: String, forceFullLaoCheck: Boolean = false): Pair<OffenderDetailSummary, InmateDetail> {
+  private fun getPersonDetail(crn: String, forceFullLaoCheck: Boolean = false): Pair<OffenderDetailSummary, InmateDetail?> {
     val user = userService.getUserForRequest()
 
     val ignoreLao = if (forceFullLaoCheck) {
@@ -252,23 +253,8 @@ class ApplicationsController(
       user.hasQualification(UserQualification.LAO)
     }
 
-    val offenderResult = offenderService.getOffenderByCrn(crn, user.deliusUsername, ignoreLao)
-
-    if (offenderResult !is AuthorisableActionResult.Success) {
-      throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
-    }
-
-    if (offenderResult.entity.otherIds.nomsNumber == null) {
-      throw InternalServerErrorProblem("No nomsNumber present for CRN")
-    }
-
-    val inmateDetailResult = offenderService.getInmateDetailByNomsNumber(crn, offenderResult.entity.otherIds.nomsNumber)
-
-    if (inmateDetailResult !is AuthorisableActionResult.Success) {
-      throw InternalServerErrorProblem("Unable to get InmateDetail via crn: $crn")
-    }
-
-    return Pair(offenderResult.entity, inmateDetailResult.entity)
+    return getPersonDetailsForCrn(log, crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
+      ?: throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
   }
 
   private fun getAssessmentTask(assessment: AssessmentEntity, user: UserEntity): AssessmentTask {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -196,7 +196,7 @@ abstract class ApplicationEntity(
   @OneToMany(mappedBy = "application")
   var assessments: MutableList<AssessmentEntity>,
 
-  var nomsNumber: String,
+  var nomsNumber: String?,
 ) {
   fun getLatestAssessment(): AssessmentEntity? = this.assessments.maxByOrNull { it.createdAt }
   abstract fun getRequiredQualifications(): List<UserQualification>
@@ -225,7 +225,7 @@ class ApprovedPremisesApplicationEntity(
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,
-  nomsNumber: String,
+  nomsNumber: String?,
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   @Convert(disableConversion = true)
   val riskRatings: PersonRisks?,
@@ -305,7 +305,7 @@ class Cas2ApplicationEntity(
   submittedAt: OffsetDateTime?,
   schemaUpToDate: Boolean,
   assessments: MutableList<AssessmentEntity>,
-  nomsNumber: String,
+  nomsNumber: String?,
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   @Convert(disableConversion = true)
   val riskRatings: PersonRisks?,
@@ -340,7 +340,7 @@ class TemporaryAccommodationApplicationEntity(
   submittedAt: OffsetDateTime?,
   schemaUpToDate: Boolean,
   assessments: MutableList<AssessmentEntity>,
-  nomsNumber: String,
+  nomsNumber: String?,
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -104,7 +104,7 @@ data class BookingEntity(
   val createdAt: OffsetDateTime,
   @OneToMany(mappedBy = "booking")
   var turnarounds: MutableList<TurnaroundEntity>,
-  var nomsNumber: String,
+  var nomsNumber: String?,
   @OneToOne(mappedBy = "booking")
   var placementRequest: PlacementRequestEntity?,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -41,7 +41,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import java.time.Instant
@@ -181,10 +180,6 @@ class ApplicationService(
 
     if (validationErrors.any()) {
       return fieldValidationError
-    }
-
-    if (offenderService.getOASysNeeds(crn) !is AuthorisableActionResult.Success) {
-      throw InternalServerErrorProblem("No OASys present for CRN: $crn")
     }
 
     var riskRatings: PersonRisks? = null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -35,7 +35,7 @@ class ApplicationsTransformer(
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
 ) {
-  fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): Application {
+  fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): Application {
     val latestAssessment = jpa.getLatestAssessment()
 
     return when (jpa) {
@@ -113,7 +113,7 @@ class ApplicationsTransformer(
     }
   }
 
-  fun transformDomainToApiSummary(domain: DomainApplicationSummary, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): ApiApplicationSummary = when (domain) {
+  fun transformDomainToApiSummary(domain: DomainApplicationSummary, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): ApiApplicationSummary = when (domain) {
     is DomainApprovedPremisesApplicationSummary -> {
       val riskRatings =
         if (domain.getRiskRatings() != null) objectMapper.readValue<PersonRisks>(domain.getRiskRatings()!!) else null
@@ -167,14 +167,14 @@ class ApplicationsTransformer(
     else -> throw RuntimeException("Unrecognised application type when transforming: ${domain::class.qualifiedName}")
   }
 
-  fun transformJpaToApi(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplication(
+  fun transformJpaToApi(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = OfflineApplication(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),
     type = "Offline",
   )
 
-  fun transformJpaToApiSummary(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = OfflineApplicationSummary(
+  fun transformJpaToApiSummary(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = OfflineApplicationSummary(
     id = jpa.id,
     person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
     createdAt = jpa.createdAt.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -31,7 +31,7 @@ class AssessmentTransformer(
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
 ) {
-  fun transformJpaToApi(jpa: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = when (jpa.application) {
+  fun transformJpaToApi(jpa: AssessmentEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = when (jpa.application) {
     is ApprovedPremisesApplicationEntity -> ApprovedPremisesAssessment(
       id = jpa.id,
       application = applicationsTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail) as ApprovedPremisesApplication,
@@ -69,7 +69,7 @@ class AssessmentTransformer(
     else -> throw RuntimeException("Unsupported Application type when transforming Assessment: ${jpa.application::class.qualifiedName}")
   }
 
-  fun transformDomainToApiSummary(ase: DomainAssessmentSummary, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): AssessmentSummary =
+  fun transformDomainToApiSummary(ase: DomainAssessmentSummary, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): AssessmentSummary =
     AssessmentSummary(
       type = when (ase.type) {
         "approved-premises" -> AssessmentSummary.Type.cAS1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -28,7 +28,7 @@ class BookingTransformer(
   private val enumConverterFactory: EnumConverterFactory,
   private val workingDayCountService: WorkingDayCountService,
 ) {
-  fun transformJpaToApi(jpa: BookingEntity, offender: OffenderDetailSummary, inmateDetail: InmateDetail, staffMember: StaffMember?): Booking {
+  fun transformJpaToApi(jpa: BookingEntity, offender: OffenderDetailSummary, inmateDetail: InmateDetail?, staffMember: StaffMember?): Booking {
     val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
 
     return Booking(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -8,13 +8,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 
 @Component
 class PersonTransformer {
-  fun transformModelToApi(offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail) = Person(
+  fun transformModelToApi(offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = Person(
     crn = offenderDetailSummary.otherIds.crn,
     name = "${offenderDetailSummary.firstName} ${offenderDetailSummary.surname}",
     dateOfBirth = offenderDetailSummary.dateOfBirth,
     sex = offenderDetailSummary.gender,
-    status = inOutStatusToApiStatus(inmateDetail.inOutStatus),
-    nomsNumber = inmateDetail.offenderNo,
+    status = inOutStatusToApiStatus(inmateDetail?.inOutStatus),
+    nomsNumber = inmateDetail?.offenderNo,
     ethnicity = offenderDetailSummary.offenderProfile.ethnicity,
     nationality = offenderDetailSummary.offenderProfile.nationality,
     religionOrBelief = offenderDetailSummary.offenderProfile.religion,
@@ -22,14 +22,15 @@ class PersonTransformer {
       "Prefer to self-describe" -> offenderDetailSummary.offenderProfile.selfDescribedGender
       else -> offenderDetailSummary.offenderProfile.genderIdentity
     },
-    prisonName = inOutStatusToApiStatus(inmateDetail.inOutStatus).takeIf { it == Person.Status.inCustody }?.let {
-      inmateDetail.assignedLivingUnit?.agencyName ?: inmateDetail.assignedLivingUnit?.agencyId
+    prisonName = inOutStatusToApiStatus(inmateDetail?.inOutStatus).takeIf { it == Person.Status.inCustody }?.let {
+      inmateDetail?.assignedLivingUnit?.agencyName ?: inmateDetail?.assignedLivingUnit?.agencyId
     },
   )
 
-  private fun inOutStatusToApiStatus(inOutStatus: InOutStatus) = when (inOutStatus) {
+  private fun inOutStatusToApiStatus(inOutStatus: InOutStatus?) = when (inOutStatus) {
     InOutStatus.IN -> Person.Status.inCustody
     InOutStatus.OUT -> Person.Status.inCommunity
     InOutStatus.TRN -> Person.Status.inCustody
+    null -> Person.Status.unknown
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -12,7 +12,7 @@ class PlacementRequestDetailTransformer(
   private val placementRequestTransformer: PlacementRequestTransformer,
   private val cancellationTransformer: CancellationTransformer,
 ) {
-  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail, cancellations: List<CancellationEntity>): PlacementRequestDetail {
+  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?, cancellations: List<CancellationEntity>): PlacementRequestDetail {
     val placementRequest = placementRequestTransformer.transformJpaToApi(jpa, offenderDetailSummary, inmateDetail)
 
     return PlacementRequestDetail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -19,7 +19,7 @@ class PlacementRequestTransformer(
   private val assessmentTransformer: AssessmentTransformer,
   private val userTransformer: UserTransformer,
 ) {
-  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail): PlacementRequest {
+  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): PlacementRequest {
     return PlacementRequest(
       id = jpa.id,
       gender = jpa.placementRequirements.gender,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -12,7 +12,7 @@ fun <T> mapAndTransformAssessmentSummaries(
   assessments: List<DomainAssessmentSummary>,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T,
+  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail?) -> T,
   ignoreLao: Boolean = false,
 ): List<T> {
   return assessments.mapNotNull {
@@ -25,7 +25,7 @@ fun <T> transformAssessmentSummary(
   assessment: DomainAssessmentSummary,
   deliusUsername: String,
   offenderService: OffenderService,
-  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail) -> T,
+  transformer: (DomainAssessmentSummary, OffenderDetailSummary, InmateDetail?) -> T,
   ignoreLao: Boolean,
 ): T {
   val (offenderDetailSummary, inmateDetail) = getPersonDetailsForCrn(log, assessment.crn, deliusUsername, offenderService, ignoreLao)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
@@ -13,34 +13,34 @@ fun getPersonDetailsForCrn(
   deliusUsername: String,
   offenderService: OffenderService,
   ignoreLao: Boolean = false,
-): Pair<OffenderDetailSummary, InmateDetail>? {
+): Pair<OffenderDetailSummary, InmateDetail?>? {
   val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(crn, deliusUsername, ignoreLao)) {
     is AuthorisableActionResult.Success -> offenderDetailsResult.entity
     is AuthorisableActionResult.NotFound -> {
       log.error("Could not get Offender Details for CRN: $crn")
       return null
     }
-
     is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
   }
 
-  if (offenderDetails.otherIds.nomsNumber == null) {
-    log.error("No NOMS number for CRN: $crn")
+  val inmateDetails = getInmateDetail(offenderDetails, offenderService)
+
+  return Pair(offenderDetails, inmateDetails)
+}
+
+fun getInmateDetail(offenderDetails: OffenderDetailSummary, offenderService: OffenderService): InmateDetail? {
+  val nomsNumber = offenderDetails.otherIds.nomsNumber
+
+  if (nomsNumber.isNullOrEmpty()) {
     return null
   }
 
-  val inmateDetails = when (
+  return when (
     val inmateDetailsResult =
       offenderService.getInmateDetailByNomsNumber(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber)
   ) {
     is AuthorisableActionResult.Success -> inmateDetailsResult.entity
-    is AuthorisableActionResult.NotFound -> {
-      log.error("Could not get Inmate Details for NOMS number: ${offenderDetails.otherIds.nomsNumber}")
-      return null
-    }
-
-    is AuthorisableActionResult.Unauthorised -> return null
+    is AuthorisableActionResult.NotFound -> null
+    is AuthorisableActionResult.Unauthorised -> null
   }
-
-  return Pair(offenderDetails, inmateDetails)
 }

--- a/src/main/resources/db/migration/all/20230629140901__make_noms_number_nullable.sql
+++ b/src/main/resources/db/migration/all/20230629140901__make_noms_number_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE applications ALTER COLUMN noms_number DROP NOT NULL;
+ALTER TABLE bookings ALTER COLUMN noms_number DROP NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3685,6 +3685,7 @@ components:
           enum:
             - InCustody
             - InCommunity
+            - Unknown
         prisonName:
           type: string
       required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.data.repository.findByIdOrNull
@@ -68,7 +67,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
@@ -271,38 +269,6 @@ class ApplicationServiceTest {
     result as AuthorisableActionResult.Success
 
     assertThat(result.entity).isEqualTo(applicationEntity)
-  }
-
-  @Test
-  fun `createApprovedPremisesApplication throws InternalServerErrorProblem when no OASys needs present`() {
-    val crn = "CRN345"
-    val username = "SOMEPERSON"
-
-    val user = userWithUsername(username)
-
-    val offenderDetails = OffenderDetailsSummaryFactory()
-      .withCrn(crn)
-      .produce()
-
-    every { mockOffenderService.getOASysNeeds(crn) } returns AuthorisableActionResult.NotFound()
-
-    every { mockApDeliusContextApiClient.getTeamsManagingCase(crn) } returns ClientResult.Success(
-      HttpStatus.OK,
-      ManagingTeamsResponse(
-        teamCodes = listOf("TEAMCODE"),
-      ),
-    )
-
-    every { mockOffenderService.getOffenderByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce(),
-    )
-    every { mockUserService.getUserForRequest() } returns user
-
-    val thrownException = assertThrows<InternalServerErrorProblem> {
-      applicationService.createApprovedPremisesApplication(offenderDetails, user, "jwt", 123, "1", "A12HI")
-    }
-
-    assertThat(thrownException.detail).isEqualTo("No OASys present for CRN: $crn")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -320,4 +320,73 @@ class PersonTransformerTest {
       ),
     )
   }
+
+  @Test
+  fun `transformModelToApi transforms correctly without a NOMS record`() {
+    val offenderDetailSummary = OffenderDetailSummary(
+      offenderId = 547839,
+      title = "Mr",
+      firstName = "Greggory",
+      middleNames = listOf(),
+      surname = "Someone",
+      previousSurname = null,
+      preferredName = null,
+      dateOfBirth = LocalDate.parse("1980-09-12"),
+      gender = "Male",
+      otherIds = OffenderIds(
+        crn = "CRN123",
+        croNumber = null,
+        immigrationNumber = null,
+        mostRecentPrisonNumber = null,
+        niNumber = null,
+        nomsNumber = "NOMS321",
+        pncNumber = null,
+      ),
+      offenderProfile = OffenderProfile(
+        ethnicity = "White and Asian",
+        nationality = "Spanish",
+        secondaryNationality = null,
+        notes = null,
+        immigrationStatus = null,
+        offenderLanguages = OffenderLanguages(
+          primaryLanguage = null,
+          otherLanguages = listOf(),
+          languageConcerns = null,
+          requiresInterpreter = null,
+        ),
+        religion = "Sikh",
+        sexualOrientation = null,
+        offenderDetails = null,
+        remandStatus = null,
+        riskColour = null,
+        disabilities = listOf(),
+        genderIdentity = null,
+        selfDescribedGender = null,
+      ),
+      softDeleted = null,
+      currentDisposal = "",
+      partitionArea = null,
+      currentRestriction = false,
+      currentExclusion = false,
+      isActiveProbationManagedSentence = false,
+    )
+
+    val result = personTransformer.transformModelToApi(offenderDetailSummary, null)
+
+    assertThat(result).isEqualTo(
+      Person(
+        crn = "CRN123",
+        name = "Greggory Someone",
+        dateOfBirth = LocalDate.parse("1980-09-12"),
+        sex = "Male",
+        status = Person.Status.unknown,
+        nomsNumber = null,
+        ethnicity = "White and Asian",
+        nationality = "Spanish",
+        religionOrBelief = "Sikh",
+        genderIdentity = null,
+        prisonName = null,
+      ),
+    )
+  }
 }


### PR DESCRIPTION
This allows us to start / continue with an application if there are no NOMIS details or Oasys entries. We'll need to do some work on the frontend to handle these eventualities and catch Oasys and NOMIS case notes / adjudication 404s, but this work is proceeding.