### PR TITLE
(Fix) Create custom SQL for the Application Reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -39,15 +39,6 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   fun <T : ApplicationEntity> findAllForServiceAndNameNull(type: Class<T>, pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
 
   @Query(
-    "SELECT * FROM approved_premises_applications apa " +
-      "LEFT JOIN applications a ON a.id = apa.id " +
-      "WHERE date_part('month', a.submitted_at) = :month " +
-      "AND date_part('year', a.submitted_at) = :year ",
-    nativeQuery = true,
-  )
-  fun findAllApprovedPremisesApplicationsByCalendarMonth(month: Int, year: Int): List<ApprovedPremisesApplicationEntity>
-
-  @Query(
     "SELECT a FROM ApplicationEntity a " +
       "LEFT JOIN ApplicationTeamCodeEntity atc ON a = atc.application " +
       "WHERE TYPE(a) = :type AND atc.teamCode IN (:managingTeamCodes)",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -1,0 +1,96 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.sql.Date
+import java.sql.Timestamp
+import java.util.UUID
+
+@Repository
+interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity, UUID> {
+  @Query(
+    """
+    SELECT
+      CAST(application.id AS TEXT) as id,
+      application.crn as crn,
+      assessment.submitted_at as applicationAssessedDate,
+      assessor_region.name as assessorCru,
+      assessment.decision as assessmentDecision,
+      assessment.rejection_rationale as assessmentDecisionRationale,
+      CAST(ap_application.risk_ratings -> 'mappa' -> 'value' -> 'level' as TEXT) as mappa,
+      ap_application.offence_id as offenceId,
+      application.noms_number as noms,
+      requirements.ap_type as premisesType,
+      ap_application.release_type as releaseType,
+      application.submitted_at as applicationSubmissionDate,
+      referrer_region.name as referrerRegion,
+      postcode_district.outcode as targetLocation,
+      ap_application.withdrawal_reason as applicationWithdrawalReason,
+      CAST(booking.id AS text) as bookingID,
+      cancellation_reason.name as bookingCancellationReason,
+      cancellation.date as bookingCancellationDate,
+      booking.arrival_date as expectedArrivalDate,
+      booking.departure_date as expectedDepartureDate,
+      premises.name as premisesName,
+      arrival.arrival_date as actualArrivalDate,
+      departure.date_time as actualDepartureDate,
+      move_on_category.name as departureMoveOnCategory,
+      non_arrival.date as nonArrivalDate
+    from
+      applications application
+      left join approved_premises_applications ap_application ON application.id = ap_application.id
+      left join assessments assessment ON (
+        application.id = assessment.application_id
+        AND assessment.reallocated_at IS NULL
+      )
+      left join users referrer ON application.created_by_user_id = referrer.id
+      left join users assessor ON assessment.allocated_to_user_id = assessor.id
+      left join probation_regions assessor_region ON assessor.probation_region_id = assessor_region.id
+      left join probation_regions referrer_region ON referrer.probation_region_id = referrer_region.id
+      left join placement_requirements requirements ON application.id = requirements.application_id
+      left join postcode_districts postcode_district ON requirements.postcode_district_id = postcode_district.id
+      left join bookings booking ON booking.application_id = application.id
+      left join cancellations cancellation ON booking.id = cancellation.booking_id
+      left join cancellation_reasons cancellation_reason ON cancellation_reason.id = cancellation.cancellation_reason_id
+      left join premises on booking.premises_id = premises.id
+      left join arrivals arrival on arrival.booking_id = booking.id
+      left join departures departure on departure.booking_id = booking.id
+      left join move_on_categories move_on_category on departure.move_on_category_id = move_on_category.id
+      left join non_arrivals non_arrival on non_arrival.booking_id = booking.id
+    where
+      date_part('month', application.submitted_at) = :month
+      AND date_part('year', application.submitted_at) = :year
+    """,
+    nativeQuery = true,
+  )
+  fun generateApprovedPremisesReportRowsForCalendarMonth(month: Int, year: Int): List<ApplicationEntityReportRow>
+}
+
+interface ApplicationEntityReportRow {
+  fun getId(): String
+  fun getCrn(): String
+  fun getApplicationAssessedDate(): Timestamp?
+  fun getAssessorCru(): String?
+  fun getAssessmentDecision(): String?
+  fun getAssessmentDecisionRationale(): String?
+  fun getMappa(): String?
+  fun getOffenceId(): String
+  fun getNoms(): String
+  fun getPremisesType(): String?
+  fun getReleaseType(): String?
+  fun getApplicationSubmissionDate(): Timestamp?
+  fun getReferrerRegion(): String?
+  fun getTargetLocation(): String?
+  fun getApplicationWithdrawalReason(): String?
+  fun getBookingID(): String?
+  fun getBookingCancellationReason(): String?
+  fun getBookingCancellationDate(): Date?
+  fun getExpectedArrivalDate(): Date?
+  fun getExpectedDepartureDate(): Date?
+  fun getPremisesName(): String?
+  fun getActualArrivalDate(): Date?
+  fun getActualDepartureDate(): Timestamp?
+  fun getDepartureMoveOnCategory(): String?
+  fun getNonArrivalDate(): Date?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.jetbrains.kotlinx.dataframe.io.writeExcel
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntityReportRowRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
@@ -28,7 +28,7 @@ class ReportService(
   private val lostBedsRepository: LostBedsRepository,
   private val bookingTransformer: BookingTransformer,
   private val workingDayCountService: WorkingDayCountService,
-  private val applicationRepository: ApplicationRepository,
+  private val applicationEntityReportRowRepository: ApplicationEntityReportRowRepository,
   private val offenderService: OffenderService,
 ) {
   fun createBookingsReport(properties: BookingsReportProperties, outputStream: OutputStream) {
@@ -70,7 +70,7 @@ class ReportService(
 
   fun createCas1ApplicationPerformanceReport(properties: ApplicationReportProperties, outputStream: OutputStream) {
     ApplicationReportGenerator(offenderService)
-      .createReport(applicationRepository.findAllApprovedPremisesApplicationsByCalendarMonth(properties.month, properties.year), properties)
+      .createReport(applicationEntityReportRowRepository.generateApprovedPremisesReportRowsForCalendarMonth(properties.month, properties.year), properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -1,9 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
 import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.api.toList
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,6 +13,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises Bed`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntityReportRowRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
@@ -19,11 +23,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.Period
+import java.util.UUID
 
 class ApplicationReportsTest : IntegrationTestBase() {
   @Autowired
@@ -31,6 +38,9 @@ class ApplicationReportsTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var realApplicationRepository: ApplicationRepository
+
+  @Autowired
+  lateinit var realApplicationEntityReportRowRepository: ApplicationEntityReportRowRepository
 
   @Autowired
   lateinit var realOffenderService: OffenderService
@@ -64,76 +74,161 @@ class ApplicationReportsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get application report returns OK with correct body`() {
-    `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { userEntity, jwt ->
-      `Given an Approved Premises Bed` { bed ->
-        createApplicationWithBooking(OffsetDateTime.parse("2023-01-01T12:00:00Z"), userEntity, bed)
+  fun `Get application report returns OK with correct applications`() {
+    `Given a User` { referrer, _ ->
+      `Given a User` { assessor, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { userEntity, jwt ->
+          `Given an Approved Premises Bed` { bed ->
+            createApplicationWithBooking(OffsetDateTime.parse("2023-01-01T12:00:00Z"), referrer, assessor, bed)
 
-        val (applicationWithBooking, _) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
-        val (applicationWithDepartedBooking, departedBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
-        val (applicationWithCancelledBooking, cancelledBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
-        val (applicationWithNonArrivedBooking, nonArrivedBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), userEntity, bed)
+            val (applicationWithBooking, _) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), referrer, assessor, bed)
+            val (applicationWithDepartedBooking, departedBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), referrer, assessor, bed)
+            val (applicationWithCancelledBooking, cancelledBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), referrer, assessor, bed)
+            val (applicationWithNonArrivedBooking, nonArrivedBooking) = createApplicationWithBooking(OffsetDateTime.parse("2023-04-01T12:00:00Z"), referrer, assessor, bed)
 
-        arrivalEntityFactory.produceAndPersist {
-          withBooking(departedBooking)
-        }
+            arrivalEntityFactory.produceAndPersist {
+              withBooking(departedBooking)
+            }
 
-        departureEntityFactory.produceAndPersist {
-          withBooking(departedBooking)
-          withYieldedReason {
-            departureReasonEntityFactory.produceAndPersist()
+            departureEntityFactory.produceAndPersist {
+              withBooking(departedBooking)
+              withYieldedReason {
+                departureReasonEntityFactory.produceAndPersist()
+              }
+              withYieldedMoveOnCategory {
+                moveOnCategoryEntityFactory.produceAndPersist()
+              }
+            }
+
+            cancellationEntityFactory.produceAndPersist {
+              withBooking(cancelledBooking)
+              withReason(cancellationReasonEntityFactory.produceAndPersist())
+            }
+
+            nonArrivalEntityFactory.produceAndPersist {
+              withBooking(nonArrivedBooking)
+              withYieldedReason { nonArrivalReasonEntityFactory.produceAndPersist() }
+            }
+
+            webTestClient.get()
+              .uri("/reports/applications?year=2023&month=4")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.approvedPremises.value)
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .consumeWith {
+                val actual = DataFrame
+                  .readExcel(it.responseBody!!.inputStream())
+                  .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
+                  .toList()
+
+                assertThat(actual.size).isEqualTo(4)
+
+                assertThat(
+                  actual.any { reportRow ->
+                    assertApplicationRowHasCorrectData(applicationWithBooking.id, reportRow, userEntity, hasBooking = true)
+                  },
+                )
+
+                assertThat(
+                  actual.any { reportRow ->
+                    assertApplicationRowHasCorrectData(applicationWithDepartedBooking.id, reportRow, userEntity, hasDeparture = true)
+                  },
+                )
+
+                assertThat(
+                  actual.any { reportRow ->
+                    assertApplicationRowHasCorrectData(applicationWithCancelledBooking.id, reportRow, userEntity, hasCancellation = true)
+                  },
+                )
+
+                assertThat(
+                  actual.any { reportRow ->
+                    assertApplicationRowHasCorrectData(applicationWithNonArrivedBooking.id, reportRow, userEntity, hasNonArrival = true)
+                  },
+                )
+              }
           }
-          withYieldedMoveOnCategory {
-            moveOnCategoryEntityFactory.produceAndPersist()
-          }
         }
-
-        cancellationEntityFactory.produceAndPersist {
-          withBooking(cancelledBooking)
-          withReason(cancellationReasonEntityFactory.produceAndPersist())
-        }
-
-        nonArrivalEntityFactory.produceAndPersist {
-          withBooking(nonArrivedBooking)
-          withYieldedReason { nonArrivalReasonEntityFactory.produceAndPersist() }
-        }
-
-        val expectedApplications = listOf(
-          realApplicationRepository.findByIdOrNull(applicationWithBooking.id) as ApprovedPremisesApplicationEntity,
-          realApplicationRepository.findByIdOrNull(applicationWithDepartedBooking.id) as ApprovedPremisesApplicationEntity,
-          realApplicationRepository.findByIdOrNull(applicationWithCancelledBooking.id) as ApprovedPremisesApplicationEntity,
-          realApplicationRepository.findByIdOrNull(applicationWithNonArrivedBooking.id) as ApprovedPremisesApplicationEntity,
-        )
-
-        val expectedDataFrame = ApplicationReportGenerator(realOffenderService)
-          .createReport(expectedApplications, ApplicationReportProperties(ServiceName.approvedPremises, 2023, 4, userEntity.deliusUsername))
-
-        webTestClient.get()
-          .uri("/reports/applications?year=2023&month=4")
-          .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .consumeWith {
-            val actual = DataFrame
-              .readExcel(it.responseBody!!.inputStream())
-              .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
-
-            Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
-          }
       }
     }
   }
 
-  private fun createApplicationWithBooking(submittedAt: OffsetDateTime, userEntity: UserEntity, bed: BedEntity): Pair<ApprovedPremisesApplicationEntity, BookingEntity> {
+  private fun assertApplicationRowHasCorrectData(applicationId: UUID, reportRow: ApplicationReportRow, userEntity: UserEntity, hasBooking: Boolean = true, hasCancellation: Boolean = false, hasDeparture: Boolean = false, hasNonArrival: Boolean = false): Boolean {
+    val application = realApplicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity
+    val assessment = application.getLatestAssessment()!!
+    val placementRequest = application.getLatestPlacementRequest()!!
+    val offenderDetailSummary = getOffenderDetailForApplication(application, userEntity.deliusUsername)
+
+    var hasCorrectData = reportRow.id == application.id.toString() &&
+      reportRow.crn == application.crn &&
+      reportRow.applicationAssessedDate == assessment.submittedAt!!.toLocalDate() &&
+      reportRow.assessorCru == assessment.allocatedToUser!!.probationRegion.name &&
+      reportRow.assessmentDecision == assessment.rejectionRationale &&
+      reportRow.assessmentDecisionRationale == assessment.rejectionRationale &&
+      reportRow.ageInYears == Period.between(offenderDetailSummary.dateOfBirth, LocalDate.now()).years &&
+      reportRow.gender == offenderDetailSummary.gender &&
+      reportRow.mappa == application.riskRatings!!.mappa.value!!.level &&
+      reportRow.offenceId == application.offenceId &&
+      reportRow.noms == application.nomsNumber &&
+      reportRow.premisesType == placementRequest.placementRequirements.apType.toString() &&
+      reportRow.releaseType == application.releaseType &&
+      reportRow.applicationSubmissionDate == application.submittedAt!!.toLocalDate() &&
+      reportRow.referrerRegion == application.createdByUser.probationRegion.name &&
+      reportRow.targetLocation == placementRequest.placementRequirements.postcodeDistrict.outcode &&
+      reportRow.applicationWithdrawalReason == application.withdrawalReason
+
+    if (hasBooking) {
+      val booking = placementRequest.booking!!
+      hasCorrectData = hasCorrectData &&
+        reportRow.bookingID == booking.id.toString() &&
+        reportRow.expectedArrivalDate == booking.arrivalDate &&
+        reportRow.expectedDepartureDate == booking.departureDate &&
+        reportRow.premisesName == booking.premises.name
+    }
+
+    if (hasCancellation) {
+      val cancellation = placementRequest.booking!!.cancellation!!
+      hasCorrectData = hasCorrectData &&
+        reportRow.bookingCancellationDate == cancellation.date
+    }
+
+    if (hasDeparture) {
+      val arrival = placementRequest.booking!!.arrival!!
+      val departure = placementRequest.booking!!.departure!!
+      hasCorrectData = hasCorrectData &&
+        reportRow.actualArrivalDate == arrival.arrivalDate &&
+        reportRow.actualDepartureDate == departure.dateTime.toLocalDate() &&
+        reportRow.departureMoveOnCategory == departure.moveOnCategory.name
+    }
+
+    if (hasNonArrival) {
+      val nonArrival = placementRequest.booking!!.nonArrival!!
+      hasCorrectData = hasCorrectData &&
+        reportRow.nonArrivalDate == nonArrival.date
+    }
+
+    return hasCorrectData
+  }
+
+  private fun getOffenderDetailForApplication(application: ApplicationEntity, deliusUsername: String): OffenderDetailSummary {
+    return when (val personInfo = realOffenderService.getInfoForPerson(application.crn, deliusUsername, true)) {
+      is PersonInfoResult.Success.Full -> personInfo.offenderDetailSummary
+      else -> throw Exception("No offender found for CRN ${application.crn}")
+    }
+  }
+
+  private fun createApplicationWithBooking(submittedAt: OffsetDateTime, referrer: UserEntity, assessor: UserEntity, bed: BedEntity): Pair<ApprovedPremisesApplicationEntity, BookingEntity> {
+    val (offenderDetails, _) = `Given an Offender`()
     val (placementRequest, application) = `Given a Placement Request`(
-      placementRequestAllocatedTo = userEntity,
-      assessmentAllocatedTo = userEntity,
-      createdByUser = userEntity,
+      placementRequestAllocatedTo = assessor,
+      assessmentAllocatedTo = assessor,
+      createdByUser = referrer,
       applicationSubmittedAt = submittedAt,
       mappa = "CAT M2/LEVEL M2",
+      crn = offenderDetails.otherIds.crn,
     )
 
     val booking = bookingEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -11,8 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 fun IntegrationTestBase.`Given an Offender`(
   offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -> Unit)? = null,
   inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
-  block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit,
-) {
+): Pair<OffenderDetailSummary, InmateDetail> {
   val inmateDetailsFactory = InmateDetailFactory()
   if (inmateDetailsConfigBlock != null) {
     inmateDetailsConfigBlock(inmateDetailsFactory)
@@ -33,6 +32,19 @@ fun IntegrationTestBase.`Given an Offender`(
   loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
   PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetails)
   loadPreemptiveCacheForInmateDetails(inmateDetails.offenderNo)
+
+  return Pair(offenderDetails, inmateDetails)
+}
+
+fun IntegrationTestBase.`Given an Offender`(
+  offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -> Unit)? = null,
+  inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
+  block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit,
+) {
+  val (offenderDetails, inmateDetails) = `Given an Offender`(
+    offenderDetailsConfigBlock,
+    inmateDetailsConfigBlock,
+  )
 
   block(offenderDetails, inmateDetails)
 }


### PR DESCRIPTION
When making its way into production, we found that the Application reports were running out of memory. This is something we’ve seen before when listing all the applications, becuase the default query loads all the application data json into memory, which overloads the service. This creates a new repository (for tidiness, as the ApplicationEntity was getting a bit big) to generate a custom report row, containing all the things we need from the database to generate a report. This should hopefully cut down on memory usage so we can actually generate reports in prod.

I’ve had to update the unit tests to cast the applications to a `ApplicationEntityReportRow`, which is a bit long-winded, but works. I’ve also updated the integration tests to be a bit more robust.