### PR TITLE
Remove cas3 user role seeding in dev and test

### DIFF
--- a/src/main/resources/db/seed/dev+test/user.csv
+++ b/src/main/resources/db/seed/dev+test/user.csv
@@ -1,5 +1,0 @@
-deliusUsername,roles,qualifications
-temporary-accommodation-training-1,"CAS3_REFERRER",""
-temporary-accommodation-training-2,"CAS3_ASSESSOR",""
-temporary-accommodation-e2e-tester,"CAS3_ASSESSOR,CAS3_REFERRER",""
-temporary-accommodation-e2e-referrer,"CAS3_REFERRER",""


### PR DESCRIPTION
We’ve found that this mechanism of seeding isn’t working. Each time the API deploys to dev the CAS3 roles are not set.

When we seed them manually they are set.
When we destroy a single pod they are set.

We think that the fact that a deployment launches multiple pods at once that a race condition means that users lost their roles. This is unconfirmed but we think the right way to fix this is to use Redlock to prevent the race.

For now we need user roles to be stable. We can’t reasonably reseed after every API deploy so we’re going to remove this and trust in manual seeding.