### PR TITLE
Return CAS2 applications for user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -131,10 +131,11 @@ SELECT
     CAST(c2a.risk_ratings AS TEXT) as riskRatings
 FROM cas_2_applications c2a
 LEFT JOIN applications a ON a.id = c2a.id
+WHERE a.created_by_user_id = :userId
 """,
     nativeQuery = true,
   )
-  fun findAllCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
+  fun findAllCas2ApplicationSummariesCreatedByUser(userId: UUID): List<Cas2ApplicationSummary>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -94,7 +94,7 @@ class ApplicationService(
     applicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(user.id)
 
   private fun getAllCas2ApplicationsForUser(user: UserEntity): List<ApplicationSummary> {
-    return applicationRepository.findAllCas2ApplicationSummaries()
+    return applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id)
   }
 
   private fun getAllTemporaryAccommodationApplicationsForUser(user: UserEntity): List<ApplicationSummary> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -160,6 +160,7 @@ class ApplicationsTransformer(
         createdAt = domain.getCreatedAt().toInstant(),
         submittedAt = domain.getSubmittedAt()?.toInstant(),
         risks = if (riskRatings != null) risksTransformer.transformDomainToApi(riskRatings, domain.getCrn()) else null,
+        status = getStatusFromSummary(domain),
         type = "CAS2",
       )
     }
@@ -214,6 +215,10 @@ class ApplicationsTransformer(
         entity.getSubmittedAt() !== null -> ApplicationStatus.submitted
         else -> ApplicationStatus.inProgress
       }
+    }
+
+    if (entity is DomainCas2ApplicationSummary) {
+      return ApplicationStatus.inProgress
     }
 
     return when {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4928,10 +4928,13 @@ components:
             createdByUserId:
               type: string
               format: uuid
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
             risks:
               $ref: '#/components/schemas/PersonRisks'
           required:
             - createdByUserId
+            - status
     ApplicationStatus:
       type: string
       enum:


### PR DESCRIPTION
We would like to have a dashboard for CAS2 users that shows their 'in progress' applications.

We previously had the functionality to get all CAS2 applications, but we had not been filtering by the User ID. This PR adds that filter to the existing query, and the `status` field to the `Cas2ApplicationSummary` model. 

We currently only have `inProgress` applications, but will shortly be adding a submitted status. 