### PR TITLE
Delete booking script removes any turnaround records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1270,6 +1270,10 @@ class BookingService(
       extensionRepository.delete(it)
     }
 
+    booking.turnarounds.forEach {
+      turnaroundRepository.delete(it)
+    }
+
     bookingRepository.delete(booking)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteBookingTest.kt
@@ -46,6 +46,10 @@ class DeleteBookingTest : IntegrationTestBase() {
       withBooking(booking)
     }
 
+    val turnarounds = turnaroundFactory.produceAndPersistMultiple(2) {
+      withBooking(booking)
+    }
+
     webTestClient.delete()
       .uri("/internal/booking/${booking.id}")
       .exchange()
@@ -59,6 +63,7 @@ class DeleteBookingTest : IntegrationTestBase() {
     val cancellationFromDatabase = cancellationRepository.findByIdOrNull(cancellation.id)
     val confirmationFromDatabase = confirmationRepository.findByIdOrNull(confirmation.id)
     val extensionsFromDatabase = extensions.map { extensionRepository.findByIdOrNull(it.id) }
+    val turnaroundsFromDatabase = turnarounds.map { turnaroundRepository.findByIdOrNull(it.id) }
 
     assertThat(bookingFromDatabase).isNull()
     assertThat(arrivalFromDatabase).isNull()
@@ -67,6 +72,7 @@ class DeleteBookingTest : IntegrationTestBase() {
     assertThat(cancellationFromDatabase).isNull()
     assertThat(confirmationFromDatabase).isNull()
     extensionsFromDatabase.forEach { assertThat(it).isNull() }
+    turnaroundsFromDatabase.forEach { assertThat(it).isNull() }
   }
 
   @Test
@@ -104,6 +110,10 @@ class DeleteBookingTest : IntegrationTestBase() {
       withBooking(booking)
     }
 
+    val turnarounds = turnaroundFactory.produceAndPersistMultiple(2) {
+      withBooking(booking)
+    }
+
     every { realExtensionRepository.delete(match { it.id == extensions.last().id }) } throws RuntimeException("Database Exception")
 
     webTestClient.delete()
@@ -119,6 +129,7 @@ class DeleteBookingTest : IntegrationTestBase() {
     val cancellationFromDatabase = cancellationRepository.findByIdOrNull(cancellation.id)
     val confirmationFromDatabase = confirmationRepository.findByIdOrNull(confirmation.id)
     val extensionsFromDatabase = extensions.map { extensionRepository.findByIdOrNull(it.id) }
+    val turnaroundsFromDatabase = turnarounds.map { turnaroundRepository.findByIdOrNull(it.id) }
 
     assertThat(bookingFromDatabase).isNotNull
     assertThat(arrivalFromDatabase).isNotNull
@@ -127,6 +138,7 @@ class DeleteBookingTest : IntegrationTestBase() {
     assertThat(cancellationFromDatabase).isNotNull
     assertThat(confirmationFromDatabase).isNotNull
     assertThat(extensionsFromDatabase).isNotNull
+    assertThat(turnaroundsFromDatabase).isNotNull
   }
 
   private fun createPremises() = approvedPremisesEntityFactory.produceAndPersist {


### PR DESCRIPTION
When we tried to use this script on prod we get the following error[1]:

```
ERROR: update or delete on table "bookings" violates foreign key constraint "turnarounds_booking_id_fkey" on table "turnarounds"
  Detail: Key (id)=(76abf8b6-2fff-40f0-aea1-c54f4d30ff5d) is still referenced from table "turnarounds".
```

This could be because turnarounds was added after this script was introduced.

This change attempts to also clear any associated turnaround records as part of the deletion.

[1] https://ministryofjustice.sentry.io/issues/4321107098/?alert_rule_id=12408391&alert_type=issue&project=4503931792392192&referrer=slack

## Before and after:

![Screenshot 2023-07-18 at 14 58 03](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/405bd338-eb18-4214-83f9-22f2acdca25b)
