### PR TITLE
Log unmapped exceptions in ExceptionHandling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -62,6 +62,8 @@ class ExceptionHandling(
       )
     }
 
+    log.error("Unhandled exception type, returning generic 500 response", throwable)
+
     return InternalServerErrorProblem(
       detail = "There was an unexpected problem",
     )


### PR DESCRIPTION
We return a generic 500 with "There was an unexpected problem" as the response but are currently discarding the actual exception - this logs the exception server side too.