### PR TITLE
(Fix) Return a 404 when a user cannot be found

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -81,7 +81,7 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    val userEntity = userService.getUserForUsername(name)
+    val userEntity = userService.getUserForUsername(name, true)
     val userTransformed = userTransformer.transformJpaToApi(userEntity, xServiceName)
     return ResponseEntity.ok(userTransformed)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundProblem.kt
@@ -4,7 +4,7 @@ import org.zalando.problem.AbstractThrowableProblem
 import org.zalando.problem.Exceptional
 import org.zalando.problem.Status
 
-class NotFoundProblem(id: Any, entityType: String) : AbstractThrowableProblem(null, "Not Found", Status.NOT_FOUND, "No $entityType with an ID of $id could be found") {
+class NotFoundProblem(id: Any, entityType: String, identifier: String? = null) : AbstractThrowableProblem(null, "Not Found", Status.NOT_FOUND, "No $entityType with ${identifier ?: "an ID"} of $id could be found") {
   override fun getCause(): Exceptional? {
     return null
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3360,6 +3360,12 @@ paths:
           $ref: '#/components/responses/401Response'
         403:
           $ref: '#/components/responses/403Response'
+        404:
+          description: User not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
   /seed:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -531,6 +531,25 @@ class UsersTest : IntegrationTestBase() {
         }
       }
     }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
+    fun `GET to search for a delius username that does not exist with a role of either ROLE_ADMIN or WORKFLOW_MANAGER returns 404`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        webTestClient.get()
+          .uri("/users/delius?name=noone")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectHeader().contentType("application/problem+json")
+          .expectStatus()
+          .isNotFound
+          .expectBody()
+          .jsonPath("title").isEqualTo("Not Found")
+          .jsonPath("status").isEqualTo(404)
+          .jsonPath("detail").isEqualTo("No user with username of noone could be found")
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
As we’re reusing `getUserForUsername` when using the `users/delius` endpoint, this adds a `throwProblemOn404` option to the service methof, which defaults to `false`. 

If it’s set to `true` and the response from Delius is a 404, we throw a `NotFoundProblem`, which bubbles up to the controller as a 404. 

I’ve also tweaked the `NotFoundProblem` to accept an optional `identifier`, which allows us to customise the JSON body of the 404 response if we need to.