### PR TITLE
Allow names of premises and rooms to be updated in Temporary Accommodation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -15,6 +16,9 @@ import javax.persistence.Table
 @Repository
 interface RoomRepository : JpaRepository<RoomEntity, UUID> {
   fun findByCode(roomCode: String): RoomEntity?
+
+  @Query("SELECT COUNT(r) = 0 FROM RoomEntity r WHERE r.name = :name AND r.premises.id = :premisesId")
+  fun nameIsUniqueForPremises(name: String, premisesId: UUID): Boolean
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -434,6 +434,29 @@ class PremisesService(
     )
   }
 
+  fun renamePremises(
+    premisesId: UUID,
+    name: String,
+  ): AuthorisableActionResult<ValidatableActionResult<PremisesEntity>> {
+    val premises = premisesRepository.findByIdOrNull(premisesId) ?: return AuthorisableActionResult.NotFound()
+
+    return AuthorisableActionResult.Success(
+      validated {
+        if (!premisesRepository.nameIsUniqueForType(name, premises::class.java)) {
+          "$.name" hasValidationError "notUnique"
+        }
+
+        if (validationErrors.any()) {
+          return@validated fieldValidationError
+        }
+
+        premises.name = name
+
+        return@validated success(premisesRepository.save(premises))
+      },
+    )
+  }
+
   fun getBeds(premisesId: UUID) = bedRepository.findAllBedsForPremises(premisesId)
 
   @Transactional

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5982,6 +5982,8 @@ components:
           format: uuid
         turnaroundWorkingDayCount:
           type: integer
+        name:
+          type: string
       required:
         - addressLine1
         - postcode

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -6262,6 +6262,8 @@ components:
           items:
             type: string
             format: uuid
+        name:
+          type: string
       required:
         - characteristicIds
     Room:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
@@ -34,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -632,5 +634,75 @@ class PremisesServiceTest {
     assertThat(resultEntity.entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
     assertThat(resultEntity.entity.referenceNumber).isEqualTo("12345")
     assertThat(resultEntity.entity.notes).isEqualTo("notes")
+  }
+
+  @Test
+  fun `renamePremises returns NotFound if the premises does not exist`() {
+    every { premisesRepositoryMock.findByIdOrNull(any()) } returns null
+
+    val result = premisesService.renamePremises(UUID.randomUUID(), "unknown-premises")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+  }
+
+  @Test
+  fun `renamePremises returns FieldValidationError if the new name is not unique for the service`() {
+    val premises = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    every { premisesRepositoryMock.findByIdOrNull(any()) } returns premises
+    every { premisesRepositoryMock.nameIsUniqueForType<TemporaryAccommodationPremisesEntity>(any(), any()) } returns false
+
+    val result = premisesService.renamePremises(premises.id, "non-unique-name-premises")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+    val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
+    assertThat(resultEntity.validationMessages).contains(
+      entry("$.name", "notUnique"),
+    )
+  }
+
+  @Test
+  fun `renamePremises returns Success containing updated premises otherwise`() {
+    val premises = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    every { premisesRepositoryMock.findByIdOrNull(any()) } returns premises
+    every { premisesRepositoryMock.nameIsUniqueForType<TemporaryAccommodationPremisesEntity>(any(), any()) } returns true
+    every { premisesRepositoryMock.save(any()) } returnsArgument 0
+
+    val result = premisesService.renamePremises(premises.id, "renamed-premises")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
+    val resultEntity = result.entity as ValidatableActionResult.Success
+    assertThat(resultEntity.entity).matches {
+      it.id == premises.id &&
+        it.name == "renamed-premises"
+    }
+
+    verify(exactly = 1) {
+      premisesRepositoryMock.save(
+        match {
+          it.id == premises.id &&
+            it.name == "renamed-premises"
+        },
+      )
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RoomServiceTest.kt
@@ -2,9 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
@@ -17,9 +19,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingReposi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
+import java.util.UUID
 
 class RoomServiceTest {
   private val roomRepository = mockk<RoomRepository>()
@@ -119,5 +123,123 @@ class RoomServiceTest {
     assertThat(result.entity.beds).hasSize(1)
     assertThat(result.entity.beds[0].room).isEqualTo(result.entity)
     assertThat(result.entity.beds[0].name).isEqualTo("default-bed")
+  }
+
+  @Test
+  fun `renameRoom returns NotFound if the room does not exist`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    every { roomRepository.findByIdOrNull(any()) } returns null
+
+    val result = roomService.renameRoom(premises, UUID.randomUUID(), "unknown-room")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+  }
+
+  @Test
+  fun `renameRoom returns NotFound if the room does not belong to the given premises`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val anotherPremises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(anotherPremises)
+      .produce()
+
+    every { roomRepository.findByIdOrNull(any()) } returns room
+
+    val result = roomService.renameRoom(premises, room.id, "wrong-premises-room")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+  }
+
+  @Test
+  fun `renameRoom returns FieldValidationError if the new name is not unique for the premises`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    every { roomRepository.findByIdOrNull(any()) } returns room
+    every { roomRepository.nameIsUniqueForPremises(any(), any()) } returns false
+
+    val result = roomService.renameRoom(premises, room.id, "non-unique-name-room")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+    val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
+    assertThat(resultEntity.validationMessages).contains(
+      entry("$.name", "notUnique"),
+    )
+  }
+
+  @Test
+  fun `renameRoom returns Success containing updated room otherwise`() {
+    val premises = TemporaryAccommodationPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    every { roomRepository.findByIdOrNull(any()) } returns room
+    every { roomRepository.nameIsUniqueForPremises(any(), any()) } returns true
+    every { roomRepository.save(any()) } returnsArgument 0
+
+    val result = roomService.renameRoom(premises, room.id, "renamed-room")
+
+    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
+    val resultEntity = result.entity as ValidatableActionResult.Success
+    assertThat(resultEntity.entity).matches {
+      it.id == room.id &&
+        it.name == "renamed-room"
+    }
+
+    verify(exactly = 1) {
+      roomRepository.save(
+        match {
+          it.id == room.id &&
+            it.name == "renamed-room"
+        },
+      )
+    }
   }
 }


### PR DESCRIPTION
> See tickets [#1518](https://trello.com/c/9j9u5rA6/1518-bedspace-references-are-editable) and [#1519](https://trello.com/c/vsOnvtbC/1519-property-references-are-editable) on the CAS3 Trello board.

This PR updates the behaviour of the `PUT /premises/{premisesId}` and `PUT /premises{premisesId}/rooms/{roomId}` endpoints to allow the name of a premises or room respectively to be updated.

The `UpdatePremises` schema for the `PUT /premises/{premisesId}` endpoint now looks like:
```jsonc
{
  "addressLine1": "1 The Street",
  "addressLine2": "",
  "town": "Faketon",
  "postcode": "AA1 1AA",
  "notes": "Some text",
  "localAuthorityAreaId": "00000000-0000-0000-0000-000000000000",
  "probationRegionId": "00000000-0000-0000-0000-000000000000",
  "characteristicIds": [
    "00000000-0000-0000-0000-000000000000",
    // ...
  ],
  "status": "active",
  "pdu": null, // deprecated in favour of probationDeliveryUnitId
  "probationDeliveryUnitId": "00000000-0000-0000-0000-000000000000",
  "turnaroundWorkingDayCount": 2,
  "name": "new-premises-name"
}
```

The `UpdateRoom` schema for the `PUT /premises/{premisesId}/rooms/{roomId}` endpoint now looks like:
```jsonc
{
  "notes": "Some text",
  "characteristicIds": [
    "00000000-0000-0000-0000-000000000000",
    // ...
  ],
  "name": "new-room-name"
}
```

In both cases, the `name` property is nullable even though both a premises and a room require a name. In the case that `name` is `null` the name will not be changed. This has been done so that no changes to the Approved Premises frontend are needed (as AP do not need this feature). Additionally, if a value for `name` is supplied, it will currently only change the name if the premises or room being renamed is in the Temporary Accommodation service.