### PR TITLE
Make `oicChargeId` and `offenceCode` nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/AdjudicationsPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/prisonsapi/AdjudicationsPage.kt
@@ -17,8 +17,8 @@ data class Adjudication(
 )
 
 data class AdjudicationCharge(
-  val oicChargeId: String,
-  val offenceCode: String,
+  val oicChargeId: String?,
+  val offenceCode: String?,
   val offenceDescription: String,
   val findingCode: String?,
 )


### PR DESCRIPTION
We can’t guarantee that these will come back from the API, and we’ve seen nullability errors when making API requests for adjudications. Given we only need `offenceDescription`, it’s safe to make these nullable.