### PR TITLE
Only fetch active users when auto-allocating

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -53,6 +53,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
     WHERE ura.role = 'CAS1_ASSESSOR' AND 
+        u.is_active = true AND
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
         u.id NOT IN (:excludedUserIds)
     ORDER BY score ASC
@@ -87,6 +88,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
     WHERE ura.role = 'CAS1_MATCHER' AND 
+        u.is_active = true AND
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
         u.id NOT IN (:excludedUserIds)
     ORDER BY score ASC 
@@ -121,6 +123,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
 	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
     WHERE ura.role = 'CAS1_MATCHER' AND 
+        u.is_active = true AND
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
         u.id NOT IN (:excludedUserIds)
     ORDER BY score ASC 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -99,6 +99,15 @@ class AllocationQueryTest : IntegrationTestBase() {
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 2,
     )
+    createUserForAssessmentQuery(
+      "Inactive Assessor with both Qualifications and zero pending allocated Assessments",
+      isAssessor = true,
+      hasQualifications = true,
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 2,
+      isActive = false,
+    )
     val excludedAllocatedUser = createUserForAssessmentQuery(
       "Excluded User",
       isAssessor = true,
@@ -154,6 +163,15 @@ class AllocationQueryTest : IntegrationTestBase() {
       numberOfPlacementApplications = 1,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 2,
+    )
+    createUserForPlacementApplicationsQuery(
+      "Inactive Matcher with both Qualifications and zero pending allocated Placement Applications",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 2,
+      isActive = false,
     )
     createUserForPlacementApplicationsQuery(
       "Matcher with both Qualifications and zero pending allocated Placement Applications",
@@ -228,6 +246,15 @@ class AllocationQueryTest : IntegrationTestBase() {
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 2,
     )
+    createUserForPlacementRequestsQuery(
+      "Inactive Matcher with both Qualifications and zero pending allocated Placement Requests",
+      isMatcher = true,
+      hasQualifications = true,
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 2,
+      isActive = false,
+    )
 
     val excludedAllocatedUser = createUserForPlacementRequestsQuery(
       "Excluded user",
@@ -243,11 +270,12 @@ class AllocationQueryTest : IntegrationTestBase() {
     assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Matcher with both Qualifications and zero pending allocated Placement Requests")
   }
 
-  private fun createUserForPlacementRequestsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementRequests: Int, numberOfRecentCompletedPlacementRequests: Int, numberOfLessRecentCompletedPlacementRequests: Int): UserEntity {
+  private fun createUserForPlacementRequestsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementRequests: Int, numberOfRecentCompletedPlacementRequests: Int, numberOfLessRecentCompletedPlacementRequests: Int, isActive: Boolean = true): UserEntity {
     val user = createUser(
       deliusUsername,
       if (isMatcher) listOf(UserRole.CAS1_MATCHER) else emptyList(),
       if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+      isActive,
     )
 
     repeat(numberOfPlacementRequests) {
@@ -265,11 +293,12 @@ class AllocationQueryTest : IntegrationTestBase() {
     return user
   }
 
-  private fun createUserForPlacementApplicationsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementApplications: Int, numberOfRecentCompletedPlacementApplications: Int, numberOfLessRecentCompletedPlacementApplications: Int): UserEntity {
+  private fun createUserForPlacementApplicationsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementApplications: Int, numberOfRecentCompletedPlacementApplications: Int, numberOfLessRecentCompletedPlacementApplications: Int, isActive: Boolean = true): UserEntity {
     val user = createUser(
       deliusUsername,
       if (isMatcher) listOf(UserRole.CAS1_MATCHER) else emptyList(),
       if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+      isActive,
     )
 
     repeat(numberOfPlacementApplications) {
@@ -322,11 +351,12 @@ class AllocationQueryTest : IntegrationTestBase() {
     return user
   }
 
-  private fun createUserForAssessmentQuery(deliusUsername: String, isAssessor: Boolean, hasQualifications: Boolean, numberOfPendingAssessments: Int, numberOfRecentCompletedAssessments: Int, numberOfLessRecentCompletedAssessments: Int): UserEntity {
+  private fun createUserForAssessmentQuery(deliusUsername: String, isAssessor: Boolean, hasQualifications: Boolean, numberOfPendingAssessments: Int, numberOfRecentCompletedAssessments: Int, numberOfLessRecentCompletedAssessments: Int, isActive: Boolean = true): UserEntity {
     val user = createUser(
       deliusUsername,
       if (isAssessor) listOf(UserRole.CAS1_ASSESSOR) else emptyList(),
       if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+      isActive,
     )
 
     repeat(numberOfPendingAssessments) {
@@ -376,7 +406,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     return user
   }
 
-  private fun createUser(deliusUsername: String, roles: List<UserRole>, qualifications: List<UserQualification>): UserEntity {
+  private fun createUser(deliusUsername: String, roles: List<UserRole>, qualifications: List<UserQualification>, isActive: Boolean = true): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(deliusUsername)
       withYieldedProbationRegion {
@@ -384,6 +414,7 @@ class AllocationQueryTest : IntegrationTestBase() {
           withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
         }
       }
+      withIsActive(isActive)
     }
 
     roles.forEach {


### PR DESCRIPTION
Now we can 'soft-delete' users, we need to make sure nothing is allocated to them, otherwise tasks will fall down a black hole!