### PR TITLE
Hide reallocated placmement request in task list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -34,8 +34,10 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
       left join booking_not_mades booking_not_made on booking_not_made.placement_request_id = placement_request.id
     where
       placement_request.booking_id IS NULL
+      AND placement_request.reallocated_at IS NULL
       AND placement_request.is_withdrawn is false
-      and booking_not_made.id IS NULL
+      AND booking_not_made.id IS NULL
+      AND placement_request.reallocated_at IS NULL
     """,
     nativeQuery = true,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -103,6 +103,14 @@ class TasksTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
             )
 
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              reallocated = true,
+              crn = offenderDetails.otherIds.crn,
+            )
+
             val (allocatableAssessment) = `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
               createdByUser = otherUser,


### PR DESCRIPTION
I was wracking my brains about why there were so many placement requests that appeared to be out of date in the task list. While all the other task queries are JPA derived queries (i.e `findBy..`), the Placement Request query is a custom one, and we left out the `reallocated_at IS NULL` conditional. This should fix it and mean there are much fewer tasks in the list now.