### PR TITLE
Add a remote_db script

### DIFF
--- a/doc/how-to/access_database_remotely.md
+++ b/doc/how-to/access_database_remotely.md
@@ -4,13 +4,39 @@
 done as a last resort. This should ideally only be done in pairs, and
 mutating any live data is STRONGLY discouraged.
 
+Both methods detailed below use [Jaqy](https://teradata.github.io/jaqy/), which
+is a Java-native universal database client. As well as carrying out simple 
+queries, you can also do exports of data (enabling, for example, one off reporting), 
+and other useful bits and pieces. For full details, check the [documentation](https://teradata.github.io/jaqy/).
+
+There are two ways to do this:
+
+## The easy way
+
+For most use cases (i.e. running simple queries etc), this will be the way
+you want to do it. The downside is you won't have access to things like
+data exports from the local shell.
+
+From your local machine run:
+
+```bash
+script/remote_db $ENVIRONMENT
+```
+
+Where $ENVIRONMENT is the environment you want to connect to.
+
+When you're finished, type the `.quit` command to end the session.
+
+## The hard(er) way
+
+This is more suitable if you need access to the bash shell, as well as
+the ability to make SQL queries.
+
 From your local machine run:
 
 ```bash
 script/remote_shell $ENVIRONMENT
 ```
-
-Where $ENVIRONMENT is the environment you want to connect to
 
 Once connected, you'll need to download [jaqy](https://teradata.github.io/jaqy/index.html)
 to connect to the database, together with an appropriate Postgres driver.

--- a/script/remote_db
+++ b/script/remote_db
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+  echo "You must specify an environment"
+  exit 1
+else
+  environment=$1
+fi
+
+namespace="hmpps-community-accommodation-$environment"
+
+pod=$(kubectl -n "$namespace" get pods -l app=hmpps-approved-premises-api -o jsonpath='{.items[0].metadata.name}')
+
+script="""
+cd ~
+curl -L https://github.com/Teradata/jaqy/releases/download/v1.2.0/jaqy-1.2.0.jar --output jaqy-1.2.0.jar
+curl -L https://jdbc.postgresql.org/download/postgresql-42.5.1.jar --output postgresql-42.5.1.jar
+java -jar jaqy-1.2.0.jar -- .classpath postgresql postgresql-42.5.1.jar \; .open -u \${SPRING_DATASOURCE_USERNAME} -p \${SPRING_DATASOURCE_PASSWORD} postgresql://\${DB_HOST}/\${DB_NAME}
+"""
+
+kubectl -n "$namespace" exec -it "$pod" -- sh -c "$script"


### PR DESCRIPTION
I got fed up of having to check the docs each time to remember how to do this, so I’ve added an easier method. I’ve updated the docs to detail both methods, as sometimes you’ll need access to the bash shell as well as Jaqy.