### PR TITLE
Attempt to fix offender name update task

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.Type
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -30,11 +30,13 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")
   fun <T : ApplicationEntity> findAllByCreatedByUser_Id(id: UUID, type: Class<T>): List<ApplicationEntity>
 
-  @Query("SELECT COUNT(*) FROM ApplicationEntity a WHERE TYPE(a) = :type")
-  fun <T : ApplicationEntity> findTotalCountForService(type: Class<T>): Int
-
-  @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type")
-  fun <T : ApplicationEntity> findAllForServiceByPage(pageable: Pageable?, type: Class<T>): Page<ApplicationEntity>
+  @Query(
+    "SELECT * FROM approved_premises_applications apa " +
+      "LEFT JOIN applications a ON a.id = apa.id " +
+      "WHERE apa.name IS NULL",
+    nativeQuery = true,
+  )
+  fun <T : ApplicationEntity> findAllForServiceAndNameNull(type: Class<T>, pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
 
   @Query(
     "SELECT a FROM ApplicationEntity a " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/FetchOffenderNamesForApplicationsFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/FetchOffenderNamesForApplicationsFromCommunityApiJob.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
 
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -16,39 +17,32 @@ class FetchOffenderNamesForApplicationsFromCommunityApiJob(
   override val shouldRunInTransaction = false
 
   override fun process() {
-    var offset = 0
-    val count = applicationRepository.findTotalCountForService(ApprovedPremisesApplicationEntity::class.java)
-    var pageable: PageRequest?
+    var hasNext = true
+    var slice: Slice<ApprovedPremisesApplicationEntity>
 
-    while (count > offset) {
-      pageable = PageRequest.of(offset, pageSize)
-      log.info("In while: $offset")
-      val response = applicationRepository.findAllForServiceByPage(pageable, ApprovedPremisesApplicationEntity::class.java)
-      response.content
-        .map { it as ApprovedPremisesApplicationEntity }
-        .forEach { application ->
-          if (application.name != null) return@forEach
+    while (hasNext) {
+      slice = applicationRepository.findAllForServiceAndNameNull(ApprovedPremisesApplicationEntity::class.java, PageRequest.of(0, pageSize))
+      slice.content.forEach { updateApplication(it) }
+      hasNext = slice.hasNext()
+    }
+  }
 
-          log.info("Fetching Offender name for Application: ${application.id}")
+  private fun updateApplication(application: ApprovedPremisesApplicationEntity) {
+    log.info("Fetching Offender name for Application: ${application.id}")
 
-          try {
-            val offenderDetailsResult = offenderService.getOffenderByCrn(application.crn, "", true)
+    try {
+      val offenderDetailsResult = offenderService.getOffenderByCrn(application.crn, "", true)
 
-            val offenderDetails = when (offenderDetailsResult) {
-              is AuthorisableActionResult.Success -> offenderDetailsResult.entity
-              is AuthorisableActionResult.NotFound -> throw RuntimeException("Could not find Offender")
-              is AuthorisableActionResult.Unauthorised -> throw RuntimeException("Unauthorised when trying to find Offender")
-            }
+      val offenderDetails = when (offenderDetailsResult) {
+        is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+        is AuthorisableActionResult.NotFound -> throw RuntimeException("Could not find Offender")
+        is AuthorisableActionResult.Unauthorised -> throw RuntimeException("Unauthorised when trying to find Offender")
+      }
 
-            application.name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}"
-            applicationRepository.save(application)
-          } catch (exception: Exception) {
-            log.error("Unable to update Offender name for Application: ${application.id}", exception)
-          }
-        }
-      Thread.sleep(500)
-      log.info("offset is: $offset")
-      offset += pageSize
+      application.name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}"
+      applicationRepository.save(application)
+    } catch (exception: Exception) {
+      log.error("Unable to update Offender name for Application: ${application.id}", exception)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/FetchOffenderNamesForApplicationsFromCommunityApiJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/FetchOffenderNamesForApplicationsFromCommunityApiJobTest.kt
@@ -2,44 +2,49 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given Some Offenders`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import java.util.*
 
 class FetchOffenderNamesForApplicationsFromCommunityApiJobTest : MigrationJobTestBase() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
   @Test
   fun `Any missing names are fetched from Community API with a 500ms artificial delay`() {
     `Given a User` { user, _ ->
-      `Given an Offender` { offenderDetailsOne, _ ->
-        `Given an Offender` { offenderDetailsTwo, _ ->
-          val schema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
-          val applicationOne = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      `Given Some Offenders` { offenderSequence ->
+        val offenders = offenderSequence.take(5).toList()
+        val schema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+
+        val applications = offenders.map { offenderDetails: Pair<OffenderDetailSummary, InmateDetail> ->
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
             withName(null)
-            withCrn(offenderDetailsOne.otherIds.crn)
+            withCrn(offenderDetails.first.otherIds.crn)
             withCreatedByUser(user)
             withApplicationSchema(schema)
           }
-
-          val applicationTwo = approvedPremisesApplicationEntityFactory.produceAndPersist {
-            withName(null)
-            withCrn(offenderDetailsTwo.otherIds.crn)
-            withCreatedByUser(user)
-            withApplicationSchema(schema)
-          }
-
-          val startTime = System.currentTimeMillis()
-          migrationJobService.runMigrationJob(MigrationJobType.fetchOffenderNamesForApplications, 1)
-          val endTime = System.currentTimeMillis()
-
-          assertThat(endTime - startTime).isGreaterThan(500 * 2)
-
-          val applicationOneAfterUpdate = approvedPremisesApplicationRepository.findByIdOrNull(applicationOne.id)!!
-          val applicationTwoAfterUpdate = approvedPremisesApplicationRepository.findByIdOrNull(applicationTwo.id)!!
-
-          assertThat(applicationOneAfterUpdate.name).isEqualTo("${offenderDetailsOne.firstName.uppercase()} ${offenderDetailsOne.surname.uppercase()}")
-          assertThat(applicationTwoAfterUpdate.name).isEqualTo("${offenderDetailsTwo.firstName.uppercase()} ${offenderDetailsTwo.surname.uppercase()}")
         }
+
+        val applicationWithName = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withName("Some Name")
+          withCreatedByUser(user)
+          withApplicationSchema(schema)
+        }
+
+        migrationJobService.runMigrationJob(MigrationJobType.fetchOffenderNamesForApplications, 1)
+
+        applications.forEachIndexed { index, application ->
+          val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)!!
+          assertThat(updatedApplication.name).isEqualTo("${offenders[index].first.firstName.uppercase()} ${offenders[index].first.surname.uppercase()}")
+        }
+
+        val reloadedApplicationWithName = approvedPremisesApplicationRepository.findByIdOrNull(applicationWithName.id)!!
+        assertThat(reloadedApplicationWithName.name).isEqualTo("Some Name")
       }
     }
   }


### PR DESCRIPTION
This seems to work in every environment except from prod. My assumption is that it’s because there’s more data in prod, and some applications have already been updated with names, so something’s getting out of whack. 

With this in mind I’ve updated the task to only fetch applications with Null names. While testing, this seemed to effect pagination too, so I’ve updated the pagination query to return a `Slice` (https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Slice.html) which only knows if there is a nextPage. 

After much wailing and gnashing of teeth, we realised that we only need to get the first page of results each time, as when we update the results, this does not update the  counter, leading every other page to get skipped.