### PR TITLE
CAS2 update application types

### DIFF
--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4832,10 +4832,14 @@ components:
         propertyName: type
         mapping:
           CAS1: '#/components/schemas/UpdateApprovedPremisesApplication'
+          CAS2: '#/components/schemas/UpdateCas2Application'
           CAS3: '#/components/schemas/UpdateTemporaryAccommodationApplication'
       required:
         - type
         - data
+    UpdateCas2Application:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
     UpdateApprovedPremisesApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4809,11 +4809,21 @@ components:
           example: "M1502750438"
       required:
         - crn
+    UpdateApplicationType:
+      type: string
+      enum:
+        - CAS1
+        - CAS2
+        - CAS3
+      x-enum-varnames:
+        - CAS1
+        - CAS2
+        - CAS3
     UpdateApplication:
       type: object
       properties:
         type:
-          type: string
+          $ref: '#/components/schemas/UpdateApplicationType'
         data:
           type: object
           additionalProperties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApproved
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
@@ -1423,7 +1424,7 @@ class ApplicationTest : IntegrationTestBase() {
                 data = mapOf("thingId" to 123),
                 isWomensApplication = false,
                 isPipeApplication = true,
-                type = "CAS1",
+                type = UpdateApplicationType.CAS1,
               ),
             )
             .exchange()


### PR DESCRIPTION
We would like to be able to update a CAS2 application. This PR makes the updates to `api.yml` to make that possible - future [work to handle them in this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/800)

1. Adding an enum for `UpdateApplication` `type` field. I wasn't sure if this should be a type that the `Application` model can also use, but that would also need to include an `offline` type, which I don't think we handle on the update method?
2. Adding a class for `UpdateCas2Application` so that in the future we can distinguish it from the other
types of applications in the `applicationsApplicationIdPut` method in
ApplicationsController.