### PR TITLE
Separate caching and downstream API request logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/AdjudicationsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/AdjudicationsApiClient.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.AdjudicationsPage
@@ -12,9 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.adjudications.Adju
 class AdjudicationsApiClient(
   @Qualifier("adjudicationsApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
 
   fun getAdjudicationsPage(nomsNumber: String, page: Int, pageSize: Int) = getRequest<AdjudicationsPage> {
     path = "/adjudications/$nomsNumber/adjudications?page=$page&size=$pageSize"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -2,9 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
@@ -15,9 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Staf
 class ApDeliusContextApiClient(
   @Qualifier("apDeliusContextApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
   @Cacheable(value = ["qCodeStaffMembersCache"], unless = IS_NOT_SUCCESSFUL)
   fun getStaffMembers(qCode: String) = getRequest<StaffMembersPage> {
     path = "/approved-premises/$qCode/staff"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApOASysContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApOASysContextApiClient.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.HealthDetails
@@ -18,9 +16,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshS
 class ApOASysContextApiClient(
   @Qualifier("apOASysContextApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
   fun getOffenceDetails(crn: String) = getRequest<OffenceDetails> {
     path = "/offence-details/$crn"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -115,6 +115,10 @@ sealed interface ClientResult<ResponseType> {
       override fun toException(): Throwable = RuntimeException("Timed out after ${timeoutMs}ms waiting for $cacheKey on pre-emptive cache $cacheName")
     }
 
+    class CachedValueUnavailable<ResponseType>(val cacheKey: String) : Failure<ResponseType> {
+      override fun toException(): Throwable = RuntimeException("No Redis entry exists for $cacheKey")
+    }
+
     class Other<ResponseType>(val method: HttpMethod, val path: String, val exception: Exception) : Failure<ResponseType> {
       override fun toException(): Throwable = RuntimeException("Unable to complete $method request to $path", exception)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CaseNotesClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CaseNotesClient.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.CaseNotesPage
@@ -15,9 +13,8 @@ import java.time.LocalTime
 class CaseNotesClient(
   @Qualifier("caseNotesWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
   fun getCaseNotesPage(nomsNumber: String, from: LocalDate, page: Int, pageSize: Int) = getRequest<CaseNotesPage> {
     val fromLocalDateTime = LocalDateTime.of(from, LocalTime.MIN)
     path = "/case-notes/$nomsNumber?startDate=$fromLocalDateTime&page=$page&size=$pageSize"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -2,11 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -27,14 +25,18 @@ import java.time.Duration
 class CommunityApiClient(
   @Qualifier("communityApiWebClient") private val webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
-  private val offenderDetailCacheConfig = PreemptiveCacheConfig(
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+  private val offenderDetailCacheConfig = WebClientCache.PreemptiveCacheConfig(
     cacheName = "offenderDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
     failureSoftTtlBackoffSeconds =
-    listOf(30, Duration.ofMinutes(5).toSeconds().toInt(), Duration.ofMinutes(10).toSeconds().toInt(), Duration.ofMinutes(30).toSeconds().toInt()),
+    listOf(
+      30,
+      Duration.ofMinutes(5).toSeconds().toInt(),
+      Duration.ofMinutes(10).toSeconds().toInt(),
+      Duration.ofMinutes(30).toSeconds().toInt(),
+    ),
     hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
@@ -2,9 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
@@ -14,9 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UK
 class GovUKBankHolidaysApiClient(
   @Qualifier("govUKBankHolidaysApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
   @Cacheable(value = ["ukBankHolidaysCache"], unless = IS_NOT_SUCCESSFUL)
   fun getUKBankHolidays() = getRequest<UKBankHolidays> {
     path = "/bank-holidays.json"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/HMPPSTierApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/HMPPSTierApiClient.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
@@ -12,9 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
 class HMPPSTierApiClient(
   @Qualifier("hmppsTierApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
   fun getTier(crn: String) = getRequest<Tier> {
     path = "/crn/$crn/tier"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.Alert
@@ -14,13 +12,17 @@ import java.time.Duration
 class PrisonsApiClient(
   @Qualifier("prisonsApiWebClient") webClient: WebClient,
   objectMapper: ObjectMapper,
-  redisTemplate: RedisTemplate<String, String>,
-  @Value("\${preemptive-cache-key-prefix}") preemptiveCacheKeyPrefix: String,
-) : BaseHMPPSClient(webClient, objectMapper, redisTemplate, preemptiveCacheKeyPrefix) {
-  private val inmateDetailsCacheConfig = PreemptiveCacheConfig(
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+  private val inmateDetailsCacheConfig = WebClientCache.PreemptiveCacheConfig(
     cacheName = "inmateDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
-    failureSoftTtlBackoffSeconds = listOf(30, Duration.ofMinutes(5).toSeconds().toInt(), Duration.ofMinutes(10).toSeconds().toInt(), Duration.ofMinutes(30).toSeconds().toInt()),
+    failureSoftTtlBackoffSeconds = listOf(
+      30,
+      Duration.ofMinutes(5).toSeconds().toInt(),
+      Duration.ofMinutes(10).toSeconds().toInt(),
+      Duration.ofMinutes(30).toSeconds().toInt(),
+    ),
     hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
@@ -1,0 +1,216 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.sentry.Sentry
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+class WebClientCache(
+  private val objectMapper: ObjectMapper,
+  private val redisTemplate: RedisTemplate<String, String>,
+  @Value("\${preemptive-cache-key-prefix}") private val preemptiveCacheKeyPrefix: String,
+) {
+  fun checkPreemptiveCacheStatus(cacheConfig: PreemptiveCacheConfig, key: String): PreemptiveCacheEntryStatus {
+    val cacheKeySet = CacheKeySet(preemptiveCacheKeyPrefix, cacheConfig.cacheName, key)
+
+    val cacheEntryMetadata = getCacheEntryMetadataIfExists(cacheKeySet.metadataKey)
+
+    return when {
+      cacheEntryMetadata == null -> PreemptiveCacheEntryStatus.MISS
+      cacheEntryMetadata.refreshableAfter < Instant.now() -> PreemptiveCacheEntryStatus.REQUIRES_REFRESH
+      else -> PreemptiveCacheEntryStatus.EXISTS
+    }
+  }
+
+  fun <ResponseType : Any> tryGetCachedValue(
+    typeReference: TypeReference<ResponseType>,
+    requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration,
+    cacheConfig: PreemptiveCacheConfig,
+    attempt: AtomicInteger,
+  ): ClientResult<ResponseType>? {
+    val cacheKeySet = getCacheKeySet(requestBuilder, cacheConfig)
+
+    if (!requestBuilder.isPreemptiveCall) {
+      return pollCacheWithBlockingWait(cacheKeySet, typeReference, requestBuilder, cacheConfig)
+    }
+
+    val cacheEntry = getCacheEntryMetadataIfExists(cacheKeySet.metadataKey)
+
+    attempt.set(cacheEntry?.attempt?.plus(1) ?: 1)
+
+    if (cacheEntry != null && cacheEntry.refreshableAfter.isAfter(Instant.now())) {
+      return resultFromCacheMetadata(cacheEntry, cacheKeySet, typeReference)
+    }
+
+    return null
+  }
+
+  fun cacheFailedWebClientResponse(
+    requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration,
+    cacheConfig: PreemptiveCacheConfig,
+    exception: WebClientResponseException,
+    attempt: Int,
+    method: HttpMethod,
+  ) {
+    val qualifiedKey = getCacheKeySet(requestBuilder, cacheConfig)
+
+    val body: String? = exception.responseBodyAsString
+
+    val backoffSeconds = if (attempt <= cacheConfig.failureSoftTtlBackoffSeconds.size) {
+      cacheConfig.failureSoftTtlBackoffSeconds[attempt - 1].toLong()
+    } else {
+      cacheConfig.failureSoftTtlBackoffSeconds.last().toLong()
+    }
+
+    val cacheEntry = PreemptiveCacheMetadata(
+      httpStatus = exception.statusCode,
+      refreshableAfter = Instant.now().plusSeconds(backoffSeconds),
+      method = method,
+      path = requestBuilder.path ?: "",
+      hasResponseBody = body != null,
+      attempt = attempt,
+    )
+
+    if (attempt >= FAILED_ATTEMPT_WARN_THRESHOLD) {
+      Sentry.captureException(RuntimeException("Unable to make upstream request after $attempt attempts", exception))
+    }
+
+    writeToRedis(qualifiedKey, cacheEntry, body, cacheConfig.hardTtlSeconds.toLong())
+  }
+
+  fun cacheSuccessfulWebClientResponse(
+    requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration,
+    cacheConfig: PreemptiveCacheConfig,
+    result: ResponseEntity<String>,
+  ) {
+    val cacheKeySet = getCacheKeySet(requestBuilder, cacheConfig)
+
+    val cacheEntry = PreemptiveCacheMetadata(
+      httpStatus = result.statusCode,
+      refreshableAfter = Instant.now().plusSeconds(cacheConfig.successSoftTtlSeconds.toLong()),
+      method = null,
+      path = null,
+      hasResponseBody = result.body != null,
+      attempt = null,
+    )
+
+    writeToRedis(cacheKeySet, cacheEntry, result.body, cacheConfig.hardTtlSeconds.toLong())
+  }
+
+  private fun <ResponseType : Any> pollCacheWithBlockingWait(
+    cacheKeySet: CacheKeySet,
+    typeReference: TypeReference<ResponseType>,
+    requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration,
+    cacheConfig: PreemptiveCacheConfig,
+  ): ClientResult<ResponseType> {
+    val pollingStart = System.currentTimeMillis()
+
+    do {
+      val cacheEntryMetadata = getCacheEntryMetadataIfExists(cacheKeySet.metadataKey)
+
+      if (cacheEntryMetadata == null) {
+        Thread.sleep(POLL_CACHE_WAIT_DURATION_BEFORE_RETRY_MS)
+        continue
+      }
+
+      return resultFromCacheMetadata(cacheEntryMetadata, cacheKeySet, typeReference)
+    } while (System.currentTimeMillis() - pollingStart < requestBuilder.preemptiveCacheTimeoutMs)
+
+    return ClientResult.Failure.PreemptiveCacheTimeout(
+      cacheConfig.cacheName,
+      cacheKeySet.metadataKey,
+      requestBuilder.preemptiveCacheTimeoutMs,
+    )
+  }
+
+  private fun getCacheKeySet(requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration, cacheConfig: PreemptiveCacheConfig): CacheKeySet {
+    val key = requestBuilder.preemptiveCacheKey ?: throw RuntimeException("Must provide a preemptiveCacheKey")
+    return CacheKeySet(preemptiveCacheKeyPrefix, cacheConfig.cacheName, key)
+  }
+
+  private fun writeToRedis(cacheKeySet: CacheKeySet, cacheEntry: PreemptiveCacheMetadata, body: String?, hardTtlSeconds: Long) {
+    redisTemplate.boundValueOps(cacheKeySet.metadataKey).set(
+      objectMapper.writeValueAsString(cacheEntry),
+      Duration.ofSeconds(hardTtlSeconds),
+    )
+
+    if (body != null) {
+      redisTemplate.boundValueOps(cacheKeySet.dataKey).set(
+        body,
+        Duration.ofSeconds(hardTtlSeconds),
+      )
+    }
+  }
+
+  private fun getCacheEntryMetadataIfExists(metaDataKey: String): PreemptiveCacheMetadata? {
+    val stringValue = redisTemplate.boundValueOps(metaDataKey).get()
+      ?: return null
+
+    return objectMapper.readValue<PreemptiveCacheMetadata>(
+      stringValue,
+    )
+  }
+
+  private fun getCacheEntryBody(dataKey: String): String {
+    return redisTemplate.boundValueOps(dataKey).get()
+      ?: throw RuntimeException("No Redis entry exists for $dataKey")
+  }
+
+  private fun <ResponseType> resultFromCacheMetadata(cacheEntry: PreemptiveCacheMetadata, cacheKeySet: CacheKeySet, typeReference: TypeReference<ResponseType>): ClientResult<ResponseType> {
+    val cachedBody = if (cacheEntry.hasResponseBody) {
+      getCacheEntryBody(cacheKeySet.dataKey)
+    } else {
+      null
+    }
+
+    if (cacheEntry.httpStatus.is2xxSuccessful) {
+      return ClientResult.Success(
+        status = cacheEntry.httpStatus,
+        body = objectMapper.readValue(cachedBody, typeReference),
+        isPreemptivelyCachedResponse = true,
+      )
+    }
+
+    return ClientResult.Failure.StatusCode(
+      status = cacheEntry.httpStatus,
+      body = cachedBody,
+      method = cacheEntry.method!!,
+      path = cacheEntry.path!!,
+      isPreemptivelyCachedResponse = true,
+    )
+  }
+
+  companion object {
+    private const val FAILED_ATTEMPT_WARN_THRESHOLD: Int = 4
+    private const val POLL_CACHE_WAIT_DURATION_BEFORE_RETRY_MS: Long = 500
+  }
+
+  data class PreemptiveCacheConfig(
+    val cacheName: String,
+    val successSoftTtlSeconds: Int,
+    val failureSoftTtlBackoffSeconds: List<Int>,
+    val hardTtlSeconds: Int,
+  )
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  data class PreemptiveCacheMetadata(
+    val httpStatus: HttpStatus,
+    val refreshableAfter: Instant,
+    val method: HttpMethod?,
+    val path: String?,
+    val hasResponseBody: Boolean,
+    val attempt: Int?,
+  )
+}


### PR DESCRIPTION
> See ticket [#1570 on the CAS3 Trello board](https://trello.com/c/KU3pJJox/1570-redis-cache-keys-are-required-for-rendering-the-assessment-page).

This PR performs a refactoring of `BaseHMPPSClient` and related classes to separate caching and outbound HTTP requests.

This was originally done as preparatory work to resolve the bug described in the Trello ticket above (ultimately from [this Sentry issue](https://ministryofjustice.sentry.io/issues/4479884804/)), however, it appears that this problem has already been resolved by some other work. An integration test verifying the fix has been added to this PR to prevent an accidental regression.

This PR refactors the specifics of interacting with the cache out of `BaseHMPPSClient.doRequest` into several methods on a new `WebClientCache` class:
- `checkPreemptiveCacheStatus`
- `tryGetCachedValue`
- `cacheSuccessfulWebClientResponse`
- `cacheFailedWebClientResponse`

Additionally, a new `ClientResult.Failure.CachedValueUnavailable` variant has been introduced to replace the original exception thrown by `getCacheEntryBody`. This improves the presentation of the error as the unhelpful exception message 'Unable to complete GET request to ' is no longer logged, and potentially allows more sophisticated handling of this particular failure mode in the future (such as by re-issuing the request to recover the data, similar to a cache timeout).