### PR TITLE
(430) Add pagination to user list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeBookedBy
@@ -36,6 +34,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -65,27 +65,10 @@ class PlacementRequestService(
   }
 
   fun getAllActive(status: PlacementRequestStatus?, crn: String?, crnOrName: String?, tier: String?, arrivalDateStart: LocalDate?, arrivalDateEnd: LocalDate?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
-    var pageable: PageRequest?
-    var metadata: PaginationMetadata? = null
-
-    if (page != null) {
-      val sort = if (sortDirection == SortDirection.desc) {
-        Sort.by(sortBy.value).descending()
-      } else {
-        Sort.by(sortBy.value).ascending()
-      }
-      pageable = PageRequest.of(page - 1, 10, sort)
-    } else {
-      pageable = null
-    }
-
+    val pageable = getPageable(sortBy.value, sortDirection, page)
     val response = placementRequestRepository.allForDashboard(status, crn, crnOrName, tier, arrivalDateStart, arrivalDateEnd, pageable)
 
-    if (page != null) {
-      metadata = PaginationMetadata(page, response.totalPages, response.totalElements, 10)
-    }
-
-    return Pair(response.content, metadata)
+    return Pair(response.content, getMetadata(response, page))
   }
 
   fun getPlacementRequestForUser(user: UserEntity, id: UUID): AuthorisableActionResult<Pair<PlacementRequestEntity, List<CancellationEntity>>> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PaginationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PaginationUtils.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+
+fun getPageable(sortBy: String, sortDirection: SortDirection?, page: Int?): Pageable? {
+  return if (page != null) {
+    val sort = if (sortDirection == SortDirection.desc) {
+      Sort.by(sortBy).descending()
+    } else {
+      Sort.by(sortBy).ascending()
+    }
+    PageRequest.of(page - 1, 10, sort)
+  } else {
+    null
+  }
+}
+
+fun <T>getMetadata(response: Page<T>, page: Int?): PaginationMetadata? {
+  return if (page != null) {
+    PaginationMetadata(page, response.totalPages, response.totalElements, 10)
+  } else {
+    null
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3249,6 +3249,21 @@ paths:
           description: Filters the user details to those relevant to the specified service.
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: page
+          in: query
+          description: Page number of results to return. If blank, returns all results
+          schema:
+            type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '#/components/schemas/UserSortField'
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank, will sort in descending order
+          schema:
+            $ref: '#/components/schemas/SortDirection'
       responses:
         200:
           description: successfully retrieved users
@@ -3258,6 +3273,23 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
+          headers:
+            X-Pagination-CurrentPage:
+              schema:
+                type: integer
+              description: The current page number
+            X-Pagination-TotalPages:
+              schema:
+                type: integer
+              description: The total number of pages
+            X-Pagination-TotalResults:
+              schema:
+                type: integer
+              description: The total number of results
+            X-Pagination-PageSize:
+              schema:
+                type: integer
+              description: The size of each page
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -7239,6 +7271,12 @@ components:
         - expected_arrival
         - created_at
         - application_date
+    UserSortField:
+      type: string
+      enum:
+        - name
+      x-enum-varnames:
+        - personName
     SortDirection:
       type: string
       enum:


### PR DESCRIPTION
This adds a page argument to the users endpoint, which allows us to paginate and sort the response, if the `page` argument is added. I’ve also added some util functions that should make dealing with pagination a bit easier / more DRY in future. These functions are now being used in the `getAllActive` function in the PlacementRequestService too.