### PR TITLE
Exclude cancelled bookings from being considered as overlaps in Temporary Accommodation bed search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -20,8 +20,8 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   @Query("SELECT b FROM BookingEntity b WHERE b.premises.id = :premisesId AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate")
   fun findAllByPremisesIdAndOverlappingDate(premisesId: UUID, startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
 
-  @Query("SELECT b FROM BookingEntity b WHERE b.premises.id IN :premisesIds AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate")
-  fun findAllByPremisesIdsAndOverLappingDate(premisesIds: List<UUID>, startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
+  @Query("SELECT b FROM BookingEntity b WHERE b.premises.id IN :premisesIds AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate AND SIZE(b.cancellations) = 0")
+  fun findAllNotCancelledByPremisesIdsAndOverlappingDate(premisesIds: List<UUID>, startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
 
   @Query("SELECT b FROM BookingEntity b WHERE b.arrivalDate <= :endDate AND b.departureDate >= :startDate")
   fun findAllByOverlappingDate(startDate: LocalDate, endDate: LocalDate): List<BookingEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -123,8 +123,8 @@ class BedSearchService(
 
         val results = candidateResults.filter { !bedsWithABookingInTurnaround.contains(it.bedId) }
 
-        val distinctIds = candidateResults.map { it.premisesId }.distinct()
-        val overlappedBookings = bookingRepository.findAllByPremisesIdsAndOverLappingDate(distinctIds, startDate, endDate)
+        val distinctIds = results.map { it.premisesId }.distinct()
+        val overlappedBookings = bookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(distinctIds, startDate, endDate)
         val groupedOverlappedBookings = overlappedBookings
           .map { transformBookingToOverlap(it, startDate, endDate) }
           .groupBy { it.premisesId }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -557,7 +557,7 @@ class BedSearchServiceTest {
 
     every { mockBookingRepository.findClosestBookingBeforeDateForBeds(any(), any()) } returns listOf()
     every { mockWorkingDayCountService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
-    every { mockBookingRepository.findAllByPremisesIdsAndOverLappingDate(any(), any(), any()) } returns listOf()
+    every { mockBookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(any(), any(), any()) } returns listOf()
 
     val authorisableResult = bedSearchService.findTemporaryAccommodationBeds(
       user = user,
@@ -730,7 +730,7 @@ class BedSearchServiceTest {
       (it.invocation.args[0] as LocalDate).plusDays((it.invocation.args[1] as Int).toLong())
     }
 
-    every { mockBookingRepository.findAllByPremisesIdsAndOverLappingDate(any(), any(), any()) } returns listOf()
+    every { mockBookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(any(), any(), any()) } returns listOf()
 
     val authorisableResult = bedSearchService.findTemporaryAccommodationBeds(
       user = user,


### PR DESCRIPTION
> See [ticket #1509 on the CAS3 Trello board](https://trello.com/c/WFeqioTH/1509-dont-include-cancellations-in-overlapping-residents).

This PR modifies the bed search logic for Temporary Accommodation to exclude bookings with one or more cancellations. As these have been cancelled, presenting these bookings to the user has the potential to cause confusion and additional work to determine which (if any) of the bookings are actually relevant.