### PR TITLE
373 - Add name to ap applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -212,6 +212,7 @@ class ApprovedPremisesApplicationEntity(
   var placementRequests: MutableList<PlacementRequestEntity>,
   var releaseType: String?,
   var arrivalDate: OffsetDateTime?,
+  var name: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -28,6 +28,9 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")
   fun <T : ApplicationEntity> findAllByCreatedByUser_Id(id: UUID, type: Class<T>): List<ApplicationEntity>
 
+  @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type")
+  fun <T : ApplicationEntity> findAllForService(type: Class<T>): List<ApplicationEntity>
+
   @Query(
     "SELECT a FROM ApplicationEntity a " +
       "LEFT JOIN ApplicationTeamCodeEntity atc ON a = atc.application " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/FetchOffenderNamesForApplicationsFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/FetchOffenderNamesForApplicationsFromCommunityApiJob.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+
+class FetchOffenderNamesForApplicationsFromCommunityApiJob(
+  private val applicationRepository: ApplicationRepository,
+  private val offenderService: OffenderService,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = false
+
+  override fun process() {
+    applicationRepository.findAllForService(ApprovedPremisesApplicationEntity::class.java)
+      .map { it as ApprovedPremisesApplicationEntity }
+      .forEach { application ->
+        if (application.name != null) return@forEach
+
+        log.info("Fetching Offender name for Application: ${application.id}")
+
+        try {
+          val offenderDetailsResult = offenderService.getOffenderByCrn(application.crn, "", true)
+
+          val offenderDetails = when (offenderDetailsResult) {
+            is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+            is AuthorisableActionResult.NotFound -> throw RuntimeException("Could not find Offender")
+            is AuthorisableActionResult.Unauthorised -> throw RuntimeException("Unauthorised when trying to find Offender")
+          }
+
+          application.name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}"
+          applicationRepository.save(application)
+        } catch (exception: Exception) {
+          log.error("Unable to update Offender name for Application: ${application.id}", exception)
+        }
+
+        Thread.sleep(500)
+      }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJob.kt
@@ -5,5 +5,6 @@ import java.util.UUID
 abstract class MigrationJob(
   val id: UUID = UUID.randomUUID(),
 ) {
+  abstract val shouldRunInTransaction: Boolean
   abstract fun process()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
@@ -9,6 +9,7 @@ class UpdateAllUsersFromCommunityApiJob(
   private val userService: UserService,
 ) : MigrationJob() {
   private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = false
 
   override fun process() {
     userRepository.findAll().forEach {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -227,6 +227,7 @@ class ApplicationService(
         withdrawalReason = null,
         otherWithdrawalReason = null,
         nomsNumber = offenderDetails.otherIds.nomsNumber,
+        name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}",
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -5,7 +5,9 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.FetchOffenderNamesForApplicationsFromCommunityApiJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
@@ -27,6 +29,10 @@ class MigrationJobService(
         MigrationJobType.updateAllUsersFromCommunityApi -> UpdateAllUsersFromCommunityApiJob(
           applicationContext.getBean(UserRepository::class.java),
           applicationContext.getBean(UserService::class.java),
+        )
+        MigrationJobType.fetchOffenderNamesForApplications -> FetchOffenderNamesForApplicationsFromCommunityApiJob(
+          applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(OffenderService::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -30,7 +30,11 @@ class MigrationJobService(
         )
       }
 
-      transactionTemplate.executeWithoutResult { job.process() }
+      if (job.shouldRunInTransaction) {
+        transactionTemplate.executeWithoutResult { job.process() }
+      } else {
+        job.process()
+      }
 
       migrationLogger.info("Finished migration job: $migrationJobType")
     } catch (exception: Exception) {

--- a/src/main/resources/db/migration/all/20230809113516__add_name_to_ap_applications.sql
+++ b/src/main/resources/db/migration/all/20230809113516__add_name_to_ap_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN name TEXT;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -6178,6 +6178,7 @@ components:
       type: string
       enum:
         - update_all_users_from_community_api
+        - fetch_offender_names_for_applications
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -44,6 +44,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var isWithdrawn: Yielded<Boolean> = { false }
   private var withdrawalReason: Yielded<String?> = { null }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+  private var name: Yielded<String?> = { "${randomStringUpperCase(4)} ${randomStringUpperCase(6)}" }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -153,6 +154,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isEsapApplication = { isEsapApplication }
   }
 
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -181,5 +186,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     withdrawalReason = this.withdrawalReason(),
     otherWithdrawalReason = null,
     nomsNumber = this.nomsNumber(),
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -154,7 +154,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isEsapApplication = { isEsapApplication }
   }
 
-  fun withName(name: String) = apply {
+  fun withName(name: String?) = apply {
     this.name = { name }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/FetchOffenderNamesForApplicationsFromCommunityApiJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/FetchOffenderNamesForApplicationsFromCommunityApiJobTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+
+class FetchOffenderNamesForApplicationsFromCommunityApiJobTest : MigrationJobTestBase() {
+  @Test
+  fun `Any missing names are fetched from Community API with a 500ms artificial delay`() {
+    `Given a User` { user, _ ->
+      `Given an Offender` { offenderDetailsOne, _ ->
+        `Given an Offender` { offenderDetailsTwo, _ ->
+          val schema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+          val applicationOne = approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withName(null)
+            withCrn(offenderDetailsOne.otherIds.crn)
+            withCreatedByUser(user)
+            withApplicationSchema(schema)
+          }
+
+          val applicationTwo = approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withName(null)
+            withCrn(offenderDetailsTwo.otherIds.crn)
+            withCreatedByUser(user)
+            withApplicationSchema(schema)
+          }
+
+          val startTime = System.currentTimeMillis()
+          migrationJobService.runMigrationJob(MigrationJobType.fetchOffenderNamesForApplications)
+          val endTime = System.currentTimeMillis()
+
+          assertThat(endTime - startTime).isGreaterThan(500 * 2)
+
+          val applicationOneAfterUpdate = approvedPremisesApplicationRepository.findByIdOrNull(applicationOne.id)!!
+          val applicationTwoAfterUpdate = approvedPremisesApplicationRepository.findByIdOrNull(applicationTwo.id)!!
+
+          assertThat(applicationOneAfterUpdate.name).isEqualTo("${offenderDetailsOne.firstName.uppercase()} ${offenderDetailsOne.surname.uppercase()}")
+          assertThat(applicationTwoAfterUpdate.name).isEqualTo("${offenderDetailsTwo.firstName.uppercase()} ${offenderDetailsTwo.surname.uppercase()}")
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -305,7 +305,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `createApprovedPremisesApplication returns Success with created Application + persisted Risk data`() {
+  fun `createApprovedPremisesApplication returns Success with created Application, persists Risk data and Offender name`() {
     val crn = "CRN345"
     val username = "SOMEPERSON"
 
@@ -374,6 +374,7 @@ class ApplicationServiceTest {
     assertThat(result.entity.createdByUser).isEqualTo(user)
     val approvedPremisesApplication = result.entity as ApprovedPremisesApplicationEntity
     assertThat(approvedPremisesApplication.riskRatings).isEqualTo(riskRatings)
+    assertThat(approvedPremisesApplication.name).isEqualTo("${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}")
   }
 
   @Test


### PR DESCRIPTION
This PR adds a name field to Approved Premises Applications and begins populating it for newly created Applications.

For existing Applications we also introduce a Migration Job which we can trigger which will backfill the names for existing Applications.  Once this has been run we can make the column not-null in a subsequent release (assuming we are able to succesfully backfill every Application with a name)