### PR TITLE
Allow overbookings for Approved Premises when extending

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -574,12 +574,6 @@ class PremisesController(
       throw ForbiddenProblem()
     }
 
-    val bedId = booking.bed?.id
-      ?: throw InternalServerErrorProblem("No bed ID present on Booking: $bookingId")
-
-    throwIfBookingDatesConflict(booking.arrivalDate, body.newDepartureDate, bookingId, bedId)
-    throwIfLostBedDatesConflict(booking.arrivalDate, body.newDepartureDate, null, bedId)
-
     val result = bookingService.createExtension(
       booking = booking,
       newDepartureDate = body.newDepartureDate,


### PR DESCRIPTION
The /extensions endpoint currently returns a 409 when there are conflicts with an AP Booking / Lost Bed. As in other endpoints, we accept overbookings, as this is how APs are used to working.

I’ve also removed some duplicated checks in the controller for TA premises, as these are already taken care of in the service method.