### PR TITLE
remove `riskRatings` and `arrivalDate` from CAS2 Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -294,9 +294,6 @@ class Cas2ApplicationEntity(
   schemaUpToDate: Boolean,
   assessments: MutableList<AssessmentEntity>,
   nomsNumber: String?,
-  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
-  @Convert(disableConversion = true)
-  val riskRatings: PersonRisks?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -265,16 +265,6 @@ class ApplicationService(
       return fieldValidationError
     }
 
-    var riskRatings: PersonRisks? = null
-
-    val riskRatingsResult = offenderService.getRiskByCrn(crn, jwt, user.deliusUsername)
-
-    riskRatings = when (riskRatingsResult) {
-      is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
-      is AuthorisableActionResult.Unauthorised -> return "$.crn" hasSingleValidationError "userPermission"
-      is AuthorisableActionResult.Success -> riskRatingsResult.entity
-    }
-
     val createdApplication = applicationRepository.save(
       Cas2ApplicationEntity(
         id = UUID.randomUUID(),
@@ -286,7 +276,6 @@ class ApplicationService(
         createdAt = OffsetDateTime.now(),
         submittedAt = null,
         schemaUpToDate = true,
-        riskRatings = riskRatings,
         assessments = mutableListOf(),
         nomsNumber = offenderDetails.otherIds.nomsNumber,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -96,14 +96,6 @@ class ApplicationsTransformer(
         submittedAt = jpa.submittedAt?.toInstant(),
         data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
         document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
-        risks = if (jpa.riskRatings != null) {
-          risksTransformer.transformDomainToApi(
-            jpa.riskRatings!!,
-            jpa.crn,
-          )
-        } else {
-          null
-        },
         status = getStatus(jpa, latestAssessment),
         type = "CAS2",
       )

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5224,11 +5224,6 @@ components:
         - $ref: '#/components/schemas/Application'
         - type: object
           properties:
-            arrivalDate:
-              type: string
-              format: date-time
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
             createdByUserId:
               type: string
               format: uuid

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -27,7 +26,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf<AssessmentEntity>() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
-  private var riskRatings: Yielded<PersonRisks> = { PersonRisksFactory().produce() }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
 
   fun withId(id: UUID) = apply {
@@ -85,7 +83,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     submittedAt = this.submittedAt(),
     schemaUpToDate = false,
     assessments = this.assessments(),
-    riskRatings = this.riskRatings(),
     nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -161,7 +161,6 @@ class ApplicationsTransformerTest {
     assertThat(result.id).isEqualTo(application.id)
     assertThat(result.createdByUserId).isEqualTo(user.id)
     assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
-    assertThat(result.risks).isNotNull
   }
 
   @Test


### PR DESCRIPTION
We are doing some work [on pulling in ROSH risks ](https://trello.com/c/dl2n6Ny1/343-rosh-rosh-risk-summary-from-oasys) which highlighted that we are getting the person's risk when a CAS2 Application is first created. We don't need to do this for CAS2 so I'm taking that field out. Same for an `arrivalDate` as I don't believe we currently use that.

This should also simplify work coming up on [CAS2 inheritance](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/960)