### PR TITLE
Fix user region not refreshing to the latest Delius value

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -138,7 +138,7 @@ data class UserEntity(
   @OneToMany(mappedBy = "user")
   val qualifications: MutableList<UserQualificationAssignmentEntity>,
   @ManyToOne
-  val probationRegion: ProbationRegionEntity,
+  var probationRegion: ProbationRegionEntity,
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -315,6 +315,6 @@ class UserService(
   }
 
   private fun userHasChanged(user: UserEntity, deliusUser: StaffUserDetails): Boolean {
-    return (deliusUser.email !== user.email) || (deliusUser.telephoneNumber !== user.telephoneNumber) || (deliusUser.staff.fullName != user.name) || (deliusUser.staffCode != user.deliusStaffCode)
+    return (deliusUser.email !== user.email) || (deliusUser.telephoneNumber !== user.telephoneNumber) || (deliusUser.staff.fullName != user.name) || (deliusUser.staffCode != user.deliusStaffCode) || (deliusUser.probationArea.code != user.probationRegion.deliusCode)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -194,6 +194,12 @@ class UserService(
       user.telephoneNumber = deliusUser.telephoneNumber
       user.deliusStaffCode = deliusUser.staffCode
 
+      deliusUser.probationArea?.let { probationArea ->
+        findProbationRegionFromArea(probationArea)?.let { probationRegion ->
+          user.probationRegion = probationRegion
+        }
+      }
+
       user = userRepository.save(user)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationAreaProbationRegionMappingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.specification.hasQualificationsAndRoles
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffProbationArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -218,8 +220,7 @@ class UserService(
       is ClientResult.Failure -> staffUserDetailsResponse.throwException()
     }
 
-    var staffProbationRegion = probationAreaProbationRegionMappingRepository
-      .findByProbationAreaDeliusCode(staffUserDetails.probationArea.code)?.probationRegion
+    var staffProbationRegion = findProbationRegionFromArea(staffUserDetails.probationArea)
 
     if (staffProbationRegion == null) {
       if (assignDefaultRegionToUsersWithUnknownRegion) {
@@ -265,6 +266,11 @@ class UserService(
     }
 
     return userRepository.save(user)
+  }
+
+  private fun findProbationRegionFromArea(probationArea: StaffProbationArea): ProbationRegionEntity? {
+    return probationAreaProbationRegionMappingRepository
+      .findByProbationAreaDeliusCode(probationArea.code)?.probationRegion
   }
 
   fun addRoleToUser(user: UserEntity, role: UserRole) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -575,7 +575,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `it does not save the object if the email, telephone number and staff code are the same as Delius`() {
+    fun `it does not save the object if the email, telephone number, staff code and probation region are the same as Delius`() {
       val email = "foo@example.com"
       val telephoneNumber = "0123456789"
       val staffCode = "STAFF1"
@@ -585,6 +585,7 @@ class UserServiceTest {
         .withEmail(email)
         .withTelephoneNumber(telephoneNumber)
         .withDeliusStaffCode(staffCode)
+        .withUnitTestControlProbationRegion()
         .produce()
 
       val deliusUser = staffUserDetailsFactory
@@ -593,6 +594,7 @@ class UserServiceTest {
         .withEmail(email)
         .withTelephoneNumber(telephoneNumber)
         .withStaffCode(staffCode)
+        .withProbationAreaCode(user.probationRegion.deliusCode)
         .produce()
 
       every { mockUserRepository.findByIdOrNull(id) } returns user

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -511,12 +511,18 @@ class UserServiceTest {
     }
 
     @Test
-    fun `it returns the user's details from the Community API and saves the email address, telephone number and staff code`() {
+    fun `it returns the user's details from the Community API and saves the email address, telephone, staff code and probation region`() {
+      val newProbationRegion = ProbationRegionEntityFactory()
+        .withYieldedApArea { ApAreaEntityFactory().produce() }
+        .produce()
+
       val user = userFactory.produce()
+
       val deliusUser = staffUserDetailsFactory
         .withEmail("foo@example.com")
         .withTelephoneNumber("0123456789")
         .withStaffCode("STAFF1")
+        .withProbationAreaCode(newProbationRegion.deliusCode)
         .produce()
 
       every { mockUserRepository.findByIdOrNull(id) } returns user
@@ -524,6 +530,10 @@ class UserServiceTest {
         HttpStatus.OK,
         deliusUser,
       )
+      every { mockProbationAreaProbationRegionMappingRepository.findByProbationAreaDeliusCode(newProbationRegion.deliusCode) } returns ProbationAreaProbationRegionMappingEntityFactory()
+        .withProbationRegion(newProbationRegion)
+        .withProbationAreaDeliusCode(newProbationRegion.deliusCode)
+        .produce()
 
       val result = userService.updateUserFromCommunityApiById(id)
 
@@ -538,6 +548,7 @@ class UserServiceTest {
       assertThat(entity.email).isEqualTo(deliusUser.email)
       assertThat(entity.telephoneNumber).isEqualTo(deliusUser.telephoneNumber)
       assertThat(entity.deliusStaffCode).isEqualTo(deliusUser.staffCode)
+      assertThat(entity.probationRegion.name).isEqualTo(newProbationRegion.name)
 
       verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
       verify(exactly = 1) { mockUserRepository.save(any()) }
@@ -545,10 +556,14 @@ class UserServiceTest {
 
     @Test
     fun `it stores a null email address if missing from Community API`() {
-      val user = userFactory.produce()
+      val user = userFactory
+        .withUnitTestControlProbationRegion()
+        .produce()
+
       val deliusUser = staffUserDetailsFactory
         .withTelephoneNumber("0123456789")
         .withoutEmail()
+        .withProbationAreaCode(user.probationRegion.deliusCode)
         .produce()
 
       every { mockUserRepository.findByIdOrNull(id) } returns user
@@ -556,6 +571,10 @@ class UserServiceTest {
         HttpStatus.OK,
         deliusUser,
       )
+      every { mockProbationAreaProbationRegionMappingRepository.findByProbationAreaDeliusCode(user.probationRegion.deliusCode) } returns ProbationAreaProbationRegionMappingEntityFactory()
+        .withProbationRegion(user.probationRegion)
+        .withProbationAreaDeliusCode(user.probationRegion.deliusCode)
+        .produce()
 
       val result = userService.updateUserFromCommunityApiById(id)
 
@@ -564,11 +583,7 @@ class UserServiceTest {
 
       var entity = result.entity
 
-      assertThat(entity.id).isEqualTo(user.id)
-      assertThat(entity.name).isEqualTo("$forename $surname")
-      assertThat(entity.deliusUsername).isEqualTo(user.deliusUsername)
       assertThat(entity.email).isEqualTo("null")
-      assertThat(entity.telephoneNumber).isEqualTo(deliusUser.telephoneNumber)
 
       verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
       verify(exactly = 1) { mockUserRepository.save(any()) }


### PR DESCRIPTION
https://trello.com/c/CyPr93lv

We had a support request for a user whom had been unable to access the service because they were appearing as "West Midlands" rather than "Kent, Surrey & Sussex".

After confirming the regional data is now set correctly after a presumed update, our users table still had the WM region associated with it.

We extend the existing update mechanism to now also update the user's region. As this is part of a scheduled job my hope is that this change will automatically keep up to date with ndelius as the canonical store for regional ids.

- add a helper method for finding the users region so we can reuse it in create and update logic