### PR TITLE
(373) Filter placement requests by status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -58,14 +59,14 @@ class PlacementRequestsController(
     )
   }
 
-  override fun placementRequestsDashboardGet(isParole: Boolean?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
+  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
     val user = userService.getUserForRequest()
 
     if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       throw ForbiddenProblem()
     }
 
-    val (requests, metadata) = placementRequestService.getAllActive(isParole ?: false, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
+    val (requests, metadata) = placementRequestService.getAllActive(status ?: PlacementRequestStatus.notMatched, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2479,11 +2479,11 @@ paths:
         - Placement requests
       summary: Gets all placement requests
       parameters:
-        - name: isParole
+        - name: status
           in: query
-          description: States whether or not to return parole cases
+          description: filter by status of an application
           schema:
-            type: boolean
+            $ref: '#/components/schemas/PlacementRequestStatus'
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -6736,8 +6736,8 @@ components:
       type: string
       enum:
         - duration
-        - expectedArrival
-        - createdAt
+        - expected_arrival
+        - created_at
     SortDirection:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
@@ -53,19 +54,111 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
       assertThat(nonParoleResults.content.map { it.id }).isEqualTo(listOf(nonParolePlacementRequests[2], nonParolePlacementRequests[3]).map { it.id })
       assertThat(paroleResults.content.map { it.id }).isEqualTo(listOf(parolePlacementRequests[2], parolePlacementRequests[3]).map { it.id })
     }
+  }
 
-    private fun createPlacementRequests(count: Int, isWithdrawn: Boolean, isReallocated: Boolean, isParole: Boolean): List<PlacementRequestEntity> {
-      val user = userEntityFactory.produceAndPersist {
+  @Nested
+  inner class AllForDashboard {
+    private lateinit var placementRequestsWithBooking: List<PlacementRequestEntity>
+    private lateinit var placementRequestsWithNoBooking: List<PlacementRequestEntity>
+    private lateinit var placementRequestsWithACancelledBooking: List<PlacementRequestEntity>
+    private lateinit var placementRequestsWithABookingNotMade: List<PlacementRequestEntity>
+
+    private lateinit var expectedNotMatchedPlacementRequests: List<PlacementRequestEntity>
+
+    @BeforeEach
+    fun setup() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
         withProbationRegion(
           probationRegionEntityFactory.produceAndPersist {
             withApArea(apAreaEntityFactory.produceAndPersist())
           },
         )
+        withLocalAuthorityArea(
+          localAuthorityEntityFactory.produceAndPersist(),
+        )
       }
 
-      return List(count) {
-        `Given a Placement Request`(user, user, user, reallocated = isReallocated, isWithdrawn = isWithdrawn, isParole = isParole).first
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premises)
       }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withRoom(room)
+      }
+
+      placementRequestsWithNoBooking = createPlacementRequests(4, isWithdrawn = false, isReallocated = false, isParole = true)
+
+      placementRequestsWithBooking = createPlacementRequests(4, isWithdrawn = false, isReallocated = false, isParole = false)
+      placementRequestsWithBooking.forEach {
+        it.booking = bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBed(bed)
+        }
+
+        realPlacementRequestRepository.save(it)
+      }
+
+      placementRequestsWithACancelledBooking = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = false)
+      placementRequestsWithACancelledBooking.forEach {
+        val booking = bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBed(bed)
+        }
+
+        it.booking = booking
+        realPlacementRequestRepository.save(it)
+
+        cancellationEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withReason(cancellationReasonEntityFactory.produceAndPersist())
+        }
+      }
+
+      placementRequestsWithABookingNotMade = createPlacementRequests(3, isWithdrawn = false, isReallocated = false, isParole = true)
+      placementRequestsWithABookingNotMade.forEach {
+        bookingNotMadeFactory.produceAndPersist {
+          withPlacementRequest(it)
+        }
+      }
+
+      expectedNotMatchedPlacementRequests = listOf(placementRequestsWithNoBooking, placementRequestsWithACancelledBooking).flatten()
+    }
+
+    @Test
+    fun `findAllByStatusAndReallocatedAtNullAndIsWithdrawnFalse returns all results when no page is provided`() {
+      val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null)
+      val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null)
+      val unableToMatchPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.unableToMatch, null)
+
+      assertThat(matchedPlacementRequests.content.map { it.id }).isEqualTo(placementRequestsWithBooking.map { it.id })
+      assertThat(notMatchedPlacementRequests.content.map { it.id }).isEqualTo(expectedNotMatchedPlacementRequests.map { it.id })
+      assertThat(unableToMatchPlacementRequests.content.map { it.id }).isEqualTo(placementRequestsWithABookingNotMade.map { it.id })
+    }
+
+    @Test
+    fun `findAllByStatusAndReallocatedAtNullAndIsWithdrawnFalse returns paginated results when a page is provided`() {
+      val pageable = PageRequest.of(1, 2, Sort.by("created_at"))
+      val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched, pageable)
+      val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, pageable)
+      val unableToMatchPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.unableToMatch, pageable)
+
+      assertThat(matchedPlacementRequests.content.map { it.id }).isEqualTo(listOf(placementRequestsWithBooking[2], placementRequestsWithBooking[3]).map { it.id })
+      assertThat(notMatchedPlacementRequests.content.map { it.id }).isEqualTo(listOf(expectedNotMatchedPlacementRequests[2], expectedNotMatchedPlacementRequests[3]).map { it.id })
+      assertThat(unableToMatchPlacementRequests.content.map { it.id }).isEqualTo(listOf(placementRequestsWithABookingNotMade[2]).map { it.id })
+    }
+  }
+
+  private fun createPlacementRequests(count: Int, isWithdrawn: Boolean, isReallocated: Boolean, isParole: Boolean): List<PlacementRequestEntity> {
+    val user = userEntityFactory.produceAndPersist {
+      withProbationRegion(
+        probationRegionEntityFactory.produceAndPersist {
+          withApArea(apAreaEntityFactory.produceAndPersist())
+        },
+      )
+    }
+
+    return List(count) {
+      `Given a Placement Request`(user, user, user, reallocated = isReallocated, isWithdrawn = isWithdrawn, isParole = isParole).first
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -626,7 +626,7 @@ class PlacementRequestServiceTest {
 
     mockkStatic(PageRequest::class)
 
-    every { PageRequest.of(0, 10, Sort.by("createdAt").ascending()) } returns pageRequest
+    every { PageRequest.of(0, 10, Sort.by("created_at").ascending()) } returns pageRequest
     every { page.content } returns placementRequests
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
@@ -650,7 +650,7 @@ class PlacementRequestServiceTest {
 
     mockkStatic(PageRequest::class)
 
-    every { PageRequest.of(0, 10, Sort.by("expectedArrival").descending()) } returns pageRequest
+    every { PageRequest.of(0, 10, Sort.by("expected_arrival").descending()) } returns pageRequest
     every { page.content } returns placementRequests
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -15,6 +15,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
@@ -609,9 +610,9 @@ class PlacementRequestServiceTest {
 
     every { page.content } returns placementRequests
 
-    every { placementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(false, null) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null) } returns page
 
-    val (requests, metadata) = placementRequestService.getAllActive(false, null, PlacementRequestSortField.createdAt, null)
+    val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, PlacementRequestSortField.createdAt, null)
 
     assertThat(requests).isEqualTo(placementRequests)
     assertThat(metadata).isNull()
@@ -630,9 +631,9 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(false, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, pageRequest) } returns page
 
-    val (requests, metadata) = placementRequestService.getAllActive(false, 1, PlacementRequestSortField.createdAt, null)
+    val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, 1, PlacementRequestSortField.createdAt, null)
 
     assertThat(requests).isEqualTo(placementRequests)
     assertThat(metadata?.currentPage).isEqualTo(1)
@@ -654,9 +655,9 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(false, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, pageRequest) } returns page
 
-    val (requests, metadata) = placementRequestService.getAllActive(false, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
+    val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 
     assertThat(requests).isEqualTo(placementRequests)
     assertThat(metadata?.currentPage).isEqualTo(1)


### PR DESCRIPTION
This updates the placement requests dashboard to be able to filter by its status, rather than the parole status.