### PR TITLE
Allow ordering by application date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -31,9 +31,11 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
   @Query(
     """
     SELECT
-      pq.*
+      pq.*,
+      application.created_at as application_date
     from
       placement_requests pq
+      left join applications application on application.id = pq.application_id
     where
       pq.reallocated_at IS NULL
       AND pq.is_withdrawn IS FALSE

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -6818,6 +6818,7 @@ components:
         - duration
         - expected_arrival
         - created_at
+        - application_date
     SortDirection:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -191,6 +191,17 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
 
       assertThat(results.content.map { it.id }).isEqualTo(requestsForCrn.map { it.id })
     }
+
+    @Test
+    fun `allForDashboard allows sorting by an application's created_at date`() {
+      val pageable = PageRequest.of(0, 20, Sort.by("application_date"))
+      val allPlacementRequests = realPlacementRequestRepository.allForDashboard(null, null, null, null, null, pageable)
+
+      val allPlacementRequestsToExpect = (placementRequestsWithNoBooking + placementRequestsWithABookingNotMade + placementRequestsWithBooking + placementRequestsWithACancelledBooking)
+        .sortedBy { it.application.createdAt }
+
+      assertThat(allPlacementRequests.content.map { it.id }).isEqualTo(allPlacementRequestsToExpect.map { it.id })
+    }
   }
 
   @Nested


### PR DESCRIPTION
This allows the API to order placement requests by their assocated application's created_at date. We have to do a join and an alias for this to work as we're querying across tables.