### PR TITLE
1310 - Missing Noms Number doesn't prevent new CAS3 applications from being created

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -308,10 +308,6 @@ class ApplicationService(
           is AuthorisableActionResult.Success -> offenderDetailsResult.entity
         }
 
-        if (offenderDetails.otherIds.nomsNumber == null) {
-          throw RuntimeException("Cannot create an Application for an Offender without a NOMS number")
-        }
-
         if (convictionId == null) {
           "$.convictionId" hasValidationError "empty"
         }


### PR DESCRIPTION
Create CAS3 Application even if a pop doesn’t have a NomsNumber

During the CAS1 release of Apply they found that there were many people who didn’t have this field. We are now following CAS1 in making this optional for an application.

https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/6fd33c4b3d6b822d73d8455ef418f38957a95094