### PR TITLE
Add a cron job to copy prod data to preprod

### DIFF
--- a/doc/how-to/preprod-database-refresh.md
+++ b/doc/how-to/preprod-database-refresh.md
@@ -1,0 +1,36 @@
+# Database refresh - Prod to Preprod
+
+The service has a [cronjob](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml) that runs every Monday at 8am
+to refresh the data in preprod using data from production.
+
+If setting this up for the first time use **extreme caution** - this job connects to production databases.
+
+**__Ensure that all environment variables are named and setup correctly.__**
+
+## Prerequisite
+
+For this job to work the preprod database credentials need to be available production namespace. 
+This is achieved by having terraform export the preprod credentials, which is an output of the 
+Terraform rds module, to a secret in the production namespace. See this example:
+
+https://github.com/ministryofjustice/cloud-platform-environments/blob/f30756a1fec8ad4857cc43b211fc4c08010890ae/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/rds.tf#L62C4-L62C4
+
+## Overview
+
+The refresh job performs a `pg_dump` using the existing production credentials, already setup in 
+the production namespace of the application. The job then dumps the existing users from preprod
+(to ensure that preprod users don't lose access). It then uses the preprod credentials 
+(see prerequisite) to carry out a `pg_restore` of the production database, and then adds the
+preprod users back to the preprod database.
+
+## Run an adhoc database refresh
+
+If you need to run the database refresh outside the schedule, you can run the follwing
+command:
+
+```
+kubectl create job --from=cronjob/db-refresh-job db-refresh-job-adhoc
+```
+
+The job creates a pod that runs to completion. You can review the command output by 
+using `kubectl` to show pod logs.

--- a/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.env_details.production_env -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-refresh-script
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -e
+
+    echo "${DB_HOST}:5432:${DB_NAME}:${DB_USER}:${DB_PASS}" > ~/.pgpass
+    echo "${DB_HOST_PREPROD}:5432:${DB_NAME_PREPROD}:${DB_USER_PREPROD}:${DB_PASS_PREPROD}" >> ~/.pgpass
+    chmod 0600 ~/.pgpass
+
+    set -x
+    # Dump production data
+    pg_dump --host="$DB_HOST" \
+      --username="$DB_USER" \
+      --format=custom \
+      --no-privileges \
+      --verbose \
+      --file=/tmp/db.dump \
+      "$DB_NAME"
+    
+    # Dump existing preprod users as upserts
+    pg_dump --host="$DB_HOST_PREPROD" \
+      --username="$DB_USER_PREPROD" \
+      --on-conflict-do-nothing \
+      --column-inserts \
+      --data-only \
+      --no-privileges \
+      --verbose \
+      --table public.users \
+      --table public.user_qualification_assignments \
+      --table public.user_role_assignments \
+      --file=/tmp/users.dump \
+      "$DB_NAME_PREPROD"
+    
+    # Restore production data to preprod
+    pg_restore --host="$DB_HOST_PREPROD" \
+      --username="$DB_USER_PREPROD" \
+      --clean \
+      --no-owner \
+      --verbose \
+      --dbname="$DB_NAME_PREPROD" \
+      /tmp/db.dump
+    
+    # Restore existing preprod users
+    psql --host="$DB_HOST_PREPROD" \
+      --username="$DB_USER_PREPROD" \
+      "$DB_NAME_PREPROD" < /tmp/users.dump
+
+    rm -v /tmp/db.dump /tmp/users.dump ~/.pgpass
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-refresh-job
+spec:
+  schedule: "0 8 * * 1"
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 1200
+      template:
+        spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
+          securityContext:
+            runAsUser: 999
+          containers:
+            - name: dbrefresh
+              image: "postgres:14"
+              command:
+                - /bin/entrypoint.sh
+              volumeMounts:
+                - name: db-refresh-script
+                  mountPath: /bin/entrypoint.sh
+                  readOnly: true
+                  subPath: entrypoint.sh
+              env:
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_name
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_username
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_password
+                - name: DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: rds_instance_address
+                - name: DB_NAME_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output-preprod
+                      key: database_name
+                - name: DB_USER_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output-preprod
+                      key: database_username
+                - name: DB_PASS_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output-preprod
+                      key: database_password
+                - name: DB_HOST_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output-preprod
+                      key: rds_instance_address
+          restartPolicy: "Never"
+          volumes:
+            - name: db-refresh-script
+              configMap:
+                name: db-refresh-script
+                defaultMode: 0755
+{{- end }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -83,3 +83,6 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises
+
+env_details:
+  production_env: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -51,3 +51,6 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev
+
+env_details:
+  production_env: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -59,3 +59,6 @@ generic-service:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
     hmpps-approved-premises-api:
       NOTIFY_APIKEY: "NOTIFY_APIKEY"
+
+env_details:
+  production_env: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -72,3 +72,6 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises
+
+env_details:
+  production_env: false


### PR DESCRIPTION
~~**Not to be merged until https://github.com/ministryofjustice/cloud-platform-environments/pull/16411 is in**~~

This cribs from work the interventions team have done to set a cron job to run every Sunday to copy prod data to preprod:

https://github.com/ministryofjustice/hmpps-interventions-service/blob/main/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml

This will allow us to make preprod a more realistic environment, allowing UAT and debugging easier to carry out.