### PR TITLE
Allow workflow managers to create bookings from any placement request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -133,7 +133,7 @@ class BookingService(
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
 
-    if (placementRequest.allocatedToUser.id != user.id) {
+    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.allocatedToUser.id != user.id) {
       return AuthorisableActionResult.Unauthorised()
     }
 


### PR DESCRIPTION
All workflow managers can create bookings regardless of if a placement
request is allocated to them.