### PR TITLE
Don’t fail when unable to allocate a user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -123,7 +123,7 @@ data class PlacementRequestEntity(
 
   @ManyToOne
   @JoinColumn(name = "allocated_to_user_id")
-  val allocatedToUser: UserEntity,
+  val allocatedToUser: UserEntity?,
 
   @OneToMany(mappedBy = "placementRequest")
   var bookingNotMades: MutableList<BookingNotMadeEntity>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -151,15 +151,17 @@ class AssessmentService(
       ),
     )
 
-    emailNotificationService.sendEmail(
-      user = allocatedUser,
-      templateId = notifyConfig.templates.assessmentAllocated,
-      personalisation = mapOf(
-        "name" to allocatedUser.name,
-        "assessmentUrl" to assessmentUrlTemplate.replace("#id", assessment.id.toString()),
-        "crn" to application.crn,
-      ),
-    )
+    if (allocatedUser != null) {
+      emailNotificationService.sendEmail(
+        user = allocatedUser,
+        templateId = notifyConfig.templates.assessmentAllocated,
+        personalisation = mapOf(
+          "name" to allocatedUser.name,
+          "assessmentUrl" to assessmentUrlTemplate.replace("#id", assessment.id.toString()),
+          "crn" to application.crn,
+        ),
+      )
+    }
 
     return assessment
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -632,15 +632,17 @@ class AssessmentService(
         ),
       )
 
-      emailNotificationService.sendEmail(
-        user = currentAssessment.allocatedToUser!!,
-        templateId = notifyConfig.templates.assessmentDeallocated,
-        personalisation = mapOf(
-          "name" to currentAssessment.allocatedToUser!!.name,
-          "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
-          "crn" to application.crn,
-        ),
-      )
+      if (currentAssessment.allocatedToUser != null) {
+        emailNotificationService.sendEmail(
+          user = currentAssessment.allocatedToUser!!,
+          templateId = notifyConfig.templates.assessmentDeallocated,
+          personalisation = mapOf(
+            "name" to currentAssessment.allocatedToUser!!.name,
+            "assessmentUrl" to assessmentUrlTemplate.replace("#id", newAssessment.id.toString()),
+            "crn" to application.crn,
+          ),
+        )
+      }
     }
 
     return AuthorisableActionResult.Success(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -137,7 +137,7 @@ class BookingService(
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
 
-    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.allocatedToUser.id != user.id) {
+    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.allocatedToUser?.id != user.id) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -80,7 +80,7 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (placementRequest.allocatedToUser.id != user.id && !user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
+    if (placementRequest.allocatedToUser?.id != user.id && !user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -119,9 +119,10 @@ class UserService(
     }
   }
 
-  fun getUserForAssessmentAllocation(application: ApplicationEntity): UserEntity {
+  fun getUserForAssessmentAllocation(application: ApplicationEntity): UserEntity? {
     val unsuitableUsers = mutableListOf<UUID>(UUID.randomUUID())
     val qualifications = application.getRequiredQualifications().toMutableList()
+    var attempts = 1
 
     if (offenderService.isLao(application.crn)) {
       qualifications += UserQualification.LAO
@@ -129,20 +130,25 @@ class UserService(
 
     while (true) {
       val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
-        ?: throw RuntimeException("Could not find a suitable assessor for assessment with qualifications (${qualifications.joinToString(",")}): ${application.crn}")
 
-      if ((qualifications.isEmpty() && potentialUser.qualifications.isNotEmpty()) || potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION)) {
-        unsuitableUsers += potentialUser.id
-        continue
+      if (potentialUser != null) {
+        if ((qualifications.isEmpty() && potentialUser.qualifications.isNotEmpty()) || potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION)) {
+          unsuitableUsers += potentialUser.id
+          attempts += 1
+          continue
+        }
+      } else {
+        log.error("Could not find a suitable assessor for assessment with qualifications (${qualifications.joinToString(",")}) after $attempts attempts: ${application.crn}")
       }
 
       return potentialUser
     }
   }
 
-  fun getUserForPlacementRequestAllocation(crn: String): UserEntity {
+  fun getUserForPlacementRequestAllocation(crn: String): UserEntity? {
     val qualifications = mutableListOf<UserQualification>()
     val unsuitableUsers = mutableListOf<UUID>(UUID.randomUUID())
+    var attempts = 1
 
     if (offenderService.isLao(crn)) {
       qualifications += UserQualification.LAO
@@ -150,20 +156,25 @@ class UserService(
 
     while (true) {
       val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
-        ?: throw RuntimeException("Could not find a suitable matcher for placement request with qualifications (${qualifications.joinToString(",")}): $crn")
 
-      if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION)) {
-        unsuitableUsers += potentialUser.id
-        continue
+      if (potentialUser != null) {
+        if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION)) {
+          unsuitableUsers += potentialUser.id
+          attempts += 1
+          continue
+        }
+      } else {
+        log.error("Could not find a suitable matcher for placement request with qualifications (${qualifications.joinToString(",")}) after $attempts attempt(s): $crn")
       }
 
       return potentialUser
     }
   }
 
-  fun getUserForPlacementApplicationAllocation(crn: String): UserEntity {
+  fun getUserForPlacementApplicationAllocation(crn: String): UserEntity? {
     val qualifications = mutableListOf<UserQualification>()
     val unsuitableUsers = mutableListOf<UUID>(UUID.randomUUID())
+    var attempts = 1
 
     if (offenderService.isLao(crn)) {
       qualifications += UserQualification.LAO
@@ -171,11 +182,15 @@ class UserService(
 
     while (true) {
       val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
-        ?: throw RuntimeException("Could not find a suitable matcher for placement application with qualifications (${qualifications.joinToString(",")}): $crn")
 
-      if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION)) {
-        unsuitableUsers += potentialUser.id
-        continue
+      if (potentialUser != null) {
+        if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION)) {
+          unsuitableUsers += potentialUser.id
+          attempts += 1
+          continue
+        }
+      } else {
+        log.error("Could not find a suitable matcher for placement application with qualifications (${qualifications.joinToString(",")}): $crn after $attempts attempts")
       }
 
       return potentialUser

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType as ApiPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType as JpaPlacementType
 
@@ -27,7 +28,7 @@ class TaskTransformer(
     personName = personName,
     crn = assessment.application.crn,
     dueDate = assessment.createdAt.plusDays(10).toLocalDate(),
-    allocatedToStaffMember = userTransformer.transformJpaToApi(assessment.allocatedToUser!!, ServiceName.approvedPremises) as ApprovedPremisesUser,
+    allocatedToStaffMember = transformUserOrNull(assessment.allocatedToUser),
     status = getAssessmentStatus(assessment),
     taskType = TaskType.assessment,
   )
@@ -38,7 +39,7 @@ class TaskTransformer(
     personName = personName,
     crn = placementRequest.application.crn,
     dueDate = placementRequest.createdAt.plusDays(10).toLocalDate(),
-    allocatedToStaffMember = userTransformer.transformJpaToApi(placementRequest.allocatedToUser, ServiceName.approvedPremises) as ApprovedPremisesUser,
+    allocatedToStaffMember = transformUserOrNull(placementRequest.allocatedToUser),
     status = getPlacementRequestStatus(placementRequest),
     taskType = TaskType.placementRequest,
     tier = risksTransformer.transformTierDomainToApi(placementRequest.application.riskRatings!!.tier),
@@ -54,7 +55,7 @@ class TaskTransformer(
     personName = personName,
     crn = placementApplication.application.crn,
     dueDate = placementApplication.createdAt.plusDays(10).toLocalDate(),
-    allocatedToStaffMember = userTransformer.transformJpaToApi(placementApplication.allocatedToUser!!, ServiceName.approvedPremises) as ApprovedPremisesUser,
+    allocatedToStaffMember = transformUserOrNull(placementApplication.allocatedToUser),
     status = getPlacementApplicationStatus(placementApplication),
     taskType = TaskType.placementApplication,
     tier = risksTransformer.transformTierDomainToApi(placementApplication.application.riskRatings!!.tier),
@@ -89,5 +90,13 @@ class TaskTransformer(
   private fun getPlacementRequestStatus(entity: PlacementRequestEntity): TaskStatus = when {
     entity.booking !== null -> TaskStatus.complete
     else -> TaskStatus.notStarted
+  }
+
+  private fun transformUserOrNull(userEntity: UserEntity?): ApprovedPremisesUser? {
+    return if (userEntity == null) {
+      null
+    } else {
+      userTransformer.transformJpaToApi(userEntity, ServiceName.approvedPremises) as ApprovedPremisesUser
+    }
   }
 }

--- a/src/main/resources/db/migration/all/20230921153329__make_placement_request_allocated_to_user_id_nullable.sql
+++ b/src/main/resources/db/migration/all/20230921153329__make_placement_request_allocated_to_user_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE placement_requests ALTER COLUMN allocated_to_user_id DROP NOT NULL;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4141,7 +4141,6 @@ components:
         - applicationId
         - personName
         - dueDate
-        - allocatedToStaffMember
         - status
         - crn
     TaskStatus:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -987,7 +987,7 @@ class AssessmentTest : IntegrationTestBase() {
 
             val persistedPlacementRequest = placementRequestRepository.findByApplication(application)!!
 
-            assertThat(persistedPlacementRequest.allocatedToUser.id).isIn(listOf(matcher1.id, matcher2.id))
+            assertThat(persistedPlacementRequest.allocatedToUser!!.id).isIn(listOf(matcher1.id, matcher2.id))
             assertThat(persistedPlacementRequest.application.id).isEqualTo(application.id)
             assertThat(persistedPlacementRequest.expectedArrival).isEqualTo(placementDates.expectedArrival)
             assertThat(persistedPlacementRequest.duration).isEqualTo(placementDates.duration)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -900,7 +900,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
 
                       val createdPlacementApplication = createdPlacementRequests[0]
 
-                      assertThat(createdPlacementApplication.allocatedToUser.id).isIn(listOf(matcher1.id, matcher2.id))
+                      assertThat(createdPlacementApplication.allocatedToUser!!.id).isIn(listOf(matcher1.id, matcher2.id))
                       assertThat(createdPlacementApplication.application.id).isEqualTo(placementApplicationEntity.application.id)
                       assertThat(createdPlacementApplication.expectedArrival).isEqualTo(placementDates.expectedArrival)
                       assertThat(createdPlacementApplication.duration).isEqualTo(placementDates.duration)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -683,7 +683,7 @@ class TasksTest : IntegrationTestBase() {
                 )
 
               val placementRequests = placementRequestRepository.findAll()
-              val allocatedPlacementRequest = placementRequests.find { it.allocatedToUser.id == assigneeUser.id }
+              val allocatedPlacementRequest = placementRequests.find { it.allocatedToUser!!.id == assigneeUser.id }
 
               Assertions.assertThat(placementRequests.first { it.id == existingPlacementRequest.id }.reallocatedAt).isNotNull
               Assertions.assertThat(allocatedPlacementRequest).isNotNull


### PR DESCRIPTION
We’re getting an unusual number of allocations failing when submitting applications etc. While we attempt to work out what’s going on, we’ll log errors and make the allocated to user null. We’ll also log the failure to allocate together with the number of attempts, which will give us more of an idea why these errors are happening.

As part of this we’ve had to make the allocated to user nullable in a few places.