### PR TITLE
Make MANUAL_BOOKINGS_DOMAIN_EVENTS_DISABLED false

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -26,6 +26,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_EMIT-ENABLED: true
     HMPPS_SQS_USE_WEB_TOKEN: true
+    MANUAL_BOOKINGS_DOMAIN_EVENTS_DISABLED: false
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -35,6 +35,7 @@ generic-service:
     DOMAIN-EVENTS_EMIT-ENABLED: true
     NOTIFY_MODE: ENABLED
     HMPPS_SQS_USE_WEB_TOKEN: true
+    MANUAL_BOOKINGS_DOMAIN_EVENTS_DISABLED: false
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id


### PR DESCRIPTION
We originally tried to enable this in prod by removing the env var entirely, but this doesn’t seem to have had the intended effect, so I’m setting the value to `false` implicitly to see if that works.