### PR TITLE
Give new CAS3 test user the referrer role

### DIFF
--- a/src/main/resources/db/seed/dev+test/user.csv
+++ b/src/main/resources/db/seed/dev+test/user.csv
@@ -2,3 +2,4 @@ deliusUsername,roles,qualifications
 temporary-accommodation-training-1,"CAS3_REFERRER",""
 temporary-accommodation-training-2,"CAS3_ASSESSOR",""
 temporary-accommodation-e2e-tester,"CAS3_ASSESSOR,CAS3_REFERRER",""
+temporary-accommodation-e2e-referrer,"CAS3_REFERRER",""


### PR DESCRIPTION
To ensure we don’t prematurely break any frontend tests we leave the previous user ‘temporary-accommodation-e2e-tester’ with both roles.

When we switch the frontend over this can be set to just `CAS3_ASSESSOR`.