### PR TITLE
373 - Placement requests search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementReq
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -60,14 +61,14 @@ class PlacementRequestsController(
     )
   }
 
-  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, crn: String?, tier: RiskTierLevel?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
+  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, crn: String?, tier: RiskTierLevel?, arrivalDateStart: LocalDate?, arrivalDateEnd: LocalDate?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
     val user = userService.getUserForRequest()
 
     if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       throw ForbiddenProblem()
     }
 
-    val (requests, metadata) = placementRequestService.getAllActive(status, crn, tier?.value, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
+    val (requests, metadata) = placementRequestService.getAllActive(status, crn, tier?.value, arrivalDateStart, arrivalDateEnd, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -66,7 +66,7 @@ class PlacementRequestsController(
       throw ForbiddenProblem()
     }
 
-    val (requests, metadata) = placementRequestService.getAllActive(status ?: PlacementRequestStatus.notMatched, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
+    val (requests, metadata) = placementRequestService.getAllActive(status, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -59,14 +59,14 @@ class PlacementRequestsController(
     )
   }
 
-  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
+  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, crn: String?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
     val user = userService.getUserForRequest()
 
     if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       throw ForbiddenProblem()
     }
 
-    val (requests, metadata) = placementRequestService.getAllActive(status, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
+    val (requests, metadata) = placementRequestService.getAllActive(status, crn, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -59,14 +60,14 @@ class PlacementRequestsController(
     )
   }
 
-  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, crn: String?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
+  override fun placementRequestsDashboardGet(status: PlacementRequestStatus?, crn: String?, tier: RiskTierLevel?, page: Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?): ResponseEntity<List<PlacementRequest>> {
     val user = userService.getUserForRequest()
 
     if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       throw ForbiddenProblem()
     }
 
-    val (requests, metadata) = placementRequestService.getAllActive(status, crn, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
+    val (requests, metadata) = placementRequestService.getAllActive(status, crn, tier?.value, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -61,11 +61,13 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
         END
       ) = :#{#status?.toString()})
       AND (:crn IS NULL OR (SELECT COUNT(1) FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn)) = 1)
-      AND (:tier IS NULL OR (SELECT COUNT(1) FROM approved_premises_applications apa WHERE apa.id = pq.application_id AND apa.risk_ratings -> 'tier' -> 'value' ->> 'level' = :tier) = 1)
+      AND (:tier IS NULL OR (SELECT COUNT(1) FROM approved_premises_applications apa WHERE apa.id = pq.application_id AND apa.risk_ratings -> 'tier' -> 'value' ->> 'level' = :tier) = 1) 
+      AND (CAST(:arrivalDateFrom AS date) IS NULL OR pq.expected_arrival >= :arrivalDateFrom) 
+      AND (CAST(:arrivalDateTo AS date) IS NULL OR pq.expected_arrival <= :arrivalDateTo)
   """,
     nativeQuery = true,
   )
-  fun allForDashboard(status: PlacementRequestStatus?, crn: String?, tier: String?, pageable: Pageable?): Page<PlacementRequestEntity>
+  fun allForDashboard(status: PlacementRequestStatus?, crn: String?, tier: String?, arrivalDateFrom: LocalDate?, arrivalDateTo: LocalDate?, pageable: Pageable?): Page<PlacementRequestEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -61,10 +61,11 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
         END
       ) = :#{#status?.toString()})
       AND (:crn IS NULL OR (SELECT COUNT(1) FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn)) = 1)
+      AND (:tier IS NULL OR (SELECT COUNT(1) FROM approved_premises_applications apa WHERE apa.id = pq.application_id AND apa.risk_ratings -> 'tier' -> 'value' ->> 'level' = :tier) = 1)
   """,
     nativeQuery = true,
   )
-  fun allForDashboard(status: PlacementRequestStatus?, crn: String?, pageable: Pageable?): Page<PlacementRequestEntity>
+  fun allForDashboard(status: PlacementRequestStatus?, crn: String?, tier: String?, pageable: Pageable?): Page<PlacementRequestEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -59,11 +59,12 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
           ) > 0 THEN 'unableToMatch'
           ELSE 'notMatched'
         END
-      ) = :#{#status.toString()}
+      ) = :#{#status.toString()} 
+      AND (:crn IS NULL OR (SELECT COUNT(1) FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn)) = 1)
   """,
     nativeQuery = true,
   )
-  fun allForDashboard(status: PlacementRequestStatus, pageable: Pageable?): Page<PlacementRequestEntity>
+  fun allForDashboard(status: PlacementRequestStatus, crn: String?, pageable: Pageable?): Page<PlacementRequestEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -37,7 +37,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
     where
       pq.reallocated_at IS NULL
       AND pq.is_withdrawn IS FALSE
-      AND (
+      AND (:status IS NULL OR (
         CASE
           WHEN (
             SELECT
@@ -59,12 +59,12 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
           ) > 0 THEN 'unableToMatch'
           ELSE 'notMatched'
         END
-      ) = :#{#status.toString()} 
+      ) = :#{#status?.toString()})
       AND (:crn IS NULL OR (SELECT COUNT(1) FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn)) = 1)
   """,
     nativeQuery = true,
   )
-  fun allForDashboard(status: PlacementRequestStatus, crn: String?, pageable: Pageable?): Page<PlacementRequestEntity>
+  fun allForDashboard(status: PlacementRequestStatus?, crn: String?, pageable: Pageable?): Page<PlacementRequestEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -78,7 +78,7 @@ class PlacementRequestService(
       pageable = null
     }
 
-    val response = placementRequestRepository.allForDashboard(status, crn, tier, pageable)
+    val response = placementRequestRepository.allForDashboard(status, crn, tier, null, null, pageable)
 
     if (page != null) {
       metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
@@ -63,7 +64,7 @@ class PlacementRequestService(
     return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse()
   }
 
-  fun getAllActive(status: PlacementRequestStatus?, crn: String?, tier: String?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
+  fun getAllActive(status: PlacementRequestStatus?, crn: String?, tier: String?, arrivalDateStart: LocalDate?, arrivalDateEnd: LocalDate?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
     var pageable: PageRequest?
     var metadata: PaginationMetadata? = null
 
@@ -78,7 +79,7 @@ class PlacementRequestService(
       pageable = null
     }
 
-    val response = placementRequestRepository.allForDashboard(status, crn, tier, null, null, pageable)
+    val response = placementRequestRepository.allForDashboard(status, crn, tier, arrivalDateStart, arrivalDateEnd, pageable)
 
     if (page != null) {
       metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -78,7 +78,7 @@ class PlacementRequestService(
       pageable = null
     }
 
-    val response = placementRequestRepository.allForDashboard(status, crn, pageable)
+    val response = placementRequestRepository.allForDashboard(status, crn, null, pageable)
 
     if (page != null) {
       metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -78,7 +78,7 @@ class PlacementRequestService(
       pageable = null
     }
 
-    val response = placementRequestRepository.allForDashboard(status, pageable)
+    val response = placementRequestRepository.allForDashboard(status, null, pageable)
 
     if (page != null) {
       metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -63,7 +63,7 @@ class PlacementRequestService(
     return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse()
   }
 
-  fun getAllActive(status: PlacementRequestStatus?, crn: String?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
+  fun getAllActive(status: PlacementRequestStatus?, crn: String?, tier: String?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
     var pageable: PageRequest?
     var metadata: PaginationMetadata? = null
 
@@ -78,7 +78,7 @@ class PlacementRequestService(
       pageable = null
     }
 
-    val response = placementRequestRepository.allForDashboard(status, crn, null, pageable)
+    val response = placementRequestRepository.allForDashboard(status, crn, tier, pageable)
 
     if (page != null) {
       metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -63,7 +63,7 @@ class PlacementRequestService(
     return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse()
   }
 
-  fun getAllActive(status: PlacementRequestStatus, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
+  fun getAllActive(status: PlacementRequestStatus?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
     var pageable: PageRequest?
     var metadata: PaginationMetadata? = null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -63,7 +63,7 @@ class PlacementRequestService(
     return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse()
   }
 
-  fun getAllActive(status: PlacementRequestStatus?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
+  fun getAllActive(status: PlacementRequestStatus?, crn: String?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
     var pageable: PageRequest?
     var metadata: PaginationMetadata? = null
 
@@ -78,7 +78,7 @@ class PlacementRequestService(
       pageable = null
     }
 
-    val response = placementRequestRepository.allForDashboard(status, null, pageable)
+    val response = placementRequestRepository.allForDashboard(status, crn, pageable)
 
     if (page != null) {
       metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2523,6 +2523,11 @@ paths:
           description: filter by status of an application
           schema:
             $ref: '#/components/schemas/PlacementRequestStatus'
+        - name: crn
+          in: query
+          description: filter by CRN
+          schema:
+            type: string
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2533,6 +2533,18 @@ paths:
           description: filter by tier of Offender at time Application was created
           schema:
             $ref: '#/components/schemas/RiskTierLevel'
+        - name: arrivalDateStart
+          in: query
+          description: filter by minimum expected arrival date
+          schema:
+            type: string
+            format: date
+        - name: arrivalDateEnd
+          in: query
+          description: filter by maximum expected arrival date
+          schema:
+            type: string
+            format: date
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2528,6 +2528,11 @@ paths:
           description: filter by CRN
           schema:
             type: string
+        - name: tier
+          in: query
+          description: filter by tier of Offender at time Application was created
+          schema:
+            $ref: '#/components/schemas/RiskTierLevel'
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results
@@ -6806,3 +6811,22 @@ components:
       enum:
         - asc
         - desc
+    RiskTierLevel:
+      type: string
+      enum:
+        - D0
+        - D1
+        - D2
+        - D3
+        - C0
+        - C1
+        - C2
+        - C3
+        - B0
+        - B1
+        - B2
+        - B3
+        - A0
+        - A1
+        - A2
+        - A3

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -33,6 +33,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     this.id = { id }
   }
 
+  fun withExpectedArrival(expectedArrival: LocalDate) = apply {
+    this.expectedArrival = { expectedArrival }
+  }
+
   fun withAllocatedToUser(user: UserEntity) = apply {
     this.allocatedToUser = { user }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -187,7 +187,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
       val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, tier = tier)
 
       val pageable = PageRequest.of(0, 2, Sort.by("created_at"))
-      val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, tier, pageable)
+      val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, tier, null, null, pageable)
 
       assertThat(results.content.map { it.id }).isEqualTo(requestsForCrn.map { it.id })
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -148,6 +148,17 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `allForDashboard returns all results when no status is provided`() {
+      val pageable = PageRequest.of(0, 20, Sort.by("created_at"))
+      val allPlacementRequests = realPlacementRequestRepository.allForDashboard(null, null, pageable)
+
+      val allPlacementRequestsToExpect = (placementRequestsWithBooking + placementRequestsWithNoBooking + placementRequestsWithACancelledBooking + placementRequestsWithABookingNotMade)
+        .sortedBy { it.createdAt }
+
+      assertThat(allPlacementRequests.content.map { it.id }).isEqualTo(allPlacementRequestsToExpect.map { it.id })
+    }
+
+    @Test
     fun `allForDashboard returns only Placement Requests for CRN when specified`() {
       val crn = "CRN456"
       val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, crn = crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -125,7 +125,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `findAllByStatusAndReallocatedAtNullAndIsWithdrawnFalse returns all results when no page is provided`() {
+    fun `allForDashboard returns all results when no page is provided`() {
       val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null)
       val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, null)
       val unableToMatchPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.unableToMatch, null, null)
@@ -136,7 +136,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `findAllByStatusAndReallocatedAtNullAndIsWithdrawnFalse returns paginated results when a page is provided`() {
+    fun `allForDashboard returns paginated results when a page is provided`() {
       val pageable = PageRequest.of(1, 2, Sort.by("created_at"))
       val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, pageable)
       val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, pageable)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -20,6 +20,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   reallocated: Boolean = false,
   isWithdrawn: Boolean = false,
   isParole: Boolean = false,
+  expectedArrival: LocalDate? = null,
   tier: String? = null,
 ): Pair<PlacementRequestEntity, ApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -37,10 +38,10 @@ fun IntegrationTestBase.`Given a Placement Request`(
         PersonRisksFactory()
           .withTier(
             RiskWithStatus(
-              RiskTier(tier, LocalDate.now())
-            )
+              RiskTier(tier, LocalDate.now()),
+            ),
           )
-          .produce()
+          .produce(),
       )
     }
   }
@@ -81,6 +82,10 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withIsWithdrawn(isWithdrawn)
     withIsParole(isParole)
     withPlacementRequirements(placementRequirements)
+
+    if (expectedArrival != null) {
+      withExpectedArrival(expectedArrival)
+    }
   }
 
   return Pair(placementRequest, application)
@@ -92,6 +97,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
+  expectedArrival: LocalDate? = null,
   tier: String? = null,
   block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit,
 ) {
@@ -101,7 +107,8 @@ fun IntegrationTestBase.`Given a Placement Request`(
     createdByUser,
     crn,
     reallocated,
-    tier = tier
+    expectedArrival = expectedArrival,
+    tier = tier,
   )
 
   block(result.first, result.second)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -610,7 +610,7 @@ class PlacementRequestServiceTest {
 
     every { page.content } returns placementRequests
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, PlacementRequestSortField.createdAt, null)
 
@@ -631,7 +631,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, 1, PlacementRequestSortField.createdAt, null)
 
@@ -655,7 +655,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 
@@ -680,7 +680,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(null, crn, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(null, crn, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(null, crn, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -610,7 +610,7 @@ class PlacementRequestServiceTest {
 
     every { page.content } returns placementRequests
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, PlacementRequestSortField.createdAt, null)
 
@@ -631,7 +631,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, 1, PlacementRequestSortField.createdAt, null)
 
@@ -655,7 +655,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -614,7 +614,7 @@ class PlacementRequestServiceTest {
 
     every { page.content } returns placementRequests
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, null) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, null, PlacementRequestSortField.createdAt, null)
 
@@ -635,7 +635,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, 1, PlacementRequestSortField.createdAt, null)
 
@@ -659,7 +659,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 
@@ -684,7 +684,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(null, crn, null, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(null, crn, null, null, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(null, crn, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 
@@ -710,7 +710,7 @@ class PlacementRequestServiceTest {
     every { page.totalPages } returns 10
     every { page.totalElements } returns 100
 
-    every { placementRequestRepository.allForDashboard(null, null, tier, pageRequest) } returns page
+    every { placementRequestRepository.allForDashboard(null, null, tier, null, null, pageRequest) } returns page
 
     val (requests, metadata) = placementRequestService.getAllActive(null, null, tier, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)
 


### PR DESCRIPTION
Change Placement Request dashboard endpoint to return all Placement Requests instead of defaulting to filtering on not matched when status not provided.

Add crn, tier, arrivalDateStart, arrivalDateEnd optional filters.