### PR TITLE
Update OpenApi spec to allow human notes to pull user information from the API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
@@ -13,7 +13,7 @@ class AssessmentReferralHistoryNoteTransformer {
       id = jpa.id,
       createdAt = jpa.createdAt.toInstant(),
       message = jpa.message,
-      createdByStaffMemberId = jpa.createdByUser.id,
+      createdByUserName = jpa.createdByUser.name,
     )
     else -> throw RuntimeException("Unsupported ReferralHistoryNote type: ${jpa::class.qualifiedName}")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -31,6 +31,10 @@ class UserTransformer(
     )
     ServiceName.temporaryAccommodation -> TemporaryAccommodationUser(
       id = jpa.id,
+      deliusUsername = jpa.deliusUsername,
+      email = jpa.email,
+      name = jpa.name,
+      telephoneNumber = jpa.telephoneNumber,
       roles = jpa.roles.mapNotNull(::transformTemporaryAccommodationRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       service = ServiceName.temporaryAccommodation.value,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5645,11 +5645,10 @@ components:
         - $ref: '#/components/schemas/ReferralHistoryNote'
         - type: object
           properties:
-            createdByStaffMemberId:
+            createdByUserName:
               type: string
-              format: uuid
           required:
-            - createdByStaffMemberId
+            - createdByUserName
     NewReferralHistoryUserNote:
       type: object
       properties:
@@ -5681,6 +5680,14 @@ components:
         id:
           type: string
           format: uuid
+        name:
+          type: string
+        deliusUsername:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
         region:
           $ref: '#/components/schemas/ProbationRegion'
       discriminator:
@@ -5691,20 +5698,14 @@ components:
       required:
         - service
         - id
+        - name
+        - deliusUsername
         - region
     ApprovedPremisesUser:
       allOf:
         - $ref: '#/components/schemas/User'
         - type: object
           properties:
-            name:
-              type: string
-            deliusUsername:
-              type: string
-            email:
-              type: string
-            telephoneNumber:
-              type: string
             qualifications:
               type: array
               items:
@@ -5714,8 +5715,6 @@ components:
               items:
                 $ref: '#/components/schemas/ApprovedPremisesUserRole'
           required:
-            - name
-            - deliusUsername
             - qualifications
             - roles
     TemporaryAccommodationUser:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -148,6 +148,10 @@ class ProfileTest : IntegrationTestBase() {
           TemporaryAccommodationUser(
             id = id,
             region = ProbationRegion(region.id, region.name),
+            deliusUsername = deliusUsername,
+            email = email,
+            name = userEntity.name,
+            telephoneNumber = telephoneNumber,
             roles = listOf(TemporaryAccommodationUserRole.assessor),
             service = ServiceName.temporaryAccommodation.value,
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -215,6 +215,10 @@ class UsersTest : IntegrationTestBase() {
           TemporaryAccommodationUser(
             id = id,
             region = ProbationRegion(region.id, region.name),
+            deliusUsername = deliusUsername,
+            name = name,
+            email = email,
+            telephoneNumber = telephoneNumber,
             roles = emptyList(),
             service = ServiceName.temporaryAccommodation.value,
           ),


### PR DESCRIPTION
Following on from a conversation with Bryan regarding how human notes (`ReferralHistoryUserNote`s) currently hold information about the user who has written them, we discovered that the intended methodology for acquiring and showing the name of the submitting user was done in a roundabout way:
- `AssessmentReferralHistoryUserNoteEntity` contains the full `UserEntity` object, called `createdByUser`.
- When transformed from JPA to API, the resulting `ReferralHistoryUserNote` only contained a `UUID` object called `createdByStaffMemberId` - this matches the approach taken for the work on Clarification Notes.
- Therefore, when attempting to display notes, the UI would need to assemble a list of staff member IDs, then make a call to `/profile/${id}` for each id, returning a `TemporaryAccommodationUser` with the name data in it.

Thus, to avoid unnecessary extra calls to the API, and since all the user information is already accessible, the following actions have been taken:

1. Update the OpenApi specification to move the following user details from subclass `ApprovedPremisesUser` to `User`:
- `name`
- `deliusUsername`
- `email`
- `telephoneNumber`

2. Update the OpenApi specification to change `ReferralHistoryUserNote`, removing `createdByStaffMemberId` and replacing it with a `String` called `createdByUserName`. Making this change allows `AssessmentReferralHistoryUserNoteEntity` access to `UserEntity.name` when transforming from JPA to `ReferralHistoryUserNote`, thus solving the above problem.

The various tests surrounding this change have been updated, namely adding these four moved fields to base-class factory and transformer calls.