### PR TITLE
Add an AllocationsEngine class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -30,7 +30,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 
   @Query(
     """
-    SELECT u.*, ura.*, uqa2.*,
+    SELECT u.*,
      RANK() OVER (
       ORDER BY
         (
@@ -49,23 +49,18 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
             )
         ) ASC
      ) as score
-    FROM "users"  u
-	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
-	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
-    WHERE ura.role = 'CAS1_ASSESSOR' AND 
-        u.is_active = true AND
-        (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
-        u.id NOT IN (:excludedUserIds)
+    FROM "users" u
+    WHERE u.id IN (:userIds)
     ORDER BY score ASC
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedAssessorWithLeastPendingOrCompletedInLastWeekAssessments(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findUserWithLeastPendingOrCompletedInLastWeekAssessments(userIds: List<UUID>): UserEntity?
 
   @Query(
     """
-    SELECT u.*, ura.*, uqa2.*,
+    SELECT u.*,
     RANK() OVER (
       ORDER BY
         (
@@ -84,23 +79,18 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
             )
         ) ASC
      ) as score
-    FROM "users"  u
-	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
-	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
-    WHERE ura.role = 'CAS1_MATCHER' AND 
-        u.is_active = true AND
-        (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
-        u.id NOT IN (:excludedUserIds)
+    FROM "users" u
+    WHERE u.id IN (:userIds)
     ORDER BY score ASC 
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementApplications(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findUserWithLeastPendingOrCompletedInLastWeekPlacementApplications(userIds: List<UUID>): UserEntity?
 
   @Query(
     """
-    SELECT u.*, ura.*, uqa2.*,
+    SELECT u.*,
     RANK() OVER (
       ORDER BY
         (
@@ -120,18 +110,13 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
         ) ASC
      ) as score
     FROM "users"  u
-	    LEFT JOIN user_role_assignments ura ON ura.user_id = u.id 
-	    LEFT JOIN user_qualification_assignments uqa2 ON uqa2.user_id = u.id 
-    WHERE ura.role = 'CAS1_MATCHER' AND 
-        u.is_active = true AND
-        (SELECT COUNT(1) FROM user_qualification_assignments uqa WHERE uqa.user_id = u.id AND uqa.qualification IN (:requiredQualifications)) = :totalRequiredQualifications AND 
-        u.id NOT IN (:excludedUserIds)
+    WHERE u.id IN (:userIds)
     ORDER BY score ASC 
     LIMIT 1
     """,
     nativeQuery = true,
   )
-  fun findQualifiedMatcherWithLeastPendingOrCompletedInLastWeekPlacementRequests(requiredQualifications: List<String>, totalRequiredQualifications: Long, excludedUserIds: List<UUID>): UserEntity?
+  fun findUserWithLeastPendingOrCompletedInLastWeekPlacementRequests(userIds: List<UUID>): UserEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserAllocationsEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserAllocationsEngine.kt
@@ -1,0 +1,136 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import java.util.UUID
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.JoinType
+import javax.persistence.criteria.Path
+import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.Root
+
+enum class AllocationType {
+  Assessment, PlacementRequest, PlacementApplication
+}
+
+class UserAllocationsEngine(private val userRepository: UserRepository, private val allocationType: AllocationType, private val requiredQualifications: List<UserQualification>, private val isLao: Boolean) {
+  fun getAllocatedUser(): UserEntity? {
+    val userIds = userRepository.findAll(this.getUserPool()).map { it.id }
+
+    return when (this.allocationType) {
+      AllocationType.Assessment -> userRepository.findUserWithLeastPendingOrCompletedInLastWeekAssessments(userIds)
+      AllocationType.PlacementRequest -> userRepository.findUserWithLeastPendingOrCompletedInLastWeekPlacementRequests(userIds)
+      AllocationType.PlacementApplication -> userRepository.findUserWithLeastPendingOrCompletedInLastWeekPlacementApplications(userIds)
+    }
+  }
+
+  private fun getUserPool(): Specification<UserEntity> {
+    return Specification { root: Root<UserEntity>, query: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+      val userQualifications = root
+        .join<UserEntity, MutableList<UserQualificationAssignmentEntity>>(UserEntity::qualifications.name, JoinType.LEFT)
+        .get<UserQualificationAssignmentEntity>(UserQualificationAssignmentEntity::qualification.name)
+
+      val userRoles = root
+        .join<UserEntity, MutableList<UserEntity>>(UserEntity::roles.name, JoinType.LEFT)
+        .get<UserRole>(UserRoleAssignmentEntity::role.name)
+
+      val predicates = mutableListOf<Predicate>(
+        allActiveUsers(criteriaBuilder, root),
+        allUsersWithRequiredRole(userRoles),
+      )
+
+      // If the offender is an LAO, we only want users with the LAO qualification
+      if (isLao) {
+        predicates.add(
+          allUsersWithLaoQualification(userQualifications),
+        )
+      }
+
+      // If we're allocating an assessment, we don't want users with any of the specialist qualifications
+      if (this.allocationType == AllocationType.Assessment && this.requiredQualifications.isEmpty()) {
+        predicates.add(
+          allUsersWithoutSpecialistQualifications(userQualifications, criteriaBuilder, root),
+        )
+      } else if (this.requiredQualifications.isNotEmpty()) {
+        // If there are required qualifications, then we ask for users that have ALL of the qualifications we want
+        predicates.add(
+          allUsersWithRequiredQualifications(root, query, criteriaBuilder),
+        )
+      }
+
+      // Finally, we want to make sure the user does not have the exclusion role for our allocation type
+      predicates.add(
+        allUsersWithoutExclusionRole(userRoles, criteriaBuilder),
+      )
+
+      criteriaBuilder.and(*predicates.toTypedArray())
+    }
+  }
+
+  private fun allActiveUsers(criteriaBuilder: CriteriaBuilder, root: Root<UserEntity>) = criteriaBuilder.isTrue(root.get("isActive"))
+
+  private fun allUsersWithRequiredRole(userRoles: Path<UserRole>): Predicate {
+    val requiredRole = when (this.allocationType) {
+      AllocationType.Assessment -> UserRole.CAS1_ASSESSOR
+      AllocationType.PlacementRequest -> UserRole.CAS1_MATCHER
+      AllocationType.PlacementApplication -> UserRole.CAS1_MATCHER
+    }
+
+    return userRoles.`in`(requiredRole)
+  }
+
+  private fun allUsersWithLaoQualification(userQualifications: Path<UserQualificationAssignmentEntity>): Predicate = userQualifications.`in`(UserQualification.LAO)
+
+  private fun allUsersWithoutSpecialistQualifications(userQualifications: Path<UserQualificationAssignmentEntity>, criteriaBuilder: CriteriaBuilder, root: Root<UserEntity>): Predicate {
+    val specialistQualifications = listOf(
+      UserQualification.ESAP,
+      UserQualification.PIPE,
+      UserQualification.EMERGENCY,
+    )
+
+    return criteriaBuilder.not(
+      userQualifications.`in`(specialistQualifications),
+    )
+  }
+
+  private fun allUsersWithRequiredQualifications(root: Root<UserEntity>, query: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder): Predicate {
+    val subQuery = query.subquery(Long::class.java)
+    val userQualificationQuery = subQuery.from(UserQualificationAssignmentEntity::class.java)
+
+    subQuery
+      .select(criteriaBuilder.count(userQualificationQuery))
+      .where(
+        criteriaBuilder.and(
+          criteriaBuilder.equal(
+            userQualificationQuery
+              .join<UserQualificationAssignmentEntity, UserEntity>("user", JoinType.LEFT)
+              .get<Set<UUID>>("id"),
+            root.get<Set<UUID>>("id"),
+          ),
+          userQualificationQuery
+            .get<UserQualificationAssignmentEntity>(UserQualificationAssignmentEntity::qualification.name)
+            .`in`(this.requiredQualifications),
+        ),
+      )
+
+    return criteriaBuilder.equal(subQuery.selection, this.requiredQualifications.size.toLong())
+  }
+
+  private fun allUsersWithoutExclusionRole(userRoles: Path<UserRole>, criteriaBuilder: CriteriaBuilder): Predicate {
+    val exclusionRole = when (this.allocationType) {
+      AllocationType.Assessment -> UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION
+      AllocationType.PlacementRequest -> UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION
+      AllocationType.PlacementApplication -> UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION
+    }
+
+    return criteriaBuilder.not(
+      userRoles.`in`(exclusionRole),
+    )
+  }
+}


### PR DESCRIPTION
The Allocations engine has been giving us a lot of grief recently. I attempted a fix in a previous PR, but I’ve since discovered that it didn’t _quite_ match up with what was expected. To try and make this a bit more configurable, and to remove some of the complex logic, I’ve added a `UserAllocationsEngine` class, which has a `getUserPool` function that uses the `CriteriaBuilder` to get a list of qualified users IDs, we then pass those IDs to get the user with the smallest workload, depending on the type of task.

It’s still a little cumbersome, but I’ve attempted to make it a little easier to grok with comments etc.