### PR TITLE
Omit Bookings from `/premises/{premises id}/bookings` where user does pass LAO check

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -90,6 +90,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrnOrNull
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -267,7 +268,7 @@ class PremisesController(
 
     return ResponseEntity.ok(
       premises.bookings.mapNotNull {
-        val personDetails = getPersonDetailsForCrn(log, it.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
+        val personDetails = getPersonDetailsForCrnOrNull(log, it.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
 
         if (personDetails == null) {
           log.warn("Unable to get Person via crn: ${it.crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
@@ -28,6 +28,27 @@ fun getPersonDetailsForCrn(
   return Pair(offenderDetails, inmateDetails)
 }
 
+fun getPersonDetailsForCrnOrNull(
+  log: Logger,
+  crn: String,
+  deliusUsername: String,
+  offenderService: OffenderService,
+  ignoreLao: Boolean = false,
+): Pair<OffenderDetailSummary, InmateDetail?>? {
+  val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(crn, deliusUsername, ignoreLao)) {
+    is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+    is AuthorisableActionResult.NotFound -> {
+      log.error("Could not get Offender Details for CRN: $crn")
+      return null
+    }
+    is AuthorisableActionResult.Unauthorised -> return null
+  }
+
+  val inmateDetails = getInmateDetail(offenderDetails, offenderService)
+
+  return Pair(offenderDetails, inmateDetails)
+}
+
 fun getInmateDetail(offenderDetails: OffenderDetailSummary, offenderService: OffenderService): InmateDetail? {
   val nomsNumber = offenderDetails.otherIds.nomsNumber
 


### PR DESCRIPTION
This is a stopgap measure to unblock people at several APs that can no longer view any Bookings until https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/804 is merged.