### PR TITLE
Take current workload into account when allocating

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -22,54 +22,105 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 
   @Query(
     """
-    SELECT u.*, ura.*, uqa2.* 
+    SELECT u.*, ura.*, uqa2.*,
+     RANK() OVER (
+      ORDER BY
+        (
+          SELECT COUNT(1)
+            FROM assessments a
+            WHERE a.allocated_to_user_id = u.id
+            AND 
+              (
+                a.submitted_at IS NULL
+                OR (
+                  a.submitted_at IS NOT NULL
+                    AND a.created_at BETWEEN 
+                      (CURRENT_TIMESTAMP - interval '1 week') AND
+                  		CURRENT_TIMESTAMP
+                )
+            )
+        ) ASC
+     ) as score
     FROM "users"  u
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
     WHERE ura.role = 'CAS1_ASSESSOR' AND 
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
         u.id NOT IN (:excludedUserIds)
-    ORDER BY 
-      (SELECT COUNT(1) FROM assessments a WHERE a.allocated_to_user_id = u.id AND a.submitted_at IS NULL) ASC 
+    ORDER BY score ASC
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedAssessorWithLeastPendingAssessments(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
 
   @Query(
     """
-    SELECT u.*, ura.*, uqa2.* 
+    SELECT u.*, ura.*, uqa2.*,
+    RANK() OVER (
+      ORDER BY
+        (
+          SELECT COUNT(1)
+            FROM placement_applications pa
+            WHERE pa.allocated_to_user_id = u.id
+            AND 
+              (
+                pa.submitted_at IS NULL
+                OR (
+                  pa.submitted_at IS NOT NULL
+                    AND pa.created_at BETWEEN 
+                      (CURRENT_TIMESTAMP - interval '1 week') AND
+                  		CURRENT_TIMESTAMP
+                )
+            )
+        ) ASC
+     ) as score
     FROM "users"  u
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
     WHERE ura.role = 'CAS1_MATCHER' AND 
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
         u.id NOT IN (:excludedUserIds)
-    ORDER BY 
-      (SELECT COUNT(1) FROM placement_applications pa WHERE pa.allocated_to_user_id = u.id AND pa.decision IS NULL) ASC 
+    ORDER BY score ASC 
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedMatcherWithLeastPendingPlacementApplications(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
 
   @Query(
     """
-    SELECT u.*, ura.*, uqa2.* 
+    SELECT u.*, ura.*, uqa2.*,
+    RANK() OVER (
+      ORDER BY
+        (
+          SELECT COUNT(1)
+            FROM placement_requests pr
+            WHERE pr.allocated_to_user_id = u.id
+            AND 
+              (
+                pr.booking_id IS NULL
+                OR (
+                  pr.booking_id IS NOT NULL
+                    AND pr.created_at BETWEEN 
+                      (CURRENT_TIMESTAMP - interval '1 week') AND
+                  		CURRENT_TIMESTAMP
+                )
+            )
+        ) ASC
+     ) as score
     FROM "users"  u
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
     WHERE ura.role = 'CAS1_MATCHER' AND 
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
         u.id NOT IN (:excludedUserIds)
-    ORDER BY 
-      (SELECT COUNT(1) FROM placement_requests pr WHERE pr.allocated_to_user_id = u.id AND pr.booking_id IS NULL) ASC 
+    ORDER BY score ASC 
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedMatcherWithLeastPendingPlacementRequests(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -73,7 +73,7 @@ class UserService(
     }
 
     while (true) {
-      val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
+      val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
         ?: throw RuntimeException("Could not find a suitable assessor for assessment with qualifications (${qualifications.joinToString(",")}): ${application.crn}")
 
       if ((qualifications.isEmpty() && potentialUser.qualifications.isNotEmpty()) || potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION)) {
@@ -94,7 +94,7 @@ class UserService(
     }
 
     while (true) {
-      val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingPlacementRequests(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
+      val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
         ?: throw RuntimeException("Could not find a suitable matcher for placement request with qualifications (${qualifications.joinToString(",")}): $crn")
 
       if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION)) {
@@ -115,7 +115,7 @@ class UserService(
     }
 
     while (true) {
-      val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingPlacementApplications(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
+      val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
         ?: throw RuntimeException("Could not find a suitable matcher for placement application with qualifications (${qualifications.joinToString(",")}): $crn")
 
       if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION)) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -63,6 +63,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     this.notes = { notes }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): PlacementRequestEntity = PlacementRequestEntity(
     id = this.id(),
     expectedArrival = this.expectedArrival(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -1,62 +1,409 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import java.time.OffsetDateTime
 
 class AllocationQueryTest : IntegrationTestBase() {
   @Autowired
   lateinit var realUserRepository: UserRepository
 
+  lateinit var applicationSchema: ApprovedPremisesApplicationJsonSchemaEntity
+  lateinit var assessmentSchema: ApprovedPremisesAssessmentJsonSchemaEntity
+  lateinit var placementApplicationSchema: ApprovedPremisesPlacementApplicationJsonSchemaEntity
+  lateinit var premises: ApprovedPremisesEntity
+  lateinit var postcodeDistrict: PostCodeDistrictEntity
+
+  @BeforeEach
+  fun setup() {
+    applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+    assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist()
+    placementApplicationSchema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist()
+    premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea {
+            apAreaEntityFactory.produceAndPersist()
+          }
+        }
+      }
+      withYieldedLocalAuthorityArea {
+        localAuthorityEntityFactory.produceAndPersist()
+      }
+    }
+    postcodeDistrict = postCodeDistrictFactory.produceAndPersist()
+  }
+
   @Test
-  fun `findQualifiedAssessorWithLeastPendingAllocations query works as described`() {
-    `Given a User that is not an Assessor`()
-    `Given a User that is an Assessor with no Qualifications`()
-    `Given a User that is an Assessor with both Qualifications and two pending allocated Assessments`()
-    val expectedAllocatedUser = `Given a User that is an Assessor with both Qualifications and one pending allocated Assessments`()
-    val excludedAllocatedUser = `Given a User that is an Assessor with both Qualifications and zero pending allocated Assessments`()
+  fun `findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments query works as described`() {
+    createUserForAssessmentQuery(
+      "Non Assessor",
+      isAssessor = false,
+      hasQualifications = false,
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 0,
+    )
+    createUserForAssessmentQuery(
+      "Assessor with no qualifications",
+      isAssessor = true,
+      hasQualifications = false,
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 0,
+    )
+    createUserForAssessmentQuery(
+      "Assessor with both Qualifications and two pending allocated Assessments",
+      isAssessor = true,
+      hasQualifications = false,
+      numberOfPendingAssessments = 2,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 0,
+    )
+    createUserForAssessmentQuery(
+      "Assessor with both Qualifications, zero pending allocated Assessments and one complete Assessment from the last week",
+      isAssessor = true,
+      hasQualifications = true,
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 1,
+      numberOfLessRecentCompletedAssessments = 2,
+    )
+    createUserForAssessmentQuery(
+      "Assessor with both Qualifications and one pending allocated Assessment",
+      isAssessor = true,
+      hasQualifications = true,
+      numberOfPendingAssessments = 1,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 2,
+    )
+    createUserForAssessmentQuery(
+      "Assessor with both Qualifications and zero pending allocated Assessments",
+      isAssessor = true,
+      hasQualifications = true,
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 2,
+    )
+    val excludedAllocatedUser = createUserForAssessmentQuery(
+      "Excluded User",
+      isAssessor = true,
+      hasQualifications = true,
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 2,
+    )
 
-    val actualAllocatedUser = realUserRepository.findQualifiedAssessorWithLeastPendingAssessments(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
+    val actualAllocatedUser = realUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
 
-    assertThat(actualAllocatedUser!!.id).isEqualTo(expectedAllocatedUser.id)
+    assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Assessor with both Qualifications and zero pending allocated Assessments")
   }
 
-  private fun `Given a User that is not an Assessor`(): UserEntity {
-    val user = userEntityFactory.produceAndPersist {
-      withDeliusUsername("NON-ASSESSOR")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
+  @Test
+  fun `findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications works as expected`() {
+    createUserForPlacementApplicationsQuery(
+      "Non Matcher",
+      isMatcher = false,
+      hasQualifications = false,
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 0,
+    )
+    createUserForPlacementApplicationsQuery(
+      "Matcher with no qualifications",
+      isMatcher = false,
+      hasQualifications = false,
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 0,
+    )
+    createUserForPlacementApplicationsQuery(
+      "Matcher with both Qualifications and two pending allocated Placement Applications",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementApplications = 2,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 0,
+    )
+    createUserForPlacementApplicationsQuery(
+      "Matcher with both Qualifications, zero pending allocated Placement Applications and one complete Placement Application from the last week",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 1,
+      numberOfLessRecentCompletedPlacementApplications = 2,
+    )
+    createUserForPlacementApplicationsQuery(
+      "Matcher with both Qualifications and one pending allocated Placement Application",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementApplications = 1,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 2,
+    )
+    createUserForPlacementApplicationsQuery(
+      "Matcher with both Qualifications and zero pending allocated Placement Applications",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 2,
+    )
+
+    val excludedAllocatedUser = createUserForPlacementApplicationsQuery(
+      "Excluded user",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 2,
+    )
+
+    val actualAllocatedUser = realUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
+
+    assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Matcher with both Qualifications and zero pending allocated Placement Applications")
+  }
+
+  @Test
+  fun `findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests works as expected`() {
+    createUserForPlacementRequestsQuery(
+      "Non Matcher",
+      isMatcher = false,
+      hasQualifications = false,
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 0,
+    )
+    createUserForPlacementRequestsQuery(
+      "Matcher with no qualifications",
+      isMatcher = false,
+      hasQualifications = false,
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 0,
+    )
+    createUserForPlacementRequestsQuery(
+      "Matcher with both Qualifications and two pending allocated Placement Requests",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementRequests = 2,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 0,
+    )
+    createUserForPlacementRequestsQuery(
+      "Matcher with both Qualifications, zero pending allocated Placement Requests and one complete Placement Request from the last week",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 1,
+      numberOfLessRecentCompletedPlacementRequests = 2,
+    )
+    createUserForPlacementRequestsQuery(
+      "Matcher with both Qualifications and one pending allocated Placement Request",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementRequests = 1,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 0,
+    )
+    createUserForPlacementRequestsQuery(
+      "Matcher with both Qualifications and zero pending allocated Placement Requests",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 2,
+    )
+
+    val excludedAllocatedUser = createUserForPlacementRequestsQuery(
+      "Excluded user",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 2,
+    )
+
+    val actualAllocatedUser = realUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
+
+    assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Matcher with both Qualifications and zero pending allocated Placement Requests")
+  }
+
+  private fun createUserForPlacementRequestsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementRequests: Int, numberOfRecentCompletedPlacementRequests: Int, numberOfLessRecentCompletedPlacementRequests: Int): UserEntity {
+    val user = createUser(
+      deliusUsername,
+      if (isMatcher) listOf(UserRole.CAS1_MATCHER) else emptyList(),
+      if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+    )
+
+    repeat(numberOfPlacementRequests) {
+      createPlacementRequest(user, false, 2)
+    }
+
+    repeat(numberOfRecentCompletedPlacementRequests) {
+      createPlacementRequest(user, true, 3)
+    }
+
+    repeat(numberOfLessRecentCompletedPlacementRequests) {
+      createPlacementRequest(user, true, 18)
+    }
+
+    return user
+  }
+
+  private fun createUserForPlacementApplicationsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementApplications: Int, numberOfRecentCompletedPlacementApplications: Int, numberOfLessRecentCompletedPlacementApplications: Int): UserEntity {
+    val user = createUser(
+      deliusUsername,
+      if (isMatcher) listOf(UserRole.CAS1_MATCHER) else emptyList(),
+      if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+    )
+
+    repeat(numberOfPlacementApplications) {
+      placementApplicationFactory.produceAndPersist {
+        withAllocatedToUser(user)
+        withSchemaVersion(placementApplicationSchema)
+        withCreatedByUser(user)
+        withApplication(
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(user)
+            withApplicationSchema(applicationSchema)
+          },
+        )
+        withSubmittedAt(null)
+      }
+    }
+
+    repeat(numberOfRecentCompletedPlacementApplications) {
+      placementApplicationFactory.produceAndPersist {
+        withAllocatedToUser(user)
+        withSchemaVersion(placementApplicationSchema)
+        withCreatedByUser(user)
+        withApplication(
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(user)
+            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+          },
+        )
+        withSubmittedAt(OffsetDateTime.now().minusDays(2))
+        withCreatedAt(OffsetDateTime.now().minusDays(3))
+      }
+    }
+
+    repeat(numberOfLessRecentCompletedPlacementApplications) {
+      placementApplicationFactory.produceAndPersist {
+        withAllocatedToUser(user)
+        withSchemaVersion(placementApplicationSchema)
+        withCreatedByUser(user)
+        withApplication(
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(user)
+            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+          },
+        )
+        withSubmittedAt(OffsetDateTime.now().minusDays(12))
+        withCreatedAt(OffsetDateTime.now().minusDays(18))
       }
     }
 
     return user
   }
 
-  private fun `Given a User that is an Assessor with no Qualifications`(): UserEntity {
-    val user = userEntityFactory.produceAndPersist {
-      withDeliusUsername("ASSESSOR-NO-QUALIFICATIONS")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
+  private fun createUserForAssessmentQuery(deliusUsername: String, isAssessor: Boolean, hasQualifications: Boolean, numberOfPendingAssessments: Int, numberOfRecentCompletedAssessments: Int, numberOfLessRecentCompletedAssessments: Int): UserEntity {
+    val user = createUser(
+      deliusUsername,
+      if (isAssessor) listOf(UserRole.CAS1_ASSESSOR) else emptyList(),
+      if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+    )
+
+    repeat(numberOfPendingAssessments) {
+      assessmentEntityFactory.produceAndPersist {
+        withAllocatedToUser(user)
+        withApplication(
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(user)
+            withApplicationSchema(applicationSchema)
+          },
+        )
+        withSubmittedAt(null)
+        withAssessmentSchema(assessmentSchema)
       }
     }
 
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withRole(UserRole.CAS1_ASSESSOR)
+    repeat(numberOfRecentCompletedAssessments) {
+      assessmentEntityFactory.produceAndPersist {
+        withAllocatedToUser(user)
+        withApplication(
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(user)
+            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+          },
+        )
+        withSubmittedAt(OffsetDateTime.now().minusDays(2))
+        withCreatedAt(OffsetDateTime.now().minusDays(3))
+        withAssessmentSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+      }
+    }
+
+    repeat(numberOfLessRecentCompletedAssessments) {
+      assessmentEntityFactory.produceAndPersist {
+        withAllocatedToUser(user)
+        withApplication(
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(user)
+            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+          },
+        )
+        withSubmittedAt(OffsetDateTime.now().minusDays(12))
+        withCreatedAt(OffsetDateTime.now().minusDays(18))
+        withAssessmentSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+      }
     }
 
     return user
   }
 
-  private fun `Given a User that is an Assessor with both Qualifications and one pending allocated Assessment`(): UserEntity {
+  private fun createUser(deliusUsername: String, roles: List<UserRole>, qualifications: List<UserQualification>): UserEntity {
+    val user = userEntityFactory.produceAndPersist {
+      withDeliusUsername(deliusUsername)
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
+
+    roles.forEach {
+      userRoleAssignmentEntityFactory.produceAndPersist {
+        withUser(user)
+        withRole(it)
+      }
+    }
+
+    qualifications.forEach {
+      userQualificationAssignmentEntityFactory.produceAndPersist {
+        withUser(user)
+        withQualification(it)
+      }
+    }
+
+    return user
+  }
+
+  private fun createApplicationAndAssessment(): Pair<ApprovedPremisesApplicationEntity, AssessmentEntity> {
     val user = userEntityFactory.produceAndPersist {
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist {
@@ -65,141 +412,52 @@ class AllocationQueryTest : IntegrationTestBase() {
       }
     }
 
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withRole(UserRole.CAS1_ASSESSOR)
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCreatedByUser(user)
+      withApplicationSchema(applicationSchema)
     }
 
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.PIPE)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.WOMENS)
-    }
-
-    assessmentEntityFactory.produceAndPersist {
+    val assessment = assessmentEntityFactory.produceAndPersist {
       withAllocatedToUser(user)
       withApplication(
-        approvedPremisesApplicationEntityFactory.produceAndPersist {
-          withCreatedByUser(user)
-          withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-        },
+        application,
       )
       withSubmittedAt(null)
-      withAssessmentSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+      withAssessmentSchema(assessmentSchema)
     }
 
-    return user
+    return Pair(application, assessment)
   }
 
-  private fun `Given a User that is an Assessor with both Qualifications and zero pending allocated Assessments`(): UserEntity {
-    val user = userEntityFactory.produceAndPersist {
-      withDeliusUsername("ASSESSOR-ZERO-ALLOCATIONS")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
-    }
+  private fun createPlacementRequest(allocatedToUser: UserEntity, withBooking: Boolean, createdAtDaysAgo: Long): PlacementRequestEntity {
+    val (application, assessment) = createApplicationAndAssessment()
 
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withRole(UserRole.CAS1_ASSESSOR)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.PIPE)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.WOMENS)
-    }
-
-    return user
-  }
-
-  private fun `Given a User that is an Assessor with both Qualifications and one pending allocated Assessments`(): UserEntity {
-    val user = userEntityFactory.produceAndPersist {
-      withDeliusUsername("ASSESSOR-ONE-ALLOCATION")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
-    }
-
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withRole(UserRole.CAS1_ASSESSOR)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.PIPE)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.WOMENS)
-    }
-
-    assessmentEntityFactory.produceAndPersist {
-      withAllocatedToUser(user)
-      withApplication(
-        approvedPremisesApplicationEntityFactory.produceAndPersist {
-          withCreatedByUser(user)
-          withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+    return placementRequestFactory.produceAndPersist {
+      withAllocatedToUser(allocatedToUser)
+      withPlacementRequirements(
+        placementRequirementsFactory.produceAndPersist {
+          withApplication(application)
+          withAssessment(assessment)
+          withPostcodeDistrict(postcodeDistrict)
+          withDesirableCriteria(
+            characteristicEntityFactory.produceAndPersistMultiple(5),
+          )
+          withEssentialCriteria(
+            characteristicEntityFactory.produceAndPersistMultiple(3),
+          )
         },
       )
-      withSubmittedAt(null)
-      withAssessmentSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-    }
-
-    return user
-  }
-
-  private fun `Given a User that is an Assessor with both Qualifications and two pending allocated Assessments`(): UserEntity {
-    val user = userEntityFactory.produceAndPersist {
-      withDeliusUsername("ASSESSOR-TWO-ALLOCATION")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
+      if (withBooking) {
+        withBooking(
+          bookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.approvedPremises)
+            withPremises(premises)
+          },
+        )
       }
+      withCreatedAt(OffsetDateTime.now().minusDays(createdAtDaysAgo))
+      withApplication(application)
+      withAssessment(assessment)
     }
-
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withRole(UserRole.CAS1_ASSESSOR)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.PIPE)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(user)
-      withQualification(UserQualification.WOMENS)
-    }
-
-    assessmentEntityFactory.produceAndPersistMultiple(2) {
-      withAllocatedToUser(user)
-      withApplication(
-        approvedPremisesApplicationEntityFactory.produceAndPersist {
-          withCreatedByUser(user)
-          withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-        },
-      )
-      withSubmittedAt(null)
-      withAssessmentSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-    }
-
-    return user
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -138,7 +138,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(application.crn) } returns true
 
     every {
-      mockUserRepository.findQualifiedAssessorWithLeastPendingAssessments(
+      mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
         excludedUserIds = any(),
@@ -170,7 +170,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(application.crn) } returns false
 
     every {
-      mockUserRepository.findQualifiedAssessorWithLeastPendingAssessments(
+      mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
         requiredQualifications = emptyList(),
         totalRequiredQualifications = 0,
         excludedUserIds = any(),
@@ -202,7 +202,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(application.crn) } returns false
 
     every {
-      mockUserRepository.findQualifiedAssessorWithLeastPendingAssessments(
+      mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
         requiredQualifications = emptyList(),
         totalRequiredQualifications = 0,
         excludedUserIds = any(),
@@ -224,7 +224,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(crn) } returns true
 
     every {
-      mockUserRepository.findQualifiedMatcherWithLeastPendingPlacementRequests(
+      mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
         excludedUserIds = any(),
@@ -250,7 +250,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(crn) } returns false
 
     every {
-      mockUserRepository.findQualifiedMatcherWithLeastPendingPlacementRequests(
+      mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(
         requiredQualifications = emptyList(),
         totalRequiredQualifications = 0,
         excludedUserIds = any(),
@@ -272,7 +272,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(crn) } returns true
 
     every {
-      mockUserRepository.findQualifiedMatcherWithLeastPendingPlacementApplications(
+      mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
         excludedUserIds = any(),
@@ -298,7 +298,7 @@ class UserServiceTest {
     every { mockOffenderService.isLao(crn) } returns false
 
     every {
-      mockUserRepository.findQualifiedMatcherWithLeastPendingPlacementApplications(
+      mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(
         requiredQualifications = emptyList(),
         totalRequiredQualifications = 0,
         excludedUserIds = any(),


### PR DESCRIPTION
The current allocations engine allocates assessments to users who have the lowest number of allocated, but incomplete assessments. This ends up penalising assessors who complete a large number of assessments quickly, meaning they keep getting assessments pile up.

This alters the query to take into account recent applications that have been assessed, so, for example, if two assessors have no pending assessments, but one assessor has recently completed an assessment, it will prioritise the one with no completed assessments in their workload.