### PR TITLE
Create system note when a Temporary Accommodation assessment changes state

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -336,6 +336,10 @@ abstract class AssessmentReferralHistoryNoteEntity(
   val createdAt: OffsetDateTime,
 
   val message: String,
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdByUser: UserEntity,
 )
 
 @Entity
@@ -345,14 +349,38 @@ class AssessmentReferralHistoryUserNoteEntity(
   assessment: AssessmentEntity,
   createdAt: OffsetDateTime,
   message: String,
-
-  @ManyToOne
-  @JoinColumn(name = "created_by_user_id")
-  val createdByUser: UserEntity,
-
+  createdByUser: UserEntity,
 ) : AssessmentReferralHistoryNoteEntity(
   id,
   assessment,
   createdAt,
   message,
+  createdByUser,
 )
+
+@Entity
+@Table(name = "assessment_referral_history_system_notes")
+class AssessmentReferralHistorySystemNoteEntity(
+  id: UUID,
+  assessment: AssessmentEntity,
+  createdAt: OffsetDateTime,
+  message: String,
+  createdByUser: UserEntity,
+  @Enumerated(EnumType.STRING)
+  val type: ReferralHistorySystemNoteType,
+) : AssessmentReferralHistoryNoteEntity(
+  id,
+  assessment,
+  createdAt,
+  message,
+  createdByUser,
+)
+
+enum class ReferralHistorySystemNoteType {
+  SUBMITTED,
+  UNALLOCATED,
+  IN_REVIEW,
+  READY_TO_PLACE,
+  REJECTED,
+  COMPLETED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -25,9 +25,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentCla
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
@@ -191,6 +193,8 @@ class AssessmentService(
       ),
     )
 
+    assessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.SUBMITTED)
+
     return assessment
   }
 
@@ -288,6 +292,10 @@ class AssessmentService(
     }
 
     val savedAssessment = assessmentRepository.save(assessment)
+
+    if (savedAssessment is TemporaryAccommodationAssessmentEntity) {
+      savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.READY_TO_PLACE)
+    }
 
     if (assessment is ApprovedPremisesAssessmentEntity) {
       val placementRequirementsValidationResult =
@@ -440,6 +448,10 @@ class AssessmentService(
 
     val savedAssessment = assessmentRepository.save(assessment)
 
+    if (savedAssessment is TemporaryAccommodationAssessmentEntity) {
+      savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.REJECTED)
+    }
+
     val application = savedAssessment.application
 
     val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(application.crn, user.deliusUsername, true)) {
@@ -542,6 +554,7 @@ class AssessmentService(
     assessment.completedAt = OffsetDateTime.now()
 
     val savedAssessment = assessmentRepository.save(assessment)
+    savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.COMPLETED)
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(savedAssessment),
@@ -652,11 +665,12 @@ class AssessmentService(
     currentAssessment.allocatedToUser = assigneeUser
     currentAssessment.allocatedAt = OffsetDateTime.now()
 
-    assessmentRepository.save(currentAssessment)
+    val savedAssessment = assessmentRepository.save(currentAssessment)
+    savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.IN_REVIEW)
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
-        currentAssessment,
+        savedAssessment,
       ),
     )
   }
@@ -674,9 +688,12 @@ class AssessmentService(
     currentAssessment.decision = null
     currentAssessment.submittedAt = null
 
+    val savedAssessment = assessmentRepository.save(currentAssessment)
+    savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.UNALLOCATED)
+
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
-        assessmentRepository.save(currentAssessment),
+        savedAssessment,
       ),
     )
   }
@@ -755,5 +772,18 @@ class AssessmentService(
     )
 
     return AuthorisableActionResult.Success(referralHistoryNoteEntity)
+  }
+
+  private fun AssessmentEntity.addSystemNote(user: UserEntity, type: ReferralHistorySystemNoteType) {
+    this.referralHistoryNotes += assessmentReferralHistoryNoteRepository.save(
+      AssessmentReferralHistorySystemNoteEntity(
+        id = UUID.randomUUID(),
+        assessment = this,
+        createdAt = OffsetDateTime.now(),
+        message = "",
+        createdByUser = user,
+        type = type,
+      ),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
@@ -2,9 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistorySystemNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryUserNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 
 @Component
 class AssessmentReferralHistoryNoteTransformer {
@@ -14,7 +17,25 @@ class AssessmentReferralHistoryNoteTransformer {
       createdAt = jpa.createdAt.toInstant(),
       message = jpa.message,
       createdByUserName = jpa.createdByUser.name,
+      type = "user",
+    )
+    is AssessmentReferralHistorySystemNoteEntity -> ReferralHistorySystemNote(
+      id = jpa.id,
+      createdAt = jpa.createdAt.toInstant(),
+      message = jpa.message,
+      createdByUserName = jpa.createdByUser.name,
+      type = "system",
+      category = transformSystemNoteTypeToCategory(jpa.type),
     )
     else -> throw RuntimeException("Unsupported ReferralHistoryNote type: ${jpa::class.qualifiedName}")
+  }
+
+  private fun transformSystemNoteTypeToCategory(type: ReferralHistorySystemNoteType): ReferralHistorySystemNote.Category = when (type) {
+    ReferralHistorySystemNoteType.SUBMITTED -> ReferralHistorySystemNote.Category.submitted
+    ReferralHistorySystemNoteType.UNALLOCATED -> ReferralHistorySystemNote.Category.unallocated
+    ReferralHistorySystemNoteType.IN_REVIEW -> ReferralHistorySystemNote.Category.inReview
+    ReferralHistorySystemNoteType.READY_TO_PLACE -> ReferralHistorySystemNote.Category.readyToPlace
+    ReferralHistorySystemNoteType.REJECTED -> ReferralHistorySystemNote.Category.rejected
+    ReferralHistorySystemNoteType.COMPLETED -> ReferralHistorySystemNote.Category.completed
   }
 }

--- a/src/main/resources/db/migration/all/20230822104736__create_table_for_assessment_system_notes.sql
+++ b/src/main/resources/db/migration/all/20230822104736__create_table_for_assessment_system_notes.sql
@@ -1,0 +1,16 @@
+ALTER TABLE assessment_referral_history_notes ADD COLUMN created_by_user_id UUID;
+
+UPDATE assessment_referral_history_notes
+SET created_by_user_id = n.created_by_user_id
+FROM assessment_referral_history_user_notes n;
+
+ALTER TABLE assessment_referral_history_notes ALTER COLUMN created_by_user_id SET NOT NULL;
+ALTER TABLE assessment_referral_history_notes ADD FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+
+ALTER TABLE assessment_referral_history_user_notes DROP COLUMN created_by_user_id;
+
+CREATE TABLE assessment_referral_history_system_notes (
+    id UUID NOT NULL,
+    type TEXT NOT NULL,
+    FOREIGN KEY (id) REFERENCES assessment_referral_history_notes(id)
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5622,23 +5622,40 @@ components:
           format: date-time
         message:
           type: string
+        createdByUserName:
+          type: string
+        type:
+          type: string
       required:
         - id
         - createdAt
         - message
+        - createdByUserName
+        - type
       discriminator:
         propertyName: type
         mapping:
           user: '#/components/schemas/ReferralHistoryUserNote'
+          system: '#/components/schemas/ReferralHistorySystemNote'
     ReferralHistoryUserNote:
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+    ReferralHistorySystemNote:
       allOf:
         - $ref: '#/components/schemas/ReferralHistoryNote'
         - type: object
           properties:
-            createdByUserName:
+            category:
               type: string
+              enum:
+                - submitted
+                - unallocated
+                - in_review
+                - ready_to_place
+                - rejected
+                - completed
           required:
-            - createdByUserName
+            - category
     NewReferralHistoryUserNote:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistorySystemNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistorySystemNoteEntityFactory.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class AssessmentReferralHistorySystemNoteEntityFactory : Factory<AssessmentReferralHistorySystemNoteEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var assessment: Yielded<AssessmentEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var message: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var createdBy: Yielded<UserEntity>? = null
+  private var type: Yielded<ReferralHistorySystemNoteType> = { randomOf(ReferralHistorySystemNoteType.entries) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAssessment(assessment: AssessmentEntity) = apply {
+    this.assessment = { assessment }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withMessage(message: String) = apply {
+    this.message = { message }
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  fun withType(type: ReferralHistorySystemNoteType) = apply {
+    this.type = { type }
+  }
+
+  override fun produce(): AssessmentReferralHistorySystemNoteEntity = AssessmentReferralHistorySystemNoteEntity(
+    id = this.id(),
+    assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
+    createdAt = this.createdAt(),
+    message = this.message(),
+    createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
+    type = this.type(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistorySystemNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistoryUserNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
@@ -86,6 +87,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
@@ -154,6 +156,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentClarificationNoteTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentReferralHistorySystemNoteTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AssessmentReferralHistoryUserNoteTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingNotMadeTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
@@ -394,6 +397,9 @@ abstract class IntegrationTestBase {
   lateinit var assessmentReferralUserNoteRepository: AssessmentReferralHistoryUserNoteTestRepository
 
   @Autowired
+  lateinit var assessmentReferralSystemNoteRepository: AssessmentReferralHistorySystemNoteTestRepository
+
+  @Autowired
   lateinit var characteristicRepository: CharacteristicRepository
 
   @Autowired
@@ -473,6 +479,7 @@ abstract class IntegrationTestBase {
   lateinit var temporaryAccommodationAssessmentEntityFactory: PersistedFactory<TemporaryAccommodationAssessmentEntity, UUID, TemporaryAccommodationAssessmentEntityFactory>
   lateinit var assessmentClarificationNoteEntityFactory: PersistedFactory<AssessmentClarificationNoteEntity, UUID, AssessmentClarificationNoteEntityFactory>
   lateinit var assessmentReferralHistoryUserNoteEntityFactory: PersistedFactory<AssessmentReferralHistoryUserNoteEntity, UUID, AssessmentReferralHistoryUserNoteEntityFactory>
+  lateinit var assessmentReferralHistorySystemNoteEntityFactory: PersistedFactory<AssessmentReferralHistorySystemNoteEntity, UUID, AssessmentReferralHistorySystemNoteEntityFactory>
   lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
   lateinit var roomEntityFactory: PersistedFactory<RoomEntity, UUID, RoomEntityFactory>
   lateinit var bedEntityFactory: PersistedFactory<BedEntity, UUID, BedEntityFactory>
@@ -553,6 +560,7 @@ abstract class IntegrationTestBase {
     temporaryAccommodationAssessmentEntityFactory = PersistedFactory({ TemporaryAccommodationAssessmentEntityFactory() }, temporaryAccommodationAssessmentRepository)
     assessmentClarificationNoteEntityFactory = PersistedFactory({ AssessmentClarificationNoteEntityFactory() }, assessmentClarificationNoteRepository)
     assessmentReferralHistoryUserNoteEntityFactory = PersistedFactory({ AssessmentReferralHistoryUserNoteEntityFactory() }, assessmentReferralUserNoteRepository)
+    assessmentReferralHistorySystemNoteEntityFactory = PersistedFactory({ AssessmentReferralHistorySystemNoteEntityFactory() }, assessmentReferralSystemNoteRepository)
     characteristicEntityFactory = PersistedFactory({ CharacteristicEntityFactory() }, characteristicRepository)
     roomEntityFactory = PersistedFactory({ RoomEntityFactory() }, roomRepository)
     bedEntityFactory = PersistedFactory({ BedEntityFactory() }, bedRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentReferralHistorySystemNoteTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentReferralHistorySystemNoteTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
+import java.util.UUID
+
+@Repository
+interface AssessmentReferralHistorySystemNoteTestRepository : JpaRepository<AssessmentReferralHistorySystemNoteEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentReferralHistoryNoteTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentReferralHistoryNoteTransformerTest.kt
@@ -1,0 +1,101 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistorySystemNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryUserNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistorySystemNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistoryUserNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
+
+class AssessmentReferralHistoryNoteTransformerTest {
+  @Test
+  fun `transformJpaToApi transforms correctly for a user note`() {
+    val probationRegion = ProbationRegionEntityFactory()
+      .withApArea(ApAreaEntityFactory().produce())
+      .produce()
+
+    val user = UserEntityFactory()
+      .withProbationRegion(probationRegion)
+      .produce()
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withProbationRegion(probationRegion)
+      .produce()
+
+    val assessment = TemporaryAccommodationAssessmentEntityFactory()
+      .withApplication(application)
+      .produce()
+
+    val note = AssessmentReferralHistoryUserNoteEntityFactory()
+      .withAssessment(assessment)
+      .withCreatedBy(user)
+      .produce()
+
+    val result = AssessmentReferralHistoryNoteTransformer().transformJpaToApi(note)
+
+    assertThat(result is ReferralHistoryUserNote).isTrue
+    result as ReferralHistoryUserNote
+    assertThat(result.id).isEqualTo(note.id)
+    assertThat(result.createdAt).isEqualTo(note.createdAt.toInstant())
+    assertThat(result.createdByUserName).isEqualTo(user.name)
+    assertThat(result.message).isEqualTo(note.message)
+    assertThat(result.type).isEqualTo("user")
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  fun `transformJpaToApi transforms correctly for a system note`(noteType: ReferralHistorySystemNoteType) {
+    val probationRegion = ProbationRegionEntityFactory()
+      .withApArea(ApAreaEntityFactory().produce())
+      .produce()
+
+    val user = UserEntityFactory()
+      .withProbationRegion(probationRegion)
+      .produce()
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withProbationRegion(probationRegion)
+      .produce()
+
+    val assessment = TemporaryAccommodationAssessmentEntityFactory()
+      .withApplication(application)
+      .produce()
+
+    val note = AssessmentReferralHistorySystemNoteEntityFactory()
+      .withAssessment(assessment)
+      .withCreatedBy(user)
+      .withType(noteType)
+      .produce()
+
+    val result = AssessmentReferralHistoryNoteTransformer().transformJpaToApi(note)
+
+    assertThat(result is ReferralHistorySystemNote).isTrue
+    result as ReferralHistorySystemNote
+    assertThat(result.id).isEqualTo(note.id)
+    assertThat(result.createdAt).isEqualTo(note.createdAt.toInstant())
+    assertThat(result.createdByUserName).isEqualTo(user.name)
+    assertThat(result.message).isEqualTo(note.message)
+    assertThat(result.type).isEqualTo("system")
+    assertThat(result.category).isEqualTo(
+      when (noteType) {
+        ReferralHistorySystemNoteType.SUBMITTED -> ReferralHistorySystemNote.Category.submitted
+        ReferralHistorySystemNoteType.UNALLOCATED -> ReferralHistorySystemNote.Category.unallocated
+        ReferralHistorySystemNoteType.IN_REVIEW -> ReferralHistorySystemNote.Category.inReview
+        ReferralHistorySystemNoteType.READY_TO_PLACE -> ReferralHistorySystemNote.Category.readyToPlace
+        ReferralHistorySystemNoteType.REJECTED -> ReferralHistorySystemNote.Category.rejected
+        ReferralHistorySystemNoteType.COMPLETED -> ReferralHistorySystemNote.Category.completed
+      },
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ReferralHistoryNoteHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ReferralHistoryNoteHelper.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
+
+import org.assertj.core.api.Assertions
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+
+fun assertAssessmentHasSystemNote(assessment: AssessmentEntity, createdByUser: UserEntity, type: ReferralHistorySystemNoteType) {
+  Assertions.assertThat(assessment.referralHistoryNotes)
+    .hasSize(1)
+    .allMatch {
+      it is AssessmentReferralHistorySystemNoteEntity &&
+        it.createdByUser == createdByUser &&
+        it.assessment == assessment &&
+        it.type == type
+    }
+}


### PR DESCRIPTION
> See [ticket #1531 on the CAS3 Trello board](https://trello.com/c/FTcVxbYl/1351-when-a-status-is-changed-a-system-note-is-created).

This PR introduces a new type of `ReferralHistoryNote` to capture and represent when various actions are performed on an assessment in the Temporary Accommodation service - `ReferralHistorySystemNote`.

A `ReferralHistorySystemNote` looks like the following:
```
{
  "id": "00000000-0000-0000-0000-000000000000",
  "createdAt": "2023-01-01T12:34:56.789Z",
  "message": "",
  "createdByUserName": "SOMEUSER",
  "type": "system",
  "category": "in_review"
}
```

A system note is created in the following situations:
- When an application is submitted. This is when the assessment is created and the note will have a category of `"submitted"`.
- When an assessment is allocated or unallocated. This will create a note with a category of `"in_review"` or `"unallocated"` respectively.
- When an assessment is accepted or rejected. This will create a note with a category of `"ready_to_place"` or `"rejected"` respectively.
- When an assessment has been completed. This will create a note with a category of `"completed"`.

In all cases a system note will have an empty message as the frontend is responsible for deciding how to present each type of system note.