### PR TITLE
Rename 'Close proximity' premises characteristic to clarify meaning

### DIFF
--- a/src/main/resources/db/migration/all/20230807115837__rename_close_proximity_premises_characteristic_to_clarify_meaning.sql
+++ b/src/main/resources/db/migration/all/20230807115837__rename_close_proximity_premises_characteristic_to_clarify_meaning.sql
@@ -1,0 +1,4 @@
+UPDATE characteristics
+SET name = 'Close proximity to another CAS3 property'
+WHERE name = 'Close proximity'
+AND service_scope = 'temporary-accommodation';


### PR DESCRIPTION
> See [ticket #1428 on the CAS3 Trello board](https://trello.com/c/5xkl5JFp/1428-update-close-proximity-property-attribute).

The characteristic has been renamed to 'Close proximity to another CAS3 property' so that it's more obvious what it's referring to.