### PR TITLE
Throw original exception if the response is 2xx

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -153,7 +153,11 @@ abstract class BaseHMPPSClient(
         writeToRedis(qualifiedKey, cacheEntry, body, cacheConfig.hardTtlSeconds.toLong())
       }
 
-      return ClientResult.Failure.StatusCode(method, requestBuilder.path ?: "", exception.statusCode, exception.responseBodyAsString, false)
+      if (!exception.statusCode.is2xxSuccessful) {
+        return ClientResult.Failure.StatusCode(method, requestBuilder.path ?: "", exception.statusCode, exception.responseBodyAsString, false)
+      } else {
+        throw exception
+      }
     } catch (exception: Exception) {
       return ClientResult.Failure.Other(method, requestBuilder.path ?: "", exception)
     }


### PR DESCRIPTION
We’re having an issue with some responses still not working, even though the upstream API returns successfully. This should help us diagnose what’s going on.