### PR TITLE
(425) Use working days for task due days

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType as ApiPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType as JpaPlacementType
 
@@ -21,13 +22,14 @@ class TaskTransformer(
   private val userTransformer: UserTransformer,
   private val risksTransformer: RisksTransformer,
   private val placementRequestTransformer: PlacementRequestTransformer,
+  private val workingDayCountService: WorkingDayCountService,
 ) {
   fun transformAssessmentToTask(assessment: AssessmentEntity, personName: String) = AssessmentTask(
     id = assessment.id,
     applicationId = assessment.application.id,
     personName = personName,
     crn = assessment.application.crn,
-    dueDate = assessment.createdAt.plusDays(10).toLocalDate(),
+    dueDate = workingDayCountService.addWorkingDays(assessment.createdAt.toLocalDate(), 10),
     allocatedToStaffMember = transformUserOrNull(assessment.allocatedToUser),
     status = getAssessmentStatus(assessment),
     taskType = TaskType.assessment,
@@ -38,7 +40,7 @@ class TaskTransformer(
     applicationId = placementRequest.application.id,
     personName = personName,
     crn = placementRequest.application.crn,
-    dueDate = placementRequest.createdAt.plusDays(10).toLocalDate(),
+    dueDate = workingDayCountService.addWorkingDays(placementRequest.createdAt.toLocalDate(), 10),
     allocatedToStaffMember = transformUserOrNull(placementRequest.allocatedToUser),
     status = getPlacementRequestStatus(placementRequest),
     taskType = TaskType.placementRequest,
@@ -54,7 +56,7 @@ class TaskTransformer(
     applicationId = placementApplication.application.id,
     personName = personName,
     crn = placementApplication.application.crn,
-    dueDate = placementApplication.createdAt.plusDays(10).toLocalDate(),
+    dueDate = workingDayCountService.addWorkingDays(placementApplication.createdAt.toLocalDate(), 10),
     allocatedToStaffMember = transformUserOrNull(placementApplication.allocatedToUser),
     status = getPlacementApplicationStatus(placementApplication),
     taskType = TaskType.placementApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Temporary Accommodation`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
@@ -31,6 +33,11 @@ class TasksTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var userTransformer: UserTransformer
+
+  @BeforeEach
+  fun stubBankHolidaysApi() {
+    GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+  }
 
   @Nested
   inner class GetAllReallocatableTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
@@ -56,6 +57,7 @@ class TaskTransformerTest {
   private val mockUser = mockk<ApprovedPremisesUser>()
   private val mockOffenderDetailSummary = mockk<OffenderDetailSummary>()
   private val mockInmateDetail = mockk<InmateDetail>()
+  private val mockWorkingDayCountService = mockk<WorkingDayCountService>()
 
   private val user = UserEntityFactory()
     .withYieldedProbationRegion {
@@ -106,11 +108,13 @@ class TaskTransformerTest {
     mockUserTransformer,
     mockRisksTransformer,
     mockPlacementRequestTransformer,
+    mockWorkingDayCountService,
   )
 
   @BeforeEach
   fun setup() {
     every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockUser
+    every { mockWorkingDayCountService.addWorkingDays(any(), any()) } returns LocalDate.now().plusDays(2)
   }
 
   @Nested
@@ -127,7 +131,7 @@ class TaskTransformerTest {
       assertThat(result.status).isEqualTo(TaskStatus.notStarted)
       assertThat(result.taskType).isEqualTo(TaskType.assessment)
       assertThat(result.applicationId).isEqualTo(application.id)
-      assertThat(result.dueDate).isEqualTo(LocalDate.parse("2022-12-17"))
+      assertThat(result.dueDate).isEqualTo(LocalDate.now().plusDays(2))
       assertThat(result.personName).isEqualTo("First Last")
       assertThat(result.crn).isEqualTo(assessment.application.crn)
       assertThat(result.allocatedToStaffMember).isEqualTo(mockUser)


### PR DESCRIPTION
This updates our `TaskTransformer` to use `addWorkingdays` instead of the blunt instrument `plusDays`.

It also (and potentially more controversially) changes the WorkingDayCountService to use a static file. We’re hitting the GOV.UK bank holidays API a lot to make these requests (even though they’re cached in Redis). In a seperate PR, we’ll add a Github action (similar to https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1050) to check the file for changes, and open a PR to replace the file if it has.