### PR TITLE
Add service name as a Sentry tag to help make notifications smarter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
+import io.sentry.Scope
+import io.sentry.Sentry
+import io.sentry.SentryOptions
 import org.slf4j.MDC
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
@@ -7,7 +10,7 @@ import org.springframework.web.servlet.HandlerMapping
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import java.util.UUID
+import java.util.*
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -33,6 +36,10 @@ class MDCHandlerInterceptor(
       MDC.put("request.params.${it.key}", it.value.joinToString(","))
     }
     MDC.put("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified")
+//    Sentry.init { options: SentryOptions ->
+//      options.environment = "local"
+//    }
+    Sentry.configureScope { scope: Scope -> scope.setTag("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified") }
     MDC.put("request.user", userService.getUserForRequestOrNull()?.deliusUsername ?: "Anonymous")
   }
 


### PR DESCRIPTION
Right now all errors for all services are being sent into both approved-premises-team-events and temporary-accommodation-team-events. There are now a lot of errors and it's unclear which frontend, feature and therefore users are affected. Based on this the respective team should triage and respond.

The hope is that we'll be able to send API errors to the respective team and Slack channel for them to keep on top of. 

In the future we may have one CAS team with one events channel where this can all be put into the same place and managed by the same time.