### PR TITLE
Link bookings to applications in Temporary Accommodation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -363,6 +363,7 @@ class PremisesController(
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
           bedId = body.bedId,
+          assessmentId = body.assessmentId,
           enableTurnarounds = body.enableTurnarounds ?: false,
         )
       }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3898,6 +3898,9 @@ components:
           $ref: '#/components/schemas/ServiceName'
         enableTurnarounds:
           type: boolean
+        assessmentId:
+          type: string
+          format: uuid
       required:
         - crn
         - arrivalDate


### PR DESCRIPTION
> See [ticket #1381 on the CAS3 Trello board](https://trello.com/c/K6AjM2OT/1381-a-user-can-also-link-to-a-referral-as-part-of-creating-a-provisional-booking).

This PR introduces the ability to link bookings to applications within the Temporary Accommodation service. This is done by passing in an `assessmentId` parameter when sending a request to the `POST /premises/{premisesId}/bookings` endpoint.

This new field is optional, so the existing behaviour is preserved if this ID is not provided.
