### PR TITLE
(323) Allow a Booking to be created without a bedID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -95,6 +95,7 @@ class PlacementRequestsController(
       user = user,
       placementRequestId = id,
       bedId = newPlacementRequestBooking.bedId,
+      premisesId = newPlacementRequestBooking.premisesId,
       arrivalDate = newPlacementRequestBooking.arrivalDate,
       departureDate = newPlacementRequestBooking.departureDate,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -399,14 +399,14 @@ class PremisesController(
       throw ForbiddenProblem()
     }
 
-    val bedId = booking.bed?.id
-      ?: throw InternalServerErrorProblem("No bed ID present on Booking: $bookingId")
-
     val result = when (body) {
       is NewCas1Arrival -> {
+        val bedId = booking.bed?.id
         val arrivalDate = LocalDate.from(body.arrivalDateTime.atZone(ZoneOffset.UTC))
 
-        throwIfLostBedDatesConflict(arrivalDate, body.expectedDepartureDate, null, bedId)
+        if (bedId != null) {
+          throwIfLostBedDatesConflict(arrivalDate, body.expectedDepartureDate, null, bedId)
+        }
 
         bookingService.createCas1Arrival(
           booking = booking,
@@ -418,6 +418,9 @@ class PremisesController(
         )
       }
       is NewCas2Arrival -> {
+        val bedId = booking.bed?.id
+          ?: throw InternalServerErrorProblem("No bed ID present on Booking: $bookingId")
+
         throwIfBookingDatesConflict(body.arrivalDate, body.expectedDepartureDate, bookingId, bedId)
         throwIfLostBedDatesConflict(body.arrivalDate, body.expectedDepartureDate, null, bedId)
 
@@ -431,6 +434,9 @@ class PremisesController(
         )
       }
       is NewCas3Arrival -> {
+        val bedId = booking.bed?.id
+          ?: throw InternalServerErrorProblem("No bed ID present on Booking: $bookingId")
+
         throwIfBookingDatesConflict(body.arrivalDate, body.expectedDepartureDate, bookingId, bedId)
         throwIfLostBedDatesConflict(body.arrivalDate, body.expectedDepartureDate, null, bedId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
@@ -57,6 +58,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundRepository
@@ -108,6 +111,7 @@ class BookingService(
   private val lostBedsRepository: LostBedsRepository,
   private val turnaroundRepository: TurnaroundRepository,
   private val bedMoveRepository: BedMoveRepository,
+  private val premisesRepository: PremisesRepository,
   private val notifyConfig: NotifyConfig,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: String,
@@ -121,7 +125,8 @@ class BookingService(
   fun createApprovedPremisesBookingFromPlacementRequest(
     user: UserEntity,
     placementRequestId: UUID,
-    bedId: UUID,
+    bedId: UUID?,
+    premisesId: UUID?,
     arrivalDate: LocalDate,
     departureDate: LocalDate,
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
@@ -132,6 +137,9 @@ class BookingService(
       return AuthorisableActionResult.Unauthorised()
     }
 
+    var bed: BedEntity?
+    var premises: PremisesEntity?
+
     val validationResult = validated {
       if (placementRequest.booking != null) {
         return@validated placementRequest.booking!!.id hasConflictError "A Booking has already been made for this Placement Request"
@@ -141,20 +149,35 @@ class BookingService(
         "$.departureDate" hasValidationError "beforeBookingArrivalDate"
       }
 
-      getBookingWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
-        return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates"
-      }
+      if (bedId != null) {
+        getBookingWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
+          return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates"
+        }
 
-      getLostBedWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
-        return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
-      }
+        getLostBedWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
+          return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
+        }
 
-      val bed = bedRepository.findByIdOrNull(bedId)
+        bed = bedRepository.findByIdOrNull(bedId)
 
-      if (bed == null) {
-        "$.bedId" hasValidationError "doesNotExist"
-      } else if (bed.room.premises !is ApprovedPremisesEntity) {
-        "$.bedId" hasValidationError "mustBelongToApprovedPremises"
+        if (bed == null) {
+          "$.bedId" hasValidationError "doesNotExist"
+        } else if (bed!!.room.premises !is ApprovedPremisesEntity) {
+          "$.bedId" hasValidationError "mustBelongToApprovedPremises"
+        }
+
+        premises = bed!!.room.premises
+      } else if (premisesId != null) {
+        premises = premisesRepository.findByIdOrNull(premisesId)
+        bed = null
+
+        if (premises == null) {
+          "$.premisesId" hasValidationError "doesNotExist"
+        } else if (premises !is ApprovedPremisesEntity) {
+          "$.premisesId" hasValidationError "mustBeAnApprovedPremises"
+        }
+      } else {
+        return@validated generalError("You must specify either a bedId or a premisesId")
       }
 
       if (validationErrors.any()) {
@@ -177,7 +200,7 @@ class BookingService(
           confirmation = null,
           extensions = mutableListOf(),
           dateChanges = mutableListOf(),
-          premises = bed!!.room.premises,
+          premises = premises!!,
           bed = bed,
           service = ServiceName.approvedPremises.value,
           originalArrivalDate = arrivalDate,
@@ -211,7 +234,7 @@ class BookingService(
         templateId = notifyConfig.templates.bookingMade,
         personalisation = mapOf(
           "name" to applicationSubmittedByUser.name,
-          "apName" to bed.room.premises.name,
+          "apName" to premises!!.name,
           "applicationUrl" to applicationUrlTemplate.replace("#id", placementRequest.application.id.toString()),
           "bookingUrl" to bookingUrlTemplate.replace("#premisesId", booking.premises.id.toString())
             .replace("#bookingId", booking.id.toString()),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1216,10 +1216,10 @@ class BookingService(
   ) = validated<ExtensionEntity> {
     val expectedLastUnavailableDate = workingDayCountService.addWorkingDays(newDepartureDate, booking.turnaround?.workingDayCount ?: 0)
 
-    val bedId = booking.bed?.id
-      ?: throw InternalServerErrorProblem("No bed ID present on Booking: ${booking.id}")
-
     if (booking.service != ServiceName.approvedPremises.value) {
+      val bedId = booking.bed?.id
+        ?: throw InternalServerErrorProblem("No bed ID present on Booking: ${booking.id}")
+
       getBookingWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, booking.id, bedId)?.let {
         return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NewPlacementRequestBookingConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/NewPlacementRequestBookingConfirmationTransformer.kt
@@ -9,6 +9,6 @@ class NewPlacementRequestBookingConfirmationTransformer {
   fun transformJpaToApi(jpa: BookingEntity) = NewPlacementRequestBookingConfirmation(
     arrivalDate = jpa.arrivalDate,
     departureDate = jpa.departureDate,
-    premisesName = jpa.bed!!.room.premises.name,
+    premisesName = jpa.premises.name,
   )
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3686,10 +3686,12 @@ components:
         bedId:
           type: string
           format: uuid
+        premisesId:
+          type: string
+          format: uuid
       required:
         - arrivalDate
         - departureDate
-        - bedId
     Booking:
       allOf:
         - $ref: '#/components/schemas/BookingBody'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -2466,6 +2466,31 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Create Extension on Approved Premises Booking returns OK when a booking has no bed`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
+      val keyWorker = ContextStaffMemberFactory().produce()
+      APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, "QCODE")
+
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withQCode("QCODE")
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val booking = bookingEntityFactory.produceAndPersist {
+        withArrivalDate(LocalDate.parse("2022-08-18"))
+        withDepartureDate(LocalDate.parse("2022-08-20"))
+        withStaffKeyWorkerCode(keyWorker.code)
+        withPremises(premises)
+      }
+
+      creatingNewExtensionReturnsCorrectly(booking, jwt, "2022-08-22")
+    }
+  }
+
+  @Test
   fun `Create Approved Premises Extension returns OK when another booking for the same bed overlaps with the new departure date`() {
     `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1426,6 +1426,56 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Create Arrival on Approved Premises Booking returns 200 with correct body when a bed is not present`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
+      val keyWorker = ContextStaffMemberFactory().produce()
+      APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, "QCODE")
+
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withQCode("QCODE")
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+          }
+        }
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premises)
+      }
+
+      val booking = bookingEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withArrivalDate(LocalDate.of(2023, 5, 20))
+        withDepartureDate(LocalDate.of(2023, 5, 30))
+      }
+
+      webTestClient.post()
+        .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewCas1Arrival(
+            type = "CAS1",
+            arrivalDateTime = Instant.parse("2023-05-20T15:00:00Z"),
+            expectedDepartureDate = LocalDate.parse("2023-06-05"),
+            notes = "Hello",
+            keyWorkerStaffCode = keyWorker.code,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
+        .jsonPath("$.arrivalDate").isEqualTo("2023-05-20")
+        .jsonPath("$.expectedDepartureDate").isEqualTo("2023-06-05")
+        .jsonPath("$.notes").isEqualTo("Hello")
+        .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+    }
+  }
+
+  @Test
   fun `Create Arrival updates arrival and departure date for an Approved Premises booking`() {
     `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -641,6 +641,46 @@ class PlacementRequestsTest : IntegrationTestBase() {
         }
       }
     }
+
+    @Test
+    fun `Creating a Booking from a Placement Request that is allocated to the User and a premisesId is specified returns a 200`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Application`(createdByUser = otherUser) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = user,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                val premises = approvedPremisesEntityFactory.produceAndPersist {
+                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+                  withYieldedProbationRegion {
+                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                  }
+                }
+
+                webTestClient.post()
+                  .uri("/placement-requests/${placementRequest.id}/booking")
+                  .header("Authorization", "Bearer $jwt")
+                  .bodyValue(
+                    NewPlacementRequestBooking(
+                      arrivalDate = LocalDate.parse("2023-03-29"),
+                      departureDate = LocalDate.parse("2023-04-01"),
+                      bedId = null,
+                      premisesId = premises.id,
+                    ),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isOk
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
This updates the `placement-requests/$id/bookings` endpoint to accept either a bedId or premisesId. As we can’t easily do an either/or null in the OpenAPI spec, we check for the presence of either bedId or premisesId, and raise an error if neither is present.

Bed IDs are already optional, so this shouldn’t cause any breakages elsewhere. I’ve had a quick look around and everything seems to work as expected when a Bed ID is missing.