### PR TITLE
(143) Add /reports/applications reports endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
@@ -8,12 +8,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReportsApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ReportService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.io.ByteArrayOutputStream
 import java.util.UUID
 
@@ -21,6 +23,7 @@ import java.util.UUID
 class ReportsController(
   private val reportService: ReportService,
   private val userAccessService: UserAccessService,
+  private val userService: UserService,
 ) : ReportsApiDelegate {
 
   override fun reportsBookingsGet(xServiceName: ServiceName, year: Int, month: Int, probationRegionId: UUID?): ResponseEntity<Resource> {
@@ -79,6 +82,23 @@ class ReportsController(
     val outputStream = ByteArrayOutputStream()
 
     reportService.createLostBedReport(properties, outputStream)
+
+    return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
+  }
+
+  override fun reportsApplicationsGet(xServiceName: ServiceName, year: Int, month: Int): ResponseEntity<Resource> {
+    if (!userAccessService.currentUserCanViewReport()) {
+      throw ForbiddenProblem()
+    }
+
+    val user = userService.getUserForRequest()
+
+    validateParameters(null, month)
+
+    val properties = ApplicationReportProperties(xServiceName, year, month, user.deliusUsername)
+    val outputStream = ByteArrayOutputStream()
+
+    reportService.createCas1ApplicationPerformanceReport(properties, outputStream)
 
     return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -39,6 +39,15 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   fun <T : ApplicationEntity> findAllForServiceAndNameNull(type: Class<T>, pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
 
   @Query(
+    "SELECT * FROM approved_premises_applications apa " +
+      "LEFT JOIN applications a ON a.id = apa.id " +
+      "WHERE date_part('month', a.submitted_at) = :month " +
+      "AND date_part('year', a.submitted_at) = :year ",
+    nativeQuery = true,
+  )
+  fun findAllApprovedPremisesApplicationsByCalendarMonth(month: Int, year: Int): List<ApprovedPremisesApplicationEntity>
+
+  @Query(
     "SELECT a FROM ApplicationEntity a " +
       "LEFT JOIN ApplicationTeamCodeEntity atc ON a = atc.application " +
       "WHERE TYPE(a) = :type AND atc.teamCode IN (:managingTeamCodes)",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import java.time.LocalDate
+import java.time.Period
+
+class ApplicationReportGenerator(
+  private val offenderService: OffenderService,
+) : ReportGenerator<ApprovedPremisesApplicationEntity, ApplicationReportRow, ApplicationReportProperties>(ApplicationReportRow::class) {
+  override fun filter(properties: ApplicationReportProperties): (ApplicationEntity) -> Boolean = {
+    true
+  }
+
+  override val convert: ApprovedPremisesApplicationEntity.(properties: ApplicationReportProperties) -> List<ApplicationReportRow> = { properties ->
+    val assessment = this.getLatestAssessment()
+    val placementRequest = this.getLatestPlacementRequest()
+    val personInfoResult = getOffenderDetailForApplication(this, properties.deliusUsername)
+    val booking = this.getLatestBooking()
+
+    listOf(
+      ApplicationReportRow(
+        id = this.id.toString(),
+        crn = this.crn,
+        applicationAssessedDate = assessment?.submittedAt?.toLocalDate(),
+        assessorCru = assessment?.allocatedToUser?.probationRegion?.name,
+        assessmentDecision = assessment?.decision?.toString(),
+        assessmentDecisionRationale = assessment?.rejectionRationale,
+        ageInYears = when (personInfoResult) {
+          is PersonInfoResult.Success.Full -> Period.between(personInfoResult.offenderDetailSummary.dateOfBirth, LocalDate.now()).years
+          else -> null
+        },
+        gender = when (personInfoResult) {
+          is PersonInfoResult.Success.Full -> personInfoResult.offenderDetailSummary.gender
+          else -> null
+        },
+        mappa = this.riskRatings?.mappa?.value?.level ?: "Not found",
+        offenceId = this.offenceId,
+        noms = this.nomsNumber,
+        premisesType = placementRequest?.placementRequirements?.apType?.toString(),
+        releaseType = this.releaseType,
+        sentenceLengthInMonths = null,
+        applicationSubmissionDate = this.submittedAt?.toLocalDate(),
+        referrerLdu = null,
+        referrerRegion = null,
+        referrerTeam = null,
+        targetLocation = placementRequest?.placementRequirements?.postcodeDistrict?.outcode,
+        applicationWithdrawalReason = this.withdrawalReason,
+        applicationWithdrawalDate = null,
+        bookingID = booking?.id?.toString(),
+        bookingCancellationReason = booking?.cancellation?.reason?.name,
+        bookingCancellationDate = booking?.cancellation?.date,
+        expectedArrivalDate = booking?.arrivalDate,
+        matcherCru = null,
+        expectedDepartureDate = booking?.departureDate,
+        premisesName = booking?.premises?.name,
+        actualArrivalDate = booking?.arrival?.arrivalDate,
+        actualDepartureDate = booking?.departure?.dateTime?.toLocalDate(),
+        departureMoveOnCategory = booking?.departure?.moveOnCategory?.name,
+        nonArrivalDate = booking?.nonArrival?.date,
+      ),
+    )
+  }
+
+  private fun getOffenderDetailForApplication(applicationEntity: ApplicationEntity, deliusUsername: String): PersonInfoResult? {
+    return when (val personInfo = offenderService.getInfoForPerson(applicationEntity.crn, deliusUsername, true)) {
+      is PersonInfoResult.Success -> personInfo
+      else -> null
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import java.time.LocalDate
+
+data class ApplicationReportRow(
+  val id: String,
+  val crn: String,
+  val applicationAssessedDate: LocalDate?,
+  val assessorCru: String?,
+  val assessmentDecision: String?,
+  val assessmentDecisionRationale: String?,
+  val ageInYears: Int?,
+  val gender: String?,
+  val mappa: String,
+  val offenceId: String,
+  val noms: String?,
+  val premisesType: String?,
+  val releaseType: String?,
+  val sentenceLengthInMonths: Int?,
+  val applicationSubmissionDate: LocalDate?,
+  val referrerLdu: String?,
+  val referrerRegion: String?,
+  val referrerTeam: String?,
+  val targetLocation: String?,
+  val applicationWithdrawalReason: String?,
+  val applicationWithdrawalDate: LocalDate?,
+  val bookingID: String?,
+  val bookingCancellationReason: String?,
+  val bookingCancellationDate: LocalDate?,
+  val expectedArrivalDate: LocalDate?,
+  val matcherCru: String?,
+  val expectedDepartureDate: LocalDate?,
+  val premisesName: String?,
+  val actualArrivalDate: LocalDate?,
+  val actualDepartureDate: LocalDate?,
+  val departureMoveOnCategory: String?,
+  val nonArrivalDate: LocalDate?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/ApplicationReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/ApplicationReportProperties.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+
+data class ApplicationReportProperties(
+  val serviceName: ServiceName,
+  val year: Int,
+  val month: Int,
+  val deliusUsername: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -3,13 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.jetbrains.kotlinx.dataframe.io.writeExcel
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.LostBedsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
@@ -25,6 +28,8 @@ class ReportService(
   private val lostBedsRepository: LostBedsRepository,
   private val bookingTransformer: BookingTransformer,
   private val workingDayCountService: WorkingDayCountService,
+  private val applicationRepository: ApplicationRepository,
+  private val offenderService: OffenderService,
 ) {
   fun createBookingsReport(properties: BookingsReportProperties, outputStream: OutputStream) {
     val startOfMonth = LocalDate.of(properties.year, properties.month, 1)
@@ -58,6 +63,14 @@ class ReportService(
   fun createLostBedReport(properties: LostBedReportProperties, outputStream: OutputStream) {
     LostBedsReportGenerator(lostBedsRepository)
       .createReport(bedRepository.findAll(), properties)
+      .writeExcel(outputStream) {
+        WorkbookFactory.create(true)
+      }
+  }
+
+  fun createCas1ApplicationPerformanceReport(properties: ApplicationReportProperties, outputStream: OutputStream) {
+    ApplicationReportGenerator(offenderService)
+      .createReport(applicationRepository.findAllApprovedPremisesApplicationsByCalendarMonth(properties.month, properties.year), properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)
       }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3572,6 +3572,38 @@ paths:
               schema:
                 type: string
                 format: binary
+  /reports/applications:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet listing all of the submitted applications for the month
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Only applications for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+        - name: year
+          in: query
+          required: true
+          description: Only applications for this year will be returned
+          schema:
+            type: integer
+        - name: month
+          in: query
+          required: true
+          description: Only applications for this month will be returned - must be provided with year
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Successfully retrieved the report
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
 components:
   responses:
     401Response:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
@@ -35,6 +35,10 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
     this.application = { application }
   }
 
+  fun withApType(apType: ApType) = apply {
+    this.apType = { apType }
+  }
+
   fun withAssessment(assessment: AssessmentEntity) = apply {
     this.assessment = { assessment }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -1,0 +1,150 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.io.readExcel
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises Bed`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import java.time.OffsetDateTime
+
+class ApplicationReportsTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var realPlacementRequestRepository: PlacementRequestRepository
+
+  @Autowired
+  lateinit var realApplicationRepository: ApplicationRepository
+
+  @Autowired
+  lateinit var realOffenderService: OffenderService
+
+  @Test
+  fun `Get application report returns 403 Forbidden if user does not have all regions access`() {
+    `Given a User` { _, jwt ->
+      webTestClient.get()
+        .uri("/reports/applications?year=2023&month=4")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `Get application report returns 400 if month is provided and not within 1-12`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
+      webTestClient.get()
+        .uri("/reports/applications?year=2023&month=-1")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("month must be between 1 and 12")
+    }
+  }
+
+  @Test
+  fun `Get application report returns OK with correct body`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { userEntity, jwt ->
+      `Given an Approved Premises Bed` { bed ->
+        createApplicationWithBooking(OffsetDateTime.parse("2023-01-01T12:00:00Z"), userEntity, bed)
+
+        val (applicationWithBooking, _) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
+        val (applicationWithDepartedBooking, departedBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
+        val (applicationWithCancelledBooking, cancelledBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
+        val (applicationWithNonArrivedBooking, nonArrivedBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
+
+        arrivalEntityFactory.produceAndPersist {
+          withBooking(departedBooking)
+        }
+
+        departureEntityFactory.produceAndPersist {
+          withBooking(departedBooking)
+          withYieldedReason {
+            departureReasonEntityFactory.produceAndPersist()
+          }
+          withYieldedMoveOnCategory {
+            moveOnCategoryEntityFactory.produceAndPersist()
+          }
+        }
+
+        cancellationEntityFactory.produceAndPersist {
+          withBooking(cancelledBooking)
+          withReason(cancellationReasonEntityFactory.produceAndPersist())
+        }
+
+        nonArrivalEntityFactory.produceAndPersist {
+          withBooking(nonArrivedBooking)
+          withYieldedReason { nonArrivalReasonEntityFactory.produceAndPersist() }
+        }
+
+        val expectedApplications = listOf(
+          realApplicationRepository.findByIdOrNull(applicationWithBooking.id) as ApprovedPremisesApplicationEntity,
+          realApplicationRepository.findByIdOrNull(applicationWithDepartedBooking.id) as ApprovedPremisesApplicationEntity,
+          realApplicationRepository.findByIdOrNull(applicationWithCancelledBooking.id) as ApprovedPremisesApplicationEntity,
+          realApplicationRepository.findByIdOrNull(applicationWithNonArrivedBooking.id) as ApprovedPremisesApplicationEntity,
+        )
+
+        val expectedDataFrame = ApplicationReportGenerator(realOffenderService)
+          .createReport(expectedApplications, ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, userEntity.deliusUsername))
+
+        webTestClient.get()
+          .uri("/reports/applications?year=2023&month=4")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
+
+            Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  private fun createApplicationWithBooking(submittedAt: OffsetDateTime, userEntity: UserEntity, bed: BedEntity): Pair<ApprovedPremisesApplicationEntity, BookingEntity> {
+    val (placementRequest, application) = `Given a Placement Request`(
+      placementRequestAllocatedTo = userEntity,
+      assessmentAllocatedTo = userEntity,
+      createdByUser = userEntity,
+      applicationSubmittedAt = submittedAt,
+      mappa = "CAT M2/LEVEL M2",
+    )
+
+    val booking = bookingEntityFactory.produceAndPersist {
+      withBed(bed)
+      withPremises(bed.room.premises)
+      withApplication(application)
+    }
+
+    placementRequest.booking = booking
+    realPlacementRequestRepository.save(placementRequest)
+
+    return Pair(application as ApprovedPremisesApplicationEntity, booking)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/ApplicationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/ApplicationReportGeneratorTest.kt
@@ -1,0 +1,410 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.generator
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PostCodeDistrictEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class ApplicationReportGeneratorTest {
+  private val mockOffenderService = mockk<OffenderService>()
+
+  private val applicationReportGenerator = ApplicationReportGenerator(mockOffenderService)
+
+  private val crn = "ABC123"
+
+  private val applicationFactory = ApprovedPremisesApplicationEntityFactory()
+    .withCrn(crn)
+    .withYieldedCreatedByUser {
+      UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .produce()
+    }
+    .withRiskRatings(
+      PersonRisksFactory()
+        .withMappa(
+          RiskWithStatus(
+            status = RiskStatus.Retrieved,
+            value = Mappa(
+              level = "CAT M2/LEVEL M2",
+              lastUpdated = LocalDate.now(),
+            ),
+          ),
+        ).produce(),
+    )
+
+  private val offender = PersonInfoResult.Success.Full(
+    crn,
+    OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withDateOfBirth(
+        LocalDate.now()
+          .minusYears(22)
+          .minusDays(42),
+      )
+      .produce(),
+    InmateDetailFactory().produce(),
+  )
+
+  private val user = UserEntityFactory()
+    .withUnitTestControlProbationRegion()
+    .produce()
+
+  private val premises = ApprovedPremisesEntityFactory()
+    .withYieldedProbationRegion {
+      ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+    }
+    .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+    .produce()
+
+  private val room = RoomEntityFactory()
+    .withPremises(premises)
+    .produce()
+
+  private val bed = BedEntityFactory()
+    .withRoom(room)
+    .produce()
+
+  @BeforeEach
+  fun setup() {
+    every { mockOffenderService.getInfoForPerson(crn, "username", true) } returns offender
+  }
+
+  @Test
+  fun `it returns report data for an unsubmitted application`() {
+    val application = applicationFactory.produce()
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::id]).isEqualTo(application.id.toString())
+    assertThat(result[0][ApplicationReportRow::crn]).isEqualTo(application.crn)
+    assertThat(result[0][ApplicationReportRow::applicationAssessedDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::assessorCru]).isNull()
+    assertThat(result[0][ApplicationReportRow::assessmentDecision]).isNull()
+    assertThat(result[0][ApplicationReportRow::assessmentDecisionRationale]).isNull()
+    assertThat(result[0][ApplicationReportRow::ageInYears]).isEqualTo(22)
+    assertThat(result[0][ApplicationReportRow::gender]).isEqualTo(offender.offenderDetailSummary.gender)
+    assertThat(result[0][ApplicationReportRow::mappa]).isEqualTo("CAT M2/LEVEL M2")
+    assertThat(result[0][ApplicationReportRow::offenceId]).isEqualTo(application.offenceId)
+    assertThat(result[0][ApplicationReportRow::noms]).isEqualTo(application.nomsNumber)
+    assertThat(result[0][ApplicationReportRow::premisesType]).isNull()
+    assertThat(result[0][ApplicationReportRow::releaseType]).isNull()
+    assertThat(result[0][ApplicationReportRow::sentenceLengthInMonths]).isNull()
+    assertThat(result[0][ApplicationReportRow::applicationSubmissionDate]).isEqualTo(application.submittedAt)
+    assertThat(result[0][ApplicationReportRow::referrerLdu]).isNull()
+    assertThat(result[0][ApplicationReportRow::referrerRegion]).isNull()
+    assertThat(result[0][ApplicationReportRow::referrerTeam]).isNull()
+    assertThat(result[0][ApplicationReportRow::targetLocation]).isNull()
+    assertThat(result[0][ApplicationReportRow::applicationWithdrawalReason]).isNull()
+    assertThat(result[0][ApplicationReportRow::applicationWithdrawalDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::bookingID]).isNull()
+    assertThat(result[0][ApplicationReportRow::bookingCancellationReason]).isNull()
+    assertThat(result[0][ApplicationReportRow::bookingCancellationDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::expectedArrivalDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::matcherCru]).isNull()
+    assertThat(result[0][ApplicationReportRow::expectedDepartureDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::premisesName]).isNull()
+    assertThat(result[0][ApplicationReportRow::actualArrivalDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::actualDepartureDate]).isNull()
+    assertThat(result[0][ApplicationReportRow::departureMoveOnCategory]).isNull()
+    assertThat(result[0][ApplicationReportRow::nonArrivalDate]).isNull()
+  }
+
+  @Test
+  fun `returns data for an assessed application`() {
+    val application = applicationFactory
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .withSubmittedAt(OffsetDateTime.now())
+      .withDecision(AssessmentDecision.REJECTED)
+      .withRejectionRationale("Some Text")
+      .produce()
+
+    application.assessments = mutableListOf(assessment)
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::applicationAssessedDate]).isEqualTo(assessment.submittedAt!!.toLocalDate())
+    assertThat(result[0][ApplicationReportRow::assessorCru]).isEqualTo(assessment.allocatedToUser!!.probationRegion.name)
+    assertThat(result[0][ApplicationReportRow::assessmentDecision]).isEqualTo("REJECTED")
+    assertThat(result[0][ApplicationReportRow::assessmentDecisionRationale]).isEqualTo("Some Text")
+  }
+
+  @Test
+  fun `returns data for an application with a placement request`() {
+    val application = applicationFactory
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withPlacementRequirements(
+        PlacementRequirementsEntityFactory()
+          .withApType(ApType.normal)
+          .withPostcodeDistrict(
+            PostCodeDistrictEntityFactory()
+              .withOutcode("ABC")
+              .produce(),
+          )
+          .withApplication(application)
+          .withAssessment(assessment)
+          .produce(),
+      )
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withAllocatedToUser(user)
+      .produce()
+
+    application.placementRequests = mutableListOf(placementRequest)
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::premisesType]).isEqualTo("normal")
+    assertThat(result[0][ApplicationReportRow::targetLocation]).isEqualTo("ABC")
+  }
+
+  @Test
+  fun `returns data for an application with a booking`() {
+    val application = applicationFactory
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withBed(bed)
+      .withPremises(premises)
+      .produce()
+
+    val placementRequirements = PlacementRequirementsEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withBooking(booking)
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withAllocatedToUser(user)
+      .produce()
+
+    application.placementRequests = mutableListOf(placementRequest)
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::bookingID]).isEqualTo(booking.id.toString())
+    assertThat(result[0][ApplicationReportRow::expectedArrivalDate]).isEqualTo(booking.arrivalDate)
+    assertThat(result[0][ApplicationReportRow::expectedDepartureDate]).isEqualTo(booking.departureDate)
+  }
+
+  @Test
+  fun `returns data for an application with a booking with an arrival and departure`() {
+    val application = applicationFactory
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withBed(bed)
+      .withPremises(premises)
+      .produce()
+      .apply {
+        arrival = ArrivalEntityFactory().withBooking(this).produce()
+        departures += DepartureEntityFactory()
+          .withYieldedReason {
+            DepartureReasonEntityFactory()
+              .produce()
+          }
+          .withYieldedMoveOnCategory {
+            MoveOnCategoryEntityFactory()
+              .produce()
+          }
+          .withBooking(this)
+          .produce()
+      }
+
+    val placementRequirements = PlacementRequirementsEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withBooking(booking)
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withAllocatedToUser(user)
+      .produce()
+
+    application.placementRequests = mutableListOf(placementRequest)
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::actualArrivalDate]).isEqualTo(booking.arrival!!.arrivalDate)
+    assertThat(result[0][ApplicationReportRow::actualDepartureDate]).isEqualTo(booking.departure!!.dateTime.toLocalDate())
+  }
+
+  @Test
+  fun `returns data for an application with a booking with a non-arrival`() {
+    val application = applicationFactory
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withBed(bed)
+      .withPremises(premises)
+      .produce()
+      .apply {
+        nonArrival = NonArrivalEntityFactory()
+          .withBooking(this)
+          .withYieldedReason { NonArrivalReasonEntityFactory().produce() }
+          .produce()
+      }
+
+    val placementRequirements = PlacementRequirementsEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withBooking(booking)
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withAllocatedToUser(user)
+      .produce()
+
+    application.placementRequests = mutableListOf(placementRequest)
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::nonArrivalDate]).isEqualTo(booking.nonArrival!!.date)
+  }
+
+  @Test
+  fun `returns data for an application with a booking with a cancellation`() {
+    val application = applicationFactory
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withBed(bed)
+      .withPremises(premises)
+      .produce()
+      .apply {
+        cancellations += CancellationEntityFactory()
+          .withBooking(this)
+          .withReason(
+            CancellationReasonEntityFactory()
+              .withName("Some cancellation reason")
+              .produce(),
+          )
+          .produce()
+      }
+
+    val placementRequirements = PlacementRequirementsEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withBooking(booking)
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withAllocatedToUser(user)
+      .produce()
+
+    application.placementRequests = mutableListOf(placementRequest)
+
+    val result = applicationReportGenerator
+      .createReport(listOf(application), ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, "username"))
+
+    assertThat(result.count()).isEqualTo(1)
+
+    assertThat(result[0][ApplicationReportRow::bookingCancellationDate]).isEqualTo(booking.cancellation!!.date)
+    assertThat(result[0][ApplicationReportRow::bookingCancellationReason]).isEqualTo("Some cancellation reason")
+  }
+}


### PR DESCRIPTION
This allows us to get a report about applications that have been submitted in a particular month. Not all the data we've been asked for is easy to get at the moment, so some of the fields are currently null.