### PR TITLE
Add an assessment decision date to an application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -61,6 +61,7 @@ class ApplicationsTransformer(
         status = getStatus(jpa, latestAssessment),
         assessmentDecision = transformJpaDecisionToApi(latestAssessment?.decision),
         assessmentId = latestAssessment?.id,
+        assessmentDecisionDate = latestAssessment?.submittedAt?.toLocalDate(),
         type = "CAS1",
       )
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5214,6 +5214,9 @@ components:
               format: uuid
             assessmentDecision:
               $ref: '#/components/schemas/AssessmentDecision'
+            assessmentDecisionDate:
+              type: string
+              format: date
             submittedAt:
               type: string
               format: date-time

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
@@ -299,6 +300,7 @@ class ApplicationsTransformerTest {
     assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
     assertThat(result.assessmentDecision).isNull()
     assertThat(result.assessmentId).isEqualTo(assessment.id)
+    assertThat(result.assessmentDecisionDate).isNull()
   }
 
   @Test
@@ -308,6 +310,7 @@ class ApplicationsTransformerTest {
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.REJECTED)
       .withApplication(application)
+      .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
     application.assessments = mutableListOf(assessment)
@@ -317,6 +320,7 @@ class ApplicationsTransformerTest {
     assertThat(result.status).isEqualTo(ApplicationStatus.rejected)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.rejected)
     assertThat(result.assessmentId).isEqualTo(assessment.id)
+    assertThat(result.assessmentDecisionDate).isEqualTo(LocalDate.now())
   }
 
   @Test
@@ -326,6 +330,7 @@ class ApplicationsTransformerTest {
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
       .withApplication(application)
+      .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
     application.assessments = mutableListOf(assessment)
@@ -335,6 +340,7 @@ class ApplicationsTransformerTest {
     assertThat(result.status).isEqualTo(ApplicationStatus.pending)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.accepted)
     assertThat(result.assessmentId).isEqualTo(assessment.id)
+    assertThat(result.assessmentDecisionDate).isEqualTo(LocalDate.now())
   }
 
   @Test
@@ -344,6 +350,7 @@ class ApplicationsTransformerTest {
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
       .withApplication(application)
+      .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
     application.assessments = mutableListOf(assessment)
@@ -371,6 +378,7 @@ class ApplicationsTransformerTest {
     assertThat(result.status).isEqualTo(ApplicationStatus.awaitingPlacement)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.accepted)
     assertThat(result.assessmentId).isEqualTo(assessment.id)
+    assertThat(result.assessmentDecisionDate).isEqualTo(LocalDate.now())
   }
 
   @Test
@@ -380,6 +388,7 @@ class ApplicationsTransformerTest {
       .withSubmittedAt(OffsetDateTime.now())
       .withDecision(AssessmentDecision.ACCEPTED)
       .withApplication(application)
+      .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
     application.assessments = mutableListOf(assessment)
@@ -416,6 +425,7 @@ class ApplicationsTransformerTest {
     assertThat(result.status).isEqualTo(ApplicationStatus.placed)
     assertThat(result.assessmentDecision).isEqualTo(ApiAssessmentDecision.accepted)
     assertThat(result.assessmentId).isEqualTo(assessment.id)
+    assertThat(result.assessmentDecisionDate).isEqualTo(LocalDate.now())
   }
 
   @Test


### PR DESCRIPTION
This will allow us to show the decision that an assessment was made when viewing an application.