### PR TITLE
Remove allocation check when making bookingNotMade

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -197,10 +197,6 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (placementRequest.allocatedToUser.id != user.id) {
-      return AuthorisableActionResult.Unauthorised()
-    }
-
     val bookingNotMade = BookingNotMadeEntity(
       id = UUID.randomUUID(),
       placementRequest = placementRequest,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -864,43 +864,13 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Create a Booking Not Made from a Placement Request that is not allocated to the user returns 403`() {
-      `Given a User` { user, jwt ->
+    fun `Create a Booking Not Made from a Placement Request returns 200`() {
+      `Given a User` { _, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             `Given an Application`(createdByUser = otherUser) {
               `Given a Placement Request`(
                 placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = otherUser,
-                crn = offenderDetails.otherIds.crn,
-              ) { placementRequest, _ ->
-                webTestClient.post()
-                  .uri("/placement-requests/${placementRequest.id}/booking-not-made")
-                  .header("Authorization", "Bearer $jwt")
-                  .bodyValue(
-                    NewBookingNotMade(
-                      notes = "some notes",
-                    ),
-                  )
-                  .exchange()
-                  .expectStatus()
-                  .isForbidden
-              }
-            }
-          }
-        }
-      }
-    }
-
-    @Test
-    fun `Create a Booking Not Made from a Placement Request returns 200`() {
-      `Given a User` { user, jwt ->
-        `Given a User` { otherUser, _ ->
-          `Given an Offender` { offenderDetails, inmateDetails ->
-            `Given an Application`(createdByUser = otherUser) {
-              `Given a Placement Request`(
-                placementRequestAllocatedTo = user,
                 assessmentAllocatedTo = otherUser,
                 createdByUser = otherUser,
                 crn = offenderDetails.otherIds.crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -364,6 +364,10 @@ class PlacementRequestServiceTest {
           .produce()
       }
 
+    val otherUser = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
     val application = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(assigneeUser)
       .produce()
@@ -382,7 +386,7 @@ class PlacementRequestServiceTest {
       )
       .withApplication(application)
       .withAssessment(assessment)
-      .withAllocatedToUser(assigneeUser)
+      .withAllocatedToUser(otherUser)
       .produce()
 
     val mockCancellations = mockk<List<CancellationEntity>>()
@@ -412,43 +416,6 @@ class PlacementRequestServiceTest {
 
     val result = placementRequestService.createBookingNotMade(requestingUser, placementRequestId, null)
     assertThat(result is AuthorisableActionResult.NotFound).isTrue
-  }
-
-  @Test
-  fun `createBookingNotMade returns Unauthorised when Placement Request isn't allocated to User`() {
-    val requestingUser = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val otherUser = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(otherUser)
-      .produce()
-
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(otherUser)
-      .produce()
-
-    val placementRequest = PlacementRequestEntityFactory()
-      .withPlacementRequirements(
-        PlacementRequirementsEntityFactory()
-          .withApplication(application)
-          .withAssessment(assessment)
-          .produce(),
-      )
-      .withAllocatedToUser(otherUser)
-      .withApplication(application)
-      .withAssessment(assessment)
-      .produce()
-
-    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
-
-    val result = placementRequestService.createBookingNotMade(requestingUser, placementRequest.id, null)
-    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
   }
 
   @Test


### PR DESCRIPTION
We don’t need to do this anymore, as anyone can mark a placement request as unable to match.