### PR TITLE
(359) Add other reason to application withdrawl

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -181,21 +181,7 @@ class ApplicationsController(
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication))
   }
 
-  override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID): ResponseEntity<Unit> {
-    val user = userService.getUserForRequest()
-
-    extractEntityFromNestedAuthorisableValidatableActionResult(
-      applicationService.withdrawApprovedPremisesApplication(
-        applicationId = applicationId,
-        user = user,
-        withdrawalReason = null,
-      ),
-    )
-
-    return ResponseEntity.ok(Unit)
-  }
-
-  override fun applicationsApplicationIdWithdrawalReasonPost(applicationId: UUID, body: NewWithdrawal): ResponseEntity<Unit> {
+  override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID, body: NewWithdrawal): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
 
     extractEntityFromNestedAuthorisableValidatableActionResult(
@@ -203,6 +189,7 @@ class ApplicationsController(
         applicationId = applicationId,
         user = user,
         withdrawalReason = body.reason.value,
+        otherReason = body.otherReason,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -198,6 +198,7 @@ class ApprovedPremisesApplicationEntity(
   var isInapplicable: Boolean?,
   var isWithdrawn: Boolean,
   var withdrawalReason: String?,
+  var otherWithdrawalReason: String?,
   val convictionId: Long,
   val eventNumber: String,
   val offenceId: String,

--- a/src/main/resources/db/migration/all/20230731121845__add_other_withdrawl_reason_to_applications.sql
+++ b/src/main/resources/db/migration/all/20230731121845__add_other_withdrawl_reason_to_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN other_withdrawal_reason TEXT;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1774,35 +1774,6 @@ paths:
     post:
       tags:
         - Operations on applications
-      summary: Withdraws an application
-      parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: successful operation
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        404:
-          description: invalid applicationId
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
-      x-codegen-request-body-name: body
-  /applications/{applicationId}/withdrawal/reason:
-    post:
-      tags:
-        - Operations on applications
       summary: Withdraws an application with a reason
       parameters:
         - name: applicationId
@@ -4062,6 +4033,8 @@ components:
       properties:
         reason:
           $ref: '#/components/schemas/WithdrawalReason'
+        otherReason:
+          type: string
       required:
         - reason
     Cancellation:

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -565,6 +565,8 @@ components:
             - probationArea
         withdrawalReason:
           type: string
+        otherWithdrawalReason:
+          type: string
       required:
         - applicationId
         - applicationUrl

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -179,6 +179,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     isInapplicable = this.isInapplicable(),
     isWithdrawn = this.isWithdrawn(),
     withdrawalReason = this.withdrawalReason(),
+    otherWithdrawalReason = null,
     nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2006,35 +2006,18 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Withdraw Application with reason returns 200`() {
-      `Given a User` { user, jwt ->
-        val application = produceAndPersistBasicApplication("ABC123", user, "TEAM")
-
-        webTestClient.post()
-          .uri("/applications/${application.id}/withdrawal/reason")
-          .header("Authorization", "Bearer $jwt")
-          .bodyValue(
-            NewWithdrawal(
-              reason = WithdrawalReason.alternativeIdentifiedPlacementNoLongerRequired,
-            ),
-          )
-          .exchange()
-          .expectStatus()
-          .isOk
-
-        val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)!!
-        assertThat(updatedApplication.isWithdrawn).isTrue
-      }
-    }
-
-    @Test
-    fun `Withdraw Application returns 200 when no reason provided`() {
+    fun `Withdraw Application 200`() {
       `Given a User` { user, jwt ->
         val application = produceAndPersistBasicApplication("ABC123", user, "TEAM")
 
         webTestClient.post()
           .uri("/applications/${application.id}/withdrawal")
           .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewWithdrawal(
+              reason = WithdrawalReason.alternativeIdentifiedPlacementNoLongerRequired,
+            ),
+          )
           .exchange()
           .expectStatus()
           .isOk


### PR DESCRIPTION
When withdrawing an application, the user has to state the "other" reason if they select "other". This adds an `otherReason` field to the endpoint, and persists this in the database and the domain event. This also deprecates the `withdrawl/reason` endpoint, as we're working on the frontend implementation now. As such this shouldn't be deployed to prod until the frontend work is complete.