### PR TITLE
(426) Fix sorting on Placement Request Dashboard

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -65,7 +65,12 @@ class PlacementRequestService(
   }
 
   fun getAllActive(status: PlacementRequestStatus?, crn: String?, crnOrName: String?, tier: String?, arrivalDateStart: LocalDate?, arrivalDateEnd: LocalDate?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
-    val pageable = getPageable(sortBy.value, sortDirection, page)
+    val sortField = when (sortBy) {
+      PlacementRequestSortField.applicationSubmittedAt -> "application.submitted_at"
+      else -> sortBy.value
+    }
+
+    val pageable = getPageable(sortField, sortDirection, page)
     val response = placementRequestRepository.allForDashboard(status, crn, crnOrName, tier, arrivalDateStart, arrivalDateEnd, pageable)
 
     return Pair(response.content, getMetadata(response, page))

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -7271,6 +7271,11 @@ components:
         - expected_arrival
         - created_at
         - application_date
+      x-enum-varnames:
+        - duration
+        - expectedArrival
+        - createdAt
+        - applicationSubmittedAt
     UserSortField:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -81,6 +81,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     this.isWithdrawn = { isWithdrawn }
   }
 
+  fun withDuration(duration: Int) = apply {
+    this.duration = { duration }
+  }
+
   override fun produce(): PlacementRequestEntity = PlacementRequestEntity(
     id = this.id(),
     expectedArrival = this.expectedArrival(),


### PR DESCRIPTION
The sorting wasn’t working correcly, because in some cases, the enums weren’t matching the actual field names. Using `x-enum-varnames` fixes this for every field except `application_date` where I’ve had to use a conditional to specify the sort field manually. I’ve also updated the tests to test the sorting, and also DRYed up some of the setup on the other dashboard tests