### PR TITLE
(455) Fetch latest placement requirements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
@@ -16,7 +16,7 @@ import javax.persistence.Table
 
 @Repository
 interface PlacementRequirementsRepository : JpaRepository<PlacementRequirementsEntity, UUID> {
-  fun findByApplication(application: ApplicationEntity): PlacementRequirementsEntity?
+  fun findTopByApplicationOrderByCreatedAtDesc(application: ApplicationEntity): PlacementRequirementsEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -129,7 +129,7 @@ class PlacementRequestService(
   }
 
   fun createPlacementRequestsFromPlacementApplication(placementApplicationEntity: PlacementApplicationEntity, notes: String?): AuthorisableActionResult<List<PlacementRequestEntity>> {
-    val placementRequirements = placementRequirementsRepository.findByApplication(
+    val placementRequirements = placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(
       placementApplicationEntity.application,
     ) ?: return AuthorisableActionResult.NotFound("Placement Requirements", placementApplicationEntity.application.id.toString())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
@@ -55,6 +55,10 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
     this.desirableCriteria = { desirableCriteria }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   override fun produce(): PlacementRequirementsEntity = PlacementRequirementsEntity(
     id = this.id(),
     gender = this.gender(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1079,7 +1079,7 @@ class AssessmentTest : IntegrationTestBase() {
 
             assertThat(placementRequestRepository.findByApplication(application)).isNull()
 
-            val persistedPlacementRequirements = placementRequirementsRepository.findByApplication(application)!!
+            val persistedPlacementRequirements = placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(application)!!
 
             assertThat(persistedPlacementRequirements.apType).isEqualTo(placementRequirements.type)
             assertThat(persistedPlacementRequirements.gender).isEqualTo(placementRequirements.gender)


### PR DESCRIPTION
There are sometimes cases when an application can have multiple assessments, so we need to ensure we only get one placement requirement object. Ordering by created at and using `findTopBy` seems to do the trick.