### PR TITLE
(Fix) Ensure all user roles are returned

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -49,7 +49,12 @@ class UserTransformer(
     UserRole.CAS1_MANAGER -> ApprovedPremisesUserRole.manager
     UserRole.CAS1_WORKFLOW_MANAGER -> ApprovedPremisesUserRole.workflowManager
     UserRole.CAS1_APPLICANT -> ApprovedPremisesUserRole.applicant
-    else -> null
+    UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION -> ApprovedPremisesUserRole.excludedFromMatchAllocation
+    UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION -> ApprovedPremisesUserRole.excludedFromAssessAllocation
+    UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION -> ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation
+    UserRole.CAS1_REPORT_VIEWER -> ApprovedPremisesUserRole.reportViewer
+    UserRole.CAS3_ASSESSOR -> null
+    UserRole.CAS3_REFERRER -> null
   }
 
   private fun transformTemporaryAccommodationRoleToApi(userRole: UserRoleAssignmentEntity): TemporaryAccommodationUserRole? = when (userRole.role) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -661,7 +661,13 @@ class UsersTest : IntegrationTestBase() {
     fun `Updating a user returns OK with correct body when user has one of roles CAS1_ADMIN, CAS1_WORKFLOW_MANAGER`(role: UserRole) {
       val id = UUID.randomUUID()
       val qualifications = listOf(APIUserQualification.emergency, APIUserQualification.pipe)
-      val roles = listOf(ApprovedPremisesUserRole.assessor, ApprovedPremisesUserRole.reportViewer)
+      val roles = listOf(
+        ApprovedPremisesUserRole.assessor,
+        ApprovedPremisesUserRole.reportViewer,
+        ApprovedPremisesUserRole.excludedFromAssessAllocation,
+        ApprovedPremisesUserRole.excludedFromMatchAllocation,
+        ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation,
+      )
       val region = probationRegionEntityFactory.produceAndPersist {
         withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
       }
@@ -689,7 +695,11 @@ class UsersTest : IntegrationTestBase() {
           .jsonPath(".qualifications").isArray
           .jsonPath(".qualifications[0]").isEqualTo("emergency")
           .jsonPath(".roles").isArray
-          .jsonPath(".roles[0]").isEqualTo("assessor")
+          .jsonPath(".roles[0]").isEqualTo(ApprovedPremisesUserRole.assessor.value)
+          .jsonPath(".roles[1]").isEqualTo(ApprovedPremisesUserRole.reportViewer.value)
+          .jsonPath(".roles[2]").isEqualTo(ApprovedPremisesUserRole.excludedFromAssessAllocation.value)
+          .jsonPath(".roles[3]").isEqualTo(ApprovedPremisesUserRole.excludedFromMatchAllocation.value)
+          .jsonPath(".roles[4]").isEqualTo(ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation.value)
       }
     }
   }


### PR DESCRIPTION
When setting the exclusion roles, it looked like they weren’t being set. These were being set in the database correctly, but the transformer was not handling them correctly, meaning the users didn’t think they were being set. I’ve updated the tests to be more robust, as well as updating the `transformApprovedPremisesRoleToApi` function to handle all roles.