### PR TITLE
(371) Fix issue with lost bed dates in the calendar not always displaying correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/CalendarRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/CalendarRepository.kt
@@ -21,7 +21,7 @@ class CalendarRepository(private val namedParameterJdbcTemplate: NamedParameterJ
     FROM premises p 
     JOIN rooms r ON r.premises_id = p.id
     JOIN beds bed ON bed.room_id = r.id 
-    LEFT JOIN bookings b ON b.bed_id = bed.id AND (b.arrival_date, b.departure_date) OVERLAPS (:startDate, :endDate)
+    LEFT JOIN bookings b ON b.bed_id = bed.id AND tsrange(b.arrival_date, b.departure_date, '[]') && tsrange(:startDate, :endDate, '[]')
     LEFT JOIN cancellations c ON c.booking_id = b.id
     LEFT JOIN non_arrivals n ON n.booking_id = b.id
     WHERE p.id = :premisesId
@@ -38,7 +38,7 @@ class CalendarRepository(private val namedParameterJdbcTemplate: NamedParameterJ
     FROM premises p 
     JOIN rooms r ON r.premises_id = p.id
     JOIN beds bed ON bed.room_id = r.id 
-    LEFT JOIN lost_beds lb ON lb.bed_id = bed.id AND (lb.start_date, lb.end_date) OVERLAPS (:startDate, :endDate)
+    LEFT JOIN lost_beds lb ON lb.bed_id = bed.id AND tsrange(lb.start_date, lb.end_date, '[]') && tsrange(:startDate, :endDate, '[]')
     LEFT JOIN lost_bed_cancellations c ON c.lost_bed_id = lb.id
     WHERE p.id = :premisesId
 """


### PR DESCRIPTION
We’ve noticed an issue where if a booking/lost bed finishes on the first day of the search period, it won’t show up. I’ve looked into this, and it seems that the Postgres `OVERLAPS` functionality is not inclusive. After a bit of Googling, it seems that using `tsrange` and the `&&` overlaps operator seems to do the trick.

I’ve also added a test to demonstrate and fix the regression.