### PR TITLE
(480) Get managing team for CRN

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,12 @@ tasks.register("bootRunLocal") {
 tasks.withType<Test> {
   jvmArgs("--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.time=ALL-UNNAMED")
 
+  if (System.getProperty("idea.active") !== null) {
+    println("Running in IDE - skipping OpenAPI generation...")
+    project.gradle.startParameter.excludedTaskNames.add("openApiGenerate")
+    project.gradle.startParameter.excludedTaskNames.add("openApiGenerateDomainEvents")
+  }
+
   if (environment["GITHUB_ACTION"] != null) {
     maxParallelForks = Runtime.getRuntime().availableProcessors()
     println("Running on GitHub Actions - setting max test processes to number of processors: $maxParallelForks")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 
@@ -23,5 +24,10 @@ class ApDeliusContextApiClient(
   @Cacheable(value = ["teamsManagingCaseCache"], unless = IS_NOT_SUCCESSFUL)
   fun getTeamsManagingCase(crn: String) = getRequest<ManagingTeamsResponse> {
     path = "/teams/managingCase/$crn"
+  }
+
+  @Cacheable(value = ["crnGetCaseDetailCache"], unless = IS_NOT_SUCCESSFUL)
+  fun getCaseDetail(crn: String) = getRequest<CaseDetail> {
+    path = "/probation-cases/$crn/details"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import java.time.Duration
@@ -39,6 +40,7 @@ class RedisConfiguration {
     @Value("\${caches.staffDetails.expiry-seconds}") staffDetailsExpirySeconds: Long,
     @Value("\${caches.teamManagingCases.expiry-seconds}") teamManagingCasesExpirySeconds: Long,
     @Value("\${caches.ukBankHolidays.expiry-seconds}") ukBankHolidaysExpirySeconds: Long,
+    @Value("21600") crnGetCaseDetailExpirySeconds: Long,
   ): RedisCacheManagerBuilderCustomizer? {
     val time = buildProperties.time.epochSecond.toString()
 
@@ -47,6 +49,7 @@ class RedisConfiguration {
         .clientCacheFor<UserOffenderAccess>("userAccessCache", Duration.ofSeconds(userAccessExpirySeconds), time, objectMapper)
         .clientCacheFor<StaffUserDetails>("staffDetailsCache", Duration.ofSeconds(staffDetailsExpirySeconds), time, objectMapper)
         .clientCacheFor<ManagingTeamsResponse>("teamsManagingCaseCache", Duration.ofSeconds(teamManagingCasesExpirySeconds), time, objectMapper)
+        .clientCacheFor<CaseDetail>("crnGetCaseDetailCache", Duration.ofSeconds(crnGetCaseDetailExpirySeconds), time, objectMapper)
         .clientCacheFor<UKBankHolidays>("ukBankHolidaysCache", Duration.ofSeconds(ukBankHolidaysExpirySeconds), time, objectMapper)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class CaseDetail(
+  val case: CaseSummary,
+  val offences: List<Offence>,
+  val registrations: List<Registration>,
+  val mappaDetail: MappaDetail?,
+)
+
+data class CaseSummary(
+  val crn: String,
+  val nomsId: String?,
+  val name: Name,
+  val dateOfBirth: LocalDate,
+  val gender: String?,
+  val profile: Profile,
+  val manager: Manager,
+  val currentExclusion: Boolean?,
+  val currentRestriction: Boolean?,
+)
+
+data class Name(
+  val forename: String,
+  val surname: String,
+  val middleNames: List<String>,
+)
+
+data class Manager(
+  val team: Team,
+)
+
+data class Team(
+  val code: String,
+  val name: String,
+  val ldu: Ldu,
+)
+
+data class Ldu(
+  val code: String,
+  val name: String,
+)
+
+data class Profile(
+  val ethnicity: String?,
+  val genderIdentity: String?,
+  val nationality: String?,
+  val religion: String?,
+)
+
+data class Offence(
+  val description: String,
+  val date: LocalDate,
+  val main: Boolean,
+  val eventNumber: String,
+)
+
+data class Registration(
+  val description: String,
+  val startDate: LocalDate,
+)
+
+data class MappaDetail(
+  val level: Int,
+  val levelDescription: String,
+  val category: Int,
+  val categoryDescription: String,
+  val startDate: LocalDate,
+  val lastUpdated: LocalDateTime,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
@@ -1,0 +1,209 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Ldu
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Manager
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Name
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Offence
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Profile
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Registration
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Team
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class CaseDetailFactory : Factory<CaseDetail> {
+  var case: Yielded<CaseSummary> = { CaseSummaryFactory().produce() }
+  var offences: Yielded<List<Offence>> = { listOf(CaseDetailOffenceFactory().produce()) }
+  var registrations: Yielded<List<Registration>> = { listOf(RegistrationFactory().produce()) }
+  var mappaDetail: Yielded<MappaDetail> = { MappaDetailFactory().produce() }
+
+  fun withCase(case: CaseSummary) = apply {
+    this.case = { case }
+  }
+
+  override fun produce(): CaseDetail = CaseDetail(
+    case = this.case(),
+    offences = this.offences(),
+    registrations = this.registrations(),
+    mappaDetail = this.mappaDetail(),
+  )
+}
+
+class CaseDetailOffenceFactory : Factory<Offence> {
+  var description: Yielded<String> = { randomStringLowerCase(10) }
+  var date: Yielded<LocalDate> = { LocalDate.now() }
+  var main: Yielded<Boolean> = { false }
+  var eventNumber: Yielded<String> = { randomStringLowerCase(10) }
+
+  override fun produce(): Offence = Offence(
+    description = this.description(),
+    date = this.date(),
+    main = this.main(),
+    eventNumber = this.eventNumber(),
+  )
+}
+
+class RegistrationFactory : Factory<Registration> {
+  var description: Yielded<String> = { randomStringLowerCase(10) }
+  var startDate: Yielded<LocalDate> = { LocalDate.now() }
+
+  override fun produce(): Registration = Registration(
+    description = this.description(),
+    startDate = this.startDate(),
+  )
+}
+
+class MappaDetailFactory : Factory<MappaDetail> {
+  var level: Yielded<Int> = { 10 }
+  var levelDescription: Yielded<String> = { randomStringUpperCase(3) }
+  var category: Yielded<Int> = { 10 }
+  var categoryDescription: Yielded<String> = { randomStringUpperCase(3) }
+  var startDate: Yielded<LocalDate> = { LocalDate.now() }
+  var lastUpdated: Yielded<LocalDateTime> = { LocalDateTime.now() }
+
+  override fun produce(): MappaDetail = MappaDetail(
+    level = this.level(),
+    levelDescription = this.levelDescription(),
+    category = this.category(),
+    categoryDescription = this.categoryDescription(),
+    startDate = this.startDate(),
+    lastUpdated = this.lastUpdated(),
+  )
+}
+
+class CaseSummaryFactory : Factory<CaseSummary> {
+  var crn: Yielded<String> = { randomStringUpperCase(10) }
+  var nomsId: Yielded<String?> = { randomStringUpperCase(10) }
+  var name: Yielded<Name> = { NameFactory().produce() }
+  var dateOfBirth: Yielded<LocalDate> = { LocalDate.now() }
+  var gender: Yielded<String> = { randomStringUpperCase(10) }
+  var profile: Yielded<Profile> = { ProfileFactory().produce() }
+  var manager: Yielded<Manager> = { ManagerFactory().produce() }
+  var currentExclusion: Yielded<Boolean> = { false }
+  var currentRestriction: Yielded<Boolean> = { false }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+  fun withNomsId(nomsId: String?) = apply {
+    this.nomsId = { nomsId }
+  }
+  fun withName(name: Name) = apply {
+    this.name = { name }
+  }
+  fun withDateOfBirth(dateOfBirth: LocalDate) = apply {
+    this.dateOfBirth = { dateOfBirth }
+  }
+  fun withGender(gender: String) = apply {
+    this.gender = { gender }
+  }
+  fun withProfile(profile: Profile) = apply {
+    this.profile = { profile }
+  }
+  fun withManager(manager: Manager) = apply {
+    this.manager = { manager }
+  }
+  fun withCurrentExclusion(currentExclusion: Boolean) = apply {
+    this.currentExclusion = { currentExclusion }
+  }
+  fun withCurrentRestriction(currentRestriction: Boolean) = apply {
+    this.currentRestriction = { currentRestriction }
+  }
+
+  override fun produce(): CaseSummary = CaseSummary(
+    crn = this.crn(),
+    nomsId = this.nomsId(),
+    name = this.name(),
+    dateOfBirth = this.dateOfBirth(),
+    gender = this.gender(),
+    profile = this.profile(),
+    manager = this.manager(),
+    currentExclusion = this.currentExclusion(),
+    currentRestriction = this.currentRestriction(),
+  )
+}
+
+class ProfileFactory : Factory<Profile> {
+  var ethnicity: Yielded<String?> = { randomStringLowerCase(10) }
+  var genderIdentity: Yielded<String?> = { randomStringLowerCase(10) }
+  var nationality: Yielded<String?> = { randomStringLowerCase(10) }
+  var religion: Yielded<String?> = { randomStringLowerCase(10) }
+
+  fun withEthnicity(ethnicity: String?) = apply {
+    this.ethnicity = { ethnicity }
+  }
+  fun withGenderIdentity(genderIdentity: String?) = apply {
+    this.genderIdentity = { genderIdentity }
+  }
+  fun withNationality(nationality: String?) = apply {
+    this.nationality = { nationality }
+  }
+  fun withReligion(religion: String?) = apply {
+    this.religion = { religion }
+  }
+
+  override fun produce(): Profile = Profile(
+    ethnicity = this.ethnicity(),
+    genderIdentity = this.genderIdentity(),
+    nationality = this.nationality(),
+    religion = this.religion(),
+  )
+}
+
+class NameFactory : Factory<Name> {
+  var forename: Yielded<String> = { randomStringUpperCase(10) }
+  var surname: Yielded<String> = { randomStringUpperCase(10) }
+  var middleNames: Yielded<List<String>> = { listOf(randomStringUpperCase(10)) }
+
+  fun withForename(forename: String) = apply {
+    this.forename = { forename }
+  }
+  fun withSurname(surname: String) = apply {
+    this.surname = { surname }
+  }
+  fun withMiddleNames(middleNames: List<String>) = apply {
+    this.middleNames = { middleNames }
+  }
+
+  override fun produce(): Name = Name(
+    forename = this.forename(),
+    surname = this.surname(),
+    middleNames = this.middleNames(),
+  )
+}
+
+class ManagerFactory : Factory<Manager> {
+  var team: Yielded<Team> = { TeamFactory().produce() }
+
+  override fun produce(): Manager = Manager(
+    team = this.team(),
+  )
+}
+
+class TeamFactory : Factory<Team> {
+  var code: Yielded<String> = { randomStringUpperCase(10) }
+  var name: Yielded<String> = { randomStringUpperCase(10) }
+  var ldu: Yielded<Ldu> = { LduFactory().produce() }
+
+  override fun produce(): Team = Team(
+    code = this.code(),
+    name = this.name(),
+    ldu = this.ldu(),
+  )
+}
+
+class LduFactory : Factory<Ldu> {
+  var code: Yielded<String> = { randomStringUpperCase(10) }
+  var name: Yielded<String> = { randomStringUpperCase(10) }
+
+  override fun produce(): Ldu = Ldu(
+    code = this.code(),
+    name = this.name(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
@@ -41,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
@@ -1507,6 +1509,11 @@ class ApplicationTest : IntegrationTestBase() {
             ),
           )
 
+          APDeliusContext_mockSuccessfulCaseDetailCall(
+            offenderDetails.otherIds.crn,
+            CaseDetailFactory().produce(),
+          )
+
           webTestClient.post()
             .uri("/applications/$applicationId/submission")
             .header("Authorization", "Bearer $jwt")
@@ -1645,6 +1652,11 @@ class ApplicationTest : IntegrationTestBase() {
             Thread.sleep(1000)
             it.invocation.args[0] as ApplicationEntity
           }
+
+          APDeliusContext_mockSuccessfulCaseDetailCall(
+            offenderDetails.otherIds.crn,
+            CaseDetailFactory().produce(),
+          )
 
           val responseStatuses = mutableListOf<HttpStatus>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -1,8 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProfileFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockServerErrorOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockServerErrorInmateDetailsCall
@@ -36,6 +41,38 @@ fun IntegrationTestBase.`Given an Offender`(
     true -> CommunityAPI_mockServerErrorOffenderDetailsCall(offenderDetails.otherIds.crn)
     false -> CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails)
   }
+
+  val caseDetail = CaseDetailFactory().withCase(
+    CaseSummaryFactory()
+      .withCrn(offenderDetails.otherIds.crn)
+      .withNomsId(offenderDetails.otherIds.nomsNumber)
+      .withGender(offenderDetails.gender)
+      .withName(
+        NameFactory()
+          .withForename(offenderDetails.firstName)
+          .withSurname(offenderDetails.surname)
+          .withMiddleNames(
+            offenderDetails.middleNames?.let {
+              offenderDetails.middleNames
+            } ?: emptyList(),
+          )
+          .produce(),
+      )
+      .withDateOfBirth(offenderDetails.dateOfBirth)
+      .withProfile(
+        ProfileFactory()
+          .withReligion(offenderDetails.offenderProfile.religion)
+          .withEthnicity(offenderDetails.offenderProfile.ethnicity)
+          .withNationality(offenderDetails.offenderProfile.nationality)
+          .withGenderIdentity(offenderDetails.offenderProfile.genderIdentity)
+          .produce(),
+      )
+      .withCurrentExclusion(offenderDetails.currentExclusion)
+      .withCurrentRestriction(offenderDetails.currentRestriction)
+      .produce(),
+  ).produce()
+
+  APDeliusContext_mockSuccessfulCaseDetailCall(offenderDetails.otherIds.crn, caseDetail)
 
   loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
@@ -12,6 +13,12 @@ fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffMembersCall(staffMemb
     responseBody = StaffMembersPage(
       content = listOf(staffMember),
     ),
+  )
+
+fun IntegrationTestBase.APDeliusContext_mockSuccessfulCaseDetailCall(crn: String, response: CaseDetail) =
+  mockSuccessfulGetCallWithJsonResponse(
+    url = "/probation-cases/$crn/details",
+    responseBody = response,
   )
 
 fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffDetailsCall(staffCode: String, staffUserDetails: StaffUserDetails) =

--- a/wiremock/mappings/ApDeliusContext_GetCaseDetail.json
+++ b/wiremock/mappings/ApDeliusContext_GetCaseDetail.json
@@ -1,0 +1,53 @@
+{
+  "id": "331bc347-d9c7-42d9-9c47-217860c35749",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/probation-cases/(.*)/details"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "case": {
+        "crn": "X371199",
+        "nomsId": "A7779DY",
+        "name": {
+          "forename": "Ben",
+          "surname": "Davies",
+          "middleNames": []
+        },
+        "dateOfBirth": "1993-04-24",
+        "gender": "Male",
+        "profile": {
+          "ethnicity": "White: British/English/Welsh/Scottish/Northern Irish",
+          "genderIdentity": "Male",
+          "nationality": "British",
+          "religion": "Apostolic"
+        },
+        "manager": {
+          "team": {
+            "code": "N07UAT",
+            "name": "Unallocated Team(N07)",
+            "ldu": {
+              "code": "N07UAT",
+              "name": "Unallocated Level 3(N07)"
+            }
+          }
+        },
+        "currentExclusion": false,
+        "currentRestriction": false
+      },
+      "offences": [
+        {
+          "description": "Arson - 05600",
+          "date": "2021-01-06",
+          "main": true,
+          "eventNumber": "2"
+        }
+      ],
+      "registrations": []
+    }
+  }
+}


### PR DESCRIPTION
As part of our reporting needs, we need to get the reporting team for a CRN (e.g. the Case Manager). Before, we were just fetching the first team of the logged in user, but it turns out this isn't what we need.

As part of the ambition to move away from Community API, the integrations team have built us a shiny new endpoint to give us all the information we need about a case, including the managing team.

This PR adds the client integration for this endpoint, and uses it when submitting an application and storing the domain event info.

Going forward, we'll want to replace all our calls to getting offender details with this new endpoint (as well as some bulk fetch endpoints, which have also been built), but let's start with this first.