### PR TITLE
Handle missing NOMS numbers in more places

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -267,7 +267,7 @@ class BookingService(
   fun createApprovedPremisesAdHocBooking(
     user: UserEntity? = null,
     crn: String,
-    nomsNumber: String,
+    nomsNumber: String?,
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     bedId: UUID,
@@ -426,7 +426,7 @@ class BookingService(
             bookingId = booking.id,
             personReference = PersonReference(
               crn = booking.application?.crn ?: booking.offlineApplication!!.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!,
+              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
             ),
             deliusEventNumber = application.eventNumber,
             createdAt = bookingCreatedAt.toInstant(),
@@ -462,7 +462,7 @@ class BookingService(
     user: UserEntity,
     premises: TemporaryAccommodationPremisesEntity,
     crn: String,
-    nomsNumber: String,
+    nomsNumber: String?,
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     bedId: UUID,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -46,7 +46,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var application: Yielded<ApplicationEntity?> = { null }
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
   private var turnarounds: Yielded<MutableList<TurnaroundEntity>>? = null
-  private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
 
   fun withId(id: UUID) = apply {
@@ -165,7 +165,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.turnarounds = { turnarounds }
   }
 
-  fun withNomsNumber(nomsNumber: String) = apply {
+  fun withNomsNumber(nomsNumber: String?) = apply {
     this.nomsNumber = { nomsNumber }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
@@ -79,6 +79,25 @@ class CaseNotesTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Getting case notes for a CRN without a NOMS number returns 404`() {
+    `Given a User` { _, jwt ->
+      `Given an Offender`(
+        offenderDetailsConfigBlock = {
+          withNomsNumber(null)
+        },
+      ) { offenderDetails, _ ->
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/prison-case-notes")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
+
+  @Test
   fun `Getting case notes returns OK with correct body`() {
     `Given a User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
@@ -96,4 +96,23 @@ class PersonAcctAlertsTest : IntegrationTestBase() {
       }
     }
   }
+
+  @Test
+  fun `Getting ACCT alerts for a CRN without a NOMS number returns 404`() {
+    `Given a User` { _, jwt ->
+      `Given an Offender`(
+        offenderDetailsConfigBlock = {
+          withNomsNumber(null)
+        },
+      ) { offenderDetails, _ ->
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/acct-alerts")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -72,6 +72,25 @@ class PersonAdjudicationsTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Getting adjudications alerts for a CRN without a NOMS number returns 404`() {
+    `Given a User` { _, jwt ->
+      `Given an Offender`(
+        offenderDetailsConfigBlock = {
+          withNomsNumber(null)
+        },
+      ) { offenderDetails, _ ->
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/acct-alerts")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
+
+  @Test
   fun `Getting adjudications for a CRN returns OK with correct body`() {
     `Given a User` { _, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -129,4 +129,50 @@ class PersonSearchTest : IntegrationTestBase() {
       }
     }
   }
+
+  @Test
+  fun `Searching for a CRN without a NomsNumber returns OK with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender`(
+        offenderDetailsConfigBlock = {
+          withCrn("CRN")
+          withDateOfBirth(LocalDate.parse("1985-05-05"))
+          withNomsNumber(null)
+          withFirstName("James")
+          withLastName("Someone")
+          withGender("Male")
+          withEthnicity("White British")
+          withNationality("English")
+          withReligionOrBelief("Judaism")
+          withGenderIdentity("Prefer to self-describe")
+          withSelfDescribedGenderIdentity("This is a self described identity")
+        },
+      ) { offenderDetails, _ ->
+        webTestClient.get()
+          .uri("/people/search?crn=CRN")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Person(
+                crn = "CRN",
+                name = "James Someone",
+                dateOfBirth = LocalDate.parse("1985-05-05"),
+                sex = "Male",
+                status = Person.Status.unknown,
+                nomsNumber = null,
+                ethnicity = "White British",
+                nationality = "English",
+                religionOrBelief = "Judaism",
+                genderIdentity = "This is a self described identity",
+                prisonName = null,
+              ),
+            ),
+          )
+      }
+    }
+  }
 }


### PR DESCRIPTION
This removes the places where we raise a 500 error when a NOMS number is missing. 

- In the case of the person search, we continue as normal (the transformer handles null inmate details)
- In the case of the case notes etc, we return a 404 (this is handled in the frontend)
- In the case of bookings, we return null for inmate details