### PR TITLE
Correct regional mapping code for Greater Manchester

### DIFF
--- a/src/main/resources/db/migration/all/20230915300000__update_greater_manchester_probation_region_mapping.sql
+++ b/src/main/resources/db/migration/all/20230915300000__update_greater_manchester_probation_region_mapping.sql
@@ -1,0 +1,3 @@
+UPDATE probation_area_probation_region_mappings
+SET probation_area_delius_code = 'N50'
+WHERE "probation_area_delius_code" = 'MCG';


### PR DESCRIPTION
There was work 3 months ago to introduce a mapping layer ontop of probation regions called `probation_area_probation_region_mappings`.[1]

Our latest attempt to seed an HPT user failed with this error related to incorrect probation region for N50[2]. This is odd because we’ve seeded users with N50 before and they’re using the service. I think the problem is coming from the changes made to how we check the probation region here[5].

This appears to have copied over the wrong Delius region code for Greater Manchester[3]. Instead of MCG it should be N50. I suspect the latest work missed the migration we made to correct this code[4] and took the values from a seed file rather than from the real values.

[1] https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/a1551b3d4daa9f749cfbbcd3fdca972f72387762
[2] https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt#L262
[3] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/758/commits/e01822dde4c60fa2ab952cad78ff8fc03991e8b5#diff-0bd31fc8ee0102525db3c54da3ecb6e42826cf10621cbf5f36ec5acfe7fbafdaR14
[4] https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/e6fdda8201262c776a7c9b05ae6c7b9bf0914e57/src/main/resources/db/migration/all/20230214123554__correct_delius_code_for_greater_manchester_region.sql#L2
[5] https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/a1551b3d4daa9f749cfbbcd3fdca972f72387762#diff-3961cf5477e37852a49aec7e386b422af36ad099859ad438fcb36b8ddfee2daaR121

I'm not familiar with flyaway to automatically generate a new migration file so i did this by hand, does that work?

Existing regions on preprod where we can see N50 remains:
![Screenshot 2023-09-12 at 16 25 37](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/fc29c72d-e642-4deb-800f-bfe0f0198ab0)

Existing mappings on preprod where we can see N50 is not present:
![Screenshot 2023-09-12 at 16 36 09](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/64c43b8f-a9da-4a8d-a568-43f2a8bc87ba)

We could also go the way and add a mapping for N50 rather than updating the existing MCG. 
