### PR TITLE
Enable domain events for manual bookings

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -50,7 +50,6 @@ generic-service:
     URL-TEMPLATES_API_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     ARRIVED-DEPARTED-DOMAIN-EVENTS-DISABLED: true
-    MANUAL-BOOKINGS-DOMAIN-EVENTS-DISABLED: true
 
   namespace_secrets:
     hmpps-domain-events-topic:


### PR DESCRIPTION
When bookings are made by CRU managers, we want to be able to ensure this is reflected in Delius too, so we want to create a domain event.