### PR TITLE
Implement service-specific statuses for assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -58,6 +58,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
            a.decision is not null as completed,
            a.decision as decision,
            a.data is not null as isStarted,
+           a.allocated_to_user_id is not null as isAllocated,
            ap.crn as crn
       from approved_premises_assessments aa
            join assessments a on aa.assessment_id = a.id
@@ -82,6 +83,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
            aa.completed_at is not null as completed,
            a.decision as decision,
            a.data is not null as isStarted,
+           a.allocated_to_user_id is not null as isAllocated,
            ap.crn as crn
       from temporary_accommodation_assessments aa
            join assessments a on aa.assessment_id = a.id
@@ -107,6 +109,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
         ColumnResult(name = "dateOfInfoRequest", type = OffsetDateTime::class),
         ColumnResult(name = "completed"),
         ColumnResult(name = "isStarted"),
+        ColumnResult(name = "isAllocated"),
         ColumnResult(name = "decision"),
         ColumnResult(name = "crn"),
       ],
@@ -243,6 +246,7 @@ open class DomainAssessmentSummary(
   val dateOfInfoRequest: OffsetDateTime?,
   val completed: Boolean,
   val isStarted: Boolean,
+  val isAllocated: Boolean,
   val decision: String?,
   val crn: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -79,7 +79,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
            CAST(taa.risk_ratings AS TEXT) as riskRatings,
            taa.arrival_date as arrivalDate,
            null as dateOfInfoRequest,
-           a.decision is not null as completed,
+           aa.completed_at is not null as completed,
            a.decision as decision,
            a.data is not null as isStarted,
            ap.crn as crn
@@ -211,6 +211,7 @@ class TemporaryAccommodationAssessmentEntity(
   rejectionRationale: String?,
   clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
   schemaUpToDate: Boolean,
+  val completedAt: OffsetDateTime?,
 ) : AssessmentEntity(
   id,
   application,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -172,6 +172,7 @@ class AssessmentService(
         schemaUpToDate = true,
         rejectionRationale = null,
         clarificationNotes = mutableListOf(),
+        completedAt = null,
       ),
     )
 

--- a/src/main/resources/db/migration/all/20230728154909__add_completed_at_column_to_temporary_accommodation_assessments_table.sql
+++ b/src/main/resources/db/migration/all/20230728154909__add_completed_at_column_to_temporary_accommodation_assessments_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE temporary_accommodation_assessments ADD COLUMN completed_at TIMESTAMP WITH TIME ZONE;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5141,8 +5141,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClarificationNote'
-        status:
-          $ref: '#/components/schemas/AssessmentStatus'
       discriminator:
         propertyName: service
         mapping:
@@ -5164,6 +5162,38 @@ components:
         - reallocated
         - in_progress
         - not_started
+        - unallocated
+        - in_review
+        - ready_to_place
+        - closed
+        - rejected
+      x-enum-varnames:
+        - cas1AwaitingResponse
+        - cas1Completed
+        - cas1Reallocated
+        - cas1InProgress
+        - cas1NotStarted
+        - cas3Unallocated
+        - cas3InReview
+        - cas3ReadyToPlace
+        - cas3Closed
+        - cas3Rejected
+    ApprovedPremisesAssessmentStatus:
+      type: string
+      enum:
+        - awaiting_response
+        - completed
+        - reallocated
+        - in_progress
+        - not_started
+    TemporaryAccommodationAssessmentStatus:
+      type: string
+      enum:
+        - unallocated
+        - in_review
+        - ready_to_place
+        - closed
+        - rejected
     ApprovedPremisesAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'
@@ -5173,6 +5203,8 @@ components:
               $ref: '#/components/schemas/ApprovedPremisesApplication'
             allocatedToStaffMember:
               $ref: '#/components/schemas/ApprovedPremisesUser'
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
           required:
             - application
     TemporaryAccommodationAssessment:
@@ -5184,6 +5216,8 @@ components:
               $ref: '#/components/schemas/TemporaryAccommodationApplication'
             allocatedToStaffMember:
               $ref: '#/components/schemas/TemporaryAccommodationUser'
+            status:
+              $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
           required:
             - application
     AssessmentSummary:
@@ -5191,9 +5225,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - CAS1
-            - CAS3
         id:
           type: string
           format: uuid
@@ -5209,8 +5240,6 @@ components:
         dateOfInfoRequest:
           type: string
           format: date-time
-        status:
-          $ref: '#/components/schemas/AssessmentStatus'
         decision:
           $ref: '#/components/schemas/AssessmentDecision'
         risks:
@@ -5222,8 +5251,30 @@ components:
         - id
         - applicationId
         - createdAt
-        - status
         - person
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesAssessmentSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationAssessmentSummary'
+    ApprovedPremisesAssessmentSummary:
+      allOf:
+        - $ref: '#/components/schemas/AssessmentSummary'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+          required:
+            - status
+    TemporaryAccommodationAssessmentSummary:
+      allOf:
+        - $ref: '#/components/schemas/AssessmentSummary'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+          required:
+            - status
     AssessmentSortField:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
@@ -30,9 +30,10 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
   private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var decision: Yielded<AssessmentDecision?> = { AssessmentDecision.ACCEPTED }
-  private var allocatedToUser: Yielded<UserEntity>? = null
+  private var allocatedToUser: Yielded<UserEntity?> = { null }
   private var rejectionRationale: Yielded<String?> = { null }
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
+  private var completedAt: Yielded<OffsetDateTime?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -78,12 +79,20 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     this.allocatedToUser = { allocatedToUser }
   }
 
+  fun withoutAllocatedToUser() = apply {
+    this.allocatedToUser = { null }
+  }
+
   fun withClarificationNotes(clarificationNotes: MutableList<AssessmentClarificationNoteEntity>) = apply {
     this.clarificationNotes = { clarificationNotes }
   }
 
   fun withRejectionRationale(rejectionRationale: String?) = apply {
     this.rejectionRationale = { rejectionRationale }
+  }
+
+  fun withCompletedAt(completedAt: OffsetDateTime) = apply {
+    this.completedAt = { completedAt }
   }
 
   override fun produce(): TemporaryAccommodationAssessmentEntity = TemporaryAccommodationAssessmentEntity(
@@ -96,10 +105,11 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     decision = this.decision(),
     schemaUpToDate = false,
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
-    allocatedToUser = this.allocatedToUser?.invoke(),
+    allocatedToUser = this.allocatedToUser(),
     allocatedAt = this.allocatedAt(),
     reallocatedAt = this.reallocatedAt(),
     rejectionRationale = this.rejectionRationale(),
     clarificationNotes = this.clarificationNotes(),
+    completedAt = this.completedAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
@@ -135,19 +136,20 @@ class AssessmentSummaryQueryTest : IntegrationTestBase() {
     assertThat(summary.applicationId).isEqualTo(application.id)
     assertThat(summary.createdAt).isEqualTo(assessment.createdAt)
     assertThat(summary.dateOfInfoRequest).isEqualTo(dateOfInfoRequest)
-    assertThat(summary.completed).isEqualTo(assessment.decision != null)
     assertThat(summary.isStarted).isEqualTo(assessment.data != null)
     assertThat(summary?.decision).isEqualTo(assessment.decision?.name)
     assertThat(summary.crn).isEqualTo(application.crn)
     when (application) {
       is ApprovedPremisesApplicationEntity -> {
         assertThat(summary.type).isEqualTo("approved-premises")
+        assertThat(summary.completed).isEqualTo(assessment.decision != null)
         assertThat(summary.arrivalDate).isEqualTo(application.arrivalDate)
         assertThat(summary.riskRatings).isEqualTo("""{"roshRisks":{"status":"NotFound","value":null},"mappa":{"status":"NotFound","value":null},"tier":{"status":"NotFound","value":null},"flags":{"status":"NotFound","value":null}}""")
       }
 
       is TemporaryAccommodationApplicationEntity -> {
         assertThat(summary.type).isEqualTo("temporary-accommodation")
+        assertThat(summary.completed).isEqualTo((assessment as TemporaryAccommodationAssessmentEntity).completedAt != null)
         assertThat(summary.riskRatings).isEqualTo("""{"roshRisks":{"status":"NotFound","value":null},"mappa":{"status":"NotFound","value":null},"tier":{"status":"NotFound","value":null},"flags":{"status":"NotFound","value":null}}""")
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -164,8 +164,8 @@ class AssessmentTest : IntegrationTestBase() {
         otherAssessment.schemaUpToDate = true
 
         val filterStatus = when (assessmentDecision) {
-          null -> AssessmentStatus.inProgress
-          else -> AssessmentStatus.completed
+          null -> AssessmentStatus.cas1InProgress
+          else -> AssessmentStatus.cas1Completed
         }
 
         webTestClient.get()
@@ -356,10 +356,14 @@ class AssessmentTest : IntegrationTestBase() {
         .minByOrNull { it.createdAt }
         ?.createdAt,
 
-      completed = assessment.decision != null,
+      completed = when (assessment) {
+        is TemporaryAccommodationAssessmentEntity -> assessment.completedAt != null
+        else -> assessment.decision != null
+      },
       decision = assessment.decision?.name,
       crn = assessment.application.crn,
       isStarted = assessment.data != null,
+      isAllocated = assessment.allocatedToUser != null,
     )
 
   @Test


### PR DESCRIPTION
> See [ticket #1308 on the CAS3 Trello board](https://trello.com/c/X2ymPmWq/1308-application-state-can-be-updated-by-the-frontend).

This PR introduces a set of statuses specific to Temporary Accommodation assessments. This was mentioned but not implemented in #841 to keep the scope of that PR small; the described change is here.

Specifically, in Temporary Accommodation, the following states are required:
![State transitions for Temporary Accommodation assessments](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/291b7417-392a-4875-9b3e-d25479d657a0)