### PR TITLE
Remove `beforeExistingDepartureDate` check

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1252,10 +1252,6 @@ class BookingService(
       }
     }
 
-    if (booking.premises is ApprovedPremisesEntity && booking.departureDate.isAfter(newDepartureDate)) {
-      return "$.newDepartureDate" hasSingleValidationError "beforeExistingDepartureDate"
-    }
-
     if (booking.arrivalDate.isAfter(newDepartureDate)) {
       return "$.newDepartureDate" hasSingleValidationError "beforeBookingArrivalDate"
     }


### PR DESCRIPTION
We want to be able to create an “extension” regardless of if the new departure date is after the old departure date. This removes the checks and updates the tests for completeness.