### PR TITLE
Return Risk To Self section of OASys report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysAssessmentState
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysRiskToSelf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSections
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSupportingInformationQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.NeedsDetails
@@ -56,6 +57,24 @@ class OASysSectionsTransformer : OASysTransformer() {
         oASysQuestionWithSingleAnswer("Monitoring and control", "RM31", riskManagementPlan.riskManagementPlan?.monitoringAndControl),
         oASysQuestionWithSingleAnswer("Supervision", "RM30", riskManagementPlan.riskManagementPlan?.supervision),
         oASysQuestionWithSingleAnswer("Key information about current situation", "RM28.1", riskManagementPlan.riskManagementPlan?.keyInformationAboutCurrentSituation),
+      ),
+    )
+  }
+
+  fun transformRiskToIndividual(
+    offenceDetails: OffenceDetails,
+    risksToTheIndividual: RisksToTheIndividual,
+  ): OASysRiskToSelf {
+    return OASysRiskToSelf(
+      assessmentId = offenceDetails.assessmentId,
+      assessmentState = if (offenceDetails.dateCompleted != null) OASysAssessmentState.completed else OASysAssessmentState.incomplete,
+      dateStarted = offenceDetails.initiationDate.toInstant(),
+      dateCompleted = offenceDetails.dateCompleted?.toInstant(),
+      riskToSelf = listOf(
+        oASysQuestionWithSingleAnswer("Current concerns about self-harm or suicide", "R8.1.1", risksToTheIndividual.riskToTheIndividual?.currentConcernsSelfHarmSuicide),
+        oASysQuestionWithSingleAnswer("Current concerns about Coping in Custody or Hostel", "R8.2.1", risksToTheIndividual.riskToTheIndividual?.currentCustodyHostelCoping),
+        oASysQuestionWithSingleAnswer("Current concerns about Vulnerability", "R8.3.1", risksToTheIndividual.riskToTheIndividual?.currentVulnerability),
+        oASysQuestionWithSingleAnswer("Previous concerns about self-harm or suicide", "R8.1.4", risksToTheIndividual.riskToTheIndividual?.previousConcernsSelfHarmSuicide),
       ),
     )
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1346,6 +1346,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/risk-to-self:
+    get:
+      tags:
+        - OASys
+      summary: Returns the Risk To Individual (known as Risk to Self on frontend) section of an OASys.
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRiskToSelf'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /people/{crn}/offences:
     get:
       summary: Returns all active offences for a Person.
@@ -6083,6 +6114,26 @@ components:
         - supportingInformation
         - riskToSelf
         - riskManagementPlan
+    OASysRiskToSelf:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        riskToSelf:
+          $ref: '#/components/schemas/ArrayOfOASysRiskToSelfQuestions'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - riskToSelf
     OASysSection:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulRiskToTheIndividualCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
+
+class PersonOASysRiskToSelfTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var oaSysSectionsTransformer: OASysSectionsTransformer
+
+  @Test
+  fun `Getting Risk to Self by CRN without a JWT returns 401`() {
+    webTestClient.get()
+      .uri("/people/CRN/oasys/risk-to-self")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting Risk to Self  for a CRN with a non-Delius JWT returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "nomis",
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/oasys/risk-to-self")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting oasys sections for a CRN without ROLE_PROBATION returns 403`() {
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius",
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/oasys/risk-to-self")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting Risk To Self for a CRN that does not exist returns 404`() {
+    `Given a User` { userEntity, jwt ->
+      val crn = "CRN123"
+
+      CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
+      loadPreemptiveCacheForOffenderDetails(crn)
+
+      webTestClient.get()
+        .uri("/people/$crn/oasys/risk-to-self")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting Risk to Self for a CRN returns OK with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val offenceDetails = OffenceDetailsFactory().produce()
+        APOASysContext_mockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
+
+        val risksToTheIndividual = RiskToTheIndividualFactory().produce()
+        APOASysContext_mockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              oaSysSectionsTransformer.transformRiskToIndividual(
+                offenceDetails,
+                risksToTheIndividual,
+              ),
+            ),
+          )
+      }
+    }
+  }
+
+  @Test
+  fun `Getting Risk to Self when upstream times out returns 404`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val risksToTheIndividual = RiskToTheIndividualFactory().produce()
+        APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, risksToTheIndividual, 2500)
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/oasys/sections?selected-sections=11&selected-sections=12")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
@@ -51,6 +51,13 @@ fun IntegrationTestBase.APOASysContext_mockUnsuccessfulNeedsDetailsCallWithDelay
     delayMs = delayMs,
   )
 
+fun IntegrationTestBase.APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay(crn: String, response: RisksToTheIndividual, delayMs: Int) =
+  mockUnsuccessfulGetCallWithDelayedResponse(
+    url = "/risk-to-the-individual/$crn",
+    responseStatus = 404,
+    delayMs = delayMs,
+  )
+
 fun IntegrationTestBase.APOASysContext_mockSuccessfulRoshRatingsCall(crn: String, response: RoshRatings) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/rosh/$crn",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
@@ -286,4 +286,69 @@ class OASysSectionsTransformerTest {
       ),
     )
   }
+
+  @Test
+  fun `transformRiskToIndividual transforms correctly`() {
+    val offenceDetailsApiResponse = OffenceDetailsFactory().apply {
+      withAssessmentId(34853487)
+      withDateCompleted(null)
+      withOffenceAnalysis("Offence Analysis")
+      withOthersInvolved("Others Involved")
+      withIssueContributingToRisk("Issue Contributing to Risk")
+      withOffenceMotivation("Offence Motivation")
+      withVictimImpact("Impact on the victim")
+      withVictimPerpetratorRel("Other victim information")
+      withVictimInfo("Victim Info")
+      withPatternOffending("Pattern Reoffending")
+      withAcceptsResponsibility("Accepts Responsibility")
+    }.produce()
+
+    val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+      withAssessmentId(34853487)
+      withDateCompleted(null)
+      withCurrentConcernsSelfHarmSuicide("currentConcernsSelfHarmSuicide")
+      withPreviousConcernsSelfHarmSuicide("previousConcernsSelfHarmSuicide")
+      withCurrentCustodyHostelCoping("currentCustodyHostelCoping")
+      withPreviousCustodyHostelCoping("previousCustodyHostelCoping")
+      withCurrentVulnerability("currentVulnerability")
+      withPreviousVulnerability("previousVulnerability")
+      withRiskOfSeriousHarm("riskOfSeriousHarm")
+      withCurrentConcernsBreachOfTrustText("currentConcernsBreachOfTrustText")
+    }.produce()
+
+    val result = oaSysSectionsTransformer.transformRiskToIndividual(
+      offenceDetailsApiResponse,
+      risksToTheIndividualApiResponse,
+    )
+
+    assertThat(result.assessmentId).isEqualTo(offenceDetailsApiResponse.assessmentId)
+    assertThat(result.assessmentState).isEqualTo(OASysAssessmentState.incomplete)
+    assertThat(result.dateStarted).isEqualTo(offenceDetailsApiResponse.initiationDate.toInstant())
+    assertThat(result.dateCompleted).isEqualTo(offenceDetailsApiResponse.dateCompleted?.toInstant())
+
+    assertThat(result.riskToSelf).containsAll(
+      listOf(
+        OASysQuestion(
+          label = "Current concerns about self-harm or suicide",
+          questionNumber = "R8.1.1",
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentConcernsSelfHarmSuicide,
+        ),
+        OASysQuestion(
+          label = "Current concerns about Coping in Custody or Hostel",
+          questionNumber = "R8.2.1",
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentCustodyHostelCoping,
+        ),
+        OASysQuestion(
+          label = "Current concerns about Vulnerability",
+          questionNumber = "R8.3.1",
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.currentVulnerability,
+        ),
+        OASysQuestion(
+          label = "Previous concerns about self-harm or suicide",
+          questionNumber = "R8.1.4",
+          answer = risksToTheIndividualApiResponse.riskToTheIndividual?.previousConcernsSelfHarmSuicide,
+        ),
+      ),
+    )
+  }
 }


### PR DESCRIPTION
CAS2 would like to request only the Risk to Self section of an OASys.  (https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/176 ) 

Currently there is the `oasys/sections` endpoint which enforces returning several sections (e.g. ROSH, Risk to Self, Risk Management Plan) and optionally returns some other sections. It also does not return one of the questions we need in Risk to Self ('historical risk of self-harm')

This PR suggests an `oasys/risk-to-self` endpoint which only returns the Risk to Self section. I'd be interested in any feedback on this approach. We will shortly need to request just the ROSH section, so I thought about having a param sent through to determine what section is returned, but having it as it's own endpoint seemed easier to understand. 