### PR TITLE
Add a CRU Dashboard Endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -21,6 +21,8 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
   fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<PlacementRequestEntity>
 
   fun findAllByReallocatedAtNullAndBooking_IdNull(): List<PlacementRequestEntity>
+
+  fun findAllByReallocatedAtNull(): List<PlacementRequestEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -56,6 +56,10 @@ class PlacementRequestService(
     return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNull()
   }
 
+  fun getAllActive(): List<PlacementRequestEntity> {
+    return placementRequestRepository.findAllByReallocatedAtNull()
+  }
+
   fun getPlacementRequestForUser(user: UserEntity, id: UUID): AuthorisableActionResult<Pair<PlacementRequestEntity, List<CancellationEntity>>> {
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2466,6 +2466,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /placement-requests/dashboard:
+    get:
+      tags:
+        - Placement requests
+      summary: Gets all placement requests
+      responses:
+        200:
+          description: successfully retrieved placement requests
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PlacementRequest'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /placement-requests/{id}:
     get:
       tags:


### PR DESCRIPTION
This adds an endpoint for CRU managers to view all Placement Requests. We will want to add pagination, filtering etc, but this gets us part of the way