### PR TITLE
Increase Case Notes timeout to 30 seconds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -21,6 +21,7 @@ import java.time.Duration
 @Configuration
 class WebClientConfiguration(
   @Value("\${upstream-timeout-ms}") private val upstreamTimeoutMs: Long,
+  @Value("\${case-notes-service-upstream-timeout-ms}") private val caseNotesServiceUpstreamTimeoutMs: Long,
   @Value("\${max-response-in-memory-size-bytes}") private val maxResponseInMemorySizeBytes: Int,
 ) {
   @Bean
@@ -154,8 +155,8 @@ class WebClientConfiguration(
         ReactorClientHttpConnector(
           HttpClient
             .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+            .responseTimeout(Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs))
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs).toMillis().toInt()),
         ),
       )
       .filter(oauth2Client)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -198,4 +198,7 @@ arrived-departed-domain-events-disabled: true
 manual-bookings-domain-events-disabled: true
 
 upstream-timeout-ms: 10000
+case-notes-service-upstream-timeout-ms: 30000
+
 max-response-in-memory-size-bytes: 512000
+


### PR DESCRIPTION
We’re having some issues with certain case note responses timing out. I’ve added a special timeout value for case notes so we can hopefully fix this. Long term fix is to get a custom API endpoint for this kind of info, but this should fix things in the short-term.