### PR TITLE
Avoid throwing an exception when inmate details are unavailable from the Prison API

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockServerErrorOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockServerErrorInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
@@ -11,6 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 fun IntegrationTestBase.`Given an Offender`(
   offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -> Unit)? = null,
   inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
+  mockServerErrorForCommunityApi: Boolean = false,
+  mockServerErrorForPrisonApi: Boolean = false,
 ): Pair<OffenderDetailSummary, InmateDetail> {
   val inmateDetailsFactory = InmateDetailFactory()
   if (inmateDetailsConfigBlock != null) {
@@ -28,9 +32,18 @@ fun IntegrationTestBase.`Given an Offender`(
 
   val offenderDetails = offenderDetailsFactory.produce()
 
-  CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails)
+  when (mockServerErrorForCommunityApi) {
+    true -> CommunityAPI_mockServerErrorOffenderDetailsCall(offenderDetails.otherIds.crn)
+    false -> CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails)
+  }
+
   loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
-  PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetails)
+
+  when (mockServerErrorForPrisonApi) {
+    true -> PrisonAPI_mockServerErrorInmateDetailsCall(inmateDetails.offenderNo)
+    false -> PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetails)
+  }
+
   loadPreemptiveCacheForInmateDetails(inmateDetails.offenderNo)
 
   return Pair(offenderDetails, inmateDetails)
@@ -39,11 +52,15 @@ fun IntegrationTestBase.`Given an Offender`(
 fun IntegrationTestBase.`Given an Offender`(
   offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -> Unit)? = null,
   inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
+  mockServerErrorForCommunityApi: Boolean = false,
+  mockServerErrorForPrisonApi: Boolean = false,
   block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit,
 ) {
   val (offenderDetails, inmateDetails) = `Given an Offender`(
     offenderDetailsConfigBlock,
     inmateDetailsConfigBlock,
+    mockServerErrorForCommunityApi,
+    mockServerErrorForPrisonApi,
   )
 
   block(offenderDetails, inmateDetails)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CommunityAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/CommunityAPI.kt
@@ -27,6 +27,12 @@ fun IntegrationTestBase.CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderD
     responseBody = offenderDetails,
   )
 
+fun IntegrationTestBase.CommunityAPI_mockServerErrorOffenderDetailsCall(crn: String) =
+  mockUnsuccessfulGetCall(
+    url = "/secure/offenders/crn/$crn",
+    responseStatus = 500,
+  )
+
 fun IntegrationTestBase.CommunityAPI_mockSuccessfulDocumentsCall(crn: String, groupedDocuments: GroupedDocuments) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/secure/offenders/crn/$crn/documents/grouped",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/PrisonAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/PrisonAPI.kt
@@ -16,6 +16,12 @@ fun IntegrationTestBase.PrisonAPI_mockNotFoundInmateDetailsCall(offenderNo: Stri
     responseStatus = 404,
   )
 
+fun IntegrationTestBase.PrisonAPI_mockServerErrorInmateDetailsCall(offenderNo: String) =
+  mockUnsuccessfulGetCall(
+    url = "/api/offenders/$offenderNo",
+    responseStatus = 500,
+  )
+
 fun IntegrationTestBase.PrisonAPI_mockSuccessfulAlertsCall(nomsNumber: String, alerts: List<Alert>) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/api/offenders/$nomsNumber/alerts/v2?alertCodes=HA&sort=dateCreated&direction=DESC",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -454,9 +454,10 @@ class OffenderServiceTest {
 
     assertThat(result is AuthorisableActionResult.Success)
     result as AuthorisableActionResult.Success
-    assertThat(result.entity.offenderNo).isEqualTo(nomsNumber)
-    assertThat(result.entity.inOutStatus).isEqualTo(InOutStatus.IN)
-    assertThat(result.entity.assignedLivingUnit).isEqualTo(
+    assertThat(result.entity).isNotNull
+    assertThat(result.entity!!.offenderNo).isEqualTo(nomsNumber)
+    assertThat(result.entity!!.inOutStatus).isEqualTo(InOutStatus.IN)
+    assertThat(result.entity!!.assignedLivingUnit).isEqualTo(
       AssignedLivingUnit(
         agencyId = "AGY",
         locationId = 89,


### PR DESCRIPTION
> See [ticket #1569 on the CAS3 Trello board](https://trello.com/c/mrl4OEIg/1569-a-user-cant-see-a-booking-if-nomis-returns-500-for-that-nomsnumber).

A CAS3 user reported being unable to make a booking on a property. An investigation determined that [this Sentry event](https://ministryofjustice.sentry.io/issues/4479799213/?environment=prod&project=4503931792392192&query=is%3Aunresolved&referrer=issue-stream&stream_index=0) corresponds to the user's request and from [AppInsights](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%22a5ddf257-3b21-4ba9-a28c-ab30f751b383%22%2C%22ResourceGroup%22%3A%22nomisapi-prod-rg%22%2C%22Name%22%3A%22nomisapi-prod%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%252FresourceGroups%252Fnomisapi-prod-rg%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fnomisapi-prod%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%222a2e541f-e11c-4962-8269-b2d96906a394%22%2C%22timestamp%22%3A%222023-09-15T10%3A12%3A24.243Z%22%2C%22cacheId%22%3A%228b5898c2-7fb9-460f-88d6-55637edc2ddb%22%2C%22eventTable%22%3A%22dependencies%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%2C%22endTime%22%3A%222023-09-15T10%3A43%3A11.160Z%22%7D%7D) it appears that a 500 response was being cached.

The `OffenderService.getInmateDetailByNomsNumber` method explicitly throws an exception if the response (either cached or direct) is in the 5xx range. However, all callers of the function either transform the returned `AuthorisableActionResult<InmateDetail>` into an `InmateDetail?` or can gracefully accept a `null` value contained within the result.

Therefore, the contract for the method has been relaxed so that in situations where an exception would have previously been thrown, the returned value will instead be `AuthorisableActionResult.Success(null)` and the exception will instead be logged at the `WARN` level, with additional preamble to explain whether the error was from the cache or a direct HTTP request, to aid any future diagnostic work involving caching of inmate details.