### PR TITLE
Allow Workflow Managers to access reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -102,7 +102,7 @@ class UserAccessService(
   fun userCanViewReport(user: UserEntity) =
     when (currentRequest.getHeader("X-Service-Name")) {
       ServiceName.temporaryAccommodation.value -> user.hasRole(UserRole.CAS3_ASSESSOR)
-      ServiceName.approvedPremises.value -> user.hasRole(UserRole.CAS1_REPORT_VIEWER)
+      ServiceName.approvedPremises.value -> user.hasAnyRole(UserRole.CAS1_REPORT_VIEWER, UserRole.CAS1_WORKFLOW_MANAGER)
       else -> false
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -994,18 +994,22 @@ class UserAccessServiceTest {
     assertThat(userAccessService.currentUserCanViewReport()).isFalse
   }
 
-  @Test
-  fun `currentUserCanViewReport returns returns false if the current request has 'X-Service-Name' header with value 'approved-premises' and the user does not have the CAS1_REPORT_VIEWER role`() {
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_REPORT_VIEWER"], mode = EnumSource.Mode.EXCLUDE)
+  fun `currentUserCanViewReport returns returns false if the current request has 'X-Service-Name' header with value 'approved-premises' and the user does not have the correct role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
 
     assertThat(userAccessService.currentUserCanViewReport()).isFalse
   }
 
-  @Test
-  fun `currentUserCanViewReport returns returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has the CAS1_REPORT_VIEWER role`() {
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_REPORT_VIEWER"])
+  fun `currentUserCanViewReport returns returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has the correct role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
-    user.addRoleForUnitTest(UserRole.CAS1_REPORT_VIEWER)
+    user.addRoleForUnitTest(role)
 
     assertThat(userAccessService.currentUserCanViewReport()).isTrue
   }


### PR DESCRIPTION
This adds the ability for workflow managers to access reports. To make the tests a bit more complete, I've added a `ParameterizedTest` to test `userCanViewReport` with all available roles