### PR TITLE
Handle missing NOMS number in domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
@@ -147,7 +147,7 @@ class ApprovedPremisesBookingSeedJob(
       result = bookingService.createApprovedPremisesAdHocBooking(
         user = null,
         crn = row.crn,
-        nomsNumber = offender.otherIds.nomsNumber!!,
+        nomsNumber = offender.otherIds.nomsNumber ?: "Unknown NOMS Number",
         arrivalDate = row.plannedArrivalDate,
         departureDate = row.plannedDepartureDate,
         bedId = bed.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -693,7 +693,7 @@ class ApplicationService(
               .replace("#id", application.id.toString()),
             personReference = PersonReference(
               crn = application.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!,
+              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
             ),
             deliusEventNumber = application.eventNumber,
             mappa = mappaLevel,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -269,7 +269,7 @@ class AssessmentService(
                 .replace("#id", application.id.toString()),
               personReference = PersonReference(
                 crn = offenderDetails.otherIds.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!,
+                noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
               ),
               deliusEventNumber = (application as ApprovedPremisesApplicationEntity).eventNumber,
               assessedAt = acceptedAt.toInstant(),
@@ -394,7 +394,7 @@ class AssessmentService(
                 .replace("#id", application.id.toString()),
               personReference = PersonReference(
                 crn = offenderDetails.otherIds.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!,
+                noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
               ),
               deliusEventNumber = (application as ApprovedPremisesApplicationEntity).eventNumber,
               assessedAt = rejectedAt.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -666,7 +666,7 @@ class BookingService(
               bookingId = booking.id,
               personReference = PersonReference(
                 crn = booking.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!,
+                noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
               ),
               deliusEventNumber = application.eventNumber,
               premises = Premises(
@@ -803,7 +803,7 @@ class BookingService(
               bookingId = booking.id,
               personReference = PersonReference(
                 crn = booking.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!,
+                noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
               ),
               deliusEventNumber = application.eventNumber,
               premises = Premises(
@@ -1009,7 +1009,7 @@ class BookingService(
               bookingId = booking.id,
               personReference = PersonReference(
                 crn = booking.crn,
-                noms = offenderDetails.otherIds.nomsNumber!!,
+                noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
               ),
               deliusEventNumber = application.eventNumber,
               premises = Premises(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -217,7 +217,7 @@ class PlacementRequestService(
             applicationUrl = applicationUrlTemplate.replace("#id", application.id.toString()),
             personReference = PersonReference(
               crn = application.crn,
-              noms = offenderDetails.otherIds.nomsNumber!!,
+              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
             ),
             deliusEventNumber = application.eventNumber,
             attemptedAt = bookingNotCreatedAt.toInstant(),


### PR DESCRIPTION
We can’t always guarantee a NOMS number will be present, so we need to handle when a NOMS is null, rather than throwing a null error.