### PR TITLE
Revert "Revert "Merge pull request #804 from ministryofjustice/309-replace-pe…"

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -52,6 +52,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromNestedAuthorisableValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getFullInfoForPersonOrThrow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getInfoForPersonOrThrow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getInfoForPersonOrThrowInternalServerError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromOffenderDetailSummaryResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
 import java.net.URI
@@ -76,34 +79,33 @@ class ApplicationsController(
   override fun applicationsGet(xServiceName: ServiceName?): ResponseEntity<List<ApplicationSummary>> {
     val serviceName = xServiceName ?: ServiceName.approvedPremises
 
-    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
-    val username = deliusPrincipal.name
-    val applications = applicationService.getAllApplicationsForUsername(username, serviceName)
+    val user = userService.getUserForRequest()
 
-    return ResponseEntity.ok(applications.map(::getPersonDetailAndTransformToSummary))
+    val applications = applicationService.getAllApplicationsForUsername(user.deliusUsername, serviceName)
+
+    return ResponseEntity.ok(applications.map { getPersonDetailAndTransformToSummary(it, user) })
   }
 
   override fun applicationsApplicationIdGet(applicationId: UUID): ResponseEntity<Application> {
-    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
-    val username = deliusPrincipal.name
+    val user = userService.getUserForRequest()
 
-    val application = when (val applicationResult = applicationService.getApplicationForUsername(applicationId, username)) {
+    val application = when (val applicationResult = applicationService.getApplicationForUsername(applicationId, user.deliusUsername)) {
       is AuthorisableActionResult.NotFound -> null
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> applicationResult.entity
     }
 
     if (application != null) {
-      return ResponseEntity.ok(getPersonDetailAndTransform(application))
+      return ResponseEntity.ok(getPersonDetailAndTransform(application, user))
     }
 
-    val offlineApplication = when (val offlineApplicationResult = applicationService.getOfflineApplicationForUsername(applicationId, username)) {
+    val offlineApplication = when (val offlineApplicationResult = applicationService.getOfflineApplicationForUsername(applicationId, user.deliusUsername)) {
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
       is AuthorisableActionResult.Success -> offlineApplicationResult.entity
     }
 
-    return ResponseEntity.ok(getPersonDetailAndTransform(offlineApplication))
+    return ResponseEntity.ok(getPersonDetailAndTransform(offlineApplication, user))
   }
 
   @Transactional
@@ -111,10 +113,10 @@ class ApplicationsController(
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val user = userService.getUserForRequest()
 
-    val (offender, inmate) = getPersonDetail(body.crn, true)
+    val personInfo = offenderService.getFullInfoForPersonOrThrow(body.crn, user)
 
     val applicationResult = when (xServiceName ?: ServiceName.approvedPremises) {
-      ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(offender, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
+      ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(personInfo.offenderDetailSummary, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
       ServiceName.cas2 -> applicationService.createCas2Application(body.crn, user, deliusPrincipal.token.tokenValue)
       ServiceName.temporaryAccommodation -> {
         when (val actionResult = applicationService.createTemporaryAccommodationApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)) {
@@ -134,13 +136,12 @@ class ApplicationsController(
 
     return ResponseEntity
       .created(URI.create("/applications/${application.id}"))
-      .body(applicationsTransformer.transformJpaToApi(application, offender, inmate))
+      .body(applicationsTransformer.transformJpaToApi(application, personInfo))
   }
 
   @Transactional
   override fun applicationsApplicationIdPut(applicationId: UUID, body: UpdateApplication): ResponseEntity<Application> {
-    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
-    val username = deliusPrincipal.name
+    val user = userService.getUserForRequest()
 
     val serializedData = objectMapper.writeValueAsString(body.data)
 
@@ -155,14 +156,14 @@ class ApplicationsController(
         releaseType = body.releaseType?.name,
         arrivalDate = body.arrivalDate,
         isInapplicable = body.isInapplicable,
-        username = username,
+        username = user.deliusUsername,
       )
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = serializedData,
-        username = username,
+        username = user.deliusUsername,
       )
-      is UpdateCas2Application -> applicationService.updateCas2Application(applicationId = applicationId, data = serializedData, username = username)
+      is UpdateCas2Application -> applicationService.updateCas2Application(applicationId = applicationId, data = serializedData, username = user.deliusUsername)
       else -> throw RuntimeException("Unsupported UpdateApplication type: ${body::class.qualifiedName}")
     }
 
@@ -179,7 +180,7 @@ class ApplicationsController(
       is ValidatableActionResult.Success -> validationResult.entity
     }
 
-    return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication))
+    return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication, user))
   }
 
   override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID, body: NewWithdrawal): ResponseEntity<Unit> {
@@ -261,8 +262,9 @@ class ApplicationsController(
       is AuthorisableActionResult.Success -> applicationResult.entity
     }
 
-    val (offender, inmate) = getPersonDetail(assessment.application.crn)
-    return ResponseEntity.ok(assessmentTransformer.transformJpaToApi(assessment, offender, inmate))
+    val personInfo = offenderService.getFullInfoForPersonOrThrow(assessment.application.crn, user)
+
+    return ResponseEntity.ok(assessmentTransformer.transformJpaToApi(assessment, personInfo))
   }
 
   private fun getPersonDetail(crn: String, forceFullLaoCheck: Boolean = false): Pair<OffenderDetailSummary, InmateDetail?> {
@@ -274,7 +276,7 @@ class ApplicationsController(
       user.hasQualification(UserQualification.LAO)
     }
 
-    return getPersonDetailsForCrn(log, crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
+    return getPersonDetailsForCrn(log, crn, user.deliusUsername, offenderService, ignoreLao)
       ?: throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
   }
 
@@ -305,21 +307,21 @@ class ApplicationsController(
     )
   }
 
-  private fun getPersonDetailAndTransform(application: ApplicationEntity): Application {
-    val (offender, inmate) = getPersonDetail(application.crn)
+  private fun getPersonDetailAndTransform(application: ApplicationEntity, user: UserEntity): Application {
+    val personInfo = offenderService.getFullInfoForPersonOrThrow(application.crn, user)
 
-    return applicationsTransformer.transformJpaToApi(application, offender, inmate)
+    return applicationsTransformer.transformJpaToApi(application, personInfo)
   }
 
-  private fun getPersonDetailAndTransformToSummary(application: uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary): ApplicationSummary {
-    val (offender, inmate) = getPersonDetail(application.getCrn())
+  private fun getPersonDetailAndTransformToSummary(application: uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary, user: UserEntity): ApplicationSummary {
+    val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn(), user)
 
-    return applicationsTransformer.transformDomainToApiSummary(application, offender, inmate)
+    return applicationsTransformer.transformDomainToApiSummary(application, personInfo)
   }
 
-  private fun getPersonDetailAndTransform(offlineApplication: OfflineApplicationEntity): Application {
-    val (offender, inmate) = getPersonDetail(offlineApplication.crn)
+  private fun getPersonDetailAndTransform(offlineApplication: OfflineApplicationEntity, user: UserEntity): Application {
+    val personInfo = offenderService.getInfoForPersonOrThrow(offlineApplication.crn, user)
 
-    return applicationsTransformer.transformJpaToApi(offlineApplication, offender, inmate)
+    return applicationsTransformer.transformJpaToApi(offlineApplication, personInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
@@ -34,8 +33,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapAndTransformAssessmentSummaries
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.filterByStatuses
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getFullInfoForPersonOrThrow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getInfoForPersonOrThrow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.sort
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -77,17 +78,15 @@ class AssessmentController(
     }
 
     return ResponseEntity.ok(
-      mapAndTransformAssessmentSummaries(
-        log,
-        summaries,
-        user.deliusUsername,
-        offenderService,
-        assessmentTransformer::transformDomainToApiSummary,
-        user.hasQualification(UserQualification.LAO),
-        sortOrder,
-        sortField,
-        statuses,
-      ),
+      summaries.map {
+        val personInfo = offenderService.getInfoForPersonOrThrow(it.crn, user)
+
+        assessmentTransformer.transformDomainToApiSummary(
+          it,
+          personInfo,
+        )
+      }.sort(sortOrder, sortField)
+        .filterByStatuses(statuses),
     )
   }
 
@@ -101,12 +100,10 @@ class AssessmentController(
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
     }
 
-    val applicationCrn = assessment.application.crn
-
-    val (offenderDetails, inmateDetails) = getPersonDetailsForCrn(log, applicationCrn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO)) ?: throw InternalServerErrorProblem("Unable to get Person via crn: $applicationCrn")
+    val personInfo = offenderService.getFullInfoForPersonOrThrow(assessment.application.crn, user)
 
     return ResponseEntity.ok(
-      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+      assessmentTransformer.transformJpaToApi(assessment, personInfo),
     )
   }
 
@@ -130,12 +127,10 @@ class AssessmentController(
       is ValidatableActionResult.Success -> assessmentValidationResult.entity
     }
 
-    val applicationCrn = assessment.application.crn
-
-    val (offenderDetails, inmateDetails) = getPersonDetailsForCrn(log, applicationCrn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO)) ?: throw InternalServerErrorProblem("Unable to get Person via crn: $applicationCrn")
+    val personInfo = offenderService.getInfoForPersonOrThrow(assessment.application.crn, user)
 
     return ResponseEntity.ok(
-      assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+      assessmentTransformer.transformJpaToApi(assessment, personInfo),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -15,6 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonAcctAlert
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PrisonCaseNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -30,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PrisonCaseNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
 
 @Service
 class PeopleController(
@@ -51,14 +52,14 @@ class PeopleController(
   override fun peopleSearchGet(crn: String): ResponseEntity<Person> {
     val user = userService.getUserForRequest()
 
-    val personDetails = getPersonDetailsForCrn(log, crn, user.deliusUsername, offenderService, true)
-      ?: throw NotFoundProblem(crn, "Person")
+    val personInfo = offenderService.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-    val (offenderDetails, inmateDetail) = personDetails
-
-    return ResponseEntity.ok(
-      personTransformer.transformModelToApi(offenderDetails, inmateDetail),
-    )
+    when (personInfo) {
+      is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
+      is PersonInfoResult.Success -> return ResponseEntity.ok(
+        personTransformer.transformModelToPersonApi(personInfo),
+      )
+    }
   }
 
   override fun peopleCrnRisksGet(crn: String): ResponseEntity<PersonRisks> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -19,9 +19,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -34,7 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NewPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getInfoForPersonOrThrow
 import java.time.LocalDate
 import java.util.UUID
 
@@ -57,7 +59,11 @@ class PlacementRequestsController(
     val requests = placementRequestService.getVisiblePlacementRequestsForUser(user)
 
     return ResponseEntity.ok(
-      mapPersonDetailOntoPlacementRequests(requests, user),
+      requests.map {
+        val personInfo = offenderService.getInfoForPersonOrThrow(it.application.crn, user)
+
+        placementRequestTransformer.transformJpaToApi(it, personInfo)
+      },
     )
   }
 
@@ -88,11 +94,10 @@ class PlacementRequestsController(
       is AuthorisableActionResult.Success -> authorisationResult.entity
     }
 
-    val (offenderDetail, inmateDetail) = getPersonDetailsForCrn(log, placementRequest.application.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
-      ?: throw NotFoundProblem(placementRequest.application.crn, "Offender")
+    val personInfo = offenderService.getInfoForPersonOrThrow(placementRequest.application.crn, user)
 
     return ResponseEntity.ok(
-      placementRequestDetailTransformer.transformJpaToApi(placementRequest, offenderDetail, inmateDetail, cancellations),
+      placementRequestDetailTransformer.transformJpaToApi(placementRequest, personInfo, cancellations),
     )
   }
 
@@ -154,13 +159,11 @@ class PlacementRequestsController(
 
   private fun mapPersonDetailOntoPlacementRequests(placementRequests: List<PlacementRequestEntity>, user: UserEntity): List<PlacementRequest> {
     return placementRequests.mapNotNull {
-      val personDetail = getPersonDetailsForCrn(log, it.application.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
+      val personInfo = offenderService.getInfoForPerson(it.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-      if (personDetail === null) {
-        return@mapNotNull null
-      }
+      if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${it.application.crn}")
 
-      placementRequestTransformer.transformJpaToApi(it, personDetail.first, personDetail.second)
+      placementRequestTransformer.transformJpaToApi(it, personInfo)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -50,6 +50,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
@@ -89,7 +90,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -266,18 +266,12 @@ class PremisesController(
     }
 
     return ResponseEntity.ok(
-      premises.bookings.mapNotNull {
-        val personDetails = getPersonDetailsForCrn(log, it.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
+      premises.bookings.map {
+        val personInfo = offenderService.getInfoForPerson(it.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-        if (personDetails == null) {
-          log.warn("Unable to get Person via crn: ${it.crn}")
-          return@mapNotNull null
-        }
-
-        val (offenderDetails, inmateDetails) = personDetails
+        if (personInfo !is PersonInfoResult.Success) throw RuntimeException("Could not retrieve person info for CRN ${it.crn}")
 
         val staffMember = it.keyWorkerStaffCode?.let { keyWorkerStaffCode ->
-          // TODO: Bookings will need to be specialised in a similar way to Premises so that TA Bookings do not have a keyWorkerStaffCode field
           if (premises !is ApprovedPremisesEntity) throw RuntimeException("Booking ${it.id} has a Key Worker specified but Premises ${premises.id} is not an ApprovedPremises")
 
           val staffMemberResult = staffMemberService.getStaffMemberByCode(keyWorkerStaffCode, premises.qCode)
@@ -289,7 +283,7 @@ class PremisesController(
           staffMemberResult.entity
         }
 
-        bookingTransformer.transformJpaToApi(it, offenderDetails, inmateDetails, staffMember)
+        bookingTransformer.transformJpaToApi(it, personInfo, staffMember)
       },
     )
   }
@@ -303,10 +297,9 @@ class PremisesController(
       throw ForbiddenProblem()
     }
 
-    val personDetails = getPersonDetailsForCrn(log, booking.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
-      ?: throw InternalServerErrorProblem("Unable to get Person via crn: ${booking.crn}")
+    val personInfo = offenderService.getInfoForPerson(booking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-    val (offenderDetails, inmateDetails) = personDetails
+    if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${booking.crn}")
 
     val staffMember = booking.keyWorkerStaffCode?.let { keyWorkerStaffCode ->
       val premises = booking.premises
@@ -323,7 +316,7 @@ class PremisesController(
       staffMemberResult.entity
     }
 
-    return ResponseEntity.ok(bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, staffMember))
+    return ResponseEntity.ok(bookingTransformer.transformJpaToApi(booking, personInfo, staffMember))
   }
 
   @Transactional
@@ -337,17 +330,19 @@ class PremisesController(
       throw ForbiddenProblem()
     }
 
-    val personDetails = getPersonDetailsForCrn(log, body.crn, user.deliusUsername, offenderService, user.hasQualification(UserQualification.LAO))
-      ?: throw InternalServerErrorProblem("Unable to get Person via crn: ${body.crn}")
+    val personInfo = offenderService.getInfoForPerson(body.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-    val (offenderDetails, inmateDetails) = personDetails
+    if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${body.crn}")
 
     val authorisableResult = when (premises) {
       is ApprovedPremisesEntity -> {
         bookingService.createApprovedPremisesAdHocBooking(
           user = user,
           crn = body.crn,
-          nomsNumber = inmateDetails?.offenderNo,
+          nomsNumber = when (personInfo) {
+            is PersonInfoResult.Success.Restricted -> personInfo.nomsNumber
+            is PersonInfoResult.Success.Full -> personInfo.inmateDetail?.offenderNo
+          },
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
           bedId = body.bedId,
@@ -359,7 +354,10 @@ class PremisesController(
           user = user,
           premises = premises,
           crn = body.crn,
-          nomsNumber = inmateDetails?.offenderNo,
+          nomsNumber = when (personInfo) {
+            is PersonInfoResult.Success.Restricted -> personInfo.nomsNumber
+            is PersonInfoResult.Success.Full -> personInfo.inmateDetail?.offenderNo
+          },
           arrivalDate = body.arrivalDate,
           departureDate = body.departureDate,
           bedId = body.bedId,
@@ -384,7 +382,7 @@ class PremisesController(
       is ValidatableActionResult.Success -> validatableResult.entity
     }
 
-    return ResponseEntity.ok(bookingTransformer.transformJpaToApi(createdBooking, offenderDetails, inmateDetails, null))
+    return ResponseEntity.ok(bookingTransformer.transformJpaToApi(createdBooking, personInfo, null))
   }
 
   override fun premisesPremisesIdBookingsBookingIdArrivalsPost(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonInfoResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonInfoResult.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+
+sealed interface PersonInfoResult {
+  val crn: String
+
+  sealed interface Success : PersonInfoResult {
+    data class Full(override val crn: String, val offenderDetailSummary: OffenderDetailSummary, val inmateDetail: InmateDetail?) : Success
+    data class Restricted(override val crn: String, val nomsNumber: String?) : Success
+  }
+
+  data class NotFound(override val crn: String) : PersonInfoResult
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonAdjudicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonCaseNotesConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonCaseNotesConfigBindingModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -402,6 +403,59 @@ class OffenderService(
   }
 
   fun getDocument(crn: String, documentId: String, outputStream: OutputStream) = communityApiClient.getDocument(crn, documentId, outputStream)
+
+  fun getInfoForPerson(crn: String, deliusUsername: String, ignoreLao: Boolean): PersonInfoResult {
+    var offenderResponse = communityApiClient.getOffenderDetailSummaryWithWait(crn)
+
+    if (offenderResponse is ClientResult.Failure.PreemptiveCacheTimeout) {
+      offenderResponse = communityApiClient.getOffenderDetailSummaryWithCall(crn)
+    }
+
+    val offender = when (offenderResponse) {
+      is ClientResult.Success -> offenderResponse.body
+      is ClientResult.Failure.StatusCode -> if (offenderResponse.status == HttpStatus.NOT_FOUND) return PersonInfoResult.NotFound(crn) else offenderResponse.throwException()
+      is ClientResult.Failure -> offenderResponse.throwException()
+    }
+
+    if (!ignoreLao) {
+      if (offender.currentExclusion || offender.currentRestriction) {
+        val access =
+          when (val accessResponse = communityApiClient.getUserAccessForOffenderCrn(deliusUsername, crn)) {
+            is ClientResult.Success -> accessResponse.body
+            is ClientResult.Failure.StatusCode -> {
+              if (accessResponse.status == HttpStatus.FORBIDDEN) {
+                try {
+                  accessResponse.deserializeTo<UserOffenderAccess>()
+                  return PersonInfoResult.Success.Restricted(crn, offender.otherIds.nomsNumber)
+                } catch (exception: Exception) {
+                  accessResponse.throwException()
+                }
+              }
+
+              accessResponse.throwException()
+            }
+            is ClientResult.Failure -> accessResponse.throwException()
+          }
+
+        if (access.userExcluded || access.userRestricted) {
+          return PersonInfoResult.Success.Restricted(crn, offender.otherIds.nomsNumber)
+        }
+      }
+    }
+
+    val inmateDetails = offender.otherIds.nomsNumber?.let { nomsNumber ->
+      when (val inmateDetailsResult = getInmateDetailByNomsNumber(offender.otherIds.crn, nomsNumber)) {
+        is AuthorisableActionResult.Success -> inmateDetailsResult.entity
+        else -> null
+      }
+    }
+
+    return PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offender,
+      inmateDetail = inmateDetails,
+    )
+  }
 
   private fun getRoshRisksEnvelope(crn: String, jwt: String): RiskWithStatus<RoshRisks> {
     when (val roshRisksResponse = apOASysContextApiClient.getRoshRatings(crn)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -8,16 +8,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary as ApiApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary as ApiApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary as ApiCas2ApplicationSummary
@@ -35,13 +33,13 @@ class ApplicationsTransformer(
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
 ) {
-  fun transformJpaToApi(jpa: ApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): Application {
+  fun transformJpaToApi(jpa: ApplicationEntity, personInfo: PersonInfoResult.Success): Application {
     val latestAssessment = jpa.getLatestAssessment()
 
     return when (jpa) {
       is ApprovedPremisesApplicationEntity -> ApprovedPremisesApplication(
         id = jpa.id,
-        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = jpa.createdByUser.id,
         schemaVersion = jpa.schemaVersion.id,
         outdatedSchema = !jpa.schemaUpToDate,
@@ -67,7 +65,7 @@ class ApplicationsTransformer(
 
       is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
         id = jpa.id,
-        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = jpa.createdByUser.id,
         schemaVersion = jpa.schemaVersion.id,
         outdatedSchema = !jpa.schemaUpToDate,
@@ -89,7 +87,7 @@ class ApplicationsTransformer(
 
       is DomainCas2ApplicationEntity -> Cas2Application(
         id = jpa.id,
-        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = jpa.createdByUser.id,
         schemaVersion = jpa.schemaVersion.id,
         outdatedSchema = !jpa.schemaUpToDate,
@@ -113,14 +111,14 @@ class ApplicationsTransformer(
     }
   }
 
-  fun transformDomainToApiSummary(domain: DomainApplicationSummary, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): ApiApplicationSummary = when (domain) {
+  fun transformDomainToApiSummary(domain: DomainApplicationSummary, personInfo: PersonInfoResult.Success): ApiApplicationSummary = when (domain) {
     is DomainApprovedPremisesApplicationSummary -> {
       val riskRatings =
         if (domain.getRiskRatings() != null) objectMapper.readValue<PersonRisks>(domain.getRiskRatings()!!) else null
 
       ApiApprovedPremisesApplicationSummary(
         id = domain.getId(),
-        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = domain.getCreatedByUserId(),
         createdAt = domain.getCreatedAt().toInstant(),
         submittedAt = domain.getSubmittedAt()?.toInstant(),
@@ -139,7 +137,7 @@ class ApplicationsTransformer(
 
       ApiTemporaryAccommodationApplicationSummary(
         id = domain.getId(),
-        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = domain.getCreatedByUserId(),
         createdAt = domain.getCreatedAt().toInstant(),
         submittedAt = domain.getSubmittedAt()?.toInstant(),
@@ -155,7 +153,7 @@ class ApplicationsTransformer(
 
       ApiCas2ApplicationSummary(
         id = domain.getId(),
-        person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = domain.getCreatedByUserId(),
         createdAt = domain.getCreatedAt().toInstant(),
         submittedAt = domain.getSubmittedAt()?.toInstant(),
@@ -168,16 +166,9 @@ class ApplicationsTransformer(
     else -> throw RuntimeException("Unrecognised application type when transforming: ${domain::class.qualifiedName}")
   }
 
-  fun transformJpaToApi(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = OfflineApplication(
+  fun transformJpaToApi(jpa: OfflineApplicationEntity, personInfo: PersonInfoResult.Success) = OfflineApplication(
     id = jpa.id,
-    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
-    createdAt = jpa.createdAt.toInstant(),
-    type = "Offline",
-  )
-
-  fun transformJpaToApiSummary(jpa: OfflineApplicationEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = OfflineApplicationSummary(
-    id = jpa.id,
-    person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+    person = personTransformer.transformModelToPersonApi(personInfo),
     createdAt = jpa.createdAt.toInstant(),
     type = "Offline",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -6,9 +6,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import java.time.LocalDate
@@ -28,12 +27,12 @@ class BookingTransformer(
   private val enumConverterFactory: EnumConverterFactory,
   private val workingDayCountService: WorkingDayCountService,
 ) {
-  fun transformJpaToApi(jpa: BookingEntity, offender: OffenderDetailSummary, inmateDetail: InmateDetail?, staffMember: StaffMember?): Booking {
+  fun transformJpaToApi(jpa: BookingEntity, personInfo: PersonInfoResult.Success, staffMember: StaffMember?): Booking {
     val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
 
     return Booking(
       id = jpa.id,
-      person = personTransformer.transformModelToApi(offender, inmateDetail),
+      person = personTransformer.transformModelToPersonApi(personInfo),
       arrivalDate = jpa.arrivalDate,
       departureDate = jpa.departureDate,
       serviceName = enumConverterFactory.getConverter(ServiceName::class.java).convert(jpa.service) ?: throw InternalServerErrorProblem("Could not convert '${jpa.service}' to a ServiceName"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -1,36 +1,44 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 
 @Component
 class PersonTransformer {
-  fun transformModelToApi(offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?) = Person(
-    crn = offenderDetailSummary.otherIds.crn,
-    name = "${offenderDetailSummary.firstName} ${offenderDetailSummary.surname}",
-    dateOfBirth = offenderDetailSummary.dateOfBirth,
-    sex = offenderDetailSummary.gender,
-    status = inOutStatusToApiStatus(inmateDetail?.inOutStatus),
-    nomsNumber = inmateDetail?.offenderNo,
-    ethnicity = offenderDetailSummary.offenderProfile.ethnicity,
-    nationality = offenderDetailSummary.offenderProfile.nationality,
-    religionOrBelief = offenderDetailSummary.offenderProfile.religion,
-    genderIdentity = when (offenderDetailSummary.offenderProfile.genderIdentity) {
-      "Prefer to self-describe" -> offenderDetailSummary.offenderProfile.selfDescribedGender
-      else -> offenderDetailSummary.offenderProfile.genderIdentity
-    },
-    prisonName = inOutStatusToApiStatus(inmateDetail?.inOutStatus).takeIf { it == Person.Status.inCustody }?.let {
-      inmateDetail?.assignedLivingUnit?.agencyName ?: inmateDetail?.assignedLivingUnit?.agencyId
-    },
-  )
+  fun transformModelToPersonApi(personInfoResult: PersonInfoResult.Success) = when (personInfoResult) {
+    is PersonInfoResult.Success.Full -> FullPerson(
+      type = PersonType.fullPerson,
+      crn = personInfoResult.offenderDetailSummary.otherIds.crn,
+      name = "${personInfoResult.offenderDetailSummary.firstName} ${personInfoResult.offenderDetailSummary.surname}",
+      dateOfBirth = personInfoResult.offenderDetailSummary.dateOfBirth,
+      sex = personInfoResult.offenderDetailSummary.gender,
+      status = inOutStatusToPersonInfoApiStatus(personInfoResult.inmateDetail?.inOutStatus),
+      nomsNumber = personInfoResult.inmateDetail?.offenderNo,
+      ethnicity = personInfoResult.offenderDetailSummary.offenderProfile.ethnicity,
+      nationality = personInfoResult.offenderDetailSummary.offenderProfile.nationality,
+      religionOrBelief = personInfoResult.offenderDetailSummary.offenderProfile.religion,
+      genderIdentity = when (personInfoResult.offenderDetailSummary.offenderProfile.genderIdentity) {
+        "Prefer to self-describe" -> personInfoResult.offenderDetailSummary.offenderProfile.selfDescribedGender
+        else -> personInfoResult.offenderDetailSummary.offenderProfile.genderIdentity
+      },
+      prisonName = inOutStatusToPersonInfoApiStatus(personInfoResult.inmateDetail?.inOutStatus).takeIf { it == FullPerson.Status.inCustody }?.let {
+        personInfoResult.inmateDetail?.assignedLivingUnit?.agencyName ?: personInfoResult.inmateDetail?.assignedLivingUnit?.agencyId
+      },
+    )
+    is PersonInfoResult.Success.Restricted -> RestrictedPerson(
+      type = PersonType.restrictedPerson,
+      crn = personInfoResult.crn,
+    )
+  }
 
-  private fun inOutStatusToApiStatus(inOutStatus: InOutStatus?) = when (inOutStatus) {
-    InOutStatus.IN -> Person.Status.inCustody
-    InOutStatus.OUT -> Person.Status.inCommunity
-    InOutStatus.TRN -> Person.Status.inCustody
-    null -> Person.Status.unknown
+  private fun inOutStatusToPersonInfoApiStatus(inOutStatus: InOutStatus?) = when (inOutStatus) {
+    InOutStatus.IN -> FullPerson.Status.inCustody
+    InOutStatus.OUT -> FullPerson.Status.inCommunity
+    InOutStatus.TRN -> FullPerson.Status.inCustody
+    null -> FullPerson.Status.unknown
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -4,8 +4,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 
 @Component
 class PlacementRequestDetailTransformer(
@@ -14,8 +13,8 @@ class PlacementRequestDetailTransformer(
   private val bookingSummaryTransformer: BookingSummaryTransformer,
   private val applicationTransformer: ApplicationsTransformer,
 ) {
-  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?, cancellations: List<CancellationEntity>): PlacementRequestDetail {
-    val placementRequest = placementRequestTransformer.transformJpaToApi(jpa, offenderDetailSummary, inmateDetail)
+  fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult.Success, cancellations: List<CancellationEntity>): PlacementRequestDetail {
+    val placementRequest = placementRequestTransformer.transformJpaToApi(jpa, personInfo)
 
     return PlacementRequestDetail(
       id = placementRequest.id,
@@ -41,7 +40,7 @@ class PlacementRequestDetailTransformer(
       cancellations = cancellations.mapNotNull { cancellationTransformer.transformJpaToApi(it) },
       booking = jpa.booking?.let { bookingSummaryTransformer.transformJpaToApi(jpa.booking!!) },
       isParole = jpa.isParole,
-      application = applicationTransformer.transformJpaToApi(jpa.application, offenderDetailSummary, inmateDetail),
+      application = applicationTransformer.transformJpaToApi(jpa.application, personInfo),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -9,8 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOpt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 
 @Component
 class PlacementRequestTransformer(
@@ -20,7 +19,7 @@ class PlacementRequestTransformer(
   private val userTransformer: UserTransformer,
   private val bookingSummaryTransformer: BookingSummaryTransformer,
 ) {
-  fun transformJpaToApi(jpa: PlacementRequestEntity, offenderDetailSummary: OffenderDetailSummary, inmateDetail: InmateDetail?): PlacementRequest {
+  fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult.Success): PlacementRequest {
     return PlacementRequest(
       id = jpa.id,
       gender = jpa.placementRequirements.gender,
@@ -31,7 +30,7 @@ class PlacementRequestTransformer(
       radius = jpa.placementRequirements.radius,
       essentialCriteria = jpa.placementRequirements.essentialCriteria.mapNotNull { characteristicToCriteria(it) },
       desirableCriteria = jpa.placementRequirements.desirableCriteria.mapNotNull { characteristicToCriteria(it) },
-      person = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail),
+      person = personTransformer.transformModelToPersonApi(personInfo),
       risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn),
       applicationId = jpa.application.id,
       assessmentId = jpa.assessment.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PersonUtils.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import org.slf4j.Logger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.into
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -58,4 +63,26 @@ fun getInmateDetail(offenderDetails: OffenderDetailSummary, offenderService: Off
     is AuthorisableActionResult.NotFound -> null
     is AuthorisableActionResult.Unauthorised -> null
   }
+}
+
+fun OffenderService.getInfoForPersonOrThrow(crn: String, user: UserEntity): PersonInfoResult.Success {
+  val personInfo = this.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+  if (personInfo is PersonInfoResult.NotFound) throw NotFoundProblem(crn, "Offender")
+
+  return personInfo as PersonInfoResult.Success
+}
+
+fun OffenderService.getInfoForPersonOrThrowInternalServerError(crn: String, user: UserEntity): PersonInfoResult.Success {
+  val personInfo = this.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+  if (personInfo is PersonInfoResult.NotFound) throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
+
+  return personInfo as PersonInfoResult.Success
+}
+
+fun OffenderService.getFullInfoForPersonOrThrow(crn: String, user: UserEntity): PersonInfoResult.Success.Full {
+  val personInfo = this.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+  if (personInfo is PersonInfoResult.NotFound) throw NotFoundProblem(crn, "Offender")
+  if (personInfo is PersonInfoResult.Success.Restricted) throw ForbiddenProblem()
+
+  return personInfo as PersonInfoResult.Success.Full
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -208,40 +208,6 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
-  /premises/{premisesId}/residents:
-    get:
-      tags:
-        - Operations on premises
-      summary: Returns all the residents in an approved premises with the given ID
-      parameters:
-      - name: premisesId
-        in: path
-        description: ID of the premises to get residents for
-        required: true
-        schema:
-          type: integer
-          format: uuid
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Person'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        404:
-          description: invalid premises ID
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/bookings:
     get:
       tags:
@@ -4068,37 +4034,54 @@ components:
       properties:
         crn:
           type: string
-        name:
-          type: string
-        dateOfBirth:
-          type: string
-          format: date
-        nomsNumber:
-          type: string
-        ethnicity:
-          type: string
-        nationality:
-          type: string
-        religionOrBelief:
-          type: string
-        sex:
-          type: string
-        genderIdentity:
-          type: string
-        status:
-          type: string
-          enum:
-            - InCustody
-            - InCommunity
-            - Unknown
-        prisonName:
-          type: string
+        type:
+          $ref: '#/components/schemas/PersonType'
+      discriminator:
+        propertyName: type
+        mapping:
+          FullPerson: '#/components/schemas/FullPerson'
+          RestrictedPerson: '#/components/schemas/RestrictedPerson'
       required:
         - crn
-        - name
-        - dateOfBirth
-        - sex
-        - status
+        - type
+    RestrictedPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+    FullPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+        - type: object
+          properties:
+            name:
+              type: string
+            dateOfBirth:
+              type: string
+              format: date
+            nomsNumber:
+              type: string
+            ethnicity:
+              type: string
+            nationality:
+              type: string
+            religionOrBelief:
+              type: string
+            sex:
+              type: string
+            genderIdentity:
+              type: string
+            status:
+              type: string
+              enum:
+                - InCustody
+                - InCommunity
+                - Unknown
+            prisonName:
+              type: string
+          required:
+            - name
+            - dateOfBirth
+            - sex
+            - status
     NewArrival:
       type: object
       properties:
@@ -6913,6 +6896,13 @@ components:
     BedOccupancyOpenEntry:
       allOf:
         - $ref: '#/components/schemas/BedOccupancyEntry'
+    PersonType:
+      type: string
+      enum:
+        - FullPerson
+        - RestrictedPerson
+        - FullPersonInfo
+        - RestrictedPersonInfo
     WithdrawalReason:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -23,10 +23,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
@@ -62,6 +62,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
@@ -497,11 +498,13 @@ class ApplicationTest : IntegrationTestBase() {
           objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {})
 
         assertThat(responseBody).matches {
+          val person = it[0].person as FullPerson
+
           application.id == it[0].id &&
-            application.crn == it[0].person.crn &&
-            it[0].person.nomsNumber == null &&
-            it[0].person.status == Person.Status.unknown &&
-            it[0].person.prisonName == null
+            application.crn == person.crn &&
+            person.nomsNumber == null &&
+            person.status == FullPerson.Status.unknown &&
+            person.prisonName == null
         }
       }
     }
@@ -544,11 +547,13 @@ class ApplicationTest : IntegrationTestBase() {
         objectMapper.readValue(rawResponseBody, object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {})
 
       assertThat(responseBody).matches {
+        val person = it[0].person as FullPerson
+
         application.id == it[0].id &&
-          application.crn == it[0].person.crn &&
-          it[0].person.nomsNumber == null &&
-          it[0].person.status == Person.Status.unknown &&
-          it[0].person.prisonName == null
+          application.crn == person.crn &&
+          person.nomsNumber == null &&
+          person.status == FullPerson.Status.unknown &&
+          person.prisonName == null
       }
     }
   }
@@ -682,12 +687,15 @@ class ApplicationTest : IntegrationTestBase() {
 
         val responseBody = objectMapper.readValue(rawResponseBody, ApprovedPremisesApplication::class.java)
 
+        assertThat(responseBody.person is FullPerson).isTrue
         assertThat(responseBody).matches {
+          val person = it.person as FullPerson
+
           application.id == it.id &&
-            application.crn == it.person.crn &&
-            it.person.nomsNumber == null &&
-            it.person.status == Person.Status.unknown &&
-            it.person.prisonName == null
+            application.crn == person.crn &&
+            person.nomsNumber == null &&
+            person.status == FullPerson.Status.unknown &&
+            person.prisonName == null
         }
       }
     }
@@ -728,12 +736,16 @@ class ApplicationTest : IntegrationTestBase() {
 
       val responseBody = objectMapper.readValue(rawResponseBody, ApprovedPremisesApplication::class.java)
 
+      assertThat(responseBody.person is FullPerson).isTrue
+
       assertThat(responseBody).matches {
+        val person = it.person as FullPerson
+
         application.id == it.id &&
-          application.crn == it.person.crn &&
-          it.person.nomsNumber == null &&
-          it.person.status == Person.Status.unknown &&
-          it.person.prisonName == null
+          application.crn == person.crn &&
+          person.nomsNumber == null &&
+          person.status == FullPerson.Status.unknown &&
+          person.prisonName == null
       }
     }
   }
@@ -1048,7 +1060,7 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Create new application returns 500 when a person cannot be found`() {
+  fun `Create new application returns 404 when a person cannot be found`() {
     `Given a User` { userEntity, jwt ->
       val crn = "X1234"
 
@@ -1070,9 +1082,9 @@ class ApplicationTest : IntegrationTestBase() {
         )
         .exchange()
         .expectStatus()
-        .is5xxServerError
+        .isNotFound
         .expectBody()
-        .jsonPath("$.detail").isEqualTo("Unable to get Person via crn: $crn")
+        .jsonPath("$.detail").isEqualTo("No Offender with an ID of $crn could be found")
     }
   }
 
@@ -1971,7 +1983,10 @@ class ApplicationTest : IntegrationTestBase() {
               .expectBody()
               .json(
                 objectMapper.writeValueAsString(
-                  assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+                  assessmentTransformer.transformJpaToApi(
+                    assessment,
+                    PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+                  ),
                 ),
               )
           }
@@ -2000,7 +2015,10 @@ class ApplicationTest : IntegrationTestBase() {
                 .expectBody()
                 .json(
                   objectMapper.writeValueAsString(
-                    assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+                    assessmentTransformer.transformJpaToApi(
+                      assessment,
+                      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+                    ),
                   ),
                 )
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
@@ -113,7 +114,12 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offenderDetails, inmateDetails)),
+              listOf(
+                assessmentTransformer.transformDomainToApiSummary(
+                  toAssessmentSummaryEntity(assessment),
+                  PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+                ),
+              ),
             ),
           )
       }
@@ -179,7 +185,7 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offenderDetails, inmateDetails)),
+              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails))),
             ),
             true,
           )
@@ -240,7 +246,7 @@ class AssessmentTest : IntegrationTestBase() {
             assessments
           }
           AssessmentSortField.assessmentCreatedAt -> assessments.sortedByDescending { it.assessment.createdAt }
-        }.map { assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(it.assessment), it.offenderDetails, it.inmateDetails) }
+        }.map { assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(it.assessment), PersonInfoResult.Success.Full(it.offenderDetails.otherIds.crn, it.offenderDetails, it.inmateDetails)) }
 
         webTestClient.get()
           .uri("/assessments?sortOrder=descending&sortField=${sortField.value}")
@@ -304,8 +310,7 @@ class AssessmentTest : IntegrationTestBase() {
           .map {
             assessmentTransformer.transformDomainToApiSummary(
               toAssessmentSummaryEntity(it.assessment),
-              it.offenderDetails,
-              it.inmateDetails,
+              PersonInfoResult.Success.Full(it.offenderDetails.otherIds.crn, it.offenderDetails, it.inmateDetails),
             )
           }
 
@@ -380,7 +385,12 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offender.first, offender.second)),
+              listOf(
+                assessmentTransformer.transformDomainToApiSummary(
+                  toAssessmentSummaryEntity(assessment),
+                  PersonInfoResult.Success.Full(offender.first.otherIds.crn, offender.first, offender.second),
+                ),
+              ),
             ),
             true,
           )
@@ -389,7 +399,7 @@ class AssessmentTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get all assessments does not return assessments for LAO`() {
+  fun `Get all assessments returns restricted person information for LAO`() {
     var offenderIndex = 0
     `Given a User` { user, jwt ->
       `Given Some Offenders`(
@@ -452,7 +462,16 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), offender.first, offender.second)),
+              listOf(
+                assessmentTransformer.transformDomainToApiSummary(
+                  toAssessmentSummaryEntity(assessment),
+                  PersonInfoResult.Success.Full(offender.first.otherIds.crn, offender.first, offender.second),
+                ),
+                assessmentTransformer.transformDomainToApiSummary(
+                  toAssessmentSummaryEntity(otherAssessment),
+                  PersonInfoResult.Success.Restricted(otherOffender.first.otherIds.crn, otherOffender.first.otherIds.nomsNumber),
+                ),
+              ),
             ),
             true,
           )
@@ -547,7 +566,10 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+              assessmentTransformer.transformJpaToApi(
+                assessment,
+                PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+              ),
             ),
           )
       }
@@ -649,7 +671,10 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+              assessmentTransformer.transformJpaToApi(
+                assessment,
+                PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+              ),
             ),
           )
       }
@@ -703,7 +728,10 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              assessmentTransformer.transformJpaToApi(assessment, offenderDetails, inmateDetails),
+              assessmentTransformer.transformJpaToApi(
+                assessment,
+                PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+              ),
             ),
           )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
@@ -83,7 +84,11 @@ class BookingTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, keyWorker),
+              bookingTransformer.transformJpaToApi(
+                booking,
+                PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+                keyWorker,
+              ),
             ),
           )
       }
@@ -123,7 +128,11 @@ class BookingTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              bookingTransformer.transformJpaToApi(booking, offenderDetails, null, keyWorker),
+              bookingTransformer.transformJpaToApi(
+                booking,
+                PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, null),
+                keyWorker,
+              ),
             ),
           )
       }
@@ -165,7 +174,11 @@ class BookingTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              bookingTransformer.transformJpaToApi(booking, offenderDetails, inmateDetails, null),
+              bookingTransformer.transformJpaToApi(
+                booking,
+                PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+                null,
+              ),
             ),
           )
       }
@@ -304,7 +317,11 @@ class BookingTest : IntegrationTestBase() {
 
         val expectedJson = objectMapper.writeValueAsString(
           bookings.map {
-            bookingTransformer.transformJpaToApi(it, offenderDetails, inmateDetails, keyWorker)
+            bookingTransformer.transformJpaToApi(
+              it,
+              PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+              keyWorker,
+            )
           },
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -4,7 +4,8 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
@@ -111,12 +112,13 @@ class PersonSearchTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              Person(
+              FullPerson(
+                type = PersonType.fullPerson,
                 crn = "CRN",
                 name = "James Someone",
                 dateOfBirth = LocalDate.parse("1985-05-05"),
                 sex = "Male",
-                status = Person.Status.inCustody,
+                status = FullPerson.Status.inCustody,
                 nomsNumber = "NOMS321",
                 ethnicity = "White British",
                 nationality = "English",
@@ -157,12 +159,13 @@ class PersonSearchTest : IntegrationTestBase() {
           .expectBody()
           .json(
             objectMapper.writeValueAsString(
-              Person(
+              FullPerson(
+                type = PersonType.fullPerson,
                 crn = "CRN",
                 name = "James Someone",
                 dateOfBirth = LocalDate.parse("1985-05-05"),
                 sex = "Male",
-                status = Person.Status.unknown,
+                status = FullPerson.Status.unknown,
                 nomsNumber = null,
                 ethnicity = "White British",
                 nationality = "English",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpMethod
@@ -11,6 +16,7 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CaseNotesClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult.Failure.StatusCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
@@ -21,9 +27,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationsPageFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AgencyFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseNoteFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
@@ -66,6 +74,12 @@ class OffenderServiceTest {
     prisonApiPageSize = 2
   }
 
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
   private val offenderService = OffenderService(
     mockCommunityApiClient,
     mockHMPPSTierApiClient,
@@ -78,14 +92,14 @@ class OffenderServiceTest {
 
   @Test
   fun `getOffenderByCrn returns NotFound result when Client returns 404`() {
-    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)
 
     assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue
   }
 
   @Test
   fun `getOffenderByCrn throws when Client returns other non-2xx status code except 403`() {
-    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)
 
     val exception = assertThrows<RuntimeException> { offenderService.getOffenderByCrn("a-crn", "distinguished.name") }
     assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/a-crn: 400 BAD_REQUEST")
@@ -156,7 +170,7 @@ class OffenderServiceTest {
     val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true, restrictionMessage = null)
 
     every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
-    every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Failure.StatusCode(
+    every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns StatusCode(
       HttpMethod.GET,
       "/secure/crn/a-crn/user/distinguished.name/userAccess",
       HttpStatus.FORBIDDEN,
@@ -176,7 +190,7 @@ class OffenderServiceTest {
       .produce()
 
     every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
-    every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Failure.StatusCode(
+    every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns StatusCode(
       HttpMethod.GET,
       "/secure/crn/a-crn/user/distinguished.name/userAccess",
       HttpStatus.FORBIDDEN,
@@ -231,14 +245,14 @@ class OffenderServiceTest {
 
   @Test
   fun `getRisksByCrn returns NotFound result when Community API Client returns 404`() {
-    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)
 
     assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue
   }
 
   @Test
   fun `getRisksByCrn throws when Community API Client returns other non-2xx status code`() {
-    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)
 
     val exception = assertThrows<RuntimeException> { offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") }
     assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/a-crn: 400 BAD_REQUEST")
@@ -383,7 +397,7 @@ class OffenderServiceTest {
     val crn = "CRN123"
     val nomsNumber = "NOMS321"
 
-    every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.NOT_FOUND, null)
+    every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.NOT_FOUND, null)
 
     val result = offenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
@@ -395,7 +409,7 @@ class OffenderServiceTest {
     val crn = "CRN123"
     val nomsNumber = "NOMS321"
 
-    every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.NOT_FOUND, null)
+    every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.NOT_FOUND, null)
 
     val result = offenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
@@ -407,7 +421,7 @@ class OffenderServiceTest {
     val crn = "CRN123"
     val nomsNumber = "NOMS321"
 
-    every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.FORBIDDEN, null)
+    every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.FORBIDDEN, null)
 
     val result = offenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
@@ -460,7 +474,7 @@ class OffenderServiceTest {
         page = 0,
         pageSize = 2,
       )
-    } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/v2", HttpStatus.NOT_FOUND, null)
+    } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/v2", HttpStatus.NOT_FOUND, null)
 
     assertThat(offenderService.getPrisonCaseNotesByNomsNumber(nomsNumber) is AuthorisableActionResult.NotFound).isTrue
   }
@@ -476,7 +490,7 @@ class OffenderServiceTest {
         page = 0,
         pageSize = 2,
       )
-    } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/v2", HttpStatus.FORBIDDEN, null)
+    } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/v2", HttpStatus.FORBIDDEN, null)
 
     assertThat(offenderService.getPrisonCaseNotesByNomsNumber(nomsNumber) is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -548,7 +562,7 @@ class OffenderServiceTest {
         pageSize = 2,
         offset = 0,
       )
-    } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.NOT_FOUND, null)
+    } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.NOT_FOUND, null)
 
     assertThat(offenderService.getAdjudicationsByNomsNumber(nomsNumber) is AuthorisableActionResult.NotFound).isTrue
   }
@@ -563,7 +577,7 @@ class OffenderServiceTest {
         pageSize = 2,
         offset = 0,
       )
-    } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.FORBIDDEN, null)
+    } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber/adjudications", HttpStatus.FORBIDDEN, null)
 
     assertThat(offenderService.getAdjudicationsByNomsNumber(nomsNumber) is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -679,6 +693,160 @@ class OffenderServiceTest {
     assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isFalse
   }
 
+  @Nested
+  inner class GetInfoForPerson {
+    @Test
+    fun `returns NotFound if Community API responds with a 404`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/ABC123", HttpStatus.NOT_FOUND, null, true)
+
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+
+      assertThat(result is PersonInfoResult.NotFound).isTrue
+    }
+
+    @Test
+    fun `returns Restricted for LAO Offender where user does not pass check and ignoreLao is false`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = OffenderDetailsSummaryFactory()
+          .withCrn(crn)
+          .withCurrentRestriction(true)
+          .produce(),
+      )
+
+      every { mockCommunityApiClient.getUserAccessForOffenderCrn(deliusUsername, crn) } returns StatusCode(
+        status = HttpStatus.FORBIDDEN,
+        method = HttpMethod.GET,
+        path = "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+        body = objectMapper.writeValueAsString(
+          UserOffenderAccess(
+            userRestricted = true,
+            userExcluded = false,
+            restrictionMessage = null,
+          ),
+        ),
+      )
+
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+
+      assertThat(result is PersonInfoResult.Success.Restricted).isTrue
+      result as PersonInfoResult.Success.Restricted
+      assertThat(result.crn).isEqualTo(crn)
+    }
+
+    @Test
+    fun `returns Full for LAO Offender where user does pass check and ignoreLao is false`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withCurrentRestriction(true)
+        .withoutNomsNumber()
+        .produce()
+
+      every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = offenderDetails,
+      )
+
+      every { mockCommunityApiClient.getUserAccessForOffenderCrn(deliusUsername, crn) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = UserOffenderAccess(
+          userRestricted = false,
+          userExcluded = false,
+          restrictionMessage = null,
+        ),
+      )
+
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+
+      assertThat(result is PersonInfoResult.Success.Full).isTrue
+      result as PersonInfoResult.Success.Full
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.offenderDetailSummary).isEqualTo(offenderDetails)
+      assertThat(result.inmateDetail).isEqualTo(null)
+    }
+
+    @Test
+    fun `returns Full for LAO Offender where user does not pass check but ignoreLao is true`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withCurrentRestriction(true)
+        .withoutNomsNumber()
+        .produce()
+
+      every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = offenderDetails,
+      )
+
+      every { mockCommunityApiClient.getUserAccessForOffenderCrn(deliusUsername, crn) } returns StatusCode(
+        status = HttpStatus.FORBIDDEN,
+        method = HttpMethod.GET,
+        path = "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+        body = objectMapper.writeValueAsString(
+          UserOffenderAccess(
+            userRestricted = true,
+            userExcluded = false,
+            restrictionMessage = null,
+          ),
+        ),
+      )
+
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, true)
+
+      assertThat(result is PersonInfoResult.Success.Full).isTrue
+      result as PersonInfoResult.Success.Full
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.offenderDetailSummary).isEqualTo(offenderDetails)
+      assertThat(result.inmateDetail).isEqualTo(null)
+    }
+
+    @Test
+    fun `returns Full for CRN with both Community API and Prison API data where Community API links to Prison API`() {
+      val crn = "ABC123"
+      val nomsNumber = "NOMSABC"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withNomsNumber(nomsNumber)
+        .produce()
+
+      every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = offenderDetails,
+      )
+
+      val inmateDetail = InmateDetailFactory()
+        .withOffenderNo(nomsNumber)
+        .produce()
+
+      every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = inmateDetail,
+      )
+
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+
+      assertThat(result is PersonInfoResult.Success.Full).isTrue
+      result as PersonInfoResult.Success.Full
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.offenderDetailSummary).isEqualTo(offenderDetails)
+      assertThat(result.inmateDetail).isEqualTo(inmateDetail)
+    }
+  }
+
   private fun mockExistingNonLaoOffender() {
     val resultBody = OffenderDetailsSummaryFactory()
       .withCrn("a-crn")
@@ -691,13 +859,13 @@ class OffenderServiceTest {
     every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
   }
 
-  private fun mock404RoSH(crn: String, jwt: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.NOT_FOUND, body = null)
-  private fun mock404Tier(crn: String) = every { mockHMPPSTierApiClient.getTier(crn) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/crn/a-crn/tier", HttpStatus.NOT_FOUND, body = null)
-  private fun mock404Registrations(crn: String) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn/registrations?activeOnly=true", HttpStatus.NOT_FOUND, body = null)
+  private fun mock404RoSH(crn: String, jwt: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.NOT_FOUND, body = null)
+  private fun mock404Tier(crn: String) = every { mockHMPPSTierApiClient.getTier(crn) } returns StatusCode(HttpMethod.GET, "/crn/a-crn/tier", HttpStatus.NOT_FOUND, body = null)
+  private fun mock404Registrations(crn: String) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn/registrations?activeOnly=true", HttpStatus.NOT_FOUND, body = null)
 
-  private fun mock500RoSH(crn: String, jwt: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.INTERNAL_SERVER_ERROR, body = null)
-  private fun mock500Tier(crn: String) = every { mockHMPPSTierApiClient.getTier(crn) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/crn/a-crn/tier", HttpStatus.INTERNAL_SERVER_ERROR, body = null)
-  private fun mock500Registrations(crn: String) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn/registrations?activeOnly=true", HttpStatus.INTERNAL_SERVER_ERROR, body = null)
+  private fun mock500RoSH(crn: String, jwt: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.INTERNAL_SERVER_ERROR, body = null)
+  private fun mock500Tier(crn: String) = every { mockHMPPSTierApiClient.getTier(crn) } returns StatusCode(HttpMethod.GET, "/crn/a-crn/tier", HttpStatus.INTERNAL_SERVER_ERROR, body = null)
+  private fun mock500Registrations(crn: String) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn/registrations?activeOnly=true", HttpStatus.INTERNAL_SERVER_ERROR, body = null)
 
   private fun mock200RoSH(crn: String, jwt: String, body: RoshRatings) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns ClientResult.Success(HttpStatus.OK, body = body)
   private fun mock200Tier(crn: String, body: Tier) = every { mockHMPPSTierApiClient.getTier(crn) } returns ClientResult.Success(HttpStatus.OK, body = body)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
@@ -110,7 +109,7 @@ class ApplicationsTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToApi(any<OffenderDetailSummary>(), any()) } returns mockk<Person>()
+    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
     every { mockRisksTransformer.transformDomainToApi(any<PersonRisks>(), any<String>()) } returns mockk()
   }
 
@@ -118,7 +117,7 @@ class ApplicationsTransformerTest {
   fun `transformJpaToApi transforms an in progress Approved Premises application correctly`() {
     val application = approvedPremisesApplicationFactory.withSubmittedAt(null).produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.createdByUserId).isEqualTo(user.id)
@@ -130,7 +129,7 @@ class ApplicationsTransformerTest {
   fun `transformJpaToApi transforms an inapplicable Approved Premises application correctly`() {
     val application = approvedPremisesApplicationFactory.withIsInapplicable(true).produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.createdByUserId).isEqualTo(user.id)
@@ -142,7 +141,7 @@ class ApplicationsTransformerTest {
   fun `transformJpaToApi transforms a withdrawn Approved Premises application correctly`() {
     val application = approvedPremisesApplicationFactory.withIsWithdrawn(true).produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.createdByUserId).isEqualTo(user.id)
@@ -156,7 +155,7 @@ class ApplicationsTransformerTest {
       .withSubmittedAt(null)
       .produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as Cas2Application
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as Cas2Application
 
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.createdByUserId).isEqualTo(user.id)
@@ -168,7 +167,7 @@ class ApplicationsTransformerTest {
   fun `transformJpaToApi transforms a submitted CAS2 application correctly`() {
     val application = submittedCas2ApplicationFactory.produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as Cas2Application
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as Cas2Application
 
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
@@ -188,7 +187,7 @@ class ApplicationsTransformerTest {
       }
       .produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as TemporaryAccommodationApplication
 
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.createdByUserId).isEqualTo(user.id)
@@ -200,7 +199,7 @@ class ApplicationsTransformerTest {
   fun `transformJpaToApi transforms a submitted Approved Premises application correctly`() {
     val application = submittedApprovedPremisesApplicationFactory.produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
     assertThat(result.assessmentDecision).isNull()
@@ -219,7 +218,7 @@ class ApplicationsTransformerTest {
       }
       .produce()
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as TemporaryAccommodationApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
   }
@@ -242,7 +241,7 @@ class ApplicationsTransformerTest {
         .produce(),
     )
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.requestedFurtherInformation)
     assertThat(result.assessmentDecision).isNull()
@@ -272,7 +271,7 @@ class ApplicationsTransformerTest {
         .produce(),
     )
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as TemporaryAccommodationApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.requestedFurtherInformation)
   }
@@ -292,7 +291,7 @@ class ApplicationsTransformerTest {
 
     application.assessments = mutableListOf(assessment)
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
     assertThat(result.assessmentDecision).isNull()
@@ -309,7 +308,7 @@ class ApplicationsTransformerTest {
 
     application.assessments = mutableListOf(assessment)
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.rejected)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.rejected)
@@ -326,7 +325,7 @@ class ApplicationsTransformerTest {
 
     application.assessments = mutableListOf(assessment)
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.pending)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.accepted)
@@ -361,7 +360,7 @@ class ApplicationsTransformerTest {
 
     application.placementRequests += placementRequest
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.awaitingPlacement)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.accepted)
@@ -405,7 +404,7 @@ class ApplicationsTransformerTest {
 
     application.placementRequests += placementRequest
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as ApprovedPremisesApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.placed)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.accepted)
@@ -433,7 +432,7 @@ class ApplicationsTransformerTest {
 
     application.assessments = mutableListOf(assessment)
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as TemporaryAccommodationApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
   }
@@ -471,7 +470,7 @@ class ApplicationsTransformerTest {
 
     application.assessments = mutableListOf(oldAssessment, latestAssessment)
 
-    val result = applicationsTransformer.transformJpaToApi(application, mockk(), mockk()) as TemporaryAccommodationApplication
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as TemporaryAccommodationApplication
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
   }
@@ -497,7 +496,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -525,7 +524,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -553,7 +552,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -581,7 +580,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = true
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -609,7 +608,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -637,7 +636,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -665,7 +664,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as ApprovedPremisesApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -687,7 +686,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as TemporaryAccommodationApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as TemporaryAccommodationApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -710,7 +709,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as TemporaryAccommodationApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as TemporaryAccommodationApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -733,7 +732,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as Cas2ApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as Cas2ApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
@@ -755,7 +754,7 @@ class ApplicationsTransformerTest {
       override fun getHasBooking() = false
     }
 
-    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk(), mockk()) as Cas2ApplicationSummary
+    val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as Cas2ApplicationSummary
 
     assertThat(result.id).isEqualTo(application.getId())
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -133,7 +133,7 @@ class AssessmentTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockApplicationsTransformer.transformJpaToApi(any<ApplicationEntity>(), any(), any()) } answers {
+    every { mockApplicationsTransformer.transformJpaToApi(any<ApplicationEntity>(), any()) } answers {
       when (it.invocation.args[0]) {
         is ApprovedPremisesApplicationEntity -> mockk<ApprovedPremisesApplication>()
         is TemporaryAccommodationApplicationEntity -> mockk<TemporaryAccommodationApplication>()
@@ -150,7 +150,7 @@ class AssessmentTransformerTest {
   fun `transformJpaToApi transforms correctly`() {
     val assessment = approvedPremisesAssessmentFactory.produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk()) as ApprovedPremisesAssessment
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk()) as ApprovedPremisesAssessment
 
     assertThat(result.id).isEqualTo(UUID.fromString("7d0d3b38-5bc3-45c7-95eb-4d714cbd0db1"))
     assertThat(result.schemaVersion).isEqualTo(UUID.fromString("aeeb6992-6485-4600-9c35-19479819c544"))
@@ -197,7 +197,7 @@ class AssessmentTransformerTest {
 
     assessment.clarificationNotes = clarificationNotes
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(ApprovedPremisesAssessment::class.java)
     result as ApprovedPremisesAssessment
@@ -210,7 +210,7 @@ class AssessmentTransformerTest {
       .withDecision(JpaAssessmentDecision.ACCEPTED)
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(ApprovedPremisesAssessment::class.java)
     result as ApprovedPremisesAssessment
@@ -224,7 +224,7 @@ class AssessmentTransformerTest {
       .withReallocatedAt(OffsetDateTime.now())
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(ApprovedPremisesAssessment::class.java)
     result as ApprovedPremisesAssessment
@@ -238,7 +238,7 @@ class AssessmentTransformerTest {
       .withDecision(null)
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(ApprovedPremisesAssessment::class.java)
     result as ApprovedPremisesAssessment
@@ -252,7 +252,7 @@ class AssessmentTransformerTest {
       .withDecision(null)
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(ApprovedPremisesAssessment::class.java)
     result as ApprovedPremisesAssessment
@@ -266,7 +266,7 @@ class AssessmentTransformerTest {
       .withoutAllocatedToUser()
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(TemporaryAccommodationAssessment::class.java)
     result as TemporaryAccommodationAssessment
@@ -279,7 +279,7 @@ class AssessmentTransformerTest {
       .withDecision(null)
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(TemporaryAccommodationAssessment::class.java)
     result as TemporaryAccommodationAssessment
@@ -292,7 +292,7 @@ class AssessmentTransformerTest {
       .withDecision(JpaAssessmentDecision.ACCEPTED)
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(TemporaryAccommodationAssessment::class.java)
     result as TemporaryAccommodationAssessment
@@ -306,7 +306,7 @@ class AssessmentTransformerTest {
       .withCompletedAt(OffsetDateTime.now())
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(TemporaryAccommodationAssessment::class.java)
     result as TemporaryAccommodationAssessment
@@ -319,7 +319,7 @@ class AssessmentTransformerTest {
       .withDecision(JpaAssessmentDecision.REJECTED)
       .produce()
 
-    val result = assessmentTransformer.transformJpaToApi(assessment, mockk(), mockk())
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
 
     assertThat(result).isInstanceOf(TemporaryAccommodationAssessment::class.java)
     result as TemporaryAccommodationAssessment
@@ -343,8 +343,8 @@ class AssessmentTransformerTest {
       isAllocated = true,
     )
 
-    every { mockPersonTransformer.transformModelToApi(any(), any()) } returns mockk<Person>()
-    val apiSummary = assessmentTransformer.transformDomainToApiSummary(domainSummary, mockk(), mockk())
+    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    val apiSummary = assessmentTransformer.transformDomainToApiSummary(domainSummary, mockk())
 
     assertThat(apiSummary).isInstanceOf(TemporaryAccommodationAssessmentSummary::class.java)
     apiSummary as TemporaryAccommodationAssessmentSummary
@@ -375,8 +375,8 @@ class AssessmentTransformerTest {
       isAllocated = true,
     )
 
-    every { mockPersonTransformer.transformModelToApi(any(), any()) } returns mockk<Person>()
-    val apiSummary = assessmentTransformer.transformDomainToApiSummary(domainSummary, mockk(), mockk())
+    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    val apiSummary = assessmentTransformer.transformDomainToApiSummary(domainSummary, mockk())
 
     assertThat(apiSummary).isInstanceOf(ApprovedPremisesAssessmentSummary::class.java)
     apiSummary as ApprovedPremisesAssessmentSummary

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -16,10 +16,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Departure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DestinationProvider
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NonArrivalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
@@ -47,6 +48,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMemberName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
@@ -193,12 +195,13 @@ class BookingTransformerTest {
       name = "first last",
     )
 
-    every { mockPersonTransformer.transformModelToApi(offenderDetails, inmateDetail) } returns Person(
+    every { mockPersonTransformer.transformModelToPersonApi(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) } returns FullPerson(
+      type = PersonType.fullPerson,
       crn = "crn",
       name = "first last",
       dateOfBirth = LocalDate.parse("2022-09-08"),
       sex = "Male",
-      status = Person.Status.inCommunity,
+      status = FullPerson.Status.inCommunity,
       nomsNumber = "NOMS321",
       nationality = "English",
       religionOrBelief = null,
@@ -216,17 +219,22 @@ class BookingTransformerTest {
   fun `Approved Premises Awaiting Arrival entity is correctly transformed`() {
     val awaitingArrivalBooking = baseBookingEntity.copy(id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"))
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(awaitingArrivalBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      awaitingArrivalBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -289,17 +297,22 @@ class BookingTransformerTest {
 
     val awaitingArrivalBooking = baseBookingEntity.copy(id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"), application = application)
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(awaitingArrivalBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      awaitingArrivalBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -331,17 +344,22 @@ class BookingTransformerTest {
       service = ServiceName.temporaryAccommodation.value,
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(awaitingArrivalBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      awaitingArrivalBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -386,17 +404,22 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(nonArrivalBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      nonArrivalBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("655f72ba-51eb-4965-b6ac-45bcc6271b19"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -451,17 +474,22 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(arrivalBooking, offenderDetails, inmateDetail, staffMember)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      arrivalBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      staffMember,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -521,17 +549,22 @@ class BookingTransformerTest {
       premisesName = premisesEntity.name,
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(cancellationBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      cancellationBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -620,17 +653,22 @@ class BookingTransformerTest {
       }
     }
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(cancellationBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      cancellationBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -756,17 +794,22 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      departedBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      staffMember,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = bookingId,
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -942,17 +985,22 @@ class BookingTransformerTest {
       bookingId = bookingId,
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      departedBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      staffMember,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = bookingId,
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -1154,17 +1202,22 @@ class BookingTransformerTest {
     every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 1) } returns departedAt.toLocalDate().plusDays(1)
     every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 2) } returns expectedEffectiveEndDate
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      departedBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      staffMember,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = bookingId,
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -1367,17 +1420,22 @@ class BookingTransformerTest {
     every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 1) } returns departedAt.toLocalDate().plusDays(1)
     every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 2) } returns expectedEffectiveEndDate
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      departedBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      staffMember,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = bookingId,
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -1612,17 +1670,22 @@ class BookingTransformerTest {
       }
     }
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(departedBooking, offenderDetails, inmateDetail, staffMember)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      departedBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      staffMember,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = bookingId,
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -1754,17 +1817,22 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(confirmationBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      confirmationBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,
@@ -1849,17 +1917,22 @@ class BookingTransformerTest {
     every { mockWorkingDayCountService.addWorkingDays(LocalDate.parse("2022-08-30"), 1) } returns LocalDate.parse("2022-08-31")
     every { mockWorkingDayCountService.addWorkingDays(LocalDate.parse("2022-08-30"), 4) } returns LocalDate.parse("2022-09-05")
 
-    val transformedBooking = bookingTransformer.transformJpaToApi(awaitingArrivalBooking, offenderDetails, inmateDetail, null)
+    val transformedBooking = bookingTransformer.transformJpaToApi(
+      awaitingArrivalBooking,
+      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
+      null,
+    )
 
     assertThat(transformedBooking).isEqualTo(
       Booking(
         id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
-        person = Person(
+        person = FullPerson(
+          type = PersonType.fullPerson,
           crn = "crn",
           name = "first last",
           dateOfBirth = LocalDate.parse("2022-09-08"),
           sex = "Male",
-          status = Person.Status.inCommunity,
+          status = FullPerson.Status.inCommunity,
           nomsNumber = "NOMS321",
           nationality = "English",
           religionOrBelief = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -2,7 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderIds
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLanguages
@@ -17,7 +21,21 @@ class PersonTransformerTest {
   private val personTransformer = PersonTransformer()
 
   @Test
-  fun `transformModelToApi transforms correctly without gender identity`() {
+  fun `transformModelToPersonInfoApi transforms correctly for a restricted person info`() {
+    val crn = "CRN123"
+
+    val personInfoResult = PersonInfoResult.Success.Restricted(crn, null)
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result is RestrictedPerson).isTrue
+    assertThat(result.crn).isEqualTo(crn)
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly for a full person info without prison info`() {
+    val crn = "CRN123"
+
     val offenderDetailSummary = OffenderDetailSummary(
       offenderId = 547839,
       title = "Mr",
@@ -29,7 +47,7 @@ class PersonTransformerTest {
       dateOfBirth = LocalDate.parse("1980-09-12"),
       gender = "Male",
       otherIds = OffenderIds(
-        crn = "CRN123",
+        crn = crn,
         croNumber = null,
         immigrationNumber = null,
         mostRecentPrisonNumber = null,
@@ -66,22 +84,25 @@ class PersonTransformerTest {
       isActiveProbationManagedSentence = false,
     )
 
-    val inmateDetail = InmateDetail(
-      offenderNo = "NOMS321",
-      inOutStatus = InOutStatus.OUT,
-      assignedLivingUnit = null,
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
     )
 
-    val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
 
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
     assertThat(result).isEqualTo(
-      Person(
+      FullPerson(
+        type = PersonType.fullPerson,
         crn = "CRN123",
         name = "Greggory Someone",
         dateOfBirth = LocalDate.parse("1980-09-12"),
         sex = "Male",
-        status = Person.Status.inCommunity,
-        nomsNumber = "NOMS321",
+        status = FullPerson.Status.unknown,
+        nomsNumber = null,
         ethnicity = "White and Asian",
         nationality = "Spanish",
         religionOrBelief = "Sikh",
@@ -92,7 +113,9 @@ class PersonTransformerTest {
   }
 
   @Test
-  fun `transformModelToApi transforms correctly with gender identity`() {
+  fun `transformModelToPersonInfoApi transforms correctly for a full person info with prison info`() {
+    val crn = "CRN123"
+
     val offenderDetailSummary = OffenderDetailSummary(
       offenderId = 547839,
       title = "Mr",
@@ -104,157 +127,7 @@ class PersonTransformerTest {
       dateOfBirth = LocalDate.parse("1980-09-12"),
       gender = "Male",
       otherIds = OffenderIds(
-        crn = "CRN123",
-        croNumber = null,
-        immigrationNumber = null,
-        mostRecentPrisonNumber = null,
-        niNumber = null,
-        nomsNumber = "NOMS321",
-        pncNumber = null,
-      ),
-      offenderProfile = OffenderProfile(
-        ethnicity = "White and Asian",
-        nationality = "Spanish",
-        secondaryNationality = null,
-        notes = null,
-        immigrationStatus = null,
-        offenderLanguages = OffenderLanguages(
-          primaryLanguage = null,
-          otherLanguages = listOf(),
-          languageConcerns = null,
-          requiresInterpreter = null,
-        ),
-        religion = "Sikh",
-        sexualOrientation = null,
-        offenderDetails = null,
-        remandStatus = null,
-        riskColour = null,
-        disabilities = listOf(),
-        genderIdentity = "Female",
-        selfDescribedGender = null,
-      ),
-      softDeleted = null,
-      currentDisposal = "",
-      partitionArea = null,
-      currentRestriction = false,
-      currentExclusion = false,
-      isActiveProbationManagedSentence = false,
-    )
-
-    val inmateDetail = InmateDetail(
-      offenderNo = "NOMS321",
-      inOutStatus = InOutStatus.OUT,
-      assignedLivingUnit = null,
-    )
-
-    val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
-
-    assertThat(result).isEqualTo(
-      Person(
-        crn = "CRN123",
-        name = "Greggory Someone",
-        dateOfBirth = LocalDate.parse("1980-09-12"),
-        sex = "Male",
-        status = Person.Status.inCommunity,
-        nomsNumber = "NOMS321",
-        ethnicity = "White and Asian",
-        nationality = "Spanish",
-        religionOrBelief = "Sikh",
-        genderIdentity = "Female",
-        prisonName = null,
-      ),
-    )
-  }
-
-  @Test
-  fun `transformModelToApi transforms correctly with self-described gender identity`() {
-    val offenderDetailSummary = OffenderDetailSummary(
-      offenderId = 547839,
-      title = "Mr",
-      firstName = "Greggory",
-      middleNames = listOf(),
-      surname = "Someone",
-      previousSurname = null,
-      preferredName = null,
-      dateOfBirth = LocalDate.parse("1980-09-12"),
-      gender = "Male",
-      otherIds = OffenderIds(
-        crn = "CRN123",
-        croNumber = null,
-        immigrationNumber = null,
-        mostRecentPrisonNumber = null,
-        niNumber = null,
-        nomsNumber = "NOMS321",
-        pncNumber = null,
-      ),
-      offenderProfile = OffenderProfile(
-        ethnicity = "White and Asian",
-        nationality = "Spanish",
-        secondaryNationality = null,
-        notes = null,
-        immigrationStatus = null,
-        offenderLanguages = OffenderLanguages(
-          primaryLanguage = null,
-          otherLanguages = listOf(),
-          languageConcerns = null,
-          requiresInterpreter = null,
-        ),
-        religion = "Sikh",
-        sexualOrientation = null,
-        offenderDetails = null,
-        remandStatus = null,
-        riskColour = null,
-        disabilities = listOf(),
-        genderIdentity = "Female",
-        selfDescribedGender = null,
-      ),
-      softDeleted = null,
-      currentDisposal = "",
-      partitionArea = null,
-      currentRestriction = false,
-      currentExclusion = false,
-      isActiveProbationManagedSentence = false,
-    )
-
-    val inmateDetail = InmateDetail(
-      offenderNo = "NOMS321",
-      inOutStatus = InOutStatus.OUT,
-      assignedLivingUnit = null,
-    )
-
-    val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
-
-    assertThat(result).isEqualTo(
-      Person(
-        crn = "CRN123",
-        name = "Greggory Someone",
-        dateOfBirth = LocalDate.parse("1980-09-12"),
-        sex = "Male",
-        status = Person.Status.inCommunity,
-        nomsNumber = "NOMS321",
-        ethnicity = "White and Asian",
-        nationality = "Spanish",
-        religionOrBelief = "Sikh",
-        genderIdentity = "Female",
-        prisonName = null,
-      ),
-    )
-  }
-
-  @Test
-  fun `transformModelToApi transforms correctly when in custody`() {
-    val offenderDetailSummary = OffenderDetailSummary(
-      offenderId = 547839,
-      title = "Mr",
-      firstName = "Greggory",
-      middleNames = listOf(),
-      surname = "Someone",
-      previousSurname = null,
-      preferredName = null,
-      dateOfBirth = LocalDate.parse("1980-09-12"),
-      gender = "Male",
-      otherIds = OffenderIds(
-        crn = "CRN123",
+        crn = crn,
         croNumber = null,
         immigrationNumber = null,
         mostRecentPrisonNumber = null,
@@ -302,15 +175,24 @@ class PersonTransformerTest {
       ),
     )
 
-    val result = personTransformer.transformModelToApi(offenderDetailSummary, inmateDetail)
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = inmateDetail,
+    )
 
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
     assertThat(result).isEqualTo(
-      Person(
+      FullPerson(
+        type = PersonType.fullPerson,
         crn = "CRN123",
         name = "Greggory Someone",
         dateOfBirth = LocalDate.parse("1980-09-12"),
         sex = "Male",
-        status = Person.Status.inCustody,
+        status = FullPerson.Status.inCustody,
         nomsNumber = "NOMS321",
         ethnicity = "White and Asian",
         nationality = "Spanish",
@@ -322,71 +204,72 @@ class PersonTransformerTest {
   }
 
   @Test
-  fun `transformModelToApi transforms correctly without a NOMS record`() {
-    val offenderDetailSummary = OffenderDetailSummary(
-      offenderId = 547839,
-      title = "Mr",
-      firstName = "Greggory",
-      middleNames = listOf(),
-      surname = "Someone",
-      previousSurname = null,
-      preferredName = null,
-      dateOfBirth = LocalDate.parse("1980-09-12"),
-      gender = "Male",
-      otherIds = OffenderIds(
-        crn = "CRN123",
-        croNumber = null,
-        immigrationNumber = null,
-        mostRecentPrisonNumber = null,
-        niNumber = null,
-        nomsNumber = "NOMS321",
-        pncNumber = null,
-      ),
-      offenderProfile = OffenderProfile(
-        ethnicity = "White and Asian",
-        nationality = "Spanish",
-        secondaryNationality = null,
-        notes = null,
-        immigrationStatus = null,
-        offenderLanguages = OffenderLanguages(
-          primaryLanguage = null,
-          otherLanguages = listOf(),
-          languageConcerns = null,
-          requiresInterpreter = null,
-        ),
-        religion = "Sikh",
-        sexualOrientation = null,
-        offenderDetails = null,
-        remandStatus = null,
-        riskColour = null,
-        disabilities = listOf(),
-        genderIdentity = null,
-        selfDescribedGender = null,
-      ),
-      softDeleted = null,
-      currentDisposal = "",
-      partitionArea = null,
-      currentRestriction = false,
-      currentExclusion = false,
-      isActiveProbationManagedSentence = false,
+  fun `transformModelToPersonInfoApi transforms correctly without gender identity`() {
+    val crn = "CRN123"
+
+    val offenderDetailSummary = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withGenderIdentity(null)
+      .produce()
+
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
     )
 
-    val result = personTransformer.transformModelToApi(offenderDetailSummary, null)
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
 
-    assertThat(result).isEqualTo(
-      Person(
-        crn = "CRN123",
-        name = "Greggory Someone",
-        dateOfBirth = LocalDate.parse("1980-09-12"),
-        sex = "Male",
-        status = Person.Status.unknown,
-        nomsNumber = null,
-        ethnicity = "White and Asian",
-        nationality = "Spanish",
-        religionOrBelief = "Sikh",
-        genderIdentity = null,
-        prisonName = null,
-      ),
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
+    result as FullPerson
+    assertThat(result.genderIdentity).isEqualTo(null)
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly with gender identity`() {
+    val crn = "CRN123"
+
+    val offenderDetailSummary = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withGenderIdentity("Male")
+      .produce()
+
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
     )
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
+    result as FullPerson
+    assertThat(result.genderIdentity).isEqualTo("Male")
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly with self described gender identity`() {
+    val crn = "CRN123"
+
+    val offenderDetailSummary = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withGenderIdentity("Prefer to self-describe")
+      .withSelfDescribedGenderIdentity("Other")
+      .produce()
+
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
+    )
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
+    result as FullPerson
+    assertThat(result.genderIdentity).isEqualTo("Other")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -56,6 +57,7 @@ class PlacementRequestTransformerTest {
 
   private val offenderDetailSummary = OffenderDetailsSummaryFactory().produce()
   private val inmateDetail = InmateDetailFactory().produce()
+  private val personInfo = PersonInfoResult.Success.Full(offenderDetailSummary.otherIds.crn, offenderDetailSummary, inmateDetail)
   private val mockBookingSummary = mockk<BookingSummary>()
 
   private val user = UserEntityFactory()
@@ -102,7 +104,7 @@ class PlacementRequestTransformerTest {
     .withAllocatedToUser(user)
 
   private val mockRisks = mockk<PersonRisks>()
-  private val mockPerson = mockk<Person>()
+  private val mockPersonInfo = mockk<Person>()
 
   private val mockUser = mockk<ApprovedPremisesUser>()
   private val decision = ApiAssessmentDecision.accepted
@@ -110,7 +112,7 @@ class PlacementRequestTransformerTest {
   @BeforeEach
   fun setup() {
     every { mockAssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns decision
-    every { mockPersonTransformer.transformModelToApi(offenderDetailSummary, inmateDetail) } returns mockPerson
+    every { mockPersonTransformer.transformModelToPersonApi(personInfo) } returns mockPersonInfo
     every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockRisks
     every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockUser
   }
@@ -140,7 +142,10 @@ class PlacementRequestTransformerTest {
       .withNotes("Some notes")
       .produce()
 
-    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, offenderDetailSummary, inmateDetail)
+    val result = placementRequestTransformer.transformJpaToApi(
+      placementRequestEntity,
+      PersonInfoResult.Success.Full(offenderDetailSummary.otherIds.crn, offenderDetailSummary, inmateDetail),
+    )
 
     assertThat(result).isEqualTo(
       PlacementRequest(
@@ -153,7 +158,7 @@ class PlacementRequestTransformerTest {
         radius = placementRequirementsEntity.radius,
         essentialCriteria = listOf(PlacementCriteria.isSemiSpecialistMentalHealth, PlacementCriteria.isRecoveryFocussed),
         desirableCriteria = listOf(PlacementCriteria.isWheelchairDesignated, PlacementCriteria.isSingle, PlacementCriteria.hasEnSuite),
-        person = mockPerson,
+        person = mockPersonInfo,
         risks = mockRisks,
         applicationId = application.id,
         assessmentId = assessment.id,
@@ -195,7 +200,7 @@ class PlacementRequestTransformerTest {
 
     every { mockBookingSummaryTransformer.transformJpaToApi(booking) } returns mockBookingSummary
 
-    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, offenderDetailSummary, inmateDetail)
+    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, personInfo)
 
     assertThat(result.status).isEqualTo(PlacementRequestStatus.matched)
     assertThat(result.booking).isEqualTo(mockBookingSummary)
@@ -215,7 +220,7 @@ class PlacementRequestTransformerTest {
 
     placementRequestEntity.bookingNotMades = mutableListOf(bookingNotMade)
 
-    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, offenderDetailSummary, inmateDetail)
+    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, personInfo)
 
     assertThat(result.status).isEqualTo(PlacementRequestStatus.unableToMatch)
   }
@@ -253,7 +258,7 @@ class PlacementRequestTransformerTest {
 
     every { mockBookingSummaryTransformer.transformJpaToApi(booking) } returns mockBookingSummary
 
-    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, offenderDetailSummary, inmateDetail)
+    val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, PersonInfoResult.Success.Full(offenderDetailSummary.otherIds.crn, offenderDetailSummary, inmateDetail))
 
     assertThat(result.status).isEqualTo(PlacementRequestStatus.notMatched)
     assertThat(result.booking).isEqualTo(mockBookingSummary)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
@@ -54,7 +53,6 @@ class TaskTransformerTest {
   private val mockRisksTransformer = mockk<RisksTransformer>()
   private val mockPlacementRequestTransformer = mockk<PlacementRequestTransformer>()
 
-  private val mockPerson = mockk<Person>()
   private val mockUser = mockk<ApprovedPremisesUser>()
   private val mockOffenderDetailSummary = mockk<OffenderDetailSummary>()
   private val mockInmateDetail = mockk<InmateDetail>()
@@ -112,7 +110,6 @@ class TaskTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToApi(mockOffenderDetailSummary, mockInmateDetail) } returns mockPerson
     every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockUser
   }
 


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-approved-premises-api#911

We're now reproposing [the API LAO changes originally set out here](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/804). 

We had to revert them from dev where we were conducting some manual tests:

- We needed to make CAS3 frontend changes (which also applies to CAS2 who have been looped in) which without blocked the deployment pipeline
- CAS1 found some odd behaviour during the test (which may require an additional change to this PR)

Before we go again we should check that each frontend has updated it's types and CAS1 is happy they've fixed any problems.


