### PR TITLE
Ensure that only CAS1 Applications are returned in the application report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -61,6 +61,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
     where
       date_part('month', application.submitted_at) = :month
       AND date_part('year', application.submitted_at) = :year
+      AND application.service = 'approved-premises'
     """,
     nativeQuery = true,
   )


### PR DESCRIPTION
The Applications report is currently returning ALL applications, which is obviously not what we want. I’ve added a query to filter for only AP applications, as well as updated the integration test to confirm that CAS3 applications get filtered out.