### PR TITLE
Get premises type correctly in Application reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import java.sql.Date
 import java.sql.Timestamp
 import java.util.UUID
@@ -21,7 +22,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
       CAST(ap_application.risk_ratings -> 'mappa' -> 'value' -> 'level' as TEXT) as mappa,
       ap_application.offence_id as offenceId,
       application.noms_number as noms,
-      requirements.ap_type as premisesType,
+      requirements.ap_type as premisesTypeIndex,
       ap_application.release_type as releaseType,
       application.submitted_at as applicationSubmissionDate,
       referrer_region.name as referrerRegion,
@@ -78,7 +79,12 @@ interface ApplicationEntityReportRow {
   fun getMappa(): String?
   fun getOffenceId(): String
   fun getNoms(): String
-  fun getPremisesType(): String?
+  fun getPremisesTypeIndex(): String?
+  fun getPremisesType(): ApType? {
+    val index = this.getPremisesTypeIndex()?.toInt()
+    return if (index != null) (ApType.entries[index]) else null
+  }
+
   fun getReleaseType(): String?
   fun getApplicationSubmissionDate(): Timestamp?
   fun getReferrerRegion(): String?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -38,7 +38,7 @@ class ApplicationReportGenerator(
         mappa = this.getMappa() ?: "Not found",
         offenceId = this.getOffenceId(),
         noms = this.getNoms(),
-        premisesType = this.getPremisesType(),
+        premisesType = this.getPremisesType()?.name,
         releaseType = this.getReleaseType(),
         sentenceLengthInMonths = null,
         applicationSubmissionDate = this.getApplicationSubmissionDate()?.toLocalDateTime()?.toLocalDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -174,7 +174,7 @@ class ApplicationReportsTest : IntegrationTestBase() {
       reportRow.mappa == application.riskRatings!!.mappa.value!!.level &&
       reportRow.offenceId == application.offenceId &&
       reportRow.noms == application.nomsNumber &&
-      reportRow.premisesType == placementRequest.placementRequirements.apType.toString() &&
+      reportRow.premisesType == placementRequest.placementRequirements.apType.name &&
       reportRow.releaseType == application.releaseType &&
       reportRow.applicationSubmissionDate == application.submittedAt!!.toLocalDate() &&
       reportRow.referrerRegion == application.createdByUser.probationRegion.name &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/ApplicationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/ApplicationReportGeneratorTest.kt
@@ -132,7 +132,8 @@ class ApplicationReportGeneratorTest {
       override fun getMappa(): String? = applicationEntity.riskRatings?.mappa?.value?.level
       override fun getOffenceId(): String = applicationEntity.offenceId
       override fun getNoms(): String = applicationEntity.nomsNumber!!
-      override fun getPremisesType(): String? = applicationEntity.getLatestPlacementRequest()?.placementRequirements?.apType?.name
+      override fun getPremisesTypeIndex(): String? = applicationEntity.getLatestPlacementRequest()?.placementRequirements?.apType?.ordinal?.toString()
+      override fun getPremisesType(): ApType? = applicationEntity.getLatestPlacementRequest()?.placementRequirements?.apType
       override fun getReleaseType(): String? = applicationEntity.releaseType
       override fun getApplicationSubmissionDate(): Timestamp? = offsetDateTimeToTimeStamp(applicationEntity.submittedAt)
       override fun getReferrerRegion(): String = applicationEntity.createdByUser.probationRegion.name


### PR DESCRIPTION
At the moment, the premises type is returning an integer, which is what gets stored in the databse, for example, if the premises type is `normal`, we get `0`, premises type is `pipe` we get `1` and so on. This updates the query to return the `ap_type` as `premisesTypeIndex`. We can then change the `getPremisesType` interface method to get the index (if it exists) and use `ApType.entries` to get the enum value by the index. I suspect this is how it’s done with normal JPA classes, but with query interfaces, it seems we need to jump through this additional hoop!