### PR TITLE
(397) Add a `notApplicable` releaseType option

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -72,6 +72,7 @@ class PlacementRequestTransformer(
     "hdc" -> ReleaseTypeOption.hdc
     "pss" -> ReleaseTypeOption.pss
     "inCommunity" -> ReleaseTypeOption.inCommunity
+    "notApplicable" -> ReleaseTypeOption.notApplicable
     else -> throw RuntimeException("Unrecognised releaseType: $releaseType")
   }
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5421,6 +5421,7 @@ components:
         - hdc
         - pss
         - in_community
+        - not_applicable
     PrisonCaseNote:
       type: object
       properties:


### PR DESCRIPTION
If an application has a non statutory sentence type, then currently, we cannot submit an application, as there is not necessarity a relevant release type for this type of sentence. This is a very unusual circumstance, as non-statutory sentence types would not ordinarily be eligible for AP, but this happens often enough for us to have to handle it.

After some discussion, we decided to add a `notApplicable` option, rather than making it non-nullable, which would have ramifications elsewhere.