### PR TITLE
Remove assessments for LAO from response for `GET /assessments` endpoint when user does not have LAO access

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/AuthorisableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/AuthorisableActionResult.kt
@@ -5,3 +5,5 @@ sealed interface AuthorisableActionResult<EntityType> {
   class Unauthorised<EntityType> : AuthorisableActionResult<EntityType>
   class NotFound<EntityType>(val entityType: String? = null, val id: String? = null) : AuthorisableActionResult<EntityType>
 }
+
+fun <T, U> AuthorisableActionResult.NotFound<T>.into(): AuthorisableActionResult.NotFound<U> = AuthorisableActionResult.NotFound(this.entityType, this.id)


### PR DESCRIPTION
> See [ticket #1452 on the CAS3 Trello board](https://trello.com/c/3Px0wqKJ/1452-filter-out-referrals-from-the-receive-table-when-the-current-user-doesnt-have-access-to-the-crn-lao).

This PR modifies the response from the `GET /assessments` endpoint to remove assessments for people who are identified as LAO when the user does not have LAO access.

Currently, if any assessment could be returned that requires LAO access, the API returns a 403 Forbidden response. In Temporary Accommodation, this has the effect that the user is signed out of the service. In this situation, no user can assess applications until someone with LAO access has processed the assessment. By filtering these assessments out instead, it allows users to continue with their work without leaking information that they are prohibited from accessing.