### PR TITLE
Improve allocation queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -55,13 +55,17 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
     WHERE ura.role = 'CAS1_ASSESSOR' AND 
         u.is_active = true AND
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
-        u.id NOT IN (:excludedUserIds)
+        u.id NOT IN (
+            SELECT u.id FROM users u
+            LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
+            WHERE ura.role = 'CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION'
+        )
     ORDER BY score ASC
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(requiredQualifications: List<String>, totalRequiredQualifications: Long): UserEntity?
 
   @Query(
     """
@@ -90,13 +94,17 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
     WHERE ura.role = 'CAS1_MATCHER' AND 
         u.is_active = true AND
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
-        u.id NOT IN (:excludedUserIds)
+        u.id NOT IN (
+            SELECT u.id FROM users u
+            LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
+            WHERE ura.role = 'CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION'
+        )
     ORDER BY score ASC 
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(requiredQualifications: List<String>, totalRequiredQualifications: Long): UserEntity?
 
   @Query(
     """
@@ -125,13 +133,17 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
     WHERE ura.role = 'CAS1_MATCHER' AND 
         u.is_active = true AND
         (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
-        u.id NOT IN (:excludedUserIds)
+        u.id NOT IN (
+            SELECT u.id FROM users u
+            LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
+            WHERE ura.role = 'CAS1_EXCLUDED_FROM_MATCH_ALLOCATION'
+        )
     ORDER BY score ASC 
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(requiredQualifications: List<String>, totalRequiredQualifications: Long): UserEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -120,81 +120,51 @@ class UserService(
   }
 
   fun getUserForAssessmentAllocation(application: ApplicationEntity): UserEntity? {
-    val unsuitableUsers = mutableListOf<UUID>(UUID.randomUUID())
     val qualifications = application.getRequiredQualifications().toMutableList()
-    var attempts = 1
 
     if (offenderService.isLao(application.crn)) {
       qualifications += UserQualification.LAO
     }
 
-    while (true) {
-      val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
+    val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong())
 
-      if (potentialUser != null) {
-        if ((qualifications.isEmpty() && potentialUser.qualifications.isNotEmpty()) || potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION)) {
-          unsuitableUsers += potentialUser.id
-          attempts += 1
-          continue
-        }
-      } else {
-        log.error("Could not find a suitable assessor for assessment with qualifications (${qualifications.joinToString(",")}) after $attempts attempts: ${application.crn}")
-      }
-
-      return potentialUser
+    if (potentialUser == null) {
+      log.error("Could not find a suitable assessor for assessment with qualifications (${qualifications.joinToString(",")}): ${application.crn}")
     }
+
+    return potentialUser
   }
 
   fun getUserForPlacementRequestAllocation(crn: String): UserEntity? {
     val qualifications = mutableListOf<UserQualification>()
-    val unsuitableUsers = mutableListOf<UUID>(UUID.randomUUID())
-    var attempts = 1
 
     if (offenderService.isLao(crn)) {
       qualifications += UserQualification.LAO
     }
 
-    while (true) {
-      val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
+    val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(qualifications.map(UserQualification::toString), qualifications.size.toLong())
 
-      if (potentialUser != null) {
-        if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION)) {
-          unsuitableUsers += potentialUser.id
-          attempts += 1
-          continue
-        }
-      } else {
-        log.error("Could not find a suitable matcher for placement request with qualifications (${qualifications.joinToString(",")}) after $attempts attempt(s): $crn")
-      }
-
-      return potentialUser
+    if (potentialUser == null) {
+      log.error("Could not find a suitable matcher for placement request with qualifications (${qualifications.joinToString(",")}): $crn")
     }
+
+    return potentialUser
   }
 
   fun getUserForPlacementApplicationAllocation(crn: String): UserEntity? {
     val qualifications = mutableListOf<UserQualification>()
-    val unsuitableUsers = mutableListOf<UUID>(UUID.randomUUID())
-    var attempts = 1
 
     if (offenderService.isLao(crn)) {
       qualifications += UserQualification.LAO
     }
 
-    while (true) {
-      val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(qualifications.map(UserQualification::toString), qualifications.size.toLong(), unsuitableUsers)
+    val potentialUser = userRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(qualifications.map(UserQualification::toString), qualifications.size.toLong())
 
-      if (potentialUser != null) {
-        if (potentialUser.hasRole(UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION)) {
-          unsuitableUsers += potentialUser.id
-          attempts += 1
-          continue
-        }
-      } else {
-        log.error("Could not find a suitable matcher for placement application with qualifications (${qualifications.joinToString(",")}): $crn after $attempts attempts")
-      }
-
-      return potentialUser
+    if (potentialUser == null) {
+      log.error("Could not find a suitable matcher for placement application with qualifications (${qualifications.joinToString(",")}): $crn")
     }
+
+    return potentialUser
   }
 
   fun deleteUser(id: UUID) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -121,12 +121,13 @@ class UserService(
 
   fun getUserForAssessmentAllocation(application: ApplicationEntity): UserEntity? {
     val qualifications = application.getRequiredQualifications().toMutableList()
+    val qualifiedUserRequired = (qualifications.size.toLong() > 0).compareTo(false)
 
     if (offenderService.isLao(application.crn)) {
       qualifications += UserQualification.LAO
     }
 
-    val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong())
+    val potentialUser = userRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(qualifications.map(UserQualification::toString), qualifications.size.toLong(), qualifiedUserRequired)
 
     if (potentialUser == null) {
       log.error("Could not find a suitable assessor for assessment with qualifications (${qualifications.joinToString(",")}): ${application.crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -92,11 +92,7 @@ class TaskTransformer(
     else -> TaskStatus.notStarted
   }
 
-  private fun transformUserOrNull(userEntity: UserEntity?): ApprovedPremisesUser? {
-    return if (userEntity == null) {
-      null
-    } else {
-      userTransformer.transformJpaToApi(userEntity, ServiceName.approvedPremises) as ApprovedPremisesUser
-    }
+  private fun transformUserOrNull(userEntity: UserEntity?) = userEntity?.let {
+    userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) as ApprovedPremisesUser
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -62,7 +62,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with no qualifications",
       isAssessor = true,
-      qualifications = listOf(),
+      qualifications = listOf(UserQualification.LAO),
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 0,
@@ -70,7 +70,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with both Qualifications and two pending allocated Assessments",
       isAssessor = true,
-      qualifications = listOf(),
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPendingAssessments = 2,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 0,
@@ -126,9 +126,11 @@ class AllocationQueryTest : IntegrationTestBase() {
       numberOfLessRecentCompletedAssessments = 2,
     )
 
-    val actualAllocatedUserWithQualifications = realUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(listOf("PIPE", "WOMENS"), 2)
+    val actualAllocatedUserWithQualifications = realUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(listOf("PIPE", "WOMENS"), 2, 1)
+    val actualAllocatedUserWithoutQualifications = realUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(emptyList(), 0, 0)
 
     assertThat(actualAllocatedUserWithQualifications!!.deliusUsername).isEqualTo("Assessor with both Qualifications and zero pending allocated Assessments")
+    assertThat(actualAllocatedUserWithoutQualifications!!.deliusUsername).isEqualTo("Assessor with no qualifications")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AllocationQueryTest.kt
@@ -54,7 +54,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Non Assessor",
       isAssessor = false,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 0,
@@ -62,7 +62,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with no qualifications",
       isAssessor = true,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 0,
@@ -70,7 +70,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with both Qualifications and two pending allocated Assessments",
       isAssessor = true,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPendingAssessments = 2,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 0,
@@ -78,7 +78,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with both Qualifications, zero pending allocated Assessments and one complete Assessment from the last week",
       isAssessor = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 1,
       numberOfLessRecentCompletedAssessments = 2,
@@ -86,7 +86,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with both Qualifications and one pending allocated Assessment",
       isAssessor = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPendingAssessments = 1,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 2,
@@ -94,7 +94,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Assessor with both Qualifications and zero pending allocated Assessments",
       isAssessor = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 2,
@@ -102,24 +102,33 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForAssessmentQuery(
       "Inactive Assessor with both Qualifications and zero pending allocated Assessments",
       isAssessor = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 2,
       isActive = false,
     )
-    val excludedAllocatedUser = createUserForAssessmentQuery(
+    createUserForAssessmentQuery(
+      "Assessor with one Qualification and zero pending allocated Assessments",
+      isAssessor = true,
+      qualifications = listOf(UserQualification.PIPE),
+      numberOfPendingAssessments = 0,
+      numberOfRecentCompletedAssessments = 0,
+      numberOfLessRecentCompletedAssessments = 2,
+    )
+    createUserForAssessmentQuery(
       "Excluded User",
       isAssessor = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
+      isExcluded = true,
       numberOfPendingAssessments = 0,
       numberOfRecentCompletedAssessments = 0,
       numberOfLessRecentCompletedAssessments = 2,
     )
 
-    val actualAllocatedUser = realUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
+    val actualAllocatedUserWithQualifications = realUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(listOf("PIPE", "WOMENS"), 2)
 
-    assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Assessor with both Qualifications and zero pending allocated Assessments")
+    assertThat(actualAllocatedUserWithQualifications!!.deliusUsername).isEqualTo("Assessor with both Qualifications and zero pending allocated Assessments")
   }
 
   @Test
@@ -127,7 +136,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementApplicationsQuery(
       "Non Matcher",
       isMatcher = false,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPlacementApplications = 0,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 0,
@@ -135,7 +144,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementApplicationsQuery(
       "Matcher with no qualifications",
       isMatcher = false,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPlacementApplications = 0,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 0,
@@ -143,7 +152,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementApplicationsQuery(
       "Matcher with both Qualifications and two pending allocated Placement Applications",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementApplications = 2,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 0,
@@ -151,7 +160,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementApplicationsQuery(
       "Matcher with both Qualifications, zero pending allocated Placement Applications and one complete Placement Application from the last week",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementApplications = 0,
       numberOfRecentCompletedPlacementApplications = 1,
       numberOfLessRecentCompletedPlacementApplications = 2,
@@ -159,7 +168,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementApplicationsQuery(
       "Matcher with both Qualifications and one pending allocated Placement Application",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementApplications = 1,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 2,
@@ -167,31 +176,39 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementApplicationsQuery(
       "Inactive Matcher with both Qualifications and zero pending allocated Placement Applications",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementApplications = 0,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 2,
       isActive = false,
     )
     createUserForPlacementApplicationsQuery(
+      "Matcher with one Qualification and zero pending allocated Placement Applications",
+      isMatcher = true,
+      qualifications = listOf(UserQualification.WOMENS),
+      numberOfPlacementApplications = 0,
+      numberOfRecentCompletedPlacementApplications = 0,
+      numberOfLessRecentCompletedPlacementApplications = 2,
+    )
+    createUserForPlacementApplicationsQuery(
       "Matcher with both Qualifications and zero pending allocated Placement Applications",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementApplications = 0,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 2,
     )
-
-    val excludedAllocatedUser = createUserForPlacementApplicationsQuery(
-      "Excluded user",
+    createUserForPlacementApplicationsQuery(
+      "Excluded Matcher with both Qualifications and zero pending allocated Placement Applications",
       isMatcher = true,
-      hasQualifications = true,
+      isExcluded = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementApplications = 0,
       numberOfRecentCompletedPlacementApplications = 0,
       numberOfLessRecentCompletedPlacementApplications = 2,
     )
 
-    val actualAllocatedUser = realUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
+    val actualAllocatedUser = realUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(listOf("PIPE", "WOMENS"), 2)
 
     assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Matcher with both Qualifications and zero pending allocated Placement Applications")
   }
@@ -201,7 +218,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementRequestsQuery(
       "Non Matcher",
       isMatcher = false,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPlacementRequests = 0,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 0,
@@ -209,7 +226,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementRequestsQuery(
       "Matcher with no qualifications",
       isMatcher = false,
-      hasQualifications = false,
+      qualifications = listOf(),
       numberOfPlacementRequests = 0,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 0,
@@ -217,7 +234,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementRequestsQuery(
       "Matcher with both Qualifications and two pending allocated Placement Requests",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementRequests = 2,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 0,
@@ -225,7 +242,7 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementRequestsQuery(
       "Matcher with both Qualifications, zero pending allocated Placement Requests and one complete Placement Request from the last week",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementRequests = 0,
       numberOfRecentCompletedPlacementRequests = 1,
       numberOfLessRecentCompletedPlacementRequests = 2,
@@ -233,15 +250,23 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementRequestsQuery(
       "Matcher with both Qualifications and one pending allocated Placement Request",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementRequests = 1,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 0,
     )
     createUserForPlacementRequestsQuery(
+      "Matcher with one Qualification and zero pending allocated Placement Requests",
+      isMatcher = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
+      numberOfPlacementRequests = 0,
+      numberOfRecentCompletedPlacementRequests = 0,
+      numberOfLessRecentCompletedPlacementRequests = 2,
+    )
+    createUserForPlacementRequestsQuery(
       "Matcher with both Qualifications and zero pending allocated Placement Requests",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementRequests = 0,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 2,
@@ -249,32 +274,42 @@ class AllocationQueryTest : IntegrationTestBase() {
     createUserForPlacementRequestsQuery(
       "Inactive Matcher with both Qualifications and zero pending allocated Placement Requests",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementRequests = 0,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 2,
       isActive = false,
     )
-
-    val excludedAllocatedUser = createUserForPlacementRequestsQuery(
-      "Excluded user",
+    createUserForPlacementRequestsQuery(
+      "Excluded Matcher with both Qualifications and zero pending allocated Placement Requests",
       isMatcher = true,
-      hasQualifications = true,
+      qualifications = listOf(UserQualification.PIPE, UserQualification.WOMENS),
       numberOfPlacementRequests = 0,
+      isExcluded = true,
       numberOfRecentCompletedPlacementRequests = 0,
       numberOfLessRecentCompletedPlacementRequests = 2,
     )
 
-    val actualAllocatedUser = realUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(listOf("PIPE", "WOMENS"), 2, listOf(excludedAllocatedUser.id))
+    val actualAllocatedUser = realUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(listOf("PIPE", "WOMENS"), 2)
 
     assertThat(actualAllocatedUser!!.deliusUsername).isEqualTo("Matcher with both Qualifications and zero pending allocated Placement Requests")
   }
 
-  private fun createUserForPlacementRequestsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementRequests: Int, numberOfRecentCompletedPlacementRequests: Int, numberOfLessRecentCompletedPlacementRequests: Int, isActive: Boolean = true): UserEntity {
+  private fun createUserForPlacementRequestsQuery(deliusUsername: String, isMatcher: Boolean, qualifications: List<UserQualification>, numberOfPlacementRequests: Int, numberOfRecentCompletedPlacementRequests: Int, numberOfLessRecentCompletedPlacementRequests: Int, isActive: Boolean = true, isExcluded: Boolean = false): UserEntity {
+    val roles = mutableListOf<UserRole>()
+
+    if (isMatcher) {
+      roles += UserRole.CAS1_MATCHER
+    }
+
+    if (isExcluded) {
+      roles += UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION
+    }
+
     val user = createUser(
       deliusUsername,
-      if (isMatcher) listOf(UserRole.CAS1_MATCHER) else emptyList(),
-      if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+      roles,
+      qualifications,
       isActive,
     )
 
@@ -293,11 +328,21 @@ class AllocationQueryTest : IntegrationTestBase() {
     return user
   }
 
-  private fun createUserForPlacementApplicationsQuery(deliusUsername: String, isMatcher: Boolean, hasQualifications: Boolean, numberOfPlacementApplications: Int, numberOfRecentCompletedPlacementApplications: Int, numberOfLessRecentCompletedPlacementApplications: Int, isActive: Boolean = true): UserEntity {
+  private fun createUserForPlacementApplicationsQuery(deliusUsername: String, isMatcher: Boolean, qualifications: List<UserQualification>, numberOfPlacementApplications: Int, numberOfRecentCompletedPlacementApplications: Int, numberOfLessRecentCompletedPlacementApplications: Int, isActive: Boolean = true, isExcluded: Boolean = false): UserEntity {
+    val roles = mutableListOf<UserRole>()
+
+    if (isMatcher) {
+      roles += UserRole.CAS1_MATCHER
+    }
+
+    if (isExcluded) {
+      roles += UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION
+    }
+
     val user = createUser(
       deliusUsername,
-      if (isMatcher) listOf(UserRole.CAS1_MATCHER) else emptyList(),
-      if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+      roles,
+      qualifications,
       isActive,
     )
 
@@ -351,11 +396,21 @@ class AllocationQueryTest : IntegrationTestBase() {
     return user
   }
 
-  private fun createUserForAssessmentQuery(deliusUsername: String, isAssessor: Boolean, hasQualifications: Boolean, numberOfPendingAssessments: Int, numberOfRecentCompletedAssessments: Int, numberOfLessRecentCompletedAssessments: Int, isActive: Boolean = true): UserEntity {
+  private fun createUserForAssessmentQuery(deliusUsername: String, isAssessor: Boolean, qualifications: List<UserQualification>, numberOfPendingAssessments: Int, numberOfRecentCompletedAssessments: Int, numberOfLessRecentCompletedAssessments: Int, isActive: Boolean = true, isExcluded: Boolean = false): UserEntity {
+    val roles = mutableListOf<UserRole>()
+
+    if (isAssessor) {
+      roles += UserRole.CAS1_ASSESSOR
+    }
+
+    if (isExcluded) {
+      roles += UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION
+    }
+
     val user = createUser(
       deliusUsername,
-      if (isAssessor) listOf(UserRole.CAS1_ASSESSOR) else emptyList(),
-      if (hasQualifications) listOf(UserQualification.PIPE, UserQualification.WOMENS) else emptyList(),
+      roles,
+      qualifications,
       isActive,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -987,6 +987,7 @@ class AssessmentTest : IntegrationTestBase() {
 
             val persistedPlacementRequest = placementRequestRepository.findByApplication(application)!!
 
+            assertThat(persistedPlacementRequest.allocatedToUser).isNotNull
             assertThat(persistedPlacementRequest.allocatedToUser!!.id).isIn(listOf(matcher1.id, matcher2.id))
             assertThat(persistedPlacementRequest.application.id).isEqualTo(application.id)
             assertThat(persistedPlacementRequest.expectedArrival).isEqualTo(placementDates.expectedArrival)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -900,6 +900,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
 
                       val createdPlacementApplication = createdPlacementRequests[0]
 
+                      assertThat(createdPlacementApplication.allocatedToUser).isNotNull
                       assertThat(createdPlacementApplication.allocatedToUser!!.id).isIn(listOf(matcher1.id, matcher2.id))
                       assertThat(createdPlacementApplication.application.id).isEqualTo(placementApplicationEntity.application.id)
                       assertThat(createdPlacementApplication.expectedArrival).isEqualTo(placementDates.expectedArrival)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -276,37 +276,6 @@ class UserServiceTest {
   }
 
   @Test
-  fun `getUserForAssessmentAllocation does not select user with qualifications when none are required to assess the application`() {
-    val createdByUser = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val userWithQualifications = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-      .addQualificationForUnitTest(UserQualification.LAO)
-
-    val userWithoutQualifications = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(createdByUser)
-      .produce()
-
-    every { mockOffenderService.isLao(application.crn) } returns false
-
-    every {
-      mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
-        requiredQualifications = emptyList(),
-        totalRequiredQualifications = 0,
-      )
-    } returns userWithQualifications andThen userWithoutQualifications
-
-    assertThat(userService.getUserForAssessmentAllocation(application)).isEqualTo(userWithoutQualifications)
-  }
-
-  @Test
   fun `getUserForPlacementRequestAllocation adds LAO qualification to requirements when application is for an LAO CRN`() {
     val userForAllocation = UserEntityFactory()
       .withUnitTestControlProbationRegion()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -269,6 +269,7 @@ class UserServiceTest {
       mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
+        0,
       )
     } returns userForAllocation
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -35,7 +35,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addQualificationForUnitTest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
 import java.util.UUID
 import javax.servlet.http.HttpServletRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
@@ -270,7 +269,6 @@ class UserServiceTest {
       mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
-        excludedUserIds = any(),
       )
     } returns userForAllocation
 
@@ -302,43 +300,10 @@ class UserServiceTest {
       mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
         requiredQualifications = emptyList(),
         totalRequiredQualifications = 0,
-        excludedUserIds = any(),
       )
     } returns userWithQualifications andThen userWithoutQualifications
 
     assertThat(userService.getUserForAssessmentAllocation(application)).isEqualTo(userWithoutQualifications)
-  }
-
-  @Test
-  fun `getUserForAssessmentAllocation does not select user with CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION role`() {
-    val createdByUser = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val userWithExclusionRole = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-      .addRoleForUnitTest(UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION)
-
-    val userWithoutExclusionRole = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(createdByUser)
-      .produce()
-
-    every { mockOffenderService.isLao(application.crn) } returns false
-
-    every {
-      mockUserRepository.findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(
-        requiredQualifications = emptyList(),
-        totalRequiredQualifications = 0,
-        excludedUserIds = any(),
-      )
-    } returns userWithExclusionRole andThen userWithoutExclusionRole
-
-    assertThat(userService.getUserForAssessmentAllocation(application)).isEqualTo(userWithoutExclusionRole)
   }
 
   @Test
@@ -356,37 +321,10 @@ class UserServiceTest {
       mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
-        excludedUserIds = any(),
       )
     } returns userForAllocation
 
     assertThat(userService.getUserForPlacementRequestAllocation(crn)).isEqualTo(userForAllocation)
-  }
-
-  @Test
-  fun `getUserForPlacementRequestAllocation does not select user with CAS1_EXCLUDED_FROM_MATCH_ALLOCATION role`() {
-    val userWithExclusionRole = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-      .addRoleForUnitTest(UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION)
-
-    val userWithoutExclusionRole = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val crn = "CRN123"
-
-    every { mockOffenderService.isLao(crn) } returns false
-
-    every {
-      mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(
-        requiredQualifications = emptyList(),
-        totalRequiredQualifications = 0,
-        excludedUserIds = any(),
-      )
-    } returns userWithExclusionRole andThen userWithoutExclusionRole
-
-    assertThat(userService.getUserForPlacementRequestAllocation(crn)).isEqualTo(userWithoutExclusionRole)
   }
 
   @Test
@@ -404,37 +342,10 @@ class UserServiceTest {
       mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(
         requiredQualifications = listOf(UserQualification.LAO.toString()),
         totalRequiredQualifications = 1,
-        excludedUserIds = any(),
       )
     } returns userForAllocation
 
     assertThat(userService.getUserForPlacementApplicationAllocation(crn)).isEqualTo(userForAllocation)
-  }
-
-  @Test
-  fun `getUserForPlacementApplicationAllocation does not select user with CAS1_EXCLUDED_FROM_MATCH_ALLOCATION role`() {
-    val userWithExclusionRole = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-      .addRoleForUnitTest(UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION)
-
-    val userWithoutExclusionRole = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .produce()
-
-    val crn = "CRN123"
-
-    every { mockOffenderService.isLao(crn) } returns false
-
-    every {
-      mockUserRepository.findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(
-        requiredQualifications = emptyList(),
-        totalRequiredQualifications = 0,
-        excludedUserIds = any(),
-      )
-    } returns userWithExclusionRole andThen userWithoutExclusionRole
-
-    assertThat(userService.getUserForPlacementApplicationAllocation(crn)).isEqualTo(userWithoutExclusionRole)
   }
 
   @Test


### PR DESCRIPTION
Rather than checking if a user is excluded from allocations and running the query again, we add a subquery to exclude these users from the query altogether, which should allow us to allocate more quickly and in a less error prone fashion.