### PR TITLE
(450) Unmatchable Placement Requests don’t show as tasks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -24,7 +24,22 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
 
   fun findAllByAllocatedToUser_IdAndReallocatedAtNullAndIsWithdrawnFalse(userId: UUID): List<PlacementRequestEntity>
 
-  fun findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse(): List<PlacementRequestEntity>
+  @Query(
+    """
+    SELECT
+      placement_request.*,
+      booking_not_made.id
+    FROM
+      placement_requests placement_request
+      left join booking_not_mades booking_not_made on booking_not_made.placement_request_id = placement_request.id
+    where
+      placement_request.booking_id IS NULL
+      AND placement_request.is_withdrawn is false
+      and booking_not_made.id IS NULL
+    """,
+    nativeQuery = true,
+  )
+  fun findAllReallocatable(): List<PlacementRequestEntity>
 
   fun findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(isParole: Boolean, pageable: Pageable?): Page<PlacementRequestEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -61,7 +61,7 @@ class PlacementRequestService(
   }
 
   fun getAllReallocatable(): List<PlacementRequestEntity> {
-    return placementRequestRepository.findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse()
+    return placementRequestRepository.findAllReallocatable()
   }
 
   fun getAllActive(status: PlacementRequestStatus?, crn: String?, crnOrName: String?, tier: String?, arrivalDateStart: LocalDate?, arrivalDateEnd: LocalDate?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -116,6 +116,17 @@ class TasksTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
             )
 
+            val (placementRequestMarkedAsUnableToMatch) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            bookingNotMadeFactory.produceAndPersist {
+              withPlacementRequest(placementRequestMarkedAsUnableToMatch)
+            }
+
             val allocatablePlacementApplication = `Given a Placement Application`(
               createdByUser = user,
               allocatedToUser = user,


### PR DESCRIPTION
This updates the `findAllByReallocatedAtNullAndBooking_IdNullAndIsWithdrawnFalse` to join the booking_not_mades table to ensure that placement requests disappear from the Tasks endpoint when they are marked as unable to match.