### PR TITLE
(460) Persist targetLocation in applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -224,6 +224,7 @@ class ApprovedPremisesApplicationEntity(
   var releaseType: String?,
   var arrivalDate: OffsetDateTime?,
   var name: String,
+  var targetLocation: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -229,6 +229,7 @@ class ApplicationService(
         otherWithdrawalReason = null,
         nomsNumber = offenderDetails.otherIds.nomsNumber,
         name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}",
+        targetLocation = null,
       ),
     )
 
@@ -655,6 +656,7 @@ class ApplicationService(
       submittedAt = OffsetDateTime.now()
       document = serializedTranslatedDocument
       releaseType = submitApplication.releaseType.toString()
+      targetLocation = submitApplication.targetLocation
       arrivalDate = if (submitApplication.arrivalDate !== null) OffsetDateTime.of(submitApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC) else null
     }
 

--- a/src/main/resources/db/migration/all/20230927134507__add_target_location_to_approved_premises_application.sql
+++ b/src/main/resources/db/migration/all/20230927134507__add_target_location_to_approved_premises_application.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN target_location TEXT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -45,6 +45,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var withdrawalReason: Yielded<String?> = { null }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
   private var name: Yielded<String> = { "${randomStringUpperCase(4)} ${randomStringUpperCase(6)}" }
+  private var targetLocation: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -158,6 +159,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.name = { name }
   }
 
+  fun withTargetLocation(targetLocation: String?) = apply {
+    this.targetLocation = { targetLocation }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -187,5 +192,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     otherWithdrawalReason = null,
     nomsNumber = this.nomsNumber(),
     name = this.name(),
+    targetLocation = this.targetLocation(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1530,6 +1530,7 @@ class ApplicationTest : IntegrationTestBase() {
 
           assertThat(persistedApplication.isWomensApplication).isTrue
           assertThat(persistedApplication.isPipeApplication).isTrue
+          assertThat(persistedApplication.targetLocation).isEqualTo("SW1A 1AA")
 
           val createdAssessment = approvedPremisesAssessmentRepository.findAll().first { it.application.id == applicationId }
           assertThat(createdAssessment.allocatedToUser!!.id).isEqualTo(assessorUser.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1461,6 +1461,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.isPipeApplication).isTrue
       assertThat(persistedApplication.isWomensApplication).isFalse
       assertThat(persistedApplication.releaseType).isEqualTo(submitApprovedPremisesApplication.releaseType.toString())
+      assertThat(persistedApplication.targetLocation).isEqualTo(submitApprovedPremisesApplication.targetLocation)
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) { mockAssessmentService.createApprovedPremisesAssessment(application) }


### PR DESCRIPTION
This field is already passed when submitting an application, but only gets used in domain events. This adds a new targetLocation field to the application location, so we can use it in reporting. We will need to look at backfilling the applications that do not have this data, possibly using the domain events.