### PR TITLE
Exclude NULL nomsNumber from preemptive cache refresh

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -117,7 +117,7 @@ WHERE taa.probation_region_id = :probationRegionId AND a.submitted_at IS NOT NUL
   @Query("SELECT DISTINCT(a.crn) FROM ApplicationEntity a")
   fun getDistinctCrns(): List<String>
 
-  @Query("SELECT DISTINCT(a.nomsNumber) FROM ApplicationEntity a")
+  @Query("SELECT DISTINCT(a.nomsNumber) FROM ApplicationEntity a WHERE a.nomsNumber IS NOT NULL")
   fun getDistinctNomsNumbers(): List<String>
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -35,7 +35,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   @Query("SELECT DISTINCT(b.crn) FROM BookingEntity b")
   fun getDistinctCrns(): List<String>
 
-  @Query("SELECT DISTINCT(b.nomsNumber) FROM BookingEntity b")
+  @Query("SELECT DISTINCT(b.nomsNumber) FROM BookingEntity b WHERE b.nomsNumber IS NOT NULL")
   fun getDistinctNomsNumbers(): List<String>
 
   @Query("SELECT b FROM BookingEntity b WHERE b.bed.id IN :bedIds")


### PR DESCRIPTION
The service is attempting to preemptively refresh NULL as a nomsNumber which is causing a kotlin not null exception to be thrown and prevent the refresher from progressing past the NULL value