### PR TITLE
(373) Return booking summary in placement request list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -18,6 +18,7 @@ class PlacementRequestTransformer(
   private val risksTransformer: RisksTransformer,
   private val assessmentTransformer: AssessmentTransformer,
   private val userTransformer: UserTransformer,
+  private val bookingSummaryTransformer: BookingSummaryTransformer,
 ) {
   fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): PlacementRequest {
     return PlacementRequest(
@@ -42,6 +43,7 @@ class PlacementRequestTransformer(
       assessor = userTransformer.transformJpaToApi(jpa.assessment.allocatedToUser!!, ServiceName.approvedPremises) as ApprovedPremisesUser,
       notes = jpa.notes,
       isParole = jpa.isParole,
+      booking = jpa.booking?.let { bookingSummaryTransformer.transformJpaToApi(jpa.booking!!) },
     )
   }
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -6199,6 +6199,8 @@ components:
               type: boolean
             notes:
               type: string
+            booking:
+              $ref: '#/components/schemas/BookingSummary'
           required:
             - person
             - risks
@@ -6221,8 +6223,6 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cancellation'
-            booking:
-              $ref: '#/components/schemas/BookingSummary'
             application:
               $ref: '#/components/schemas/Application'
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
@@ -198,12 +198,14 @@ class PlacementRequestDetailTransformerTest {
     val mockPersonTransformer = mockk<PersonTransformer>()
     val mockRisksTransformer = mockk<RisksTransformer>()
     val mockUserTransformer = mockk<UserTransformer>()
+    val mockBookingSummaryTransformer = mockk<BookingSummaryTransformer>()
 
     val realPlacementRequestTransformer = PlacementRequestTransformer(
       mockPersonTransformer,
       mockRisksTransformer,
       mockAssessmentTransformer,
       mockUserTransformer,
+      mockBookingSummaryTransformer,
     )
 
     every { mockAssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns AssessmentDecision.accepted


### PR DESCRIPTION
This allows us to get the premises name for a placement requests’s booking when listing the placement requests.