### PR TITLE
NN-5366: get adjudication data from AdjudicationsAPI instead of PrisonAPI 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/AdjudicationsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/AdjudicationsApiClient.kt
@@ -16,13 +16,7 @@ class AdjudicationsApiClient(
   @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
 ) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
 
-  fun getAdjudicationsPage(nomsNumber: String, offset: Int?, pageSize: Int) = getRequest<AdjudicationsPage> {
-    withHeader("Page-Limit", pageSize.toString())
-
-    if (offset != null) {
-      withHeader("Page-Offset", offset.toString())
-    }
-
-    path = "/adjudications/$nomsNumber/adjudications"
+  fun getAdjudicationsPage(nomsNumber: String, page: Int, pageSize: Int) = getRequest<AdjudicationsPage> {
+    path = "/adjudications/$nomsNumber/adjudications?page=$page&size=$pageSize"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/PrisonAdjudicationsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/PrisonAdjudicationsConfig.kt
@@ -10,5 +10,5 @@ class PrisonAdjudicationsConfigBindingModel {
 }
 
 data class PrisonAdjudicationsConfig(
-  val prisonApiPageSize: Int,
+  val adjudicationsApiPageSize: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/adjudications/AdjudicationsPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/adjudications/AdjudicationsPage.kt
@@ -3,8 +3,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications
 import java.time.LocalDateTime
 
 data class AdjudicationsPage(
-  val results: List<Adjudication>,
+  val results: Results,
   val agencies: List<Agency>,
+)
+
+data class Results(
+  val content: List<Adjudication>,
 )
 
 data class Adjudication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -21,6 +21,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Adjudication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Agency
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Conviction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
@@ -31,9 +34,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.Offen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskManagementPlan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Adjudication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Agency
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.Alert
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.CaseNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.CaseNotesPage

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AdjudicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AdjudicationTransformer.kt
@@ -7,7 +7,7 @@ import java.time.ZoneOffset
 
 @Component
 class AdjudicationTransformer {
-  fun transformToApi(adjudicationsPage: AdjudicationsPage) = adjudicationsPage.results.flatMap { result ->
+  fun transformToApi(adjudicationsPage: AdjudicationsPage): List<Adjudication> = adjudicationsPage.results.content.flatMap { result ->
     result.adjudicationCharges.map { charge ->
       Adjudication(
         id = result.adjudicationNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationsPageFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationsPageFactory.kt
@@ -2,17 +2,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Adjudication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsApiResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Agency
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Results
 
-class AdjudicationsApiFactory : Factory<AdjudicationsApiResponse> {
-  private var results: Yielded<Page<Adjudication>> = {
-    PageImpl(
-      listOf(
+class AdjudicationsPageFactory : Factory<AdjudicationsPage> {
+  private var results: Yielded<Results> = {
+    Results(
+      content = listOf(
         AdjudicationFactory().produce(),
       ),
     )
@@ -24,15 +22,19 @@ class AdjudicationsApiFactory : Factory<AdjudicationsApiResponse> {
     )
   }
 
-  fun withResults(results: Page<Adjudication>) = apply {
-    this.results = { results }
+  fun withResults(content: List<Adjudication>) = apply {
+    this.results = {
+      Results(
+        content = content,
+      )
+    }
   }
 
   fun withAgencies(agencies: List<Agency>) = apply {
     this.agencies = { agencies }
   }
 
-  override fun produce(): AdjudicationsApiResponse = AdjudicationsApiResponse(
+  override fun produce(): AdjudicationsPage = AdjudicationsPage(
     results = this.results(),
     agencies = this.agencies(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationsPageFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AdjudicationsPageFactory.kt
@@ -2,14 +2,19 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Adjudication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsApiResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Agency
 
-class AdjudicationsPageFactory : Factory<AdjudicationsPage> {
-  private var results: Yielded<List<Adjudication>> = {
-    listOf(
-      AdjudicationFactory().produce(),
+class AdjudicationsApiFactory : Factory<AdjudicationsApiResponse> {
+  private var results: Yielded<Page<Adjudication>> = {
+    PageImpl(
+      listOf(
+        AdjudicationFactory().produce(),
+      ),
     )
   }
 
@@ -19,7 +24,7 @@ class AdjudicationsPageFactory : Factory<AdjudicationsPage> {
     )
   }
 
-  fun withResults(results: List<Adjudication>) = apply {
+  fun withResults(results: Page<Adjudication>) = apply {
     this.results = { results }
   }
 
@@ -27,7 +32,7 @@ class AdjudicationsPageFactory : Factory<AdjudicationsPage> {
     this.agencies = { agencies }
   }
 
-  override fun produce(): AdjudicationsPage = AdjudicationsPage(
+  override fun produce(): AdjudicationsApiResponse = AdjudicationsApiResponse(
     results = this.results(),
     agencies = this.agencies(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -109,7 +109,7 @@ class PersonAdjudicationsTest : IntegrationTestBase() {
           )
           .produce()
 
-        AdjudicationsAPI_mockSuccessfulAdjudicationsCall(offenderDetails.otherIds.nomsNumber!!, adjudicationsResponse)
+        AdjudicationsAPI_mockSuccessfulAdjudicationsCall(offenderDetails.otherIds.nomsNumber!!, 0, 30, adjudicationsResponse)
 
         webTestClient.get()
           .uri("/people/${offenderDetails.otherIds.crn}/adjudications")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -7,8 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationsPag
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AgencyFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AdjudicationsAPI_mockSuccessfulAdjudicationsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AdjudicationTransformer
 
 class PersonAdjudicationsTest : IntegrationTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/AdjudicationsAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/AdjudicationsAPI.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
 
-fun IntegrationTestBase.AdjudicationsAPI_mockSuccessfulAdjudicationsCall(nomsNumber: String, response: AdjudicationsPage) =
+fun IntegrationTestBase.AdjudicationsAPI_mockSuccessfulAdjudicationsCall(nomsNumber: String, page: Int, pageSize: Int, response: AdjudicationsPage) =
   mockSuccessfulGetCallWithJsonResponse(
-    url = "/adjudications/$nomsNumber/adjudications",
+    url = "/adjudications/$nomsNumber/adjudications?page=$page&size=$pageSize",
     responseBody = response,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -548,10 +548,15 @@ class OffenderServiceTest {
     every {
       mockAdjudicationsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
+        page = 0,
         pageSize = 2,
-        offset = 0,
       )
-    } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.NOT_FOUND, null)
+    } returns ClientResult.Failure.StatusCode(
+      HttpMethod.GET,
+      "/api/offenders/$nomsNumber/adjudications",
+      HttpStatus.NOT_FOUND,
+      null,
+    )
 
     assertThat(offenderService.getAdjudicationsByNomsNumber(nomsNumber) is AuthorisableActionResult.NotFound).isTrue
   }
@@ -563,10 +568,15 @@ class OffenderServiceTest {
     every {
       mockAdjudicationsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
+        page = 0,
         pageSize = 2,
-        offset = 0,
       )
-    } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.FORBIDDEN, null)
+    } returns ClientResult.Failure.StatusCode(
+      HttpMethod.GET,
+      "/api/offenders/$nomsNumber/adjudications",
+      HttpStatus.FORBIDDEN,
+      null,
+    )
 
     assertThat(offenderService.getAdjudicationsByNomsNumber(nomsNumber) is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -606,8 +616,8 @@ class OffenderServiceTest {
     every {
       mockAdjudicationsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
+        page = 0,
         pageSize = 2,
-        offset = 0,
       )
     } returns ClientResult.Success(
       HttpStatus.OK,
@@ -617,8 +627,8 @@ class OffenderServiceTest {
     every {
       mockAdjudicationsApiClient.getAdjudicationsPage(
         nomsNumber = nomsNumber,
+        page = 1,
         pageSize = 2,
-        offset = 2,
       )
     } returns ClientResult.Success(
       HttpStatus.OK,
@@ -629,8 +639,8 @@ class OffenderServiceTest {
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     result as AuthorisableActionResult.Success
-    assertThat(result.entity.results).containsAll(
-      adjudicationsPageOne.results.plus(adjudicationsPageTwo.results),
+    assertThat(result.entity.results.content).containsAll(
+      adjudicationsPageOne.results.content.plus(adjudicationsPageTwo.results.content),
     )
     assertThat(result.entity.agencies).containsExactlyInAnyOrder(
       *adjudicationsPageOne.agencies.union(adjudicationsPageTwo.agencies).toTypedArray(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AdjudicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AdjudicationTransformerTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Adju
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationCharge
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Agency
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Results
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AdjudicationTransformer
 import java.time.Instant
 import java.time.LocalDateTime
@@ -37,21 +38,23 @@ class AdjudicationTransformerTest {
   }
 
   @Test
-  fun `transformToApi transforms chage with held hearing correctly`() {
+  fun `transformToApi transforms charge with held hearing correctly`() {
     val adjudicationsPage = AdjudicationsPage(
-      results = listOf(
-        Adjudication(
-          adjudicationNumber = 12345,
-          reportTime = LocalDateTime.parse("2022-10-28T15:15:15"),
-          agencyIncidentId = 78910,
-          agencyId = "PLACE",
-          partySeq = 1,
-          adjudicationCharges = listOf(
-            AdjudicationCharge(
-              oicChargeId = "CHARGE",
-              offenceCode = "OFFENCE",
-              offenceDescription = "Something, something",
-              findingCode = "QUASHED",
+      Results(
+        content = listOf(
+          Adjudication(
+            adjudicationNumber = 12345,
+            reportTime = LocalDateTime.parse("2022-10-28T15:15:15"),
+            agencyIncidentId = 78910,
+            agencyId = "PLACE",
+            partySeq = 1,
+            adjudicationCharges = listOf(
+              AdjudicationCharge(
+                oicChargeId = "CHARGE",
+                offenceCode = "OFFENCE",
+                offenceDescription = "Something, something",
+                findingCode = "QUASHED",
+              ),
             ),
           ),
         ),
@@ -81,21 +84,23 @@ class AdjudicationTransformerTest {
   }
 
   @Test
-  fun `transformToApi transforms chage without held hearing correctly`() {
+  fun `transformToApi transforms charge without held hearing correctly`() {
     val adjudicationsPage = AdjudicationsPage(
-      results = listOf(
-        Adjudication(
-          adjudicationNumber = 12345,
-          reportTime = LocalDateTime.parse("2022-10-28T15:15:15"),
-          agencyIncidentId = 78910,
-          agencyId = "PLACE",
-          partySeq = 1,
-          adjudicationCharges = listOf(
-            AdjudicationCharge(
-              oicChargeId = "CHARGE",
-              offenceCode = "OFFENCE",
-              offenceDescription = "Something, something",
-              findingCode = null,
+      Results(
+        content = listOf(
+          Adjudication(
+            adjudicationNumber = 12345,
+            reportTime = LocalDateTime.parse("2022-10-28T15:15:15"),
+            agencyIncidentId = 78910,
+            agencyId = "PLACE",
+            partySeq = 1,
+            adjudicationCharges = listOf(
+              AdjudicationCharge(
+                oicChargeId = "CHARGE",
+                offenceCode = "OFFENCE",
+                offenceDescription = "Something, something",
+                findingCode = null,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
With https://dsdmoj.atlassian.net/browse/NN-5366 and the epic https://dsdmoj.atlassian.net/browse/NN-5363 the Adjudications team are switching consumers of PrisonAPI `/adjudications` endpoints to source data from the AdjudicationsAPI instead