### PR TITLE
1547 - withdraw application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -151,6 +151,7 @@ class ApplicationsController(
         releaseType = body.releaseType?.name,
         arrivalDate = body.arrivalDate,
         isInapplicable = body.isInapplicable,
+        isWithdrawn = body.isWithdrawn,
         username = username,
       )
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -222,6 +222,7 @@ class ApprovedPremisesApplicationEntity(
   var isEmergencyApplication: Boolean?,
   var isEsapApplication: Boolean?,
   var isInapplicable: Boolean?,
+  var isWithdrawn: Boolean?,
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -219,6 +219,7 @@ class ApplicationService(
         releaseType = null,
         arrivalDate = null,
         isInapplicable = null,
+        isWithdrawn = null,
         nomsNumber = offenderDetails.otherIds.nomsNumber,
       ),
     )
@@ -375,6 +376,7 @@ class ApplicationService(
     arrivalDate: LocalDate?,
     data: String,
     isInapplicable: Boolean?,
+    isWithdrawn: Boolean?,
     username: String,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
@@ -406,6 +408,7 @@ class ApplicationService(
 
     application.apply {
       this.isInapplicable = isInapplicable
+      this.isWithdrawn = isWithdrawn
       this.isWomensApplication = isWomensApplication
       this.isPipeApplication = isPipeApplication
       this.isEmergencyApplication = isEmergencyApplication

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -185,6 +185,7 @@ class ApplicationsTransformer(
     if (entity is ApprovedPremisesApplicationEntity) {
       return when {
         entity.isInapplicable == true -> ApplicationStatus.inapplicable
+        entity.isWithdrawn == true -> ApplicationStatus.withdrawn
         latestAssessment?.submittedAt != null && latestAssessment.decision == AssessmentDecision.REJECTED -> ApplicationStatus.rejected
         latestAssessment?.submittedAt != null && latestAssessment.decision == AssessmentDecision.ACCEPTED && entity.getLatestPlacementRequest() == null -> ApplicationStatus.pending
         latestAssessment?.submittedAt != null && latestAssessment.decision == AssessmentDecision.ACCEPTED && entity.getLatestBooking() == null -> ApplicationStatus.awaitingPlacement

--- a/src/main/resources/db/migration/all/20230710115405__add_withdrawn_application_property.sql
+++ b/src/main/resources/db/migration/all/20230710115405__add_withdrawn_application_property.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN is_withdrawn BOOLEAN;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4709,6 +4709,8 @@ components:
           properties:
             isInapplicable:
               type: boolean
+            isWithdrawn:
+              type: boolean
             isWomensApplication:
               type: boolean
             isPipeApplication:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4666,6 +4666,7 @@ components:
         - awaitingPlacement
         - placed
         - inapplicable
+        - withdrawn
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
     NewApplication:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -41,6 +41,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var releaseType: Yielded<String?> = { null }
   private var arrivalDate: Yielded<OffsetDateTime?> = { null }
   private var isInapplicable: Yielded<Boolean?> = { null }
+  private var isWithdrawn: Yielded<Boolean?> = { null }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
 
   fun withId(id: UUID) = apply {
@@ -131,6 +132,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isInapplicable = { isInapplicable }
   }
 
+  fun withIsWithdrawn(isWithdrawn: Boolean?) = apply {
+    this.isWithdrawn = { isWithdrawn }
+  }
+
   fun withNomsNumber(nomsNumber: String) = apply {
     this.nomsNumber = { nomsNumber }
   }
@@ -167,6 +172,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     releaseType = this.releaseType(),
     arrivalDate = this.arrivalDate(),
     isInapplicable = this.isInapplicable(),
+    isWithdrawn = this.isWithdrawn(),
     nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -694,6 +694,7 @@ class ApplicationServiceTest {
         data = "{}",
         username = username,
         isInapplicable = null,
+        isWithdrawn = null,
       ) is AuthorisableActionResult.NotFound,
     ).isTrue
   }
@@ -739,6 +740,7 @@ class ApplicationServiceTest {
         data = "{}",
         username = username,
         isInapplicable = null,
+        isWithdrawn = null,
       ) is AuthorisableActionResult.Unauthorised,
     ).isTrue
   }
@@ -781,6 +783,7 @@ class ApplicationServiceTest {
       data = "{}",
       username = username,
       isInapplicable = null,
+      isWithdrawn = null,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -833,6 +836,7 @@ class ApplicationServiceTest {
       data = "{}",
       username = username,
       isInapplicable = null,
+      isWithdrawn = null,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -892,6 +896,7 @@ class ApplicationServiceTest {
       data = updatedData,
       username = username,
       isInapplicable = false,
+      isWithdrawn = false,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -907,6 +912,7 @@ class ApplicationServiceTest {
     assertThat(approvedPremisesApplication.isPipeApplication).isEqualTo(true)
     assertThat(approvedPremisesApplication.releaseType).isEqualTo("rotl")
     assertThat(approvedPremisesApplication.isInapplicable).isEqualTo(false)
+    assertThat(approvedPremisesApplication.isWithdrawn).isEqualTo(false)
     assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T00:00:00Z"))
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -136,6 +136,18 @@ class ApplicationsTransformerTest {
   }
 
   @Test
+  fun `transformJpaToApi transforms a withdrawn Approved Premises application correctly`() {
+    val application = approvedPremisesApplicationFactory.withIsWithdrawn(true).produce()
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.id).isEqualTo(application.id)
+    assertThat(result.createdByUserId).isEqualTo(user.id)
+    assertThat(result.status).isEqualTo(ApplicationStatus.withdrawn)
+    assertThat(result.assessmentDecision).isNull()
+  }
+
+  @Test
   fun `transformJpaToApi transforms an in progress CAS-2 application correctly`() {
     val application = cas2ApplicationFactory
       .withSubmittedAt(null)


### PR DESCRIPTION
Allow withdrawin an Application by setting its `isWithdrawn` property to true when updating it.  This then changes the status to `withdrawn` which the FE can use to filter out withdrawn Applications.