### PR TITLE
Chore/update cas3 booking seeds

### DIFF
--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
@@ -20,7 +20,7 @@ INSERT INTO
   )
 VALUES
   (
-    '80d5337f-4af4-4df9-a1ae-bb909444715f',
+    '1d0f6bcb-b742-4a53-8988-aeb192350824',
     CURRENT_DATE + 4,
     CURRENT_DATE + 84,
     'X371199',

--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
@@ -34,6 +34,22 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    'c30a8ddb-fd44-40ac-b2ba-5ce5c15e110a',
+    '1d0f6bcb-b742-4a53-8988-aeb192350824',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+
 --- Add a confirmed booking ---
 
 INSERT INTO
@@ -66,6 +82,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    'ec8d595a-25db-48cd-b9a0-2576998825a5',
+    '1de846dd-9617-4488-9b05-d54c9f955e2b',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   confirmations (
@@ -117,6 +148,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    '96ef4637-a768-457f-b803-aa22343d4934',
+    '713943e2-1ae4-4101-aa6c-9a40e7930168',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   arrivals (
@@ -195,6 +241,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    '312f3b79-c3b3-4792-8e63-c86f6f9c3f78',
+    '13145d61-6ea7-4e77-9c89-cbbd2f7d85c4',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   arrivals (
@@ -248,6 +309,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    '60f56560-7499-4c60-bae8-63ea7cbe685e',
+    'a6fc549a-915d-4884-97f0-bc1cee84208c',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   arrivals (
@@ -301,6 +377,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    '84807d77-1ccb-408a-b307-df79980791cd',
+    'e3a08fac-88b3-4691-ad6f-b26b9180b1c6',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   departures (

--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
@@ -366,7 +366,7 @@ VALUES
     'e3a08fac-88b3-4691-ad6f-b26b9180b1c6',
     CURRENT_DATE - 168,
     CURRENT_DATE - 1,
-    'X371199',
+    'X320741',
     CURRENT_DATE - 168,
     CURRENT_DATE - 1,
     '70a6046c-23fc-4a30-b151-582ffd509e6a',

--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_eofe.sql
@@ -184,7 +184,7 @@ VALUES
     '13145d61-6ea7-4e77-9c89-cbbd2f7d85c4',
     CURRENT_DATE - 84,
     CURRENT_DATE + 3,
-    'X698234', -- Multiple Offences
+    'X698334', -- LAO
     CURRENT_DATE - 84,
     CURRENT_DATE + 3,
     '70a6046c-23fc-4a30-b151-582ffd509e6a',

--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
@@ -367,7 +367,7 @@ VALUES
     'e3a08fac-88b3-4691-ad6f-b26b9180b1c6',
     CURRENT_DATE - 168,
     CURRENT_DATE - 1,
-    'X371199',
+    'X320741',
     CURRENT_DATE - 168,
     CURRENT_DATE - 1,
     'd6447105-4bfe-4f1e-add7-4668e1ca28b0',

--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
@@ -238,7 +238,7 @@ VALUES
     'a6fc549a-915d-4884-97f0-bc1cee84208c',
     CURRENT_DATE - 7,
     CURRENT_DATE + 51,
-    'X698320', -- Multiple offences
+    'X698334', -- Multiple offences
     CURRENT_DATE - 7,
     CURRENT_DATE + 51,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',

--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
@@ -34,6 +34,22 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    'cc3b1ef5-b492-4771-9cb9-975cf36c7f19',
+    '80d5337f-4af4-4df9-a1ae-bb909444715f',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
+
 --- Add a confirmed booking ---
 
 INSERT INTO
@@ -66,6 +82,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    'ec0580b0-9c93-4114-b5c5-5e9da19af5d3',
+    '1de846dd-9617-4488-9b05-d54c9f955e2b',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   confirmations (
@@ -117,6 +148,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    'f1f6801f-a900-4acf-9908-7b4568e23ec1',
+    '713943e2-1ae4-4101-aa6c-9a40e7930168',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   arrivals (
@@ -196,6 +242,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    'c9c40961-5fe8-46e7-bf9c-38d2daf4074a',
+    '13145d61-6ea7-4e77-9c89-cbbd2f7d85c4',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   arrivals (
@@ -249,6 +310,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    '9c209338-9a57-43da-a35e-0dd22db4240f',
+    'a6fc549a-915d-4884-97f0-bc1cee84208c',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   arrivals (
@@ -302,6 +378,21 @@ VALUES
   )
 ON CONFLICT(id) DO NOTHING;
 
+INSERT INTO
+  turnarounds (
+    "id",
+    "booking_id",
+    "working_day_count",
+    "created_at"
+  )
+VALUES
+  (
+    '49d5cdc3-bd54-4954-8dcb-ee4fd45ba573',
+    'e3a08fac-88b3-4691-ad6f-b26b9180b1c6',
+    2,
+    CURRENT_DATE
+  )
+ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
   departures (


### PR DESCRIPTION
These seeds run on dev and test environments.

We found that [viewing these bookings breaks since there's no turnaround record](https://ministryofjustice.sentry.io/issues/4218927270/?environment=prod&project=4504129156218880&query=&referrer=project-issue-stream) so this proposal starts by fixing that.

We then change up some CRN's to make sure we get some names through on both dev and test environments.

I've run this locally to verify. You can do the same by moving these scripts into src/main/resources/db/migration/local and modifying src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql so that the JIMSNOWLDAP user belongs to the east of england region:

```
    ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', 2500041001, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE')
 ```
 
 To run locally be sure to throw away your old database `docker-compose down -v && tilt up -- --local-api --local-ui`