### PR TITLE
Update properties to add unique property and bedspace identifiers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUsageReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUsageReportGenerator.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
@@ -48,6 +49,8 @@ class BedUsageReportGenerator(
         bookingStatus = bookingTransformer.determineStatus(booking),
         voidCategory = null,
         voidNotes = null,
+        uniquePropertyRef = premises.id.toShortBase58(),
+        uniqueBedspaceRef = this.room.id.toShortBase58(),
       )
 
       val turnaround = booking.turnaround
@@ -68,6 +71,8 @@ class BedUsageReportGenerator(
           bookingStatus = null,
           voidCategory = null,
           voidNotes = null,
+          uniquePropertyRef = premises.id.toShortBase58(),
+          uniqueBedspaceRef = this.room.id.toShortBase58(),
         )
       }
     }
@@ -86,6 +91,8 @@ class BedUsageReportGenerator(
         bookingStatus = null,
         voidCategory = lostBed.reason.name,
         voidNotes = lostBed.notes,
+        uniquePropertyRef = premises.id.toShortBase58(),
+        uniqueBedspaceRef = this.room.id.toShortBase58(),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.earliestDateOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
@@ -93,6 +94,8 @@ class BedUtilisationReportGenerator(
         totalBookedDays = totalBookedDays,
         totalDaysInTheMonth = daysInMonth,
         occupancyRate = totalBookedDays.toDouble() / daysInMonth,
+        uniquePropertyRef = premises.id.toShortBase58(),
+        uniqueBedspaceRef = this.room.id.toShortBase58(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUsageReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUsageReportRow.kt
@@ -16,6 +16,8 @@ data class BedUsageReportRow(
   val bookingStatus: BookingStatus?,
   val voidCategory: String?,
   val voidNotes: String?,
+  val uniquePropertyRef: String,
+  val uniqueBedspaceRef: String,
 )
 
 enum class BedUsageType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportRow.kt
@@ -14,4 +14,6 @@ data class BedUtilisationReportRow(
   val totalBookedDays: Int,
   val totalDaysInTheMonth: Int,
   val occupancyRate: Double,
+  val uniquePropertyRef: String,
+  val uniqueBedspaceRef: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/ReportingUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/ReportingUtils.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util
+
+import java.util.UUID
+
+fun UUID.toShortBase58(): String {
+  val alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+  val base = alphabet.length.toULong()
+
+  val xorResult = mostSignificantBits xor leastSignificantBits
+  var num = xorResult.toULong()
+
+  val sb = StringBuilder()
+  while (num > 0uL) {
+    val remainder = (num % base).toInt()
+    sb.append(alphabet[remainder])
+    num /= base
+  }
+
+  return sb.reverse().toString()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import java.time.LocalDate
@@ -96,6 +97,7 @@ class BedUsageReportGeneratorTest {
 
     assertThat(result.count()).isEqualTo(1)
     assertThat(result[0][BedUsageReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremises.name)
+    assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
   }
 
   @Test
@@ -169,6 +171,7 @@ class BedUsageReportGeneratorTest {
 
     assertThat(result.count()).isEqualTo(1)
     assertThat(result[0][BedUsageReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)
+    assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())
   }
 
   @Test
@@ -242,7 +245,9 @@ class BedUsageReportGeneratorTest {
 
     assertThat(result.count()).isEqualTo(2)
     assertThat(result[0][BedUsageReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)
+    assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())
     assertThat(result[1][BedUsageReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.name)
+    assertThat(result[1][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.id.toShortBase58())
   }
 
   @Test
@@ -303,6 +308,8 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::bookingStatus]).isEqualTo(BookingStatus.closed)
     assertThat(result[0][BedUsageReportRow::voidCategory]).isEqualTo(null)
     assertThat(result[0][BedUsageReportRow::voidNotes]).isEqualTo(null)
+    assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
+    assertThat(result[0][BedUsageReportRow::uniqueBedspaceRef]).isEqualTo(temporaryAccommodationRoom.id.toShortBase58())
   }
 
   @Test
@@ -372,6 +379,8 @@ class BedUsageReportGeneratorTest {
     assertThat(result[1][BedUsageReportRow::bookingStatus]).isEqualTo(null)
     assertThat(result[1][BedUsageReportRow::voidCategory]).isEqualTo(null)
     assertThat(result[1][BedUsageReportRow::voidNotes]).isEqualTo(null)
+    assertThat(result[1][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
+    assertThat(result[1][BedUsageReportRow::uniqueBedspaceRef]).isEqualTo(temporaryAccommodationRoom.id.toShortBase58())
   }
 
   @Test
@@ -430,5 +439,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::bookingStatus]).isEqualTo(null)
     assertThat(result[0][BedUsageReportRow::voidCategory]).isEqualTo(temporaryAccommodationLostBed.reason.name)
     assertThat(result[0][BedUsageReportRow::voidNotes]).isEqualTo(temporaryAccommodationLostBed.notes)
+    assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
+    assertThat(result[0][BedUsageReportRow::uniqueBedspaceRef]).isEqualTo(temporaryAccommodationRoom.id.toShortBase58())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -96,6 +97,7 @@ class BedUtilisationReportGeneratorTest {
 
     assertThat(result.count()).isEqualTo(1)
     assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremises.name)
+    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
   }
 
   @Test
@@ -169,6 +171,7 @@ class BedUtilisationReportGeneratorTest {
 
     assertThat(result.count()).isEqualTo(1)
     assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)
+    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())
   }
 
   @Test
@@ -242,7 +245,9 @@ class BedUtilisationReportGeneratorTest {
 
     assertThat(result.count()).isEqualTo(2)
     assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)
+    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())
     assertThat(result[1][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.name)
+    assertThat(result[1][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.id.toShortBase58())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/ReportingUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/ReportingUtilsTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
+import java.util.UUID
+
+class ReportingUtilsTest {
+  @Test
+  fun `toShortBase58 should return different hashed values for different UUIDs`() {
+    val uuid1 = UUID.randomUUID()
+    val uuid2 = UUID.randomUUID()
+
+    assertThat(uuid1.toShortBase58()).isNotBlank()
+    assertThat(uuid2.toShortBase58()).isNotBlank()
+    assertThat(uuid1.toShortBase58()).isNotEqualTo(uuid2.toShortBase58())
+  }
+
+  @Test
+  fun `toShortBase58 should return the same hashed value for the same UUID`() {
+    val uuid1 = UUID.fromString("e11e2d61-a84e-4c49-8955-a259ee178fbd")
+    val uuid2 = UUID.fromString("e11e2d61-a84e-4c49-8955-a259ee178fbd")
+
+    assertThat(uuid1.toShortBase58()).isNotBlank()
+    assertThat(uuid2.toShortBase58()).isNotBlank()
+    assertThat(uuid1.toShortBase58()).isEqualTo(uuid2.toShortBase58())
+  }
+
+  @Test
+  fun `toShortBase58 should return the correct hashed value for a specific UUID`() {
+    val specificUUID = UUID.fromString("57fbee87-03c0-4696-b3af-cc18f12d7034")
+    val specificHash = "fC5HnCZA11T"
+
+    assertThat(specificUUID.toShortBase58()).isNotBlank()
+    assertThat(specificUUID.toShortBase58()).isEqualTo(specificHash)
+  }
+}


### PR DESCRIPTION
> [see #1508 on the CAS3 Trello board.](https://trello.com/c/Vr2C038X/1508-update-reports-to-include-unique-property-and-bedspace-identifiers)

This PR implements a change to the report-generation for bed usage and bed utilisation. Previously property and bedspace references were set in the `name` field and cannot be edited by the user.

The scope of this PR, rather than open editing of this field to the user, is to add two new fields - `uniquePropertyRef` and `uniqueBedspaceRef`. These fields hash the UUIDs given in the `propertyRef` and `bedspaceRef` fields respectively to a base-58 version (alphanumeric minus 0, O, I, and l), resulting in a maximum of 11 easily-readable characters. Hashes persist for the same `propertyRef` and `bedspaceRef` for ease-of-use in the real world.

Editing of the `propertyRef` and `bedspaceRef` fields might be visited in a future PR.