### PR TITLE
Show placement requests with cancelled booking as notMatched

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -46,7 +46,7 @@ class PlacementRequestTransformer(
   }
 
   fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
-    if (placementRequest.booking == null) {
+    if (placementRequest.booking == null || placementRequest.booking?.cancellations?.any() == true) {
       if (placementRequest.bookingNotMades.any()) {
         return PlacementRequestStatus.unableToMatch
       }


### PR DESCRIPTION
This ensures a placement request with a cancelled booking can be rebooked.