### PR TITLE
(Fix) Make offenceId nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -12,7 +12,7 @@ data class ApplicationReportRow(
   val ageInYears: Int?,
   val gender: String?,
   val mappa: String,
-  val offenceId: String,
+  val offenceId: String?,
   val noms: String?,
   val premisesType: String?,
   val releaseType: String?,


### PR DESCRIPTION
This field is not always present, so should be nullable