### PR TITLE
Relegate `BookingSearchResultPersonSummary.name` to be an optional field for allowing nulls for LAO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSearchResultTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSearchResultTransformer.kt
@@ -20,7 +20,7 @@ class BookingSearchResultTransformer {
 
   private fun transformResult(result: DomainBookingSearchResult) = ApiBookingSearchResult(
     person = BookingSearchResultPersonSummary(
-      name = result.personName ?: "",
+      name = result.personName,
       crn = result.personCrn,
     ),
     booking = BookingSearchResultBookingSummary(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -6692,7 +6692,6 @@ components:
         crn:
           type: string
       required:
-        - name
         - crn
     BookingSearchResultBookingSummary:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSearchTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSearchTransformerTest.kt
@@ -47,7 +47,7 @@ class BookingSearchTransformerTest {
     result.results.forEachIndexed { index, it ->
       val domainResult = domainResults[index]
 
-      assertThat(it.person.name).isEqualTo(domainResult.personName ?: "")
+      assertThat(it.person.name).isEqualTo(domainResult.personName)
       assertThat(it.person.crn).isEqualTo(domainResult.personCrn)
       assertThat(it.booking.id).isEqualTo(domainResult.bookingId)
       assertThat(it.booking.status.value).isEqualTo(domainResult.bookingStatus)


### PR DESCRIPTION
> [see #1503 on the CAS3 Trello board.](https://trello.com/c/fWgW7BRK/1503-person-name-on-bookingsearchresultpersonsummary-should-be-optional)

[`BookingSearchResultPersonSummary.name` was previously a required field in the OpenApi specification.](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/2abdd8ab637020ea0c0620701c3e806a8fbb1a4b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSearchResultTransformer.kt#L23)

We now require this field to allow `null` values in the case of LAO individuals, as their names should not be revealed to the current logged-in user.
