### PR TITLE
Increase parallelism on CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           paths:
             - build
   test:
-    parallelism: 5
+    parallelism: 6
     environment:
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"


### PR DESCRIPTION
This is a bit of a blunt instrument, but the CI times seem to be creeping up, so let’s throw another container at it.