### PR TITLE
Update repeatable Flyway migration to add missing column 'is_withdrawn' to Approved Premises applications

### DIFF
--- a/src/main/resources/db/migration/test/R__1_create_users.sql
+++ b/src/main/resources/db/migration/test/R__1_create_users.sql
@@ -13,7 +13,7 @@
   )
   values
     (
-      '21183',
+      '13590',
       'AP_USER_TEST_1',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'AP Test User 1',
@@ -34,7 +34,7 @@
   )
   values
     (
-      '17569',
+      '61194',
       'AP_USER_TEST_2',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       'AP Test User 2',
@@ -55,7 +55,7 @@
   )
   values
     (
-      '313',
+      '92202',
       'AP_USER_TEST_3',
       '68715a03-06af-49ee-bae5-039c824ab9af',
       'AP Test User 3',
@@ -76,7 +76,7 @@
   )
   values
     (
-      '4171',
+      '90015',
       'AP_USER_TEST_4',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       'AP Test User 4',
@@ -97,7 +97,7 @@
   )
   values
     (
-      '53561',
+      '99798',
       'AP_USER_TEST_5',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'AP Test User 5',
@@ -118,7 +118,7 @@
   )
   values
     (
-      '46293',
+      '94653',
       'CAS_NCC_TEST1',
       '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       'NCC User 1',
@@ -139,7 +139,7 @@
   )
   values
     (
-      '13169',
+      '77947',
       'CAS_NCC_TEST2',
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       'NCC User 2',

--- a/src/main/resources/db/migration/test/R__3_create_bookings.sql
+++ b/src/main/resources/db/migration/test/R__3_create_bookings.sql
@@ -18,7 +18,7 @@ INSERT INTO
   )
 VALUES
   (
-    'c2fac91e-ebd1-4385-9706-2dfa6d5ddbf3',
+    '5d5f5d8f-a1f2-4011-9033-31110855966b',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '315VWWC',
@@ -49,7 +49,7 @@ INSERT INTO
   )
 VALUES
   (
-    '30aa1edb-91f0-495d-90ac-7e203208e85b',
+    '36857c66-c06d-404f-ada9-2edbf8828ae1',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '4Y29R9P',
@@ -80,7 +80,7 @@ INSERT INTO
   )
 VALUES
   (
-    '144bdd22-d5ae-4f6c-898f-c2bc3850bcef',
+    '81c6a11e-0c71-4610-835c-3be958c7fdc9',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     '4ZUIHFX',
@@ -112,17 +112,17 @@ INSERT INTO
   )
 VALUES
   (
-    'dca7487d-aea0-4722-ba3d-72b7f45b9187',
+    '9e52ec2a-f7ca-450f-ba7d-0bd0b3c988ae',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'PR5E5Y2',
+    'N6OUTAY',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     'fe86a602-6873-49d3-ac3a-3dfef743ae03',
     'temporary-accommodation',
     CURRENT_DATE,
-   'HBVE0LJ'
+   '6X1DNW1'
   )
 ON CONFLICT(id) DO NOTHING;
 
@@ -143,17 +143,17 @@ INSERT INTO
   )
 VALUES
   (
-    'a4aa8a84-1d2e-4164-a179-fcbfe13d0802',
+    '842ff087-9c64-47bd-8cd9-5069fcc964a0',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'Z33A1BU',
+    'QA93YYK',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     'e8887df9-b31b-4e9c-931a-e063d778ab0d',
     'temporary-accommodation',
     CURRENT_DATE,
-   'M9XWJ1S'
+   'HIR0PIN'
   )
 ON CONFLICT(id) DO NOTHING;
 
@@ -168,8 +168,8 @@ INSERT INTO
   )
 VALUES
   (
-    '1762b7c9-59d8-4731-b238-a184c05d0e9c',
-    'a4aa8a84-1d2e-4164-a179-fcbfe13d0802',
+    '36dd373b-33e8-444c-ac8b-5b67674159d9',
+    '842ff087-9c64-47bd-8cd9-5069fcc964a0',
     CURRENT_DATE,
     NULL,
     CURRENT_DATE
@@ -193,17 +193,17 @@ INSERT INTO
   )
 VALUES
   (
-    '3059fd6e-fdab-4580-8cb3-f934c31c580e',
+    '7169ba8a-2b5a-44c8-9729-55041d9a1c65',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'PR5E5Y2',
+    'GSR1T2F',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     '135812b4-e6c0-4ccf-9502-4bfea66f3bd3',
     'temporary-accommodation',
     CURRENT_DATE,
-   'KWAPTC7'
+   'XWU5JWQ'
   )
 ON CONFLICT(id) DO NOTHING;
 
@@ -220,10 +220,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE,
-    '3059fd6e-fdab-4580-8cb3-f934c31c580e',
+    '7169ba8a-2b5a-44c8-9729-55041d9a1c65',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'de4ce219-33a7-488e-9a3a-cad70c82d8cc',
+    '10abb045-112c-4d00-ae3c-65e96ad652ec',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -239,8 +239,8 @@ INSERT INTO
   )
 VALUES
   (
-    '40c1aa8a-d70d-43c7-96c5-6cae4f6223c6',
-    '3059fd6e-fdab-4580-8cb3-f934c31c580e',
+    'c080d4a8-b2b4-41b9-9494-32f2c531c672',
+    '7169ba8a-2b5a-44c8-9729-55041d9a1c65',
     CURRENT_DATE,
     NULL,
     CURRENT_DATE
@@ -264,17 +264,17 @@ INSERT INTO
   )
 VALUES
   (
-    '2bac3a05-ca83-4beb-a9ba-72e3ac717f84',
+    'e0fc6cf2-8909-426a-adcf-eb3812255a3d',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'N6OUTAY',
+    '4ZUIHFX',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     'd97bdcb9-f7b3-477b-a073-71939fac297a',
     'temporary-accommodation',
     CURRENT_DATE,
-   'M9XWJ1S'
+   '6X1DNW1'
   )
 ON CONFLICT(id) DO NOTHING;
 
@@ -292,13 +292,13 @@ INSERT INTO
   )
 VALUES
   (
-    'c790c4de-d666-4766-8e95-910c85df82d0',
+    '24ecbe8d-71b0-481c-936d-b0c41f609ec3',
     CURRENT_DATE + 84,
     'f4d00e1c-8bfd-40e9-8241-a7d0f744e737',
     '587dc0dc-9073-4992-9d58-5576753050e9',
     NULL,
     NULL,
-    '2bac3a05-ca83-4beb-a9ba-72e3ac717f84',
+    'e0fc6cf2-8909-426a-adcf-eb3812255a3d',
     CURRENT_DATE
   )
 ON CONFLICT(id) DO NOTHING;
@@ -316,10 +316,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE,
-    '2bac3a05-ca83-4beb-a9ba-72e3ac717f84',
+    'e0fc6cf2-8909-426a-adcf-eb3812255a3d',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    '3b72ed4b-f451-4e66-acf4-10c6a1fbd066',
+    '2847a51c-cf0f-4f0b-accc-b3fc5e27def8',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -335,8 +335,8 @@ INSERT INTO
   )
 VALUES
   (
-    '5943907b-d027-4758-a0e0-8a06ac133d09',
-    '2bac3a05-ca83-4beb-a9ba-72e3ac717f84',
+    '67acac14-09c1-42f2-b4e8-3847b48542f0',
+    'e0fc6cf2-8909-426a-adcf-eb3812255a3d',
     CURRENT_DATE,
     NULL,
     CURRENT_DATE
@@ -360,10 +360,10 @@ INSERT INTO
   )
 VALUES
   (
-    '9fa491d7-d3b7-4cd5-a28b-3b99e22cb382',
+    '41439378-a366-4a3f-a0b0-68ae514be8b4',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'PR5E5Y2',
+    'PI251LM',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
@@ -386,10 +386,10 @@ INSERT INTO
   )
 VALUES
   (
-    'c3439d8e-0129-407f-943e-9b85e9e678ab',
+    'cfe9a46a-c8ef-48b8-af17-1d6f16c01afe',
     CURRENT_DATE - 14,
     NULL,
-    '9fa491d7-d3b7-4cd5-a28b-3b99e22cb382',
+    '41439378-a366-4a3f-a0b0-68ae514be8b4',
     'd2a0d037-53db-4bb2-b9f7-afa07948a3f5',
     CURRENT_DATE
   )
@@ -412,17 +412,17 @@ INSERT INTO
   )
 VALUES
   (
-    'ab210bba-2fae-4026-b95a-9047be86f434',
+    '1e09a600-7fed-40c0-81b7-66d4399ff0db',
     CURRENT_DATE,
     CURRENT_DATE + 84,
-    'GSR1T2F',
+    'HUN3BN0',
     CURRENT_DATE,
     CURRENT_DATE + 84,
     'd33006b7-55d9-4a8e-b722-5e18093dbcdf',
     'bdf9f9f6-6d53-4577-bffe-fc5f0ab3de0f',
     'temporary-accommodation',
     CURRENT_DATE,
-   '530X5EC'
+   'N1RRJZU'
   )
 ON CONFLICT(id) DO NOTHING;
 
@@ -438,10 +438,10 @@ INSERT INTO
   )
 VALUES
   (
-    '86a3be96-8698-43f3-9233-7b025630b07a',
+    'be9cf40c-bbf4-4ed4-8a1d-ce5eeb69b5cf',
     CURRENT_DATE + 2,
     NULL,
-    'ab210bba-2fae-4026-b95a-9047be86f434',
+    '1e09a600-7fed-40c0-81b7-66d4399ff0db',
     'e9184f2e-f409-461e-b149-492a02cb1655',
     CURRENT_DATE
   )
@@ -458,8 +458,8 @@ INSERT INTO
   )
 VALUES
   (
-    'f7ab4ff7-a255-4128-8ba3-cb4cd17d7115',
-    'ab210bba-2fae-4026-b95a-9047be86f434',
+    'dd6d3d5e-d7b5-4eb8-ab5c-b678916384fd',
+    '1e09a600-7fed-40c0-81b7-66d4399ff0db',
     CURRENT_DATE,
     NULL,
     CURRENT_DATE
@@ -484,11 +484,11 @@ INSERT INTO
   )
 VALUES
   (
-    '527f41dd-3f09-460c-a983-f1017d15c5da',
-    CURRENT_DATE + 3,
+    '08689e01-9d93-48f6-bffe-910688c5c3bc',
+    CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     '52W7TQG',
-    CURRENT_DATE + 3,
+    CURRENT_DATE + 2,
     CURRENT_DATE + 84,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
@@ -515,11 +515,11 @@ INSERT INTO
   )
 VALUES
   (
-    'fb29625c-1eba-4625-8837-9427be371ad6',
-    CURRENT_DATE + 1,
+    '913716e1-b4d1-4fe9-86aa-a50328e36799',
+    CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     '5EC66UT',
-    CURRENT_DATE + 1,
+    CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
@@ -546,7 +546,7 @@ INSERT INTO
   )
 VALUES
   (
-    'c7ede9ab-9dce-4cdb-b8f0-044b4bfbca28',
+    '2b428837-c72e-4df2-940e-3be51176235e',
     CURRENT_DATE + 1,
     CURRENT_DATE + 84,
     'BWEFOI7',
@@ -577,7 +577,7 @@ INSERT INTO
   )
 VALUES
   (
-    'd17a81a4-a647-48c3-ae1c-9fc41f9c9bb9',
+    '030a8ce8-f8d8-4709-9bd6-9166dbaee8fd',
     CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     'GSR1T2F',
@@ -609,7 +609,7 @@ INSERT INTO
   )
 VALUES
   (
-    '18dce513-f47c-4650-ab6b-8a29fcdfce3e',
+    '1b723c34-51c2-4c9d-a96c-a29df81f2b71',
     CURRENT_DATE - 84,
     CURRENT_DATE,
     'HRV83TE',
@@ -636,10 +636,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '18dce513-f47c-4650-ab6b-8a29fcdfce3e',
+    '1b723c34-51c2-4c9d-a96c-a29df81f2b71',
     CURRENT_DATE,
     CURRENT_DATE,
-    '74746a02-a2e9-4113-bc4c-616941704385',
+    '44e56f1d-92d1-4689-8f9a-e8c66f528853',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -661,7 +661,7 @@ INSERT INTO
   )
 VALUES
   (
-    'f69f89e8-6c13-4fd8-bbe7-46a6ee6f5479',
+    'de25bf21-dc7a-4bb0-a2ef-b55a2d4be78d',
     CURRENT_DATE - 84,
     CURRENT_DATE,
     'HTVI42B',
@@ -688,10 +688,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    'f69f89e8-6c13-4fd8-bbe7-46a6ee6f5479',
+    'de25bf21-dc7a-4bb0-a2ef-b55a2d4be78d',
     CURRENT_DATE,
     CURRENT_DATE,
-    'b905285b-0af8-469b-81e8-ada9adf6665d',
+    'd0f18137-b23c-42f9-acd5-7e2679db2c23',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -714,12 +714,12 @@ INSERT INTO
   )
 VALUES
   (
-    '80bd2d37-e552-41b5-825a-a0ec00b82cfa',
+    'e8a99da9-e21d-4839-bc28-38754bdcc359',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 3,
+    CURRENT_DATE + 4,
     'HRV83TE',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 3,
+    CURRENT_DATE + 4,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -741,10 +741,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '80bd2d37-e552-41b5-825a-a0ec00b82cfa',
+    'e8a99da9-e21d-4839-bc28-38754bdcc359',
     CURRENT_DATE,
-    CURRENT_DATE + 3,
-    '6f47be3e-e1af-4bf5-8b71-d2b6609a2a84',
+    CURRENT_DATE + 4,
+    '3490a001-6012-4fa2-85fe-e07f3f904248',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -766,12 +766,12 @@ INSERT INTO
   )
 VALUES
   (
-    '155d4358-d852-4020-8208-68ee094145f9',
+    'ee478e6f-faa6-4d9f-b9d9-b427e508c000',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 2,
+    CURRENT_DATE + 4,
     'HTVI42B',
     CURRENT_DATE - 84,
-    CURRENT_DATE + 2,
+    CURRENT_DATE + 4,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -793,10 +793,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 84,
-    '155d4358-d852-4020-8208-68ee094145f9',
+    'ee478e6f-faa6-4d9f-b9d9-b427e508c000',
     CURRENT_DATE,
-    CURRENT_DATE + 2,
-    'c4dea1f4-aa81-4f21-bb2f-216ca21bbc6d',
+    CURRENT_DATE + 4,
+    'd5be0235-e16e-49a9-8a99-2dcffcfa59bd',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -819,12 +819,12 @@ INSERT INTO
   )
 VALUES
   (
-    'dc1cc901-344a-4401-9d31-6383393b19db',
+    '26c28f9c-df5f-4b48-92e0-7aaf93edabf3',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 51,
+    CURRENT_DATE + 33,
     'HUN3BN0',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 51,
+    CURRENT_DATE + 33,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -846,10 +846,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    'dc1cc901-344a-4401-9d31-6383393b19db',
+    '26c28f9c-df5f-4b48-92e0-7aaf93edabf3',
     CURRENT_DATE,
-    CURRENT_DATE + 51,
-    '125f2da8-2e23-4626-9c74-34040e43e813',
+    CURRENT_DATE + 33,
+    'f73e0988-3357-4b67-a45a-3b688016109d',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -871,12 +871,12 @@ INSERT INTO
   )
 VALUES
   (
-    '9732a2fb-9cc8-4cf1-91e8-b7ba4374f9dd',
+    '86a751f5-30f8-4940-a8e8-02f41d0653aa',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 43,
+    CURRENT_DATE + 12,
     'IHGHXYM',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 43,
+    CURRENT_DATE + 12,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -898,10 +898,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '9732a2fb-9cc8-4cf1-91e8-b7ba4374f9dd',
+    '86a751f5-30f8-4940-a8e8-02f41d0653aa',
     CURRENT_DATE,
-    CURRENT_DATE + 43,
-    'ed055ade-ec66-4104-bbce-5955ee90893d',
+    CURRENT_DATE + 12,
+    'c69947bc-e3c1-41da-8608-530b2d6bffed',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -923,12 +923,12 @@ INSERT INTO
   )
 VALUES
   (
-    'b9e70ef9-1a83-4656-a6ff-cd091ebd8041',
+    '02b2d503-912b-4f8a-8873-a76141154393',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 41,
+    CURRENT_DATE + 48,
     'JCRH9V5',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 41,
+    CURRENT_DATE + 48,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -950,10 +950,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    'b9e70ef9-1a83-4656-a6ff-cd091ebd8041',
+    '02b2d503-912b-4f8a-8873-a76141154393',
     CURRENT_DATE,
-    CURRENT_DATE + 41,
-    '037d9868-65ef-4b8b-9720-63542bd259ac',
+    CURRENT_DATE + 48,
+    '9bf8e777-e83d-45fc-9cc4-fd7046870360',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -975,12 +975,12 @@ INSERT INTO
   )
 VALUES
   (
-    '097d8fc9-387b-4c35-9e4e-3935ebfeb752',
+    '043c2ad6-aec2-4be2-ae83-b564be9c97cf',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 19,
+    CURRENT_DATE + 38,
     'N6OUTAY',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 19,
+    CURRENT_DATE + 38,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -1002,10 +1002,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '097d8fc9-387b-4c35-9e4e-3935ebfeb752',
+    '043c2ad6-aec2-4be2-ae83-b564be9c97cf',
     CURRENT_DATE,
-    CURRENT_DATE + 19,
-    '43ea70f7-abaf-4850-b652-c828e48dde26',
+    CURRENT_DATE + 38,
+    'c1435028-2dea-4ab8-89f0-5e8b7ca12759',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;
@@ -1027,12 +1027,12 @@ INSERT INTO
   )
 VALUES
   (
-    '002caec5-145e-4fb4-a2df-0805d34c664a',
+    '036421b4-a3f8-4897-b7c9-a5b66f8c7861',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 8,
+    CURRENT_DATE + 52,
     'PR5E5Y2',
     CURRENT_DATE - 7,
-    CURRENT_DATE + 8,
+    CURRENT_DATE + 52,
     '459eeaba-55ac-4a1f-bae2-bad810d4016b',
     NULL,
     'approved-premises',
@@ -1054,10 +1054,10 @@ INSERT INTO
 VALUES
   (
     CURRENT_DATE - 7,
-    '002caec5-145e-4fb4-a2df-0805d34c664a',
+    '036421b4-a3f8-4897-b7c9-a5b66f8c7861',
     CURRENT_DATE,
-    CURRENT_DATE + 8,
-    '704b4d8a-f6e1-4d7d-8f8c-1faacf813572',
+    CURRENT_DATE + 52,
+    '05743e84-a3d6-40e8-9e8a-1c1b5ba91ddc',
     NULL
   )
 ON CONFLICT(id) DO NOTHING;

--- a/src/main/resources/db/migration/test/R__4_create_applications.sql
+++ b/src/main/resources/db/migration/test/R__4_create_applications.sql
@@ -25,8 +25,8 @@ BEGIN
   )
   values
     (
-      'fe1d197f-9025-489e-8f3a-a38c40be3d5c',
-      CURRENT_DATE + 28,
+      '970a6675-0bc7-4bd1-a279-1ba03e399241',
+      CURRENT_DATE + 11,
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       '315VWWC',
       applicationData,
@@ -41,7 +41,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 16,
+      CURRENT_DATE + 2,
       'M59CS58'
     );
   
@@ -53,16 +53,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      'fe1d197f-9025-489e-8f3a-a38c40be3d5c',
+      '970a6675-0bc7-4bd1-a279-1ba03e399241',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -73,14 +75,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '76b4a657-bcb0-41e4-9efc-b22b8df2fc17',
-      'fe1d197f-9025-489e-8f3a-a38c40be3d5c',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'd1ee7cdb-f50d-46d0-8cdc-be767e021669',
+      '970a6675-0bc7-4bd1-a279-1ba03e399241',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -109,9 +110,9 @@ BEGIN
   )
   values
     (
-      'a1fac092-1acb-4288-978f-a9844167b98b',
+      'b1e38d0c-026c-40cc-987d-6bb3b6f23855',
       CURRENT_DATE + 6,
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       '4Y29R9P',
       applicationData,
       applicationDocument,
@@ -125,7 +126,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 28,
+      CURRENT_DATE + 22,
       'XWU5JWQ'
     );
   
@@ -137,16 +138,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      'a1fac092-1acb-4288-978f-a9844167b98b',
+      'b1e38d0c-026c-40cc-987d-6bb3b6f23855',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -157,97 +160,12 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '652a578d-9c26-423e-8a57-ad3337674190',
-      'a1fac092-1acb-4288-978f-a9844167b98b',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at",
-    "noms_number"
-  )
-  values
-    (
-      '31482b90-33f5-49ac-86ef-b60df16a7812',
-      CURRENT_DATE + 27,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      '4ZUIHFX',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 12,
-      '5A5C8WL'
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '31482b90-33f5-49ac-86ef-b60df16a7812',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'd36fe117-c760-4bd0-9649-89c21834fe95',
-      '31482b90-33f5-49ac-86ef-b60df16a7812',
+      '5403568d-4fc1-45b9-8e5b-afbb8e6c13e7',
+      'b1e38d0c-026c-40cc-987d-6bb3b6f23855',
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -277,10 +195,10 @@ BEGIN
   )
   values
     (
-      '384c27ba-0f03-470c-9e98-599db620e303',
-      CURRENT_DATE + 20,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      '52W7TQG',
+      'a8911538-b822-44d4-8c1e-c9349bb7812f',
+      CURRENT_DATE + 8,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '4ZUIHFX',
       applicationData,
       applicationDocument,
       (
@@ -293,8 +211,8 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 25,
-      '5HBWEG1'
+      CURRENT_DATE + 17,
+      '5A5C8WL'
     );
   
 
@@ -305,16 +223,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '384c27ba-0f03-470c-9e98-599db620e303',
+      'a8911538-b822-44d4-8c1e-c9349bb7812f',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -325,14 +245,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '39db6071-b8ce-4575-8066-048b2db1ff69',
-      '384c27ba-0f03-470c-9e98-599db620e303',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '7cc5218b-2dfd-4092-8703-8b34153f10c5',
+      'a8911538-b822-44d4-8c1e-c9349bb7812f',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -361,10 +280,10 @@ BEGIN
   )
   values
     (
-      'd1fa54b2-ffb9-4ac7-91db-154dab8e6a5e',
-      CURRENT_DATE + 0,
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
-      '5EC66UT',
+      'f6ecc7cb-d860-4382-86d5-1a25b344f6e5',
+      CURRENT_DATE + 5,
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '52W7TQG',
       applicationData,
       applicationDocument,
       (
@@ -378,6 +297,91 @@ BEGIN
       ),
       'approved-premises',
       CURRENT_DATE + 15,
+      '5HBWEG1'
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "is_withdrawn",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'f6ecc7cb-d860-4382-86d5-1a25b344f6e5',
+      false,
+      false,
+      'M2500295343',
+      false,
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '6db5c3af-a674-40a2-b881-4af2bef892f2',
+      'f6ecc7cb-d860-4382-86d5-1a25b344f6e5',
+      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at",
+    "noms_number"
+  )
+  values
+    (
+      '7cfbfd0f-7446-4733-8297-96928a9f6c0a',
+      CURRENT_DATE + 23,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '5EC66UT',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 13,
       '530X5EC'
     );
   
@@ -389,16 +393,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      'd1fa54b2-ffb9-4ac7-91db-154dab8e6a5e',
+      '7cfbfd0f-7446-4733-8297-96928a9f6c0a',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -409,13 +415,12 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '6cfd4d77-6273-4c42-becb-bf7790355462',
-      'd1fa54b2-ffb9-4ac7-91db-154dab8e6a5e',
+      '1c095116-1f67-4d88-939e-68c4a271a06d',
+      '7cfbfd0f-7446-4733-8297-96928a9f6c0a',
       '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -445,8 +450,8 @@ BEGIN
   )
   values
     (
-      '7279e532-a436-4eb1-b898-c2af4062f601',
-      CURRENT_DATE + 9,
+      'a999fa4d-1db8-4cd5-af39-99d6ca9d6c1d',
+      CURRENT_DATE + 6,
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       '8LO3HSH',
       applicationData,
@@ -461,7 +466,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 22,
+      CURRENT_DATE + 28,
       'JD5CLIA'
     );
   
@@ -473,16 +478,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '7279e532-a436-4eb1-b898-c2af4062f601',
+      'a999fa4d-1db8-4cd5-af39-99d6ca9d6c1d',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -493,13 +500,12 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      'b89f5cd6-3b9c-4f9b-ab2c-0ae812240be3',
-      '7279e532-a436-4eb1-b898-c2af4062f601',
+      'f976becc-0bf2-46fe-97ec-f3eab7aedff0',
+      'a999fa4d-1db8-4cd5-af39-99d6ca9d6c1d',
       'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -529,9 +535,9 @@ BEGIN
   )
   values
     (
-      'ed8719e5-646d-4c64-bd32-3cd290b609a2',
-      CURRENT_DATE + 21,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '54430b83-a1b2-4c3b-88d7-3dced8df89a0',
+      CURRENT_DATE + 14,
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
       'BWEFOI7',
       applicationData,
       applicationDocument,
@@ -557,16 +563,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      'ed8719e5-646d-4c64-bd32-3cd290b609a2',
+      '54430b83-a1b2-4c3b-88d7-3dced8df89a0',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -577,14 +585,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '93786321-6ac3-473b-8504-c5e4ce32d93a',
-      'ed8719e5-646d-4c64-bd32-3cd290b609a2',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'f287cc27-b4a7-4333-9db8-f07b1d939268',
+      '54430b83-a1b2-4c3b-88d7-3dced8df89a0',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -613,9 +620,9 @@ BEGIN
   )
   values
     (
-      'f4aad217-048a-4ff7-9897-76f6cf2ad6dc',
+      '516100fb-acd9-4001-b54b-43cbe7f20d6a',
       CURRENT_DATE + 5,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       'GSR1T2F',
       applicationData,
       applicationDocument,
@@ -629,7 +636,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 26,
+      CURRENT_DATE + 29,
       'KXTJQEF'
     );
   
@@ -641,16 +648,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      'f4aad217-048a-4ff7-9897-76f6cf2ad6dc',
+      '516100fb-acd9-4001-b54b-43cbe7f20d6a',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -661,14 +670,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '9b74922b-da80-430d-abfd-eb7494dd26bc',
-      'f4aad217-048a-4ff7-9897-76f6cf2ad6dc',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '735bc450-a14c-463b-9e10-0e5f93279e31',
+      '516100fb-acd9-4001-b54b-43cbe7f20d6a',
+      '68715a03-06af-49ee-bae5-039c824ab9af',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -697,9 +705,9 @@ BEGIN
   )
   values
     (
-      '14e56cfe-00ad-4137-88f9-50c1b10d2bb2',
-      CURRENT_DATE + 13,
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
+      '2a246c11-c98f-4fa7-9979-b9c4b4e9968b',
+      CURRENT_DATE + 5,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'HRV83TE',
       applicationData,
       applicationDocument,
@@ -725,16 +733,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '14e56cfe-00ad-4137-88f9-50c1b10d2bb2',
+      '2a246c11-c98f-4fa7-9979-b9c4b4e9968b',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -745,14 +755,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '0ba78bae-aa42-4bd2-97d6-4e50c20949f8',
-      '14e56cfe-00ad-4137-88f9-50c1b10d2bb2',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
+      '0288eba9-81c2-4274-9379-8ca8f60a5246',
+      '2a246c11-c98f-4fa7-9979-b9c4b4e9968b',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -781,8 +790,8 @@ BEGIN
   )
   values
     (
-      '92e90a5b-9ccd-40d4-93d3-3bff7c1ad6c9',
-      CURRENT_DATE + 3,
+      '3e884906-e5cd-46d8-b2d9-da5cc681f08f',
+      CURRENT_DATE + 8,
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'HTVI42B',
       applicationData,
@@ -797,7 +806,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 2,
+      CURRENT_DATE + 15,
       '6X1DNW1'
     );
   
@@ -809,16 +818,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '92e90a5b-9ccd-40d4-93d3-3bff7c1ad6c9',
+      '3e884906-e5cd-46d8-b2d9-da5cc681f08f',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -829,13 +840,12 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '8ffe3515-6a52-43d1-9848-789c9428d2d6',
-      '92e90a5b-9ccd-40d4-93d3-3bff7c1ad6c9',
+      '5d6c029a-258a-4611-b229-1936ee1dfdb5',
+      '3e884906-e5cd-46d8-b2d9-da5cc681f08f',
       '7a424213-3a0c-45b0-9a51-4977243c2b21',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -865,8 +875,8 @@ BEGIN
   )
   values
     (
-      '6bdbe139-5b6c-457a-95e9-3acb6e1f1bfb',
-      CURRENT_DATE + 0,
+      'a6774caf-53ca-497f-996c-ad4ac1219a90',
+      CURRENT_DATE + 28,
       '531455f4-c76f-4943-b4eb-3c02d8fefa69',
       'HUN3BN0',
       applicationData,
@@ -881,7 +891,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 15,
+      CURRENT_DATE + 27,
       'YCSW8BD'
     );
   
@@ -893,16 +903,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '6bdbe139-5b6c-457a-95e9-3acb6e1f1bfb',
+      'a6774caf-53ca-497f-996c-ad4ac1219a90',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -913,349 +925,12 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      'b2092cbf-837f-4046-8d87-66990965fe0f',
-      '6bdbe139-5b6c-457a-95e9-3acb6e1f1bfb',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at",
-    "noms_number"
-  )
-  values
-    (
-      '9f757c8c-9d1e-4bcb-932f-391fdba33391',
-      CURRENT_DATE + 9,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'IHGHXYM',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 24,
-      'KWAPTC7'
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '9f757c8c-9d1e-4bcb-932f-391fdba33391',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '5277c81b-d500-4d24-9bc0-f5d8eb18fd7a',
-      '9f757c8c-9d1e-4bcb-932f-391fdba33391',
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at",
-    "noms_number"
-  )
-  values
-    (
-      '4afbacac-a8c2-45d7-9f4d-10b40695edff',
-      CURRENT_DATE + 8,
-      '531455f4-c76f-4943-b4eb-3c02d8fefa69',
-      'JCRH9V5',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 18,
-      'VTDINBA'
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '4afbacac-a8c2-45d7-9f4d-10b40695edff',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'a1285cc1-8482-45cf-8ff7-4f04d64f2f7d',
-      '4afbacac-a8c2-45d7-9f4d-10b40695edff',
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at",
-    "noms_number"
-  )
-  values
-    (
-      'd81ba3cf-feb8-4e43-8e10-175c18a75bdd',
-      CURRENT_DATE + 24,
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
-      'N6OUTAY',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 14,
-      'HIR0PIN'
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'd81ba3cf-feb8-4e43-8e10-175c18a75bdd',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      'bb5444b4-ba08-42d2-aba6-48ee774f42b5',
-      'd81ba3cf-feb8-4e43-8e10-175c18a75bdd',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at",
-    "noms_number"
-  )
-  values
-    (
-      'b0b17e97-f3ac-49dd-95b3-1073d7ee14b3',
-      CURRENT_DATE + 14,
-      '68715a03-06af-49ee-bae5-039c824ab9af',
-      'PI251LM',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 22,
-      'QGH3OL6'
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      'b0b17e97-f3ac-49dd-95b3-1073d7ee14b3',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '03bccc5b-0354-4559-879b-677d1f1b232e',
-      'b0b17e97-f3ac-49dd-95b3-1073d7ee14b3',
+      '1b8ff903-14f4-4f4b-ae77-daecf886be49',
+      'a6774caf-53ca-497f-996c-ad4ac1219a90',
       '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -1285,10 +960,10 @@ BEGIN
   )
   values
     (
-      '2bd7afdd-d861-477c-a6c7-85395bb0d6b4',
-      CURRENT_DATE + 26,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'PR5E5Y2',
+      '57158b92-b8c2-41e3-bab5-456462032ccc',
+      CURRENT_DATE + 11,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'IHGHXYM',
       applicationData,
       applicationDocument,
       (
@@ -1301,8 +976,8 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 1,
-      'M9XWJ1S'
+      CURRENT_DATE + 15,
+      'KWAPTC7'
     );
   
 
@@ -1313,16 +988,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '2bd7afdd-d861-477c-a6c7-85395bb0d6b4',
+      '57158b92-b8c2-41e3-bab5-456462032ccc',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -1333,97 +1010,12 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      'd29156d8-24f0-4d6e-8222-10d9dc403582',
-      '2bd7afdd-d861-477c-a6c7-85395bb0d6b4',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      CURRENT_DATE,
-      CURRENT_DATE,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_ASSESSMENT'
-        LIMIT 1
-      )
-    );
-  
-
-  insert into applications (
-    "id",
-    "created_at",
-    "created_by_user_id",
-    "crn",
-    "data",
-    "document",
-    "schema_version",
-    "service",
-    "submitted_at",
-    "noms_number"
-  )
-  values
-    (
-      '667a407f-609a-4ebc-bf67-4e36e1df7e35',
-      CURRENT_DATE + 28,
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
-      'QA93YYK',
-      applicationData,
-      applicationDocument,
-      (
-        SELECT
-          id
-        FROM
-          json_schemas
-        WHERE
-          type = 'APPROVED_PREMISES_APPLICATION'
-        LIMIT 1
-      ),
-      'approved-premises',
-      CURRENT_DATE + 27,
-      'YX2YNT2'
-    );
-  
-
-  insert into approved_premises_applications (
-      "conviction_id",
-      "event_number",
-      "id",
-      "is_pipe_application",
-      "is_womens_application",
-      "offence_id",
-      "risk_ratings"
-    )
-  values
-    (
-      '2500295345',
-      '2',
-      '667a407f-609a-4ebc-bf67-4e36e1df7e35',
-      false,
-      false,
-      'M2500295343',
-      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
-    );
-  
-
-  INSERT into
-  assessments (
-    "id",
-    "application_id",
-    "allocated_to_user_id",
-    "created_at",
-    "allocated_at",
-    "schema_version"
-  )
-  VALUES
-    (
-      '0ae6f411-0957-4790-b853-8883af16f577',
-      '667a407f-609a-4ebc-bf67-4e36e1df7e35',
+      '9a6e3663-bab4-46dc-884f-ce9bd84d7584',
+      '57158b92-b8c2-41e3-bab5-456462032ccc',
       '8a39870c-3a1f-4e05-ad45-a450e15b242d',
       CURRENT_DATE,
       CURRENT_DATE,
@@ -1453,8 +1045,433 @@ BEGIN
   )
   values
     (
-      '71db43c7-b9d0-4830-8102-0542b0ee4277',
+      'c3f7ee7f-fbf5-4040-a363-a18631c34b3e',
+      CURRENT_DATE + 21,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'JCRH9V5',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 9,
+      'VTDINBA'
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "is_withdrawn",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'c3f7ee7f-fbf5-4040-a363-a18631c34b3e',
+      false,
+      false,
+      'M2500295343',
+      false,
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'e988fd99-e834-45e9-9729-8bddc43d7948',
+      'c3f7ee7f-fbf5-4040-a363-a18631c34b3e',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at",
+    "noms_number"
+  )
+  values
+    (
+      'f74b1ab2-f194-4b34-9205-e34e75f69a53',
+      CURRENT_DATE + 28,
+      '68715a03-06af-49ee-bae5-039c824ab9af',
+      'N6OUTAY',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 13,
+      'HIR0PIN'
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "is_withdrawn",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      'f74b1ab2-f194-4b34-9205-e34e75f69a53',
+      false,
+      false,
+      'M2500295343',
+      false,
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'f0a40b46-7079-4ecd-8544-6b7bcc7515e3',
+      'f74b1ab2-f194-4b34-9205-e34e75f69a53',
+      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at",
+    "noms_number"
+  )
+  values
+    (
+      '77063f49-e078-416a-a952-7693c4a6cd88',
+      CURRENT_DATE + 17,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
+      'PI251LM',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 28,
+      'QGH3OL6'
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "is_withdrawn",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '77063f49-e078-416a-a952-7693c4a6cd88',
+      false,
+      false,
+      'M2500295343',
+      false,
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      'dea03574-9320-4239-bfb7-6d4268a06aa6',
+      '77063f49-e078-416a-a952-7693c4a6cd88',
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at",
+    "noms_number"
+  )
+  values
+    (
+      '215da410-44ab-4234-9730-f5c2b49a3384',
       CURRENT_DATE + 11,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      'PR5E5Y2',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 9,
+      'M9XWJ1S'
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "is_withdrawn",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '215da410-44ab-4234-9730-f5c2b49a3384',
+      false,
+      false,
+      'M2500295343',
+      false,
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '2b21ebe8-c39d-4f30-b356-d44f44113da8',
+      '215da410-44ab-4234-9730-f5c2b49a3384',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at",
+    "noms_number"
+  )
+  values
+    (
+      '6f19ef0e-bef1-4b11-a5ed-a51725bef15c',
+      CURRENT_DATE + 8,
+      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      'QA93YYK',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 9,
+      'YX2YNT2'
+    );
+  
+
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "is_withdrawn",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '6f19ef0e-bef1-4b11-a5ed-a51725bef15c',
+      false,
+      false,
+      'M2500295343',
+      false,
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  
+
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '40c27500-6b52-4a0c-b95b-e6d7acab5ff8',
+      '6f19ef0e-bef1-4b11-a5ed-a51725bef15c',
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  
+
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at",
+    "noms_number"
+  )
+  values
+    (
+      '5a138e27-f4eb-4b52-958a-d3284987f1db',
+      CURRENT_DATE + 13,
       '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       'XCMSG3I',
       applicationData,
@@ -1469,7 +1486,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 20,
+      CURRENT_DATE + 4,
       'NYVS303'
     );
   
@@ -1481,16 +1498,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '71db43c7-b9d0-4830-8102-0542b0ee4277',
+      '5a138e27-f4eb-4b52-958a-d3284987f1db',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -1501,14 +1520,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      'd354aa03-a2a0-473d-8f42-b6f450ff681d',
-      '71db43c7-b9d0-4830-8102-0542b0ee4277',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '41ba2c85-1374-4126-bc10-bb28da8ab933',
+      '5a138e27-f4eb-4b52-958a-d3284987f1db',
+      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -1537,9 +1555,9 @@ BEGIN
   )
   values
     (
-      '34ca7199-09c6-469f-ab00-c7bc10a598db',
-      CURRENT_DATE + 3,
-      '8a39870c-3a1f-4e05-ad45-a450e15b242d',
+      '2a6be6b7-eafa-4f57-82c8-f92263d583e2',
+      CURRENT_DATE + 1,
+      '7a424213-3a0c-45b0-9a51-4977243c2b21',
       'YRPARSH',
       applicationData,
       applicationDocument,
@@ -1553,7 +1571,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 10,
+      CURRENT_DATE + 19,
       'HBVE0LJ'
     );
   
@@ -1565,16 +1583,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '34ca7199-09c6-469f-ab00-c7bc10a598db',
+      '2a6be6b7-eafa-4f57-82c8-f92263d583e2',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -1585,14 +1605,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '348fee4c-d625-426b-ab41-864ff480413b',
-      '34ca7199-09c6-469f-ab00-c7bc10a598db',
-      '7a424213-3a0c-45b0-9a51-4977243c2b21',
+      '0573f229-b245-4e01-b6fd-c2b91eafc975',
+      '2a6be6b7-eafa-4f57-82c8-f92263d583e2',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       CURRENT_DATE,
       CURRENT_DATE,
       (
@@ -1621,9 +1640,9 @@ BEGIN
   )
   values
     (
-      '5e575fe9-28a7-4f7c-ba1a-7ae264c0ed15',
-      CURRENT_DATE + 8,
-      '7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2',
+      '4741af48-aac8-41f1-9b53-56d1e1afe92a',
+      CURRENT_DATE + 27,
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       'Z33A1BU',
       applicationData,
       applicationDocument,
@@ -1637,7 +1656,7 @@ BEGIN
         LIMIT 1
       ),
       'approved-premises',
-      CURRENT_DATE + 10,
+      CURRENT_DATE + 8,
       '6DO89QY'
     );
   
@@ -1649,16 +1668,18 @@ BEGIN
       "is_pipe_application",
       "is_womens_application",
       "offence_id",
+      "is_withdrawn",
       "risk_ratings"
     )
   values
     (
       '2500295345',
       '2',
-      '5e575fe9-28a7-4f7c-ba1a-7ae264c0ed15',
+      '4741af48-aac8-41f1-9b53-56d1e1afe92a',
       false,
       false,
       'M2500295343',
+      false,
       '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
     );
   
@@ -1669,14 +1690,13 @@ BEGIN
     "application_id",
     "allocated_to_user_id",
     "created_at",
-    "allocated_at",
     "schema_version"
   )
   VALUES
     (
-      '30d9ce53-50e2-4282-b823-7e4ada027c73',
-      '5e575fe9-28a7-4f7c-ba1a-7ae264c0ed15',
-      '6dcd2559-2d14-4feb-8faf-89ad30dfa765',
+      '148e0532-aecd-480b-a68e-ecb293d5c828',
+      '4741af48-aac8-41f1-9b53-56d1e1afe92a',
+      'f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc',
       CURRENT_DATE,
       CURRENT_DATE,
       (


### PR DESCRIPTION
This PR updates the repeatable migrations for the test environment so that seeding the Approved Premises application data succeeds. Currently, the migrations fail due to the missing `is_withdrawn` column on the table.

See also: https://github.com/ministryofjustice/hmpps-community-accommodation-wiremock/pull/34