### PR TITLE
Add offence ID to Temporary Accommodation applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -86,6 +86,7 @@ class ApplicationsTransformer(
         },
         status = getStatus(jpa, latestAssessment),
         type = "CAS3",
+        offenceId = jpa.offenceId,
       )
 
       is DomainCas2ApplicationEntity -> Cas2Application(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5444,11 +5444,14 @@ components:
             arrivalDate:
               type: string
               format: date-time
+            offenceId:
+              type: string
           required:
             - createdByUserId
             - schemaVersion
             - outdatedSchema
             - status
+            - offenceId
     ApplicationSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1284,6 +1284,8 @@ class ApplicationTest : IntegrationTestBase() {
           withId(UUID.randomUUID())
         }
 
+        val offenceId = "789"
+
         val result = webTestClient.post()
           .uri("/applications")
           .header("Authorization", "Bearer $jwt")
@@ -1293,7 +1295,7 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789",
+              offenceId = offenceId,
             ),
           )
           .exchange()
@@ -1307,7 +1309,8 @@ class ApplicationTest : IntegrationTestBase() {
 
         assertThat(result.responseBody.blockFirst()).matches {
           it.person.crn == offenderDetails.otherIds.crn &&
-            it.schemaVersion == applicationSchema.id
+            it.schemaVersion == applicationSchema.id &&
+            it.offenceId == offenceId
         }
       }
     }
@@ -1324,6 +1327,8 @@ class ApplicationTest : IntegrationTestBase() {
           withId(UUID.randomUUID())
         }
 
+        val offenceId = "789"
+
         val result = webTestClient.post()
           .uri("/applications")
           .header("Authorization", "Bearer $jwt")
@@ -1333,7 +1338,7 @@ class ApplicationTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
               convictionId = 123,
               deliusEventNumber = "1",
-              offenceId = "789",
+              offenceId = offenceId,
             ),
           )
           .exchange()
@@ -1347,7 +1352,8 @@ class ApplicationTest : IntegrationTestBase() {
 
         assertThat(result.responseBody.blockFirst()).matches {
           it.person.crn == offenderDetails.otherIds.crn &&
-            it.schemaVersion == applicationSchema.id
+            it.schemaVersion == applicationSchema.id &&
+            it.offenceId == offenceId
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -196,6 +196,7 @@ class ApplicationsTransformerTest {
     assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
     assertThat(result.risks).isNotNull
     assertThat(result.arrivalDate).isNull()
+    assertThat(result.offenceId).isEqualTo(application.offenceId)
   }
 
   @Test
@@ -225,6 +226,7 @@ class ApplicationsTransformerTest {
 
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
     assertThat(result.arrivalDate).isEqualTo(application.arrivalDate!!.toInstant())
+    assertThat(result.offenceId).isEqualTo(application.offenceId)
   }
 
   @Test


### PR DESCRIPTION
Currently there is no way to retrieve the index offence for a referral in the Temporary Accommodation service. When creating an application, the offence ID is required and stored in the database already. By including the offence ID in the `TemporaryAccommodationApplication` schema, it becomes accessible when users of the API send a request for an application or for an assessment (which include its application), allowing the presentation of the index offence.