### PR TITLE
Allow filtering of Temporary Accommodation assessments by CRN

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -57,10 +57,14 @@ class AssessmentController(
     sortOrder: SortOrder?,
     sortField: AssessmentSortField?,
     statuses: List<AssessmentStatus>?,
+    crn: String?,
   ): ResponseEntity<List<AssessmentSummary>> {
     val user = userService.getUserForRequest()
 
-    val summaries = assessmentService.getVisibleAssessmentSummariesForUser(user, xServiceName)
+    val summaries = when {
+      xServiceName == ServiceName.temporaryAccommodation && crn != null -> assessmentService.getAssessmentSummariesByCrnForUser(user, crn, xServiceName)
+      else -> assessmentService.getVisibleAssessmentSummariesForUser(user, xServiceName)
+    }
 
     val sortOrder = when {
       xServiceName == ServiceName.temporaryAccommodation && sortOrder == null -> SortOrder.ascending

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -66,6 +66,11 @@ class AssessmentService(
     else -> listOf()
   }
 
+  fun getAssessmentSummariesByCrnForUser(user: UserEntity, crn: String, serviceName: ServiceName): List<DomainAssessmentSummary> = when (serviceName) {
+    ServiceName.temporaryAccommodation -> assessmentRepository.findTemporaryAccommodationAssessmentSummariesForRegionAndCrn(user.probationRegion.id, crn)
+    else -> throw RuntimeException("Only CAS3 assessments are currently supported")
+  }
+
   fun getAllReallocatable(): List<AssessmentEntity> {
     val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)
     val assessments = assessmentRepository.findAllByReallocatedAtNullAndSubmittedAtNullAndType(ApprovedPremisesAssessmentEntity::class.java)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2898,6 +2898,12 @@ paths:
             type: array
             items:
               $ref: "#/components/schemas/AssessmentStatus"
+        - name: crn
+          in: query
+          description: If provided, return only results for the given CRN
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: successfully retrieved assessments

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -325,6 +325,69 @@ class AssessmentTest : IntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `Get all assessments filters correctly when 'crn' query parameter is provided`() {
+    `Given a User` { user, jwt ->
+      `Given Some Offenders` { offenderSequence ->
+        val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+
+        val assessmentSchema = temporaryAccommodationAssessmentJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+          withAddedAt(OffsetDateTime.now())
+        }
+
+        val (offender, otherOffender) = offenderSequence.take(2).toList()
+
+        val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withCrn(offender.first.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withProbationRegion(user.probationRegion)
+        }
+
+        val otherApplication = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withCrn(otherOffender.first.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(applicationSchema)
+          withProbationRegion(user.probationRegion)
+        }
+
+        val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
+          withAllocatedToUser(user)
+          withApplication(application)
+          withAssessmentSchema(assessmentSchema)
+        }
+
+        assessment.schemaUpToDate = true
+
+        val otherAssessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
+          withAllocatedToUser(user)
+          withApplication(otherApplication)
+          withAssessmentSchema(assessmentSchema)
+        }
+
+        otherAssessment.schemaUpToDate = true
+
+        webTestClient.get()
+          .uri("/assessments?crn=${offender.first.otherIds.crn}")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offender.first, offender.second)),
+            ),
+            true,
+          )
+      }
+    }
+  }
+
   private fun toAssessmentSummaryEntity(assessment: AssessmentEntity): DomainAssessmentSummary =
     DomainAssessmentSummary(
       type = when (assessment.application) {


### PR DESCRIPTION
> See [ticket #1425 on the CAS3 Trello board](https://trello.com/c/swZZtC2L/1425-frontend-can-query-for-referrals-by-crn).

This PR introduces the `crn` query parameter for the `GET /assessments` endpoint, which allows users of the API to query for Temporary Accommodation assessments for a specific person.

This parameter has not been implemented for the other CAS services, so using it will have no effect unless the `X-Service-Name` header is set to `temporary-accommodation`.