### PR TITLE
Provide summary data to Temporary Accommodation assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -250,6 +250,8 @@ class TemporaryAccommodationAssessmentEntity(
   referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>,
   schemaUpToDate: Boolean,
   var completedAt: OffsetDateTime?,
+  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
+  var summaryData: String,
 ) : AssessmentEntity(
   id,
   application,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -663,7 +663,7 @@ class ApplicationService(
       arrivalDate = if (submitApplication.arrivalDate !== null) OffsetDateTime.of(submitApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC) else null
     }
 
-    assessmentService.createAssessment(application)
+    assessmentService.createApprovedPremisesAssessment(application)
 
     application = applicationRepository.save(application)
 
@@ -806,7 +806,7 @@ class ApplicationService(
       arrivalDate = OffsetDateTime.of(submitApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC)
     }
 
-    assessmentService.createAssessment(application)
+    assessmentService.createTemporaryAccommodationAssessment(application, submitApplication.summaryData ?: {})
 
     application = applicationRepository.save(application)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -190,6 +190,7 @@ class AssessmentService(
         clarificationNotes = mutableListOf(),
         referralHistoryNotes = mutableListOf(),
         completedAt = null,
+        summaryData = "{}",
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
@@ -125,12 +124,6 @@ class AssessmentService(
     assessment.schemaUpToDate = assessment.schemaVersion.id == latestSchema.id
 
     return AuthorisableActionResult.Success(assessment)
-  }
-
-  fun createAssessment(application: ApplicationEntity): AssessmentEntity = when (application) {
-    is ApprovedPremisesApplicationEntity -> createApprovedPremisesAssessment(application)
-    is TemporaryAccommodationApplicationEntity -> createTemporaryAccommodationAssessment(application, {})
-    else -> throw RuntimeException("Application type '${application::class.qualifiedName}' is not supported")
   }
 
   fun createApprovedPremisesAssessment(application: ApprovedPremisesApplicationEntity): ApprovedPremisesAssessmentEntity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -70,6 +70,7 @@ class AssessmentTransformer(
       decision = transformJpaDecisionToApi(jpa.decision),
       rejectionRationale = jpa.rejectionRationale,
       status = getStatusForTemporaryAccommodationAssessment(jpa),
+      summaryData = "{}",
       service = "CAS3",
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -15,11 +15,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -36,8 +35,8 @@ class AssessmentTransformer(
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
 ) {
-  fun transformJpaToApi(jpa: AssessmentEntity, personInfo: PersonInfoResult.Success) = when (jpa.application) {
-    is ApprovedPremisesApplicationEntity -> ApprovedPremisesAssessment(
+  fun transformJpaToApi(jpa: AssessmentEntity, personInfo: PersonInfoResult.Success) = when (jpa) {
+    is ApprovedPremisesAssessmentEntity -> ApprovedPremisesAssessment(
       id = jpa.id,
       application = applicationsTransformer.transformJpaToApi(jpa.application, personInfo) as ApprovedPremisesApplication,
       schemaVersion = jpa.schemaVersion.id,
@@ -55,7 +54,7 @@ class AssessmentTransformer(
       service = "CAS1",
     )
 
-    is TemporaryAccommodationApplicationEntity -> TemporaryAccommodationAssessment(
+    is TemporaryAccommodationAssessmentEntity -> TemporaryAccommodationAssessment(
       id = jpa.id,
       application = applicationsTransformer.transformJpaToApi(jpa.application, personInfo) as TemporaryAccommodationApplication,
       schemaVersion = jpa.schemaVersion.id,
@@ -70,7 +69,7 @@ class AssessmentTransformer(
       decision = transformJpaDecisionToApi(jpa.decision),
       rejectionRationale = jpa.rejectionRationale,
       status = getStatusForTemporaryAccommodationAssessment(jpa),
-      summaryData = "{}",
+      summaryData = objectMapper.readTree(jpa.summaryData),
       service = "CAS3",
     )
 

--- a/src/main/resources/db/migration/all/20230830105713__add_summary_data_json_column_to_temporary_accommodation_assessments.sql
+++ b/src/main/resources/db/migration/all/20230830105713__add_summary_data_json_column_to_temporary_accommodation_assessments.sql
@@ -1,0 +1,6 @@
+ALTER TABLE temporary_accommodation_assessments ADD COLUMN summary_data JSON;
+
+UPDATE temporary_accommodation_assessments
+SET summary_data = '{}';
+
+ALTER TABLE temporary_accommodation_assessments ALTER COLUMN summary_data SET NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5417,6 +5417,8 @@ components:
             arrivalDate:
               type: string
               format: date
+            summaryData:
+              $ref: '#/components/schemas/AnyValue'
           required:
             - arrivalDate
     ReleaseTypeOption:
@@ -5595,8 +5597,11 @@ components:
               $ref: '#/components/schemas/TemporaryAccommodationUser'
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            summaryData:
+              $ref: '#/components/schemas/AnyValue'
           required:
             - application
+            - summaryData
     AssessmentSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
@@ -36,6 +36,7 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
   private var referralHistoryNotes: Yielded<MutableList<AssessmentReferralHistoryNoteEntity>> = { mutableListOf() }
   private var completedAt: Yielded<OffsetDateTime?> = { null }
+  private var summaryData: Yielded<String> = { "{}" }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -101,6 +102,10 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     this.completedAt = { completedAt }
   }
 
+  fun withSummaryData(summaryData: String) = apply {
+    this.summaryData = { summaryData }
+  }
+
   override fun produce(): TemporaryAccommodationAssessmentEntity = TemporaryAccommodationAssessmentEntity(
     id = this.id(),
     data = this.data(),
@@ -118,6 +123,6 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     clarificationNotes = this.clarificationNotes(),
     referralHistoryNotes = this.referralHistoryNotes(),
     completedAt = this.completedAt(),
-    summaryData = "{}",
+    summaryData = this.summaryData(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
@@ -118,5 +118,6 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     clarificationNotes = this.clarificationNotes(),
     referralHistoryNotes = this.referralHistoryNotes(),
     completedAt = this.completedAt(),
+    summaryData = "{}",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1892,6 +1892,7 @@ class ApplicationTest : IntegrationTestBase() {
                 translatedDocument = {},
                 type = "CAS3",
                 arrivalDate = LocalDate.now(),
+                summaryData = {},
               ),
             )
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -59,6 +59,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -1892,12 +1893,20 @@ class ApplicationTest : IntegrationTestBase() {
                 translatedDocument = {},
                 type = "CAS3",
                 arrivalDate = LocalDate.now(),
-                summaryData = {},
+                summaryData = object {
+                  val num = 50
+                  val text = "Hello world!"
+                },
               ),
             )
             .exchange()
             .expectStatus()
             .isOk
+
+          val persistedApplication = temporaryAccommodationApplicationRepository.findByIdOrNull(applicationId)!!
+          val persistedAssessment = persistedApplication.getLatestAssessment() as TemporaryAccommodationAssessmentEntity
+
+          assertThat(persistedAssessment.summaryData).isEqualTo("{\"num\":50,\"text\":\"Hello world!\"}")
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1338,7 +1338,10 @@ class ApplicationServiceTest {
       translatedDocument = {},
       type = "CAS3",
       arrivalDate = LocalDate.now(),
-      summaryData = {},
+      summaryData = {
+        val num = 50
+        val text = "Hello world!"
+      },
     )
 
     private val submitCas2Application = SubmitCas2Application(
@@ -1466,7 +1469,7 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockAssessmentService.createAssessment(application) } returns ApprovedPremisesAssessmentEntityFactory()
+      every { mockAssessmentService.createApprovedPremisesAssessment(application) } returns ApprovedPremisesAssessmentEntityFactory()
         .withApplication(application)
         .withAllocatedToUser(user)
         .produce()
@@ -1528,7 +1531,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.releaseType).isEqualTo(submitApprovedPremisesApplication.releaseType.toString())
 
       verify { mockApplicationRepository.save(any()) }
-      verify(exactly = 1) { mockAssessmentService.createAssessment(application) }
+      verify(exactly = 1) { mockAssessmentService.createApprovedPremisesAssessment(application) }
 
       verify(exactly = 1) {
         mockDomainEventService.saveApplicationSubmittedDomainEvent(
@@ -1709,8 +1712,11 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockAssessmentService.createAssessment(application) } returns TemporaryAccommodationAssessmentEntityFactory()
+      every {
+        mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplication.summaryData!!)
+      } returns TemporaryAccommodationAssessmentEntityFactory()
         .withApplication(application)
+        .withSummaryData("{\"num\":50,\"text\":\"Hello world!\"}")
         .produce()
 
       val result = applicationService.submitTemporaryAccommodationApplication(applicationId, submitTemporaryAccommodationApplication)
@@ -1724,7 +1730,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.arrivalDate).isEqualTo(OffsetDateTime.of(submitTemporaryAccommodationApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC))
 
       verify { mockApplicationRepository.save(any()) }
-      verify(exactly = 1) { mockAssessmentService.createAssessment(application) }
+      verify(exactly = 1) { mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplication.summaryData!!) }
       verify { mockDomainEventService wasNot called }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1338,6 +1338,7 @@ class ApplicationServiceTest {
       translatedDocument = {},
       type = "CAS3",
       arrivalDate = LocalDate.now(),
+      summaryData = {},
     )
 
     private val submitCas2Application = SubmitCas2Application(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.assessmentservice
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -80,6 +81,7 @@ class AcceptAssessmentTest {
   private val placementRequestServiceMock = mockk<PlacementRequestService>()
   private val emailNotificationServiceMock = mockk<EmailNotificationService>()
   private val placementRequirementsServiceMock = mockk<PlacementRequirementsService>()
+  private val objectMapperMock = mockk<ObjectMapper>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -96,6 +98,7 @@ class AcceptAssessmentTest {
     emailNotificationServiceMock,
     NotifyConfig(),
     placementRequirementsServiceMock,
+    objectMapperMock,
     "http://frontend/applications/#id",
     "http://frontend/assessments/#id",
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -327,6 +327,26 @@ class AssessmentTransformerTest {
   }
 
   @Test
+  fun `transformJpaToApi for Temporary Accommodation serializes the summary data blob correctly`() {
+    val assessment = temporaryAccommodationAssessmentFactory
+      .withSummaryData("{\"num\": 50, \"text\": \"Hello world!\"}")
+      .produce()
+
+    val result = assessmentTransformer.transformJpaToApi(assessment, mockk())
+
+    assertThat(result).isInstanceOf(TemporaryAccommodationAssessment::class.java)
+    result as TemporaryAccommodationAssessment
+    assertThat(result.summaryData).isEqualTo(
+      objectMapper.valueToTree(
+        object {
+          val num = 50
+          val text = "Hello world!"
+        },
+      ),
+    )
+  }
+
+  @Test
   fun `transform domain to api summary - temporary application`() {
     val domainSummary = DomainAssessmentSummary(
       type = "temporary-accommodation",


### PR DESCRIPTION
> See [ticket #1504 on the CAS3 Trello board](https://trello.com/c/Sb4KYeHX/1504-referral-data-can-be-presented-without-knowledge-of-how-to-navigate-the-question-answer-data-blob).

This PR introduces the `summaryData` field on a Temporary Accommodation assessment. This is a user-defined bag of data intended to allow the assessment summary page in the UI to present basic information from the application in a version-agnostic way. For example, whether the offender can share accommodation with others could be represented as `summaryData.canShare`, allowing the application schema to be modified independently, such as by reordering the application questions.

As the assessment is created when the application is submitted, this information is required as part of the `SubmitTemporaryAccommodationApplication` schema (i.e. when `POST`ing to `/applications/{applicationId}/submission`), which now looks like:
```jsonc
{
  "type": "CAS3",
  "translatedDocument": {
    // ...
  },
  "arrivalDate": "2000-01-01",
  "summaryData": { // This can be any object
    // ...
  }
}
```

Similarly, any endpoint that responds with an `Assessment` will include the `summaryData` field when returning a Temporary Accommodation assessment. For existing assessments, this has been set to the empty object (`{}`).