### PR TITLE
Run migration jobs async

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/MigrationJobController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/MigrationJobController.kt
@@ -12,7 +12,7 @@ class MigrationJobController(private val migrationJobService: MigrationJobServic
   override fun migrationJobPost(migrationJobRequest: MigrationJobRequest): ResponseEntity<Unit> {
     throwIfNotLoopbackRequest()
 
-    migrationJobService.runMigrationJob(migrationJobRequest.jobType)
+    migrationJobService.runMigrationJobAsync(migrationJobRequest.jobType)
 
     return ResponseEntity(HttpStatus.ACCEPTED)
   }


### PR DESCRIPTION
We should be running long-running jobs async, as running the `fetch_offender_names_for_applications` job in prod with lots of data is timing out.