### PR TITLE
Add application ID and assessment ID to bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -55,6 +55,8 @@ class BookingTransformer(
       turnarounds = jpa.turnarounds.map(turnaroundTransformer::transformJpaToApi),
       turnaroundStartDate = if (hasNonZeroDayTurnaround) workingDayCountService.addWorkingDays(jpa.departureDate, 1) else null,
       effectiveEndDate = if (hasNonZeroDayTurnaround) workingDayCountService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount) else jpa.departureDate,
+      applicationId = jpa.application?.id,
+      assessmentId = jpa.application?.getLatestAssessment()?.id,
     )
   }
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3652,6 +3652,12 @@ components:
             effectiveEndDate:
               type: string
               format: date
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
           required:
             - status
             - extensions


### PR DESCRIPTION
This will allow us to link tho the application and/or assessment when viewing applications. These are optional fields because CAS3 don't currently have the concept of applications and assessments, and ad-hoc bookings in CAS1 will not have associated applications/assessments too.