### PR TITLE
1321 - Add human notes to applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -14,6 +14,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
@@ -30,15 +32,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapAndTransformAssessmentSummaries
 import java.util.UUID
 import javax.transaction.Transactional
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryUserNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 
 @Service
 class AssessmentController(
@@ -258,20 +257,20 @@ class AssessmentController(
     )
   }
 
-  override fun assessmentsAssessmentIdReferralHistoryUserNotePost(
+  override fun assessmentsAssessmentIdReferralHistoryNotesPost(
     assessmentId: UUID,
-    newReferralHistoryUserNote: NewReferralHistoryUserNote
+    newReferralHistoryUserNote: NewReferralHistoryUserNote,
   ): ResponseEntity<ReferralHistoryNote> {
-    val user= userService.getUserForRequest()
+    val user = userService.getUserForRequest()
 
-    val referralHistoryUserNote = when(val referralHistoryUserNoteResult = assessmentService.addAssessmentReferralHistoryUserNote(user, assessmentId, newReferralHistoryUserNote.message)) {
+    val referralHistoryUserNote = when (val referralHistoryUserNoteResult = assessmentService.addAssessmentReferralHistoryUserNote(user, assessmentId, newReferralHistoryUserNote.message)) {
       is AuthorisableActionResult.Success -> referralHistoryUserNoteResult.entity
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
     }
 
     return ResponseEntity.ok(
-      assessmentReferralHistoryNoteTransformer.transformJpaToApi(referralHistoryUserNote)
+      assessmentReferralHistoryNoteTransformer.transformJpaToApi(referralHistoryUserNote),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -155,6 +155,9 @@ abstract class AssessmentEntity(
   @OneToMany(mappedBy = "assessment")
   var clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
 
+  @OneToMany(mappedBy = "assessment")
+  var referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>,
+
   @Transient
   var schemaUpToDate: Boolean,
 )
@@ -177,6 +180,7 @@ class ApprovedPremisesAssessmentEntity(
   decision: AssessmentDecision?,
   rejectionRationale: String?,
   clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
+  referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>,
   schemaUpToDate: Boolean,
 ) : AssessmentEntity(
   id,
@@ -192,6 +196,7 @@ class ApprovedPremisesAssessmentEntity(
   decision,
   rejectionRationale,
   clarificationNotes,
+  referralHistoryNotes,
   schemaUpToDate,
 )
 
@@ -213,6 +218,7 @@ class TemporaryAccommodationAssessmentEntity(
   decision: AssessmentDecision?,
   rejectionRationale: String?,
   clarificationNotes: MutableList<AssessmentClarificationNoteEntity>,
+  referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>,
   schemaUpToDate: Boolean,
   var completedAt: OffsetDateTime?,
 ) : AssessmentEntity(
@@ -229,6 +235,7 @@ class TemporaryAccommodationAssessmentEntity(
   decision,
   rejectionRationale,
   clarificationNotes,
+  referralHistoryNotes,
   schemaUpToDate,
 )
 
@@ -281,4 +288,45 @@ data class AssessmentClarificationNoteEntity(
   var response: String?,
 
   var responseReceivedOn: LocalDate?,
+)
+
+@Repository
+interface AssessmentReferralHistoryNoteRepository: JpaRepository<AssessmentReferralHistoryNoteEntity, UUID>
+
+@Entity
+@Table(name = "assessment_referral_history_notes")
+@DiscriminatorColumn(name = "type")
+@Inheritance(strategy = InheritanceType.JOINED)
+abstract class AssessmentReferralHistoryNoteEntity(
+  @Id
+  val id: UUID,
+
+  @ManyToOne
+  @JoinColumn(name = "assessment_id")
+  val assessment: AssessmentEntity,
+
+  val createdAt: OffsetDateTime,
+
+  val message: String,
+)
+
+@Entity
+@DiscriminatorValue("user-note")
+@Table(name = "assessment_referral_history_user_notes")
+@PrimaryKeyJoinColumn(name = "assessment_id")
+class AssessmentReferralHistoryUserNoteEntity(
+  id: UUID,
+  assessment: AssessmentEntity,
+  createdAt: OffsetDateTime,
+  message: String,
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdByUser: UserEntity,
+
+) : AssessmentReferralHistoryNoteEntity(
+  id,
+  assessment,
+  createdAt,
+  message,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -291,11 +291,10 @@ data class AssessmentClarificationNoteEntity(
 )
 
 @Repository
-interface AssessmentReferralHistoryNoteRepository: JpaRepository<AssessmentReferralHistoryNoteEntity, UUID>
+interface AssessmentReferralHistoryNoteRepository : JpaRepository<AssessmentReferralHistoryNoteEntity, UUID>
 
 @Entity
 @Table(name = "assessment_referral_history_notes")
-@DiscriminatorColumn(name = "type")
 @Inheritance(strategy = InheritanceType.JOINED)
 abstract class AssessmentReferralHistoryNoteEntity(
   @Id
@@ -311,9 +310,7 @@ abstract class AssessmentReferralHistoryNoteEntity(
 )
 
 @Entity
-@DiscriminatorValue("user-note")
 @Table(name = "assessment_referral_history_user_notes")
-@PrimaryKeyJoinColumn(name = "assessment_id")
 class AssessmentReferralHistoryUserNoteEntity(
   id: UUID,
   assessment: AssessmentEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -39,12 +39,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 
 @Service
 class AssessmentService(
   private val userService: UserService,
   private val assessmentRepository: AssessmentRepository,
   private val assessmentClarificationNoteRepository: AssessmentClarificationNoteRepository,
+  private val assessmentReferralHistoryNoteRepository: AssessmentReferralHistoryNoteRepository,
   private val jsonSchemaService: JsonSchemaService,
   private val domainEventService: DomainEventService,
   private val offenderService: OffenderService,
@@ -145,6 +148,7 @@ class AssessmentService(
         schemaUpToDate = true,
         rejectionRationale = null,
         clarificationNotes = mutableListOf(),
+        referralHistoryNotes = mutableListOf(),
       ),
     )
 
@@ -180,6 +184,7 @@ class AssessmentService(
         schemaUpToDate = true,
         rejectionRationale = null,
         clarificationNotes = mutableListOf(),
+        referralHistoryNotes = mutableListOf(),
         completedAt = null,
       ),
     )
@@ -599,6 +604,7 @@ class AssessmentService(
         schemaUpToDate = true,
         rejectionRationale = null,
         clarificationNotes = mutableListOf(),
+        referralHistoryNotes = mutableListOf(),
       ),
     )
 
@@ -728,4 +734,25 @@ class AssessmentService(
       ValidatableActionResult.Success(savedNote),
     )
   }
+
+  fun addAssessmentReferralHistoryUserNote(user: UserEntity, assessmentId: UUID, text: String): AuthorisableActionResult<AssessmentReferralHistoryUserNoteEntity> {
+    val assessment = when(val assessmentResult = getAssessmentForUser(user, assessmentId)) {
+      is AuthorisableActionResult.Success -> assessmentResult.entity
+      is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised()
+      is AuthorisableActionResult.NotFound -> return AuthorisableActionResult.NotFound()
+    }
+
+    val referralHistoryNoteEntity = assessmentReferralHistoryNoteRepository.save(
+      AssessmentReferralHistoryUserNoteEntity(
+        id = UUID.randomUUID(),
+        assessment = assessment,
+        createdAt = OffsetDateTime.now(),
+        message = text,
+        createdByUser = user,
+      )
+    )
+
+    return AuthorisableActionResult.Success(referralHistoryNoteEntity)
+  }
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -24,6 +24,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentCla
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -39,8 +41,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 
 @Service
 class AssessmentService(
@@ -736,7 +736,7 @@ class AssessmentService(
   }
 
   fun addAssessmentReferralHistoryUserNote(user: UserEntity, assessmentId: UUID, text: String): AuthorisableActionResult<AssessmentReferralHistoryUserNoteEntity> {
-    val assessment = when(val assessmentResult = getAssessmentForUser(user, assessmentId)) {
+    val assessment = when (val assessmentResult = getAssessmentForUser(user, assessmentId)) {
       is AuthorisableActionResult.Success -> assessmentResult.entity
       is AuthorisableActionResult.Unauthorised -> return AuthorisableActionResult.Unauthorised()
       is AuthorisableActionResult.NotFound -> return AuthorisableActionResult.NotFound()
@@ -749,10 +749,9 @@ class AssessmentService(
         createdAt = OffsetDateTime.now(),
         message = text,
         createdByUser = user,
-      )
+      ),
     )
 
     return AuthorisableActionResult.Success(referralHistoryNoteEntity)
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryUserNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
+
+@Component
+class AssessmentReferralHistoryNoteTransformer {
+  fun transformJpaToApi(jpa: AssessmentReferralHistoryNoteEntity): ReferralHistoryNote = when(jpa) {
+    is AssessmentReferralHistoryUserNoteEntity -> ReferralHistoryUserNote(
+      id = jpa.id,
+      createdAt = jpa.createdAt.toInstant(),
+      message = jpa.message,
+      createdByStaffMemberId = jpa.createdByUser.id
+    )
+    else -> throw RuntimeException("Unsupported ReferralHistoryNote type: ${jpa::class.qualifiedName}" )
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
@@ -8,14 +8,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRef
 
 @Component
 class AssessmentReferralHistoryNoteTransformer {
-  fun transformJpaToApi(jpa: AssessmentReferralHistoryNoteEntity): ReferralHistoryNote = when(jpa) {
+  fun transformJpaToApi(jpa: AssessmentReferralHistoryNoteEntity): ReferralHistoryNote = when (jpa) {
     is AssessmentReferralHistoryUserNoteEntity -> ReferralHistoryUserNote(
       id = jpa.id,
       createdAt = jpa.createdAt.toInstant(),
       message = jpa.message,
-      createdByStaffMemberId = jpa.createdByUser.id
+      createdByStaffMemberId = jpa.createdByUser.id,
     )
-    else -> throw RuntimeException("Unsupported ReferralHistoryNote type: ${jpa::class.qualifiedName}" )
+    else -> throw RuntimeException("Unsupported ReferralHistoryNote type: ${jpa::class.qualifiedName}")
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessment
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -32,6 +34,7 @@ class AssessmentTransformer(
   private val objectMapper: ObjectMapper,
   private val applicationsTransformer: ApplicationsTransformer,
   private val assessmentClarificationNoteTransformer: AssessmentClarificationNoteTransformer,
+  private val assessmentReferralHistoryNoteTransformer: AssessmentReferralHistoryNoteTransformer,
   private val userTransformer: UserTransformer,
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
@@ -46,6 +49,7 @@ class AssessmentTransformer(
       allocatedAt = jpa.allocatedAt!!.toInstant(),
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
+      referralHistoryNotes = jpa.referralHistoryNotes.map(assessmentReferralHistoryNoteTransformer::transformJpaToApi),
       allocatedToStaffMember = userTransformer.transformJpaToApi(jpa.allocatedToUser!!, ServiceName.approvedPremises) as ApprovedPremisesUser,
       submittedAt = jpa.submittedAt?.toInstant(),
       decision = transformJpaDecisionToApi(jpa.decision),
@@ -63,6 +67,7 @@ class AssessmentTransformer(
       allocatedAt = jpa.allocatedAt?.toInstant(),
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       clarificationNotes = jpa.clarificationNotes.map(assessmentClarificationNoteTransformer::transformJpaToApi),
+      referralHistoryNotes = jpa.referralHistoryNotes.map(assessmentReferralHistoryNoteTransformer::transformJpaToApi),
       allocatedToStaffMember = jpa.allocatedToUser?.let { userTransformer.transformJpaToApi(it, ServiceName.temporaryAccommodation) as TemporaryAccommodationUser },
       submittedAt = jpa.submittedAt?.toInstant(),
       decision = transformJpaDecisionToApi(jpa.decision),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessment
@@ -19,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity

--- a/src/main/resources/db/migration/all/20230807153538__add_referral_history_notes_tables.sql
+++ b/src/main/resources/db/migration/all/20230807153538__add_referral_history_notes_tables.sql
@@ -1,0 +1,15 @@
+CREATE TABLE assessment_referral_history_notes (
+    id UUID NOT NULL,
+    assessment_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    message TEXT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (assessment_id) REFERENCES assessments(id)
+);
+
+CREATE TABLE assessment_referral_history_user_notes (
+    id UUID NOT NULL,
+    created_by_user_id UUID NOT NULL,
+    FOREIGN KEY (id) REFERENCES assessment_referral_history_notes(id),
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3044,7 +3044,7 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
-  /assessments/{assessmentId}/referralHistory/userNote:
+  /assessments/{assessmentId}/referral-history-notes:
     post:
       tags:
         - Assessment data

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3044,6 +3044,39 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /assessments/{assessmentId}/referralHistory/userNote:
+    post:
+      tags:
+        - Assessment data
+      summary: Adds a user-written note to an assessment
+      parameters:
+        - in: path
+          name: assessmentId
+          required: true
+          description: Id of the assessment
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: User note
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewReferralHistoryUserNote'
+        required: true
+      responses:
+        201:
+          description: successfully created a user-written note
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ReferralHistoryNote'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}/acceptance:
     post:
       tags:
@@ -5307,6 +5340,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClarificationNote'
+        referralHistoryNotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferralHistoryNote'
       discriminator:
         propertyName: service
         mapping:
@@ -5574,6 +5611,42 @@ components:
           type: string
       required:
         - query
+    ReferralHistoryNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        message:
+          type: string
+      required:
+        - id
+        - createdAt
+        - message
+      discriminator:
+        propertyName: type
+        mapping:
+          user: '#/components/schemas/ReferralHistoryUserNote'
+    ReferralHistoryUserNote:
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+        - type: object
+          properties:
+            createdByStaffMemberId:
+              type: string
+              format: uuid
+          required:
+            - createdByStaffMemberId
+    NewReferralHistoryUserNote:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
     NewReallocation:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
@@ -7,12 +7,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 
 class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessmentEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 
 class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessmentEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
@@ -33,6 +34,7 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
   private var allocatedToUser: Yielded<UserEntity>? = null
   private var rejectionRationale: Yielded<String?> = { null }
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
+  private var referralHistoryNotes: Yielded<MutableList<AssessmentReferralHistoryNoteEntity>> = { mutableListOf() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -82,6 +84,10 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
     this.clarificationNotes = { clarificationNotes }
   }
 
+  fun withReferralHistoryNotes(referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>) = apply {
+    this.referralHistoryNotes = { referralHistoryNotes }
+  }
+
   fun withRejectionRationale(rejectionRationale: String?) = apply {
     this.rejectionRationale = { rejectionRationale }
   }
@@ -101,5 +107,6 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
     reallocatedAt = this.reallocatedAt(),
     rejectionRationale = this.rejectionRationale(),
     clarificationNotes = this.clarificationNotes(),
+    referralHistoryNotes = this.referralHistoryNotes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistoryUserNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistoryUserNoteEntityFactory.kt
@@ -1,17 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
-
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import java.time.OffsetDateTime
-import java.util.*
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
 
-class AssessmentReferralHistoryUserNoteEntityFactory: Factory<AssessmentReferralHistoryUserNoteEntity> {
+class AssessmentReferralHistoryUserNoteEntityFactory : Factory<AssessmentReferralHistoryUserNoteEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var assessment: Yielded<AssessmentEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistoryUserNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistoryUserNoteEntityFactory.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import java.time.OffsetDateTime
+import java.util.*
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+class AssessmentReferralHistoryUserNoteEntityFactory: Factory<AssessmentReferralHistoryUserNoteEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var assessment: Yielded<AssessmentEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var message: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var createdBy: Yielded<UserEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAssessment(assessment: AssessmentEntity) = apply {
+    this.assessment = { assessment }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withMessage(message: String) = apply {
+    this.message = { message }
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  override fun produce(): AssessmentReferralHistoryUserNoteEntity = AssessmentReferralHistoryUserNoteEntity(
+    id = this.id(),
+    assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
+    createdAt = this.createdAt(),
+    message = this.message(),
+    createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 
 class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommodationAssessmentEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
@@ -33,6 +34,7 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
   private var allocatedToUser: Yielded<UserEntity?> = { null }
   private var rejectionRationale: Yielded<String?> = { null }
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
+  private var referralHistoryNotes: Yielded<MutableList<AssessmentReferralHistoryNoteEntity>> = { mutableListOf() }
   private var completedAt: Yielded<OffsetDateTime?> = { null }
 
   fun withId(id: UUID) = apply {
@@ -87,6 +89,10 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     this.clarificationNotes = { clarificationNotes }
   }
 
+  fun withReferralHistoryNotes(referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>) = apply {
+    this.referralHistoryNotes = { referralHistoryNotes }
+  }
+
   fun withRejectionRationale(rejectionRationale: String?) = apply {
     this.rejectionRationale = { rejectionRationale }
   }
@@ -110,6 +116,7 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     reallocatedAt = this.reallocatedAt(),
     rejectionRationale = this.rejectionRationale(),
     clarificationNotes = this.clarificationNotes(),
+    referralHistoryNotes = this.referralHistoryNotes(),
     completedAt = this.completedAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
@@ -6,13 +6,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 
 class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommodationAssessmentEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
@@ -41,7 +42,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
 
 class AssessmentTest : IntegrationTestBase() {
   @Autowired
@@ -1081,11 +1081,11 @@ class AssessmentTest : IntegrationTestBase() {
         }
 
         webTestClient.post()
-          .uri("/assessments/${assessment.id}/referralHistory/userNote")
+          .uri("/assessments/${assessment.id}/referral-history-notes")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             NewReferralHistoryUserNote(
-              message = "Some text"
+              message = "Some text",
             ),
           )
           .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -194,6 +194,9 @@ import java.nio.file.StandardOpenOption
 import java.time.Duration
 import java.util.TimeZone
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistoryUserNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentReferralHistoryUserNoteTestRepository
 
 object WiremockPortHolder {
   private val possiblePorts = 57830..57880
@@ -388,6 +391,9 @@ abstract class IntegrationTestBase {
   lateinit var assessmentClarificationNoteRepository: AssessmentClarificationNoteTestRepository
 
   @Autowired
+  lateinit var assessmentReferralUserNoteRepository: AssessmentReferralHistoryUserNoteTestRepository
+
+  @Autowired
   lateinit var characteristicRepository: CharacteristicRepository
 
   @Autowired
@@ -466,6 +472,7 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesAssessmentEntityFactory: PersistedFactory<ApprovedPremisesAssessmentEntity, UUID, ApprovedPremisesAssessmentEntityFactory>
   lateinit var temporaryAccommodationAssessmentEntityFactory: PersistedFactory<TemporaryAccommodationAssessmentEntity, UUID, TemporaryAccommodationAssessmentEntityFactory>
   lateinit var assessmentClarificationNoteEntityFactory: PersistedFactory<AssessmentClarificationNoteEntity, UUID, AssessmentClarificationNoteEntityFactory>
+  lateinit var assessmentReferralHistoryUserNoteEntityFactory: PersistedFactory<AssessmentReferralHistoryUserNoteEntity, UUID, AssessmentReferralHistoryUserNoteEntityFactory>
   lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
   lateinit var roomEntityFactory: PersistedFactory<RoomEntity, UUID, RoomEntityFactory>
   lateinit var bedEntityFactory: PersistedFactory<BedEntity, UUID, BedEntityFactory>
@@ -545,6 +552,7 @@ abstract class IntegrationTestBase {
     approvedPremisesAssessmentEntityFactory = PersistedFactory({ ApprovedPremisesAssessmentEntityFactory() }, approvedPremisesAssessmentRepository)
     temporaryAccommodationAssessmentEntityFactory = PersistedFactory({ TemporaryAccommodationAssessmentEntityFactory() }, temporaryAccommodationAssessmentRepository)
     assessmentClarificationNoteEntityFactory = PersistedFactory({ AssessmentClarificationNoteEntityFactory() }, assessmentClarificationNoteRepository)
+    assessmentReferralHistoryUserNoteEntityFactory = PersistedFactory({ AssessmentReferralHistoryUserNoteEntityFactory() }, assessmentReferralUserNoteRepository)
     characteristicEntityFactory = PersistedFactory({ CharacteristicEntityFactory() }, characteristicRepository)
     roomEntityFactory = PersistedFactory({ RoomEntityFactory() }, roomRepository)
     bedEntityFactory = PersistedFactory({ BedEntityFactory() }, bedRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistoryUserNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingNotMadeEntityFactory
@@ -85,6 +86,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
@@ -152,6 +154,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentClarificationNoteTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentReferralHistoryUserNoteTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingNotMadeTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
@@ -194,9 +197,6 @@ import java.nio.file.StandardOpenOption
 import java.time.Duration
 import java.util.TimeZone
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistoryUserNoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentReferralHistoryUserNoteTestRepository
 
 object WiremockPortHolder {
   private val possiblePorts = 57830..57880

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentReferralHistoryUserNoteTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentReferralHistoryUserNoteTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import java.util.*
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
+
+@Repository
+interface AssessmentReferralHistoryUserNoteTestRepository: JpaRepository<AssessmentReferralHistoryUserNoteEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentReferralHistoryUserNoteTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentReferralHistoryUserNoteTestRepository.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
-import java.util.*
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
+import java.util.UUID
 
 @Repository
-interface AssessmentReferralHistoryUserNoteTestRepository: JpaRepository<AssessmentReferralHistoryUserNoteEntity, UUID>
+interface AssessmentReferralHistoryUserNoteTestRepository : JpaRepository<AssessmentReferralHistoryUserNoteEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -66,6 +67,7 @@ class AssessmentServiceTest {
   private val userServiceMock = mockk<UserService>()
   private val assessmentRepositoryMock = mockk<AssessmentRepository>()
   private val assessmentClarificationNoteRepositoryMock = mockk<AssessmentClarificationNoteRepository>()
+  private val assessmentReferralHistoryNoteRepositoryMock = mockk<AssessmentReferralHistoryNoteRepository>()
   private val jsonSchemaServiceMock = mockk<JsonSchemaService>()
   private val domainEventServiceMock = mockk<DomainEventService>()
   private val offenderServiceMock = mockk<OffenderService>()
@@ -79,6 +81,7 @@ class AssessmentServiceTest {
     userServiceMock,
     assessmentRepositoryMock,
     assessmentClarificationNoteRepositoryMock,
+    assessmentReferralHistoryNoteRepositoryMock,
     jsonSchemaServiceMock,
     domainEventServiceMock,
     offenderServiceMock,
@@ -433,6 +436,27 @@ class AssessmentServiceTest {
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
     verify(exactly = 1) { assessmentClarificationNoteRepositoryMock.save(any()) }
+  }
+
+
+  @Test
+  fun `addReferralHistoryUserNote returns not found for non-existent Assessment`() {
+    val assessmentId = UUID.randomUUID()
+
+    val user = UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .produce()
+
+    every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns null
+    every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
+
+    val result = assessmentService.addAssessmentReferralHistoryUserNote(user, assessmentId, "referral history note")
+
+    assertThat(result is AuthorisableActionResult.NotFound).isTrue()
   }
 
   @Test
@@ -1872,6 +1896,7 @@ class AssessmentServiceTest {
     private val userServiceMock = mockk<UserService>()
     private val assessmentRepositoryMock = mockk<AssessmentRepository>()
     private val assessmentClarificationNoteRepositoryMock = mockk<AssessmentClarificationNoteRepository>()
+    private val assessmentReferralHistoryNoteRepositoryMock = mockk<AssessmentReferralHistoryNoteRepository>()
     private val jsonSchemaServiceMock = mockk<JsonSchemaService>()
     private val domainEventServiceMock = mockk<DomainEventService>()
     private val offenderServiceMock = mockk<OffenderService>()
@@ -1885,6 +1910,7 @@ class AssessmentServiceTest {
       userServiceMock,
       assessmentRepositoryMock,
       assessmentClarificationNoteRepositoryMock,
+      assessmentReferralHistoryNoteRepositoryMock,
       jsonSchemaServiceMock,
       domainEventServiceMock,
       offenderServiceMock,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -41,8 +41,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
@@ -437,7 +437,6 @@ class AssessmentServiceTest {
 
     verify(exactly = 1) { assessmentClarificationNoteRepositoryMock.save(any()) }
   }
-
 
   @Test
   fun `addReferralHistoryUserNote returns not found for non-existent Assessment`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
@@ -61,7 +62,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 
 class AcceptAssessmentTest {
   private val userServiceMock = mockk<UserService>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -61,11 +61,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 
 class AcceptAssessmentTest {
   private val userServiceMock = mockk<UserService>()
   private val assessmentRepositoryMock = mockk<AssessmentRepository>()
   private val assessmentClarificationNoteRepositoryMock = mockk<AssessmentClarificationNoteRepository>()
+  private val assessmentReferralHistoryNoteRepositoryMock = mockk<AssessmentReferralHistoryNoteRepository>()
   private val jsonSchemaServiceMock = mockk<JsonSchemaService>()
   private val domainEventServiceMock = mockk<DomainEventService>()
   private val offenderServiceMock = mockk<OffenderService>()
@@ -79,6 +81,7 @@ class AcceptAssessmentTest {
     userServiceMock,
     assessmentRepositoryMock,
     assessmentClarificationNoteRepositoryMock,
+    assessmentReferralHistoryNoteRepositoryMock,
     jsonSchemaServiceMock,
     domainEventServiceMock,
     offenderServiceMock,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -50,12 +50,16 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.stream.Stream
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as JpaAssessmentDecision
 
 class AssessmentTransformerTest {
   private val mockApplicationsTransformer = mockk<ApplicationsTransformer>()
   private val mockAssessmentClarificationNoteTransformer = mockk<AssessmentClarificationNoteTransformer>()
+  private val mockAssessmentReferralHistoryNoteTransformer = mockk<AssessmentReferralHistoryNoteTransformer>()
   private val mockUserTransformer = mockk<UserTransformer>()
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val risksTransformer = RisksTransformer()
@@ -78,6 +82,7 @@ class AssessmentTransformerTest {
     objectMapper,
     mockApplicationsTransformer,
     mockAssessmentClarificationNoteTransformer,
+    mockAssessmentReferralHistoryNoteTransformer,
     mockUserTransformer,
     mockPersonTransformer,
     risksTransformer,
@@ -138,6 +143,7 @@ class AssessmentTransformerTest {
       }
     }
     every { mockAssessmentClarificationNoteTransformer.transformJpaToApi(any()) } returns mockk()
+    every { mockAssessmentReferralHistoryNoteTransformer.transformJpaToApi(any()) } returns mockk()
     every { mockUserTransformer.transformJpaToApi(any(), ServiceName.approvedPremises) } returns approvedPremisesUser
     every { mockUserTransformer.transformJpaToApi(any(), ServiceName.temporaryAccommodation) } returns temporaryAccommodationUser
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -40,6 +40,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
@@ -50,9 +51,6 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.stream.Stream
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as JpaAssessmentDecision
 


### PR DESCRIPTION
> See [ticket #1321 on the CAS3 Trello board.](https://trello.com/c/iIjSVHfm/1321-human-notes-can-be-added-to-applications)

CAS1 originally had the idea of building a generic notes system that allowed for both human-written and system-generated notes to be associated with applications. This PR implements the human side of this system for use in both CAS1 and CAS3.

These notes will be collated together to show the history of a referral; as demonstrated below:
![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/136325256/fbd6cb02-7b08-4747-bfb2-a13a51229382)

The base-level note functionality, and the human side, is implemented here. [The system notes half of this functionality will be added in #1351.](https://trello.com/c/FTcVxbYl/1351-when-a-status-is-changed-a-system-note-is-created)