### PR TITLE
Return RoSH section of an OASys report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysAssessmentState
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysRiskOfSeriousHarm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysRiskToSelf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSections
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSupportingInformationQuestion
@@ -75,6 +76,25 @@ class OASysSectionsTransformer : OASysTransformer() {
         oASysQuestionWithSingleAnswer("Current concerns about Coping in Custody or Hostel", "R8.2.1", risksToTheIndividual.riskToTheIndividual?.currentCustodyHostelCoping),
         oASysQuestionWithSingleAnswer("Current concerns about Vulnerability", "R8.3.1", risksToTheIndividual.riskToTheIndividual?.currentVulnerability),
         oASysQuestionWithSingleAnswer("Previous concerns about self-harm or suicide", "R8.1.4", risksToTheIndividual.riskToTheIndividual?.previousConcernsSelfHarmSuicide),
+      ),
+    )
+  }
+
+  fun transformRiskOfSeriousHarm(
+    offenceDetails: OffenceDetails,
+    roshSummary: RoshSummary,
+  ): OASysRiskOfSeriousHarm {
+    return OASysRiskOfSeriousHarm(
+      assessmentId = offenceDetails.assessmentId,
+      assessmentState = if (offenceDetails.dateCompleted != null) OASysAssessmentState.completed else OASysAssessmentState.incomplete,
+      dateStarted = offenceDetails.initiationDate.toInstant(),
+      dateCompleted = offenceDetails.dateCompleted?.toInstant(),
+      rosh = listOf(
+        oASysQuestionWithSingleAnswer("Who is at risk", "R10.1", roshSummary.roshSummary?.whoIsAtRisk),
+        oASysQuestionWithSingleAnswer("What is the nature of the risk", "R10.2", roshSummary.roshSummary?.natureOfRisk),
+        oASysQuestionWithSingleAnswer("When is the risk likely to be the greatest", "R10.3", roshSummary.roshSummary?.riskGreatest),
+        oASysQuestionWithSingleAnswer("What circumstances are likely to increase risk", "R10.4", roshSummary.roshSummary?.riskIncreaseLikelyTo),
+        oASysQuestionWithSingleAnswer("What circumstances are likely to reduce the risk", "R10.5", roshSummary.roshSummary?.riskReductionLikelyTo),
       ),
     )
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1377,6 +1377,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/oasys/rosh:
+    get:
+      tags:
+        - OASys
+      summary: Returns the Risk of Serious Harm section of an OASys.
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OASysRiskOfSeriousHarm'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /people/{crn}/offences:
     get:
       summary: Returns all active offences for a Person.
@@ -6327,6 +6358,26 @@ components:
         - assessmentState
         - dateStarted
         - riskToSelf
+    OASysRiskOfSeriousHarm:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        rosh:
+          $ref: '#/components/schemas/ArrayOfOASysRiskOfSeriousHarmSummaryQuestions'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - rosh
     OASysSection:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
@@ -109,7 +109,7 @@ class PersonOASysRiskToSelfTest : IntegrationTestBase() {
         APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, risksToTheIndividual, 2500)
 
         webTestClient.get()
-          .uri("/people/${offenderDetails.otherIds.crn}/oasys/sections?selected-sections=11&selected-sections=12")
+          .uri("/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulRoSHSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockUnsuccessfulRoshCallWithDelay
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
+
+class PersonOASysRoshTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var oaSysSectionsTransformer: OASysSectionsTransformer
+
+  @Test
+  fun `Getting RoSH by CRN without a JWT returns 401`() {
+    webTestClient.get()
+      .uri("/people/CRN/oasys/rosh")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting RoSH  for a CRN with a non-Delius JWT returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "nomis",
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/oasys/rosh")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting RoSH for a CRN without ROLE_PROBATION returns 403`() {
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius",
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/oasys/rosh")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting Rosh for a CRN that does not exist returns 404`() {
+    `Given a User` { userEntity, jwt ->
+      val crn = "CRN123"
+
+      CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
+      loadPreemptiveCacheForOffenderDetails(crn)
+
+      webTestClient.get()
+        .uri("/people/$crn/oasys/rosh")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting RoSH for a CRN returns OK with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val offenceDetails = OffenceDetailsFactory().produce()
+        APOASysContext_mockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
+
+        val rosh = RoshSummaryFactory().produce()
+        APOASysContext_mockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, rosh)
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/oasys/rosh")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              oaSysSectionsTransformer.transformRiskOfSeriousHarm(
+                offenceDetails,
+                rosh,
+              ),
+            ),
+          )
+      }
+    }
+  }
+
+  @Test
+  fun `Getting RoSH when upstream times out returns 404`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, inmateDetails ->
+        val rosh = RoshSummaryFactory().produce()
+        APOASysContext_mockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, rosh, 2500)
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/oasys/rosh")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APOASysContext.kt
@@ -63,3 +63,10 @@ fun IntegrationTestBase.APOASysContext_mockSuccessfulRoshRatingsCall(crn: String
     url = "/rosh/$crn",
     responseBody = response,
   )
+
+fun IntegrationTestBase.APOASysContext_mockUnsuccessfulRoshCallWithDelay(crn: String, response: RoshSummary, delayMs: Int) =
+  mockUnsuccessfulGetCallWithDelayedResponse(
+    url = "/rosh/$crn",
+    responseStatus = 404,
+    delayMs = delayMs,
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
@@ -351,4 +351,71 @@ class OASysSectionsTransformerTest {
       ),
     )
   }
+
+  @Test
+  fun `transformRiskOfSeriousHarm transforms correctly`() {
+    val offenceDetailsApiResponse = OffenceDetailsFactory().apply {
+      withAssessmentId(34853487)
+      withDateCompleted(null)
+      withOffenceAnalysis("Offence Analysis")
+      withOthersInvolved("Others Involved")
+      withIssueContributingToRisk("Issue Contributing to Risk")
+      withOffenceMotivation("Offence Motivation")
+      withVictimImpact("Impact on the victim")
+      withVictimPerpetratorRel("Other victim information")
+      withVictimInfo("Victim Info")
+      withPatternOffending("Pattern Reoffending")
+      withAcceptsResponsibility("Accepts Responsibility")
+    }.produce()
+
+    val roshApiResponse = RoshSummaryFactory().apply {
+      withAssessmentId(34853487)
+      withDateCompleted(null)
+      withWhoAtRisk("whoIsAtRisk")
+      withNatureOfRisk("natureOfRisk")
+      withRiskGreatest("riskGreatest")
+      withRiskIncreaseLikelyTo("riskIncreaseLikelyTo")
+      withRiskReductionLikelyTo("riskReductionLikelyTo")
+    }.produce()
+
+    val result = oaSysSectionsTransformer.transformRiskOfSeriousHarm(
+      offenceDetailsApiResponse,
+      roshApiResponse,
+    )
+
+    assertThat(result.assessmentId).isEqualTo(offenceDetailsApiResponse.assessmentId)
+    assertThat(result.assessmentState).isEqualTo(OASysAssessmentState.incomplete)
+    assertThat(result.dateStarted).isEqualTo(offenceDetailsApiResponse.initiationDate.toInstant())
+    assertThat(result.dateCompleted).isEqualTo(offenceDetailsApiResponse.dateCompleted?.toInstant())
+
+    assertThat(result.rosh).containsAll(
+      listOf(
+        OASysQuestion(
+          label = "Who is at risk",
+          questionNumber = "R10.1",
+          answer = roshApiResponse.roshSummary?.whoIsAtRisk,
+        ),
+        OASysQuestion(
+          label = "What is the nature of the risk",
+          questionNumber = "R10.2",
+          answer = roshApiResponse.roshSummary?.natureOfRisk,
+        ),
+        OASysQuestion(
+          label = "When is the risk likely to be the greatest",
+          questionNumber = "R10.3",
+          answer = roshApiResponse.roshSummary?.riskGreatest,
+        ),
+        OASysQuestion(
+          label = "What circumstances are likely to increase risk",
+          questionNumber = "R10.4",
+          answer = roshApiResponse.roshSummary?.riskIncreaseLikelyTo,
+        ),
+        OASysQuestion(
+          label = "What circumstances are likely to reduce the risk",
+          questionNumber = "R10.5",
+          answer = roshApiResponse.roshSummary?.riskReductionLikelyTo,
+        ),
+      ),
+    )
+  }
 }


### PR DESCRIPTION
Following [CAS2’s implementation of an `oasys/risk-to-self` risk to self specific endpoint ](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/920)(as an alternative to the generic OASys endpoint which returns all sections), this PR does the same for risk of serious harm (RoSH), creating an `oasys/rosh` endpoint.