### PR TITLE
Update type generation workflows

### DIFF
--- a/.github/workflows/generate-cas2-ui-types.yml
+++ b/.github/workflows/generate-cas2-ui-types.yml
@@ -1,0 +1,32 @@
+name: Generate UI Types
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/main/resources/static/codegen/built-cas2-api-spec.yml'
+
+jobs:
+  generate-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Trigger CAS-2 UI Type Generation Workflow
+        if: ${{ github.ref == 'refs/heads/main' }}
+        id: sa-trigger-ui-workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'hmpps-community-accommodation-tier-2-ui',
+              workflow_id: 'generate-types.yml',
+              ref: 'main'
+            })

--- a/.github/workflows/generate-ui-types.yml
+++ b/.github/workflows/generate-ui-types.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'src/main/resources/static/api.yml'
+      - 'src/main/resources/static/codegen/built-api-spec.yml'
 
 jobs:
   generate-ui:
@@ -27,19 +27,6 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: 'hmpps-approved-premises-ui',
-              workflow_id: 'generate-types.yml',
-              ref: 'main'
-            })
-      - name: Trigger CAS-2 UI Type Generation Workflow
-        if: ${{ github.ref == 'refs/heads/main' }}
-        id: sa-trigger-ui-workflow
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: 'hmpps-community-accommodation-tier-2-ui',
               workflow_id: 'generate-types.yml',
               ref: 'main'
             })


### PR DESCRIPTION
We now need to watch the build YML files for changes, not the source ones. I’ve also added a seperate CAS2 workflow to watch the CAS2 YAML file.