### PR TITLE
Implement API endpoints to change the state of a Temporary Accommodation assessment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -186,6 +186,25 @@ class AssessmentController(
     return ResponseEntity(HttpStatus.OK)
   }
 
+  override fun assessmentsAssessmentIdClosurePost(assessmentId: UUID): ResponseEntity<Unit> {
+    val user = userService.getUserForRequest()
+
+    val assessmentValidationResult = when (val assessmentAuthResult = assessmentService.closeAssessment(user, assessmentId)) {
+      is AuthorisableActionResult.Success -> assessmentAuthResult.entity
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    }
+
+    when (assessmentValidationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = assessmentValidationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = assessmentValidationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = assessmentValidationResult.conflictingEntityId, conflictReason = assessmentValidationResult.message)
+      is ValidatableActionResult.Success -> Unit
+    }
+
+    return ResponseEntity(HttpStatus.OK)
+  }
+
   override fun assessmentsAssessmentIdNotesPost(
     assessmentId: UUID,
     newClarificationNote: NewClarificationNote,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -214,7 +214,7 @@ class TemporaryAccommodationAssessmentEntity(
   rejectionRationale: String?,
   clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
   schemaUpToDate: Boolean,
-  val completedAt: OffsetDateTime?,
+  var completedAt: OffsetDateTime?,
 ) : AssessmentEntity(
   id,
   application,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -140,9 +140,9 @@ abstract class AssessmentEntity(
 
   @ManyToOne
   @JoinColumn(name = "allocated_to_user_id")
-  val allocatedToUser: UserEntity?,
+  var allocatedToUser: UserEntity?,
 
-  val allocatedAt: OffsetDateTime?,
+  var allocatedAt: OffsetDateTime?,
   var reallocatedAt: OffsetDateTime?,
 
   val createdAt: OffsetDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -585,6 +585,25 @@ class AssessmentService(
     )
   }
 
+  fun deallocateAssessment(id: UUID): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
+    val currentAssessment = assessmentRepository.findByIdOrNull(id)
+      ?: return AuthorisableActionResult.NotFound()
+
+    if (currentAssessment !is TemporaryAccommodationAssessmentEntity) {
+      throw RuntimeException("Only CAS3 Assessments are currently supported")
+    }
+
+    currentAssessment.allocatedToUser = null
+    currentAssessment.allocatedAt = null
+    currentAssessment.decision = null
+
+    return AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(
+        assessmentRepository.save(currentAssessment),
+      ),
+    )
+  }
+
   fun addAssessmentClarificationNote(user: UserEntity, assessmentId: UUID, text: String): AuthorisableActionResult<AssessmentClarificationNoteEntity> {
     val assessmentResult = getAssessmentForUser(user, assessmentId)
     val assessment = when (assessmentResult) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -250,14 +250,16 @@ class AssessmentService(
     val validationErrors = ValidationErrors()
     val assessmentData = assessment.data
 
-    if (assessmentData == null) {
-      validationErrors["$.data"] = "empty"
-    } else if (!jsonSchemaService.validate(assessment.schemaVersion, assessmentData)) {
-      validationErrors["$.data"] = "invalid"
-    }
+    if (assessment is ApprovedPremisesAssessmentEntity) {
+      if (assessmentData == null) {
+        validationErrors["$.data"] = "empty"
+      } else if (!jsonSchemaService.validate(assessment.schemaVersion, assessmentData)) {
+        validationErrors["$.data"] = "invalid"
+      }
 
-    if (placementRequirements == null && assessment is ApprovedPremisesAssessmentEntity) {
-      validationErrors["$.requirements"] = "empty"
+      if (placementRequirements == null) {
+        validationErrors["$.requirements"] = "empty"
+      }
     }
 
     if (validationErrors.any()) {
@@ -398,10 +400,12 @@ class AssessmentService(
     val validationErrors = ValidationErrors()
     val assessmentData = assessment.data
 
-    if (assessmentData == null) {
-      validationErrors["$.data"] = "empty"
-    } else if (!jsonSchemaService.validate(assessment.schemaVersion, assessmentData)) {
-      validationErrors["$.data"] = "invalid"
+    if (assessment is ApprovedPremisesAssessmentEntity) {
+      if (assessmentData == null) {
+        validationErrors["$.data"] = "empty"
+      } else if (!jsonSchemaService.validate(assessment.schemaVersion, assessmentData)) {
+        validationErrors["$.data"] = "invalid"
+      }
     }
 
     if (validationErrors.any()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -235,7 +235,7 @@ class AssessmentService(
       )
     }
 
-    if (assessment.submittedAt != null) {
+    if (assessment is ApprovedPremisesAssessmentEntity && assessment.submittedAt != null) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment"),
       )
@@ -271,6 +271,10 @@ class AssessmentService(
     assessment.document = document
     assessment.submittedAt = acceptedAt
     assessment.decision = AssessmentDecision.ACCEPTED
+
+    if (assessment is TemporaryAccommodationAssessmentEntity) {
+      assessment.completedAt = null
+    }
 
     val savedAssessment = assessmentRepository.save(assessment)
 
@@ -385,7 +389,7 @@ class AssessmentService(
       )
     }
 
-    if (assessment.submittedAt != null) {
+    if (assessment is ApprovedPremisesAssessmentEntity && assessment.submittedAt != null) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("A decision has already been taken on this assessment"),
       )
@@ -418,6 +422,10 @@ class AssessmentService(
     assessment.submittedAt = rejectedAt
     assessment.decision = AssessmentDecision.REJECTED
     assessment.rejectionRationale = rejectionRationale
+
+    if (assessment is TemporaryAccommodationAssessmentEntity) {
+      assessment.completedAt = null
+    }
 
     val savedAssessment = assessmentRepository.save(assessment)
 
@@ -652,6 +660,7 @@ class AssessmentService(
     currentAssessment.allocatedToUser = null
     currentAssessment.allocatedAt = null
     currentAssessment.decision = null
+    currentAssessment.submittedAt = null
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -20,12 +19,13 @@ import java.util.UUID
 class TaskService(
   private val assessmentService: AssessmentService,
   private val userService: UserService,
+  private val userAccessService: UserAccessService,
   private val placementRequestService: PlacementRequestService,
   private val userTransformer: UserTransformer,
   private val placementApplicationService: PlacementApplicationService,
 ) {
   fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, id: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
-    if (!requestUser.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
+    if (!userAccessService.userCanReallocateTask(requestUser)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -145,6 +145,14 @@ class UserAccessService(
       user.hasRole(UserRole.CAS3_ASSESSOR) &&
       application.submittedAt != null
   }
+
+  fun currentUserCanReallocateTask() = userCanReallocateTask(userService.getUserForRequest())
+
+  fun userCanReallocateTask(user: UserEntity): Boolean = when (currentRequest.getHeader("X-Service-Name")) {
+    ServiceName.temporaryAccommodation.value -> user.hasRole(UserRole.CAS3_ASSESSOR)
+    ServiceName.approvedPremises.value -> user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+    else -> false
+  }
 }
 
 enum class ApprovedPremisesApplicationAccessLevel {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -153,6 +153,13 @@ class UserAccessService(
     ServiceName.approvedPremises.value -> user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
     else -> false
   }
+
+  fun currentUserCanDeallocateTask() = userCanDeallocateTask(userService.getUserForRequest())
+
+  fun userCanDeallocateTask(user: UserEntity): Boolean = when (currentRequest.getHeader("X-Service-Name")) {
+    ServiceName.temporaryAccommodation.value -> user.hasRole(UserRole.CAS3_ASSESSOR)
+    else -> false
+  }
 }
 
 enum class ApprovedPremisesApplicationAccessLevel {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2453,6 +2453,39 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+    delete:
+      tags:
+        - Operations on applications
+      summary: Unallocates a task for an application
+      parameters:
+        - name: id
+          in: path
+          description: ID of the task
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: taskType
+          required: true
+          description: Task type
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /placement-requests:
     get:
       tags:
@@ -3035,6 +3068,28 @@ paths:
       responses:
         200:
           description: successfully rejected the assessment
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /assessments/{assessmentId}/closure:
+    post:
+      tags:
+        - Assessment data
+      summary: Closes an Assessment
+      parameters:
+        - in: path
+          name: assessmentId
+          required: true
+          description: Id of the assessment
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successfully closed the assessment
         401:
           $ref: '#/components/responses/401Response'
         403:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2427,12 +2427,18 @@ paths:
           description: Task type
           schema:
             type: string
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Only assessments for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
       requestBody:
         content:
           'application/json':
             schema:
               $ref: '#/components/schemas/NewReallocation'
-        required: true
+        required: false
       responses:
         201:
           description: successful operation
@@ -5549,8 +5555,6 @@ components:
         userId:
           type: string
           format: uuid
-      required:
-        - userId
     Reallocation:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5490,7 +5490,6 @@ components:
           type: string
       required:
         - document
-        - requirements
     AssessmentRejection:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReallocationAtomicTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -37,6 +38,7 @@ class ReallocationAtomicTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/tasks/assessment/${existingAssessment.id}/allocations")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.approvedPremises.value)
             .bodyValue(
               NewReallocation(
                 userId = assigneeUser.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -461,6 +461,7 @@ class TasksTest : IntegrationTestBase() {
                 webTestClient.post()
                   .uri("/tasks/assessment/${existingAssessment.id}/allocations")
                   .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.approvedPremises.value)
                   .bodyValue(
                     NewReallocation(
                       userId = assigneeUser.id,
@@ -507,6 +508,7 @@ class TasksTest : IntegrationTestBase() {
               webTestClient.post()
                 .uri("/tasks/placement-request/${existingPlacementRequest.id}/allocations")
                 .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .bodyValue(
                   NewReallocation(
                     userId = assigneeUser.id,
@@ -565,6 +567,7 @@ class TasksTest : IntegrationTestBase() {
                 webTestClient.post()
                   .uri("/tasks/placement-application/${placementApplication.id}/allocations")
                   .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.approvedPremises.value)
                   .bodyValue(
                     NewReallocation(
                       userId = assigneeUser.id,
@@ -609,6 +612,7 @@ class TasksTest : IntegrationTestBase() {
             webTestClient.post()
               .uri("/tasks/booking-appeal/${application.id}/allocations")
               .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.approvedPremises.value)
               .bodyValue(
                 NewReallocation(
                   userId = userToReallocate.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -223,6 +224,49 @@ class TaskServiceTest {
     validationResult as ValidatableActionResult.Success
 
     Assertions.assertThat(validationResult.entity).isEqualTo(reallocation)
+  }
+
+  @Test
+  fun `deallocateTask returns Unauthorised when requestUser does not have permissions to deallocate the task`() {
+    val requestUser = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    every { userAccessServiceMock.userCanDeallocateTask(any()) } returns false
+
+    val result = taskService.deallocateTask(requestUser, TaskType.assessment, UUID.randomUUID())
+
+    Assertions.assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `deallocateTask deallocates an assessment`() {
+    every { userAccessServiceMock.userCanDeallocateTask(any()) } returns true
+
+    val assigneeUser = generateAndStubAssigneeUser()
+    val application = generateApplication()
+
+    val assessment = TemporaryAccommodationAssessmentEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(assigneeUser)
+      .produce()
+
+    every { assessmentServiceMock.deallocateAssessment(assessment.id) } returns AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(
+        assessment,
+      ),
+    )
+
+    val result = taskService.deallocateTask(requestUserWithPermission, TaskType.assessment, assessment.id)
+
+    Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+    val validationResult = (result as AuthorisableActionResult.Success).entity
+
+    Assertions.assertThat(validationResult is ValidatableActionResult.Success).isTrue
   }
 
   private fun generateAndStubAssigneeUser(): UserEntity {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1085,4 +1085,50 @@ class UserAccessServiceTest {
 
     assertThat(userAccessService.currentUserCanReallocateTask()).isFalse
   }
+
+  @Test
+  fun `userCanDeallocateTask returns true if the current request has 'X-Service-Name' header with value 'temporary-accommodation' and the user has the CAS3_ASSESSOR role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.userCanDeallocateTask(user)).isTrue
+  }
+
+  @Test
+  fun `userCanDeallocateTask returns false otherwise if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanDeallocateTask(user)).isFalse
+  }
+
+  @Test
+  fun `userCanDeallocateTask returns false by default`() {
+    currentRequestIsForArbitraryService()
+
+    assertThat(userAccessService.userCanDeallocateTask(user)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanDeallocateTask returns true if the current request has 'X-Service-Name' header with value 'temporary-accommodation' and the user has the CAS3_ASSESSOR role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.currentUserCanDeallocateTask()).isTrue
+  }
+
+  @Test
+  fun `currentUserCanDeallocateTask returns false otherwise if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanDeallocateTask()).isFalse
+  }
+
+  @Test
+  fun `currentUserCanDeallocateTask returns false by default`() {
+    currentRequestIsForArbitraryService()
+
+    assertThat(userAccessService.currentUserCanDeallocateTask()).isFalse
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1007,4 +1007,82 @@ class UserAccessServiceTest {
 
     assertThat(userAccessService.currentUserCanViewReport()).isTrue
   }
+
+  @Test
+  fun `userCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'temporary-accommodation' and the user has the CAS3_ASSESSOR role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.userCanReallocateTask(user)).isTrue
+  }
+
+  @Test
+  fun `userCanReallocateTask returns false otherwise if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanReallocateTask(user)).isFalse
+  }
+
+  @Test
+  fun `userCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has the CAS1_WORKFLOW_MANAGER role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
+
+    assertThat(userAccessService.userCanReallocateTask(user)).isTrue
+  }
+
+  @Test
+  fun `userCanReallocateTask returns false otherwise if the current request has 'X-Service-Name' header with value 'approved-premises'`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanReallocateTask(user)).isFalse
+  }
+
+  @Test
+  fun `userCanReallocateTask returns false by default`() {
+    currentRequestIsForArbitraryService()
+
+    assertThat(userAccessService.userCanReallocateTask(user)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'temporary-accommodation' and the user has the CAS3_ASSESSOR role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.currentUserCanReallocateTask()).isTrue
+  }
+
+  @Test
+  fun `currentUserCanReallocateTask returns false otherwise if the current request has 'X-Service-Name' header with value 'temporary-accommodation'`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanReallocateTask()).isFalse
+  }
+
+  @Test
+  fun `currentUserCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has the CAS1_WORKFLOW_MANAGER role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
+
+    assertThat(userAccessService.currentUserCanReallocateTask()).isTrue
+  }
+
+  @Test
+  fun `currentUserCanReallocateTask returns false otherwise if the current request has 'X-Service-Name' header with value 'approved-premises'`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanReallocateTask()).isFalse
+  }
+
+  @Test
+  fun `currentUserCanReallocateTask returns false by default`() {
+    currentRequestIsForArbitraryService()
+
+    assertThat(userAccessService.currentUserCanReallocateTask()).isFalse
+  }
 }


### PR DESCRIPTION
> See [ticket #1308 on the CAS3 Trello board](https://trello.com/c/X2ymPmWq/1308-application-state-can-be-updated-by-the-frontend).

This PR modifies existing endpoints and introduces new endpoints to allow changing the state of a Temporary Accommodation assessment.

Specifically, the list of states a Temporary Accommodation assessment can be in and the corresponding API endpoint are as follows:
- `unallocated`: This is the default state when the assessment is created, but can be reached using the `DELETE /tasks/assessment/{assessmentId}/allocations` endpoint if a user needs to unallocate an assessment from themself.
- `rejected`: The `POST /assessments/{assessmentId}/rejection` endpoint is used to reject an application.
- `closed`: The `POST /assessments/{assessmentId}/closure` endpoint is used to close an assessment once an assessment has been successfully placed.
- `ready_to_place`: The `POST /assessments/{assessmentId}/acceptance` endpoint is used to accept an application and allow a booking to be made. This has been modified to make the `requirements` optional, as it is not currently needed for Temorary Accommodation. Validation logic has been added to enforce the field's non-nullability for other services.
- `in_review`: The `POST /tasks/assessment/{assessmentId}/allocations` endpoint is used to assign an assessment to the current user. This has been modified to make the request body optional, as in Temporary Accommodation the assessment should always be assigned to the current user when they mark it as being in review. Validation logic has been added to enforce that the request body is provided for other services.

These endpoints should correspond to the state transitions given in the diagram below:
![State transitions for Temporary Accommodation assessments](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/291b7417-392a-4875-9b3e-d25479d657a0)