### PR TITLE
Fix for Application Withdrawal issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -181,14 +181,28 @@ class ApplicationsController(
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication))
   }
 
-  override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID, body: NewWithdrawal?): ResponseEntity<Unit> {
+  override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
 
     extractEntityFromNestedAuthorisableValidatableActionResult(
       applicationService.withdrawApprovedPremisesApplication(
         applicationId = applicationId,
         user = user,
-        withdrawalReason = body?.reason?.value,
+        withdrawalReason = null,
+      ),
+    )
+
+    return ResponseEntity.ok(Unit)
+  }
+
+  override fun applicationsApplicationIdWithdrawalReasonPost(applicationId: UUID, body: NewWithdrawal): ResponseEntity<Unit> {
+    val user = userService.getUserForRequest()
+
+    extractEntityFromNestedAuthorisableValidatableActionResult(
+      applicationService.withdrawApprovedPremisesApplication(
+        applicationId = applicationId,
+        user = user,
+        withdrawalReason = body.reason.value,
       ),
     )
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1783,13 +1783,42 @@ paths:
           schema:
             type: string
             format: uuid
+      responses:
+        200:
+          description: successful operation
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+  /applications/{applicationId}/withdrawal/reason:
+    post:
+      tags:
+        - Operations on applications
+      summary: Withdraws an application with a reason
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         description: details of the withdrawal
         content:
           'application/json':
             schema:
               $ref: '#/components/schemas/NewWithdrawal'
-        required: false
+        required: true
       responses:
         200:
           description: successful operation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1991,18 +1991,35 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Withdraw Application returns 200`() {
+    fun `Withdraw Application with reason returns 200`() {
       `Given a User` { user, jwt ->
         val application = produceAndPersistBasicApplication("ABC123", user, "TEAM")
 
         webTestClient.post()
-          .uri("/applications/${application.id}/withdrawal")
+          .uri("/applications/${application.id}/withdrawal/reason")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             NewWithdrawal(
               reason = WithdrawalReason.alternativeIdentifiedPlacementNoLongerRequired,
             ),
           )
+          .exchange()
+          .expectStatus()
+          .isOk
+
+        val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)!!
+        assertThat(updatedApplication.isWithdrawn).isTrue
+      }
+    }
+
+    @Test
+    fun `Withdraw Application returns 200 when no reason provided`() {
+      `Given a User` { user, jwt ->
+        val application = produceAndPersistBasicApplication("ABC123", user, "TEAM")
+
+        webTestClient.post()
+          .uri("/applications/${application.id}/withdrawal")
+          .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
           .isOk


### PR DESCRIPTION
Optional body was failing validation.  Splitting out into two endpoints until the reason is added in the frontend.