### PR TITLE
Add an isParole column to PlacementRequests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -61,4 +61,6 @@ data class PlacementRequestEntity(
   @ManyToOne
   @JoinColumn(name = "placement_requirements_id")
   var placementRequirements: PlacementRequirementsEntity,
+
+  var isParole: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -235,7 +235,7 @@ class AssessmentService(
     }
 
     if (placementDates != null) {
-      placementRequestService.createPlacementRequest(placementRequirementsValidationResult.entity, placementDates, notes)
+      placementRequestService.createPlacementRequest(placementRequirementsValidationResult.entity, placementDates, notes, false)
     }
 
     val application = savedAssessment.application

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -975,6 +975,7 @@ class BookingService(
           duration = placementRequest.duration,
         ),
         notes = placementRequest.notes,
+        isParole = false,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -128,13 +129,14 @@ class PlacementRequestService(
         expectedArrival = it.expectedArrival,
         duration = it.duration,
       )
-      this.createPlacementRequest(placementRequirements, placementDates, notes)
+      val isParole = placementApplicationEntity.placementType == PlacementType.RELEASE_FOLLOWING_DECISION
+      this.createPlacementRequest(placementRequirements, placementDates, notes, isParole)
     }
 
     return AuthorisableActionResult.Success(placementRequests)
   }
 
-  fun createPlacementRequest(placementRequirements: PlacementRequirementsEntity, placementDates: PlacementDates, notes: String?): PlacementRequestEntity {
+  fun createPlacementRequest(placementRequirements: PlacementRequirementsEntity, placementDates: PlacementDates, notes: String?, isParole: Boolean): PlacementRequestEntity {
     val user = userService
 
     return placementRequestRepository.save(
@@ -151,6 +153,7 @@ class PlacementRequestService(
         bookingNotMades = mutableListOf(),
         reallocatedAt = null,
         notes = notes,
+        isParole = isParole ?: false,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -12,6 +12,7 @@ class PlacementRequestDetailTransformer(
   private val placementRequestTransformer: PlacementRequestTransformer,
   private val cancellationTransformer: CancellationTransformer,
   private val bookingSummaryTransformer: BookingSummaryTransformer,
+  private val applicationTransformer: ApplicationsTransformer,
 ) {
   fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?, cancellations: List<CancellationEntity>): PlacementRequestDetail {
     val placementRequest = placementRequestTransformer.transformJpaToApi(jpa, offenderDetailSummary, inmateDetail)
@@ -40,6 +41,7 @@ class PlacementRequestDetailTransformer(
       cancellations = cancellations.mapNotNull { cancellationTransformer.transformJpaToApi(it) },
       booking = jpa.booking?.let { bookingSummaryTransformer.transformJpaToApi(jpa.booking!!) },
       isParole = jpa.isParole,
+      application = applicationTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -39,6 +39,7 @@ class PlacementRequestDetailTransformer(
       notes = placementRequest.notes,
       cancellations = cancellations.mapNotNull { cancellationTransformer.transformJpaToApi(it) },
       booking = jpa.booking?.let { bookingSummaryTransformer.transformJpaToApi(jpa.booking!!) },
+      isParole = jpa.isParole,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -41,6 +41,7 @@ class PlacementRequestTransformer(
       applicationDate = jpa.application.submittedAt?.toInstant()!!,
       assessor = userTransformer.transformJpaToApi(jpa.assessment.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
       notes = jpa.notes,
+      isParole = jpa.isParole,
     )
   }
 

--- a/src/main/resources/db/migration/all/20230725101601__add_is_parole_to_placement_requests.sql
+++ b/src/main/resources/db/migration/all/20230725101601__add_is_parole_to_placement_requests.sql
@@ -1,0 +1,3 @@
+ALTER TABLE placement_requests ADD COLUMN is_parole BOOLEAN;
+UPDATE placement_requests SET is_parole = FALSE;
+ALTER TABLE placement_requests ALTER COLUMN is_parole SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5963,6 +5963,8 @@ components:
               format: date-time
             assessor:
               $ref: '#/components/schemas/ApprovedPremisesUser'
+            isParole:
+              type: boolean
             notes:
               type: string
           required:
@@ -5977,6 +5979,7 @@ components:
             - assessmentDate
             - applicationDate
             - assessor
+            - isParole
     PlacementRequestDetail:
       allOf:
         - $ref: '#/components/schemas/PlacementRequest'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5991,8 +5991,11 @@ components:
                 $ref: '#/components/schemas/Cancellation'
             booking:
               $ref: '#/components/schemas/BookingSummary'
+            application:
+              $ref: '#/components/schemas/Application'
           required:
             - cancellations
+            - application
     PlacementRequestStatus:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -26,6 +26,7 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
   private var bookingNotMades: Yielded<MutableList<BookingNotMadeEntity>> = { mutableListOf() }
   private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
   private var notes: Yielded<String?> = { null }
+  private var isParole: Yielded<Boolean> = { false }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -67,6 +68,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     this.createdAt = { createdAt }
   }
 
+  fun withIsParole(isParole: Boolean) = apply {
+    this.isParole = { isParole }
+  }
+
   override fun produce(): PlacementRequestEntity = PlacementRequestEntity(
     id = this.id(),
     expectedArrival = this.expectedArrival(),
@@ -80,5 +85,6 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     bookingNotMades = this.bookingNotMades(),
     reallocatedAt = this.reallocatedAt(),
     notes = this.notes(),
+    isParole = this.isParole(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -19,6 +19,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   submittedAt: OffsetDateTime? = null,
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
+  placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
 ): PlacementApplicationEntity {
   val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
@@ -47,7 +48,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
     withSchemaVersion(schema)
     withSubmittedAt(submittedAt)
     withDecision(decision)
-    withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
+    withPlacementType(placementType!!)
     if (reallocated) {
       withReallocatedAt(OffsetDateTime.now())
     }
@@ -63,6 +64,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   submittedAt: OffsetDateTime? = null,
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
+  placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
   block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
 ) {
   block(
@@ -75,6 +77,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
       submittedAt,
       decision,
       reallocated,
+      placementType,
     ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2083,6 +2083,7 @@ class BookingServiceTest {
           duration = originalPlacementRequest.duration,
         ),
         notes = originalPlacementRequest.notes,
+        isParole = false,
       )
     } answers {
       val placementRequirementsArgument = it.invocation.args[0] as PlacementRequirementsEntity
@@ -2116,6 +2117,7 @@ class BookingServiceTest {
           duration = originalPlacementRequest.duration,
         ),
         notes = originalPlacementRequest.notes,
+        isParole = false,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -332,7 +332,7 @@ class AcceptAssessmentTest {
     verifyDomainEventSent(offenderDetails, staffUserDetails, assessment)
 
     verify(exactly = 0) {
-      placementRequestServiceMock.createPlacementRequest(any(), any(), any())
+      placementRequestServiceMock.createPlacementRequest(any(), any(), any(), false)
     }
 
     verify(exactly = 1) {
@@ -373,7 +373,7 @@ class AcceptAssessmentTest {
 
     every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.Success(placementRequirementEntity)
 
-    every { placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes) } returns PlacementRequestEntityFactory()
+    every { placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes, false) } returns PlacementRequestEntityFactory()
       .withPlacementRequirements(
         PlacementRequirementsEntityFactory()
           .withApplication(assessment.application as ApprovedPremisesApplicationEntity)
@@ -416,7 +416,7 @@ class AcceptAssessmentTest {
     verifyDomainEventSent(offenderDetails, staffUserDetails, assessment)
 
     verify(exactly = 1) {
-      placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes)
+      placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes, false)
     }
 
     verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
@@ -65,6 +65,7 @@ class PlacementRequestDetailTransformerTest {
     val transformedPlacementRequest = getTransformedPlacementRequest()
 
     every { mockPlacementRequestEntity.booking } returns null
+    every { mockPlacementRequestEntity.isParole } returns false
 
     every { mockCancellationTransformer.transformJpaToApi(any<CancellationEntity>()) } returns mockCancellation
     every { mockPlacementRequestTransformer.transformJpaToApi(mockPlacementRequestEntity, mockOffenderDetailSummary, mockInmateDetail) } returns transformedPlacementRequest
@@ -93,6 +94,7 @@ class PlacementRequestDetailTransformerTest {
     assertThat(result.notes).isEqualTo(transformedPlacementRequest.notes)
     assertThat(result.cancellations).isEqualTo(listOf(mockCancellation, mockCancellation))
     assertThat(result.booking).isNull()
+    assertThat(result.isParole).isEqualTo(false)
 
     verify(exactly = 1) {
       mockPlacementRequestTransformer.transformJpaToApi(mockPlacementRequestEntity, mockOffenderDetailSummary, mockInmateDetail)
@@ -124,6 +126,7 @@ class PlacementRequestDetailTransformerTest {
     val transformedPlacementRequest = getTransformedPlacementRequest()
 
     every { mockPlacementRequestEntity.booking } returns booking
+    every { mockPlacementRequestEntity.isParole } returns false
 
     every { mockCancellationTransformer.transformJpaToApi(any<CancellationEntity>()) } returns mockCancellation
     every { mockPlacementRequestTransformer.transformJpaToApi(mockPlacementRequestEntity, mockOffenderDetailSummary, mockInmateDetail) } returns transformedPlacementRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -157,6 +157,7 @@ class PlacementRequestTransformerTest {
         applicationDate = applicationSubmittedAt.toInstant(),
         assessor = mockUser,
         notes = placementRequestEntity.notes,
+        isParole = placementRequestEntity.isParole,
       ),
     )
   }


### PR DESCRIPTION
This will usually be `false`, but in the case of when a Request is created from a PlacementApplication that has a type of `RELEASE_FOLLOWING_DECISION`, we need to set `isParole` to true, so the assessors know that the startDate is malleable and can be within six weeks of the stated date.