### PR TITLE
Present bookings when person information is unavailable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -257,26 +257,21 @@ abstract class BaseHMPPSClient(
 sealed interface ClientResult<ResponseType> {
   class Success<ResponseType>(val status: HttpStatus, val body: ResponseType, val isPreemptivelyCachedResponse: Boolean = false) : ClientResult<ResponseType>
   sealed interface Failure<ResponseType> : ClientResult<ResponseType> {
-    fun throwException(): Nothing
+    fun throwException(): Nothing = throw toException()
+    fun toException(): Throwable
 
     class StatusCode<ResponseType>(val method: HttpMethod, val path: String, val status: HttpStatus, val body: String?, val isPreemptivelyCachedResponse: Boolean = false) : Failure<ResponseType> {
-      override fun throwException(): Nothing {
-        throw RuntimeException("Unable to complete $method request to $path: $status")
-      }
+      override fun toException(): Throwable = RuntimeException("Unable to complete $method request to $path: $status")
 
       inline fun <reified ResponseType> deserializeTo(): ResponseType = jacksonObjectMapper().readValue(body, ResponseType::class.java)
     }
 
     class PreemptiveCacheTimeout<ResponseType>(val cacheName: String, val cacheKey: String, val timeoutMs: Int) : Failure<ResponseType> {
-      override fun throwException(): Nothing {
-        throw RuntimeException("Timed out after ${timeoutMs}ms waiting for $cacheKey on pre-emptive cache $cacheName")
-      }
+      override fun toException(): Throwable = RuntimeException("Timed out after ${timeoutMs}ms waiting for $cacheKey on pre-emptive cache $cacheName")
     }
 
     class Other<ResponseType>(val method: HttpMethod, val path: String, val exception: Exception) : Failure<ResponseType> {
-      override fun throwException(): Nothing {
-        throw RuntimeException("Unable to complete $method request to $path", exception)
-      }
+      override fun toException(): Throwable = RuntimeException("Unable to complete $method request to $path", exception)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -56,6 +56,7 @@ class PeopleController(
 
     when (personInfo) {
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
+      is PersonInfoResult.Unknown -> throw personInfo.throwable ?: RuntimeException("Could not retrieve person info for CRN: $crn")
       is PersonInfoResult.Success -> return ResponseEntity.ok(
         personTransformer.transformModelToPersonApi(personInfo),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -269,8 +269,6 @@ class PremisesController(
       premises.bookings.map {
         val personInfo = offenderService.getInfoForPerson(it.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-        if (personInfo !is PersonInfoResult.Success) throw RuntimeException("Could not retrieve person info for CRN ${it.crn}")
-
         val staffMember = it.keyWorkerStaffCode?.let { keyWorkerStaffCode ->
           if (premises !is ApprovedPremisesEntity) throw RuntimeException("Booking ${it.id} has a Key Worker specified but Premises ${premises.id} is not an ApprovedPremises")
 
@@ -298,8 +296,6 @@ class PremisesController(
     }
 
     val personInfo = offenderService.getInfoForPerson(booking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
-
-    if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${booking.crn}")
 
     val staffMember = booking.keyWorkerStaffCode?.let { keyWorkerStaffCode ->
       val premises = booking.premises

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonInfoResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonInfoResult.kt
@@ -12,4 +12,5 @@ sealed interface PersonInfoResult {
   }
 
   data class NotFound(override val crn: String) : PersonInfoResult
+  data class Unknown(override val crn: String, val throwable: Throwable? = null) : PersonInfoResult
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -413,8 +413,14 @@ class OffenderService(
 
     val offender = when (offenderResponse) {
       is ClientResult.Success -> offenderResponse.body
-      is ClientResult.Failure.StatusCode -> if (offenderResponse.status == HttpStatus.NOT_FOUND) return PersonInfoResult.NotFound(crn) else offenderResponse.throwException()
-      is ClientResult.Failure -> offenderResponse.throwException()
+
+      is ClientResult.Failure.StatusCode -> if (offenderResponse.status == HttpStatus.NOT_FOUND) {
+        return PersonInfoResult.NotFound(crn)
+      } else {
+        return PersonInfoResult.Unknown(crn, offenderResponse.toException())
+      }
+
+      is ClientResult.Failure -> return PersonInfoResult.Unknown(crn, offenderResponse.toException())
     }
 
     if (!ignoreLao) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -27,7 +27,7 @@ class BookingTransformer(
   private val enumConverterFactory: EnumConverterFactory,
   private val workingDayCountService: WorkingDayCountService,
 ) {
-  fun transformJpaToApi(jpa: BookingEntity, personInfo: PersonInfoResult.Success, staffMember: StaffMember?): Booking {
+  fun transformJpaToApi(jpa: BookingEntity, personInfo: PersonInfoResult, staffMember: StaffMember?): Booking {
     val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
 
     return Booking(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -34,7 +34,7 @@ class PersonTransformer {
       type = PersonType.restrictedPerson,
       crn = personInfoResult.crn,
     )
-    is PersonInfoResult.NotFound -> UnknownPerson(
+    is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> UnknownPerson(
       type = PersonType.unknownPerson,
       crn = personInfoResult.crn,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -4,12 +4,13 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
 
 @Component
 class PersonTransformer {
-  fun transformModelToPersonApi(personInfoResult: PersonInfoResult.Success) = when (personInfoResult) {
+  fun transformModelToPersonApi(personInfoResult: PersonInfoResult) = when (personInfoResult) {
     is PersonInfoResult.Success.Full -> FullPerson(
       type = PersonType.fullPerson,
       crn = personInfoResult.offenderDetailSummary.otherIds.crn,
@@ -31,6 +32,10 @@ class PersonTransformer {
     )
     is PersonInfoResult.Success.Restricted -> RestrictedPerson(
       type = PersonType.restrictedPerson,
+      crn = personInfoResult.crn,
+    )
+    is PersonInfoResult.NotFound -> UnknownPerson(
+      type = PersonType.unknownPerson,
       crn = personInfoResult.crn,
     )
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4041,9 +4041,13 @@ components:
         mapping:
           FullPerson: '#/components/schemas/FullPerson'
           RestrictedPerson: '#/components/schemas/RestrictedPerson'
+          UnknownPerson: '#/components/schemas/FullPerson'
       required:
         - crn
         - type
+    UnknownPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
     RestrictedPerson:
       allOf:
         - $ref: '#/components/schemas/Person'
@@ -6901,6 +6905,7 @@ components:
       enum:
         - FullPerson
         - RestrictedPerson
+        - UnknownPerson
         - FullPersonInfo
         - RestrictedPersonInfo
     WithdrawalReason:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -96,6 +96,43 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get a booking returns OK with the correct body when person details for a booking could not be found`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+      }
+
+      val keyWorker = ContextStaffMemberFactory().produce()
+      APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
+
+      val booking = bookingEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withStaffKeyWorkerCode(keyWorker.code)
+        withCrn("SOME-CRN")
+        withServiceName(ServiceName.approvedPremises)
+      }
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/bookings/${booking.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            bookingTransformer.transformJpaToApi(
+              booking,
+              PersonInfoResult.NotFound("SOME-CRN"),
+              keyWorker,
+            ),
+          ),
+        )
+    }
+  }
+
+  @Test
   fun `Get a booking for an Approved Premises returns OK with the correct body when the NOMS number is null`() {
     `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
       `Given an Offender`(
@@ -334,6 +371,47 @@ class BookingTest : IntegrationTestBase() {
           .expectBody()
           .json(expectedJson)
       }
+    }
+  }
+
+  @Test
+  fun `Get all Bookings returns OK with correct body when person details for a booking could not be found`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val keyWorker = ContextStaffMemberFactory().produce()
+      APDeliusContext_mockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
+
+      val booking = bookingEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withStaffKeyWorkerCode(keyWorker.code)
+        withCrn("SOME-CRN")
+        withServiceName(ServiceName.approvedPremises)
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(
+        listOf(
+          bookingTransformer.transformJpaToApi(
+            booking,
+            PersonInfoResult.NotFound("SOME-CRN"),
+            keyWorker,
+          ),
+        ),
+      )
+
+      webTestClient.get()
+        .uri("/premises/${premises.id}/bookings")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -708,6 +708,20 @@ class OffenderServiceTest {
     }
 
     @Test
+    fun `returns Unknown if Community API responds with a 500`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/ABC123", HttpStatus.INTERNAL_SERVER_ERROR, null, true)
+
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+
+      assertThat(result is PersonInfoResult.Unknown).isTrue
+      result as PersonInfoResult.Unknown
+      assertThat(result.throwable).isNotNull()
+    }
+
+    @Test
     fun `returns Restricted for LAO Offender where user does not pass check and ignoreLao is false`() {
       val crn = "ABC123"
       val deliusUsername = "USER"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
@@ -29,6 +30,18 @@ class PersonTransformerTest {
     val result = personTransformer.transformModelToPersonApi(personInfoResult)
 
     assertThat(result is RestrictedPerson).isTrue
+    assertThat(result.crn).isEqualTo(crn)
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly for an unknown person info`() {
+    val crn = "CRN123"
+
+    val personInfoResult = PersonInfoResult.NotFound(crn)
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result is UnknownPerson).isTrue
     assertThat(result.crn).isEqualTo(crn)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -34,10 +34,22 @@ class PersonTransformerTest {
   }
 
   @Test
-  fun `transformModelToPersonInfoApi transforms correctly for an unknown person info`() {
+  fun `transformModelToPersonInfoApi transforms correctly for a not found person info`() {
     val crn = "CRN123"
 
     val personInfoResult = PersonInfoResult.NotFound(crn)
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result is UnknownPerson).isTrue
+    assertThat(result.crn).isEqualTo(crn)
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly for an unknown person info`() {
+    val crn = "CRN123"
+
+    val personInfoResult = PersonInfoResult.Unknown(crn)
 
     val result = personTransformer.transformModelToPersonApi(personInfoResult)
 


### PR DESCRIPTION
> See [ticket #1433 on the CAS3 Trello board](https://trello.com/c/vZ1cG8c0/1433-the-api-should-not-remove-a-booking-from-the-list-if-we-have-any-problem-fetching-data-spike).

This PR allows bookings to be returned by the `GET /premises/{premisesId}/bookings` and `GET /premises/{premisesId}/bookings/{bookingId}` endpoints when information about the person for whom the booking has been made is unavailable. It introduces a new `UnknownPerson` schema in the API specification, which allows consumers of the API to distinguish between a situation where the information is being intentionally withheld (represented by `RestrictedPerson`) and where the information is not currently available for some other reason (represented by `UnknownPerson`).

This PR depends on #804, and has the branch `309-replace-person-with-personinfo` set as the base to clarify the changes made for this PR. When that PR has been merged this will be updated to make `main` the base.