### PR TITLE
Increase memory size for Community API responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -13,12 +13,16 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 import java.time.Duration
 
 @Configuration
-class WebClientConfiguration(@Value("\${upstream-timeout-ms}") private val upstreamTimeoutMs: Long) {
+class WebClientConfiguration(
+  @Value("\${upstream-timeout-ms}") private val upstreamTimeoutMs: Long,
+  @Value("\${max-response-in-memory-size-bytes}") private val maxResponseInMemorySizeBytes: Int,
+) {
   @Bean
   fun authorizedClientManager(clients: ClientRegistrationRepository): OAuth2AuthorizedClientManager {
     val service: OAuth2AuthorizedClientService = InMemoryOAuth2AuthorizedClientService(clients)
@@ -76,6 +80,11 @@ class WebClientConfiguration(@Value("\${upstream-timeout-ms}") private val upstr
             .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
         ),
+      )
+      .exchangeStrategies(
+        ExchangeStrategies.builder().codecs {
+          it.defaultCodecs().maxInMemorySize(maxResponseInMemorySizeBytes)
+        }.build(),
       )
       .build()
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -198,3 +198,4 @@ arrived-departed-domain-events-disabled: true
 manual-bookings-domain-events-disabled: true
 
 upstream-timeout-ms: 10000
+max-response-in-memory-size-bytes: 51200


### PR DESCRIPTION
We are getting some absolutely huge responses (400k+) from Community API for some CRNs which is blowing out the default in-memory size that Spring expects (262144 bytes). This adds a config value to increase this limit to try and combat this. Going forward, we’ll want to optimise the response and there is an ongoing discussion with the integrations team about this, but upping the memory limit should hopefully fix the immediate problem.