### PR TITLE
Authorise user access to assessments in a service-aware way

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -45,6 +45,7 @@ import java.util.UUID
 @Service
 class AssessmentService(
   private val userService: UserService,
+  private val userAccessService: UserAccessService,
   private val assessmentRepository: AssessmentRepository,
   private val assessmentClarificationNoteRepository: AssessmentClarificationNoteRepository,
   private val assessmentReferralHistoryNoteRepository: AssessmentReferralHistoryNoteRepository,
@@ -92,11 +93,7 @@ class AssessmentService(
       else -> throw RuntimeException("Assessment type '${assessment::class.qualifiedName}' is not currently supported")
     }
 
-    // TODO: This should be delegated to a method in UserAccessService so that the check can be done in a service-aware way
-    //   to prevent (for example) a user with the `CAS1_WORKFLOW_MANAGER` role from being able to access other users'
-    //   assessments in CAS3.
-    //   See: https://trello.com/c/WKfi06nk
-    if (!user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS3_ASSESSOR) && assessment.allocatedToUser != user) {
+    if (!userAccessService.userCanViewAssessment(user, assessment)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1060,7 +1060,7 @@ class AssessmentTest : IntegrationTestBase() {
 
   @Test
   fun `Close assessment returns 200 OK, persists closure timestamp`() {
-    `Given a User` { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
           withPermissiveSchema()
@@ -1192,7 +1192,7 @@ class AssessmentTest : IntegrationTestBase() {
 
   @Test
   fun `Create referral history user note returns 200 with correct body`() {
-    `Given a User` { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
           withPermissiveSchema()


### PR DESCRIPTION
> See [ticket #1449 on the CAS3 Trello board](https://trello.com/c/WKfi06nk/1449-proper-fix-in-the-api-for-non-author-access-to-applicationsassessments).

We discovered a bug where Temporary Accommodation assessments that were not created by the current user were not able to be accessed, giving a 403 Forbidden response in the API. This was fixed in #877, but the fix was implemented very quickly due to time constraints. As a result, it's currently possible for a user with the `CAS1_WORKFLOW_MANAGER` role to access Temporary Accommodation assessments, and likewise with the `CAS3_ASSESSOR` role and Approved Premises assessments.

This PR updates the authorisation logic such that:
- For Approved Premises, the user can access the assessment if they have the `CAS1_WORKFLOW_MANAGER` role *or* if the assessment is allocated to that user.
- For Temporary Accommodation, the user can access the assessment if they have the `CAS3_ASSESSOR` role *and* the assessment is for an application within their probation region.

This prevents roles from the wrong service from incorrectly allowing access to assessments.