### PR TITLE
Filter out Documents without IDs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
@@ -10,7 +10,7 @@ data class GroupedDocuments(
 }
 
 data class Document(
-  val id: String,
+  val id: String?,
   val documentName: String,
   val author: String?,
   val type: DocumentType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
@@ -5,13 +5,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Document
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DocumentLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
 import java.time.ZoneOffset
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Document as CommunityApiDocument
 
 @Component
 class DocumentTransformer {
   fun transformToApi(groupedDocuments: GroupedDocuments, convictionId: Long): List<Document> {
-    val offenderDocuments = groupedDocuments.documents.map {
+    val offenderDocuments = documentsWithIds(groupedDocuments.documents).map {
       Document(
-        id = it.id,
+        id = it.id!!,
         level = DocumentLevel.offender,
         fileName = it.documentName,
         createdAt = it.createdAt.toInstant(ZoneOffset.UTC),
@@ -21,12 +22,13 @@ class DocumentTransformer {
       )
     }
 
-    val convictionDocuments = groupedDocuments.convictions
+    val documentsForConvictionId = groupedDocuments.convictions
       .firstOrNull { it.convictionId == convictionId.toString() }
-      ?.documents
-      ?.map {
+
+    val convictionDocuments = if (documentsForConvictionId != null) {
+      documentsWithIds(documentsForConvictionId.documents).map {
         Document(
-          id = it.id,
+          id = it.id!!,
           level = DocumentLevel.conviction,
           fileName = it.documentName,
           createdAt = it.createdAt.toInstant(ZoneOffset.UTC),
@@ -34,8 +36,15 @@ class DocumentTransformer {
           typeDescription = it.type.description,
           description = it.extendedDescription,
         )
-      } ?: emptyList()
+      }
+    } else {
+      emptyList()
+    }
 
     return offenderDocuments + convictionDocuments
   }
+
+  // Filter out any documents without IDs - at the moment, we don't have a way of fetching documents without IDs
+  // This fixes the nullability problem we have previously had with documents with no ID
+  fun documentsWithIds(documents: List<CommunityApiDocument>) = documents.filter { it.id != null }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class DocumentFactory : Factory<Document> {
-  private var id: Yielded<String> = { UUID.randomUUID().toString() }
+  private var id: Yielded<String?> = { UUID.randomUUID().toString() }
   private var documentName: Yielded<String> = { "${randomStringMultiCaseWithNumbers(5)}.pdf" }
   private var author: Yielded<String?> = { randomStringMultiCaseWithNumbers(4) }
   private var typeCode: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
@@ -20,7 +20,7 @@ class DocumentFactory : Factory<Document> {
   private var createdAt: Yielded<LocalDateTime> = { LocalDateTime.now().randomDateTimeBefore(5) }
   private var parentPrimaryKeyId: Yielded<Long?> = { null }
 
-  fun withId(id: String) = apply {
+  fun withId(id: String?) = apply {
     this.id = { id }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
@@ -27,6 +27,11 @@ class DocumentTransformerTest {
           .withExtendedDescription("Extended Description 1")
           .produce(),
       )
+      .withOffenderLevelDocument(
+        DocumentFactory()
+          .withId(null)
+          .produce(),
+      )
       .withConvictionLevelDocument(
         "12345",
         DocumentFactory()
@@ -37,6 +42,12 @@ class DocumentTransformerTest {
           .withTypeDescription("Type 2 Description")
           .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
           .withExtendedDescription("Extended Description 2")
+          .produce(),
+      )
+      .withConvictionLevelDocument(
+        "12345",
+        DocumentFactory()
+          .withId(null)
           .produce(),
       )
       .withConvictionLevelDocument(


### PR DESCRIPTION
A small amount of documents don’t seem to have IDs, as we treat them as non nullable, when we get them back from the API, an error is thrown. We need to IDs to be able to download the documents, so it’s not as simple as making the ID nullable. 

To get around this for now, we’ll filter out any documents that have no ID, so they don’t get returned. This will unblock the immediate issue that some applicants have. If it transpires that users are expecting those documents without IDs to be visible, we’ll revisit.