### PR TITLE
Handle non-arrivals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -36,10 +36,13 @@ const val bedSummaryQuery =
         from bookings booking
           left join cancellations cancellation
             on booking.id = cancellation.booking_id
+          left join non_arrivals non_arrival 
+            on non_arrival.booking_id = booking.id
         where booking.bed_id = b.id
           and booking.arrival_date <= CURRENT_DATE
           and booking.departure_date >= CURRENT_DATE
           and cancellation IS NULL
+          and non_arrival IS NULL
       ) > 0 as bedBooked,
       (
         select count(lost_bed.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -41,10 +41,12 @@ WHERE
     #OPTIONAL_FILTERS
     (SELECT COUNT(1) FROM bookings books
          LEFT JOIN cancellations books_cancel ON books_cancel.booking_id = books.id
+         LEFT JOIN non_arrivals books_non_arrival ON books_non_arrival.booking_id = books.id
      WHERE
          books.bed_id = b.id AND
          (books.arrival_date, books.departure_date) OVERLAPS (:start_date, :end_date) AND
          books_cancel.id IS NULL
+         AND books_non_arrival.id IS NULL
      ) = 0 AND
     (SELECT COUNT(1) FROM lost_beds lostbeds
          LEFT JOIN lost_bed_cancellations lostbeds_cancel ON lostbeds_cancel.lost_bed_id = lostbeds.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/CalendarRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/CalendarRepository.kt
@@ -17,12 +17,13 @@ class CalendarRepository(private val namedParameterJdbcTemplate: NamedParameterJ
            b.arrival_date AS arrival_date, 
            b.departure_date AS departure_date,
            b.crn AS crn,
-           (c.id IS NULL) AS active
+           ((n.id, c.id) IS NULL) AS active
     FROM premises p 
     JOIN rooms r ON r.premises_id = p.id
     JOIN beds bed ON bed.room_id = r.id 
     LEFT JOIN bookings b ON b.bed_id = bed.id AND (b.arrival_date, b.departure_date) OVERLAPS (:startDate, :endDate)
     LEFT JOIN cancellations c ON c.booking_id = b.id
+    LEFT JOIN non_arrivals n ON n.booking_id = b.id
     WHERE p.id = :premisesId
 """
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
@@ -362,6 +362,25 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
 
     bedsThatShouldAppearInSearchResults += bedWithCancelledBooking
 
+    val bedWithNonArrivedBooking = bedEntityFactory.produceAndPersist {
+      withName("Matching Bed with nonArrived booking")
+      withRoom(roomMatchingEverythingInPremisesThree)
+    }
+
+    val nonArrivedBooking = bookingEntityFactory.produceAndPersist {
+      withPremises(premisesThreeMatchingEverything)
+      withBed(bedWithNonArrivedBooking)
+      withArrivalDate(LocalDate.parse("2023-03-08"))
+      withDepartureDate(LocalDate.parse("2023-03-10"))
+    }
+
+    nonArrivalEntityFactory.produceAndPersist {
+      withBooking(nonArrivedBooking)
+      withReason(nonArrivalReasonEntityFactory.produceAndPersist())
+    }
+
+    bedsThatShouldAppearInSearchResults += bedWithNonArrivedBooking
+
     val nonActivePremisesMatchingEverything = approvedPremisesEntityFactory.produceAndPersist {
       withProbationRegion(probationRegion)
       withLocalAuthorityArea(localAuthorityArea)


### PR DESCRIPTION
Currently, if a booking is recorded as non-arrived, then it still shows in the calendar and blocks the bed for future bookings. This should fix the underlying issue.