### PR TITLE
Add support for CAS3 domain events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,6 +189,25 @@ tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("ope
   importMappings.put("Instant", "java.time.Instant")
 }
 
+tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openApiGenerateCas3DomainEvents") {
+  generatorName.set("kotlin-spring")
+  inputSpec.set("$rootDir/src/main/resources/static/cas3-domain-events-api.yml")
+  outputDir.set("$buildDir/generated")
+  apiPackage.set("uk.gov.justice.digital.hmpps.approvedpremisesapi.api")
+  modelPackage.set("uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model")
+  configOptions.apply {
+    put("basePackage", "uk.gov.justice.digital.hmpps.approvedpremisesapi")
+    put("delegatePattern", "true")
+    put("gradleBuildFile", "false")
+    put("exceptionHandler", "false")
+    put("useBeanValidation", "false")
+    put("dateLibrary", "custom")
+    put("useTags", "true")
+  }
+  typeMappings.put("DateTime", "Instant")
+  importMappings.put("Instant", "java.time.Instant")
+}
+
 tasks.register("openApiPreCompilation") {
 
   // Generate OpenAPI spec files suited to Kotlin code generator
@@ -235,6 +254,7 @@ tasks.register("openApiPreCompilation") {
 
 tasks.get("openApiGenerate").dependsOn(
   "openApiGenerateDomainEvents",
+  "openApiGenerateCas3DomainEvents",
   "openApiPreCompilation",
   "openApiGenerateCas2Namespace"
 )

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -27,7 +27,8 @@ generic-service:
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: dev
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    DOMAIN-EVENTS_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: true
     PREEMPTIVE-CACHE-LOGGING-ENABLED: true
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
@@ -38,16 +39,16 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
-    URL-TEMPLATES_API_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
-    URL-TEMPLATES_API_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
-    URL-TEMPLATES_API_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -26,23 +26,24 @@ generic-service:
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    DOMAIN-EVENTS_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: false
     HMPPS_SQS_USE_WEB_TOKEN: true
     MANUAL_BOOKINGS_DOMAIN_EVENTS_DISABLED: false
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
-    URL-TEMPLATES_API_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
-    URL-TEMPLATES_API_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
-    URL-TEMPLATES_API_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -34,7 +34,8 @@ generic-service:
     LOG-CLIENT-CREDENTIALS-JWT-INFO: false
     SENTRY_ENVIRONMENT: prod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
-    DOMAIN-EVENTS_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: false
     PREEMPTIVE-CACHE-LOGGING-ENABLED: true
     NOTIFY_MODE: ENABLED
     HMPPS_SQS_USE_WEB_TOKEN: true
@@ -43,16 +44,16 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
-    URL-TEMPLATES_API_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
-    URL-TEMPLATES_API_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
-    URL-TEMPLATES_API_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     ARRIVED-DEPARTED-DOMAIN-EVENTS-DISABLED: true
 
   namespace_secrets:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -25,23 +25,24 @@ generic-service:
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    DOMAIN-EVENTS_EMIT-ENABLED: false
+    DOMAIN-EVENTS_CAS1_EMIT-ENABLED: false
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: false
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_API_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
-    URL-TEMPLATES_API_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
-    URL-TEMPLATES_API_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId
-    URL-TEMPLATES_API_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
-    URL-TEMPLATES_API_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-departed/#eventId
-    URL-TEMPLATES_API_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
-    URL-TEMPLATES_API_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
-    URL-TEMPLATES_API_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
-    URL-TEMPLATES_API_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-NOT-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/person-not-arrived/#eventId
+    URL-TEMPLATES_API_CAS1_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/person-departed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
 
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -41,7 +41,8 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 data class DomainEventEntity(
   @Id
   val id: UUID,
-  val applicationId: UUID,
+  val applicationId: UUID?,
+  val bookingId: UUID?,
   val crn: String,
   @Enumerated(value = EnumType.STRING)
   val type: DomainEventType,
@@ -49,6 +50,7 @@ data class DomainEventEntity(
   val createdAt: OffsetDateTime,
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   val data: String,
+  val service: String,
 ) {
   final inline fun <reified T> toDomainEvent(objectMapper: ObjectMapper): DomainEvent<T> {
     val data = when {
@@ -77,7 +79,7 @@ data class DomainEventEntity(
 
     return DomainEvent(
       id = this.id,
-      applicationId = this.applicationId,
+      applicationId = this.applicationId!!,
       crn = this.crn,
       occurredAt = this.occurredAt.toInstant(),
       data = data,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -5,7 +5,8 @@ import java.util.UUID
 
 data class DomainEvent<T> (
   val id: UUID,
-  val applicationId: UUID,
+  val applicationId: UUID? = null,
+  val bookingId: UUID? = null,
   val crn: String,
   val occurredAt: Instant,
   val data: T,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
@@ -23,5 +23,6 @@ data class SnsEventPersonReference(
 )
 
 data class SnsEventAdditionalInformation(
-  val applicationId: UUID,
+  val applicationId: UUID? = null,
+  val bookingId: UUID? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -195,11 +195,13 @@ class DomainEventService(
       DomainEventEntity(
         id = domainEvent.id,
         applicationId = domainEvent.applicationId,
+        bookingId = null,
         crn = domainEvent.crn,
         type = enumTypeFromDataType(domainEvent.data!!::class.java),
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
+        service = "CAS1",
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -37,17 +37,17 @@ class DomainEventService(
   private val objectMapper: ObjectMapper,
   private val domainEventRepository: DomainEventRepository,
   private val hmppsQueueService: HmppsQueueService,
-  @Value("\${domain-events.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
-  @Value("\${url-templates.api.application-submitted-event-detail}") private val applicationSubmittedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.application-assessed-event-detail}") private val applicationAssessedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.booking-made-event-detail}") private val bookingMadeDetailUrlTemplate: String,
-  @Value("\${url-templates.api.person-arrived-event-detail}") private val personArrivedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.person-not-arrived-event-detail}") private val personNotArrivedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.person-departed-event-detail}") private val personDepartedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.booking-not-made-event-detail}") private val bookingNotMadeDetailUrlTemplate: String,
-  @Value("\${url-templates.api.booking-cancelled-event-detail}") private val bookingCancelledDetailUrlTemplate: String,
-  @Value("\${url-templates.api.booking-changed-event-detail}") private val bookingChangedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.application-withdrawn-event-detail}") private val applicationWithdrawnDetailUrlTemplate: String,
+  @Value("\${domain-events.cas1.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
+  @Value("\${url-templates.api.cas1.application-submitted-event-detail}") private val applicationSubmittedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.application-assessed-event-detail}") private val applicationAssessedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.booking-made-event-detail}") private val bookingMadeDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.person-arrived-event-detail}") private val personArrivedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.person-not-arrived-event-detail}") private val personNotArrivedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.person-departed-event-detail}") private val personDepartedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.booking-not-made-event-detail}") private val bookingNotMadeDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.booking-cancelled-event-detail}") private val bookingCancelledDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.booking-changed-event-detail}") private val bookingChangedDetailUrlTemplate: String,
+  @Value("\${url-templates.api.cas1.application-withdrawn-event-detail}") private val applicationWithdrawnDetailUrlTemplate: String,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -228,7 +228,7 @@ class DomainEventService(
 
       log.info("Emitted SNS event (Message Id: ${publishResult.messageId}, Sequence Id: ${publishResult.sequenceNumber}) for Domain Event: ${domainEvent.id} of type: ${snsEvent.eventType}")
     } else {
-      log.info("Not emitting SNS event for domain event because domain-events.emit-enabled is not enabled")
+      log.info("Not emitting SNS event for domain event because domain-events.cas1.emit-enabled is not enabled")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3
+
+import org.springframework.stereotype.Component
+
+@Component
+class DomainEventBuilder

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3
+
+import com.amazonaws.services.sns.model.MessageAttributeValue
+import com.amazonaws.services.sns.model.PublishRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3Event
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.MissingTopicException
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.reflect.KClass
+
+@Service(
+  "uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventService",
+)
+class DomainEventService(
+  private val objectMapper: ObjectMapper,
+  private val domainEventRepository: DomainEventRepository,
+  private val domainEventBuilder: DomainEventBuilder,
+  private val hmppsQueueService: HmppsQueueService,
+  @Value("\${domain-events.cas3.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  private val domainTopic by lazy {
+    hmppsQueueService.findByTopicId("domainevents")
+      ?: throw MissingTopicException("domainevents not found")
+  }
+
+  private inline fun <reified T : CAS3Event> get(id: UUID): DomainEvent<T>? {
+    val domainEventEntity = domainEventRepository.findByIdOrNull(id) ?: return null
+
+    val data = when {
+      enumTypeFromDataType(T::class) == domainEventEntity.type ->
+        objectMapper.readValue(domainEventEntity.data, T::class.java)
+      else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${domainEventEntity.type.name}")
+    }
+    return DomainEvent(
+      id = domainEventEntity.id,
+      applicationId = domainEventEntity.applicationId,
+      bookingId = domainEventEntity.bookingId,
+      crn = domainEventEntity.crn,
+      occurredAt = domainEventEntity.occurredAt.toInstant(),
+      data = data,
+    )
+  }
+
+  private fun <T : CAS3Event> saveAndEmit(
+    domainEvent: DomainEvent<T>,
+    typeName: String,
+    typeDescription: String,
+    detailUrl: String,
+    crn: String,
+    nomsNumber: String?,
+  ) {
+    domainEventRepository.save(
+      DomainEventEntity(
+        id = domainEvent.id,
+        applicationId = domainEvent.applicationId,
+        bookingId = domainEvent.bookingId,
+        crn = domainEvent.crn,
+        type = enumTypeFromDataType(domainEvent.data::class),
+        occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
+        createdAt = OffsetDateTime.now(),
+        data = objectMapper.writeValueAsString(domainEvent.data),
+        service = "CAS3",
+      ),
+    )
+
+    if (emitDomainEventsEnabled) {
+      val personReferenceIdentifiers = when (nomsNumber) {
+        null -> listOf(
+          SnsEventPersonReference("CRN", crn),
+        )
+        else -> listOf(
+          SnsEventPersonReference("CRN", crn),
+          SnsEventPersonReference("NOMS", nomsNumber),
+        )
+      }
+
+      val snsEvent = SnsEvent(
+        eventType = typeName,
+        version = 1,
+        description = typeDescription,
+        detailUrl = detailUrl,
+        occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
+        additionalInformation = SnsEventAdditionalInformation(
+          applicationId = domainEvent.applicationId,
+          bookingId = domainEvent.bookingId,
+        ),
+        personReference = SnsEventPersonReferenceCollection(
+          identifiers = personReferenceIdentifiers,
+        ),
+      )
+
+      val publishResult = domainTopic.snsClient.publish(
+        PublishRequest(domainTopic.arn, objectMapper.writeValueAsString(snsEvent))
+          .withMessageAttributes(mapOf("eventType" to MessageAttributeValue().withDataType("String").withStringValue(snsEvent.eventType))),
+      )
+
+      log.info("Emitted SNS event (Message Id: ${publishResult.messageId}, Sequence Id: ${publishResult.sequenceNumber}) for Domain Event: ${domainEvent.id} of type: ${snsEvent.eventType}")
+    } else {
+      log.info("Not emitting SNS event for domain event because domain-events.cas3.emit-enabled is not enabled")
+    }
+  }
+
+  private fun <T : CAS3Event> enumTypeFromDataType(type: KClass<T>): DomainEventType = when (type) {
+    else -> throw RuntimeException("Unrecognised domain event type: ${type.qualifiedName}")
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,7 +20,10 @@ hmpps.sqs:
       arn: arn:aws:sns:eu-west-2:000000000000:domainevents
 
 domain-events:
-  emit-enabled: true
+  cas1:
+    emit-enabled: true
+  cas3:
+    emit-enabled: true
 
 log-client-credentials-jwt-info: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -190,16 +190,18 @@ assign-default-region-to-users-with-unknown-region: false
 
 url-templates:
   api:
-    application-submitted-event-detail: http://localhost:3000/events/application-submitted/#eventId
-    application-assessed-event-detail: http://localhost:3000/events/application-assessed/#eventId
-    booking-made-event-detail: http://localhost:3000/events/booking-made/#eventId
-    person-arrived-event-detail: http://localhost:3000/events/person-arrived/#eventId
-    person-not-arrived-event-detail: http://localhost:3000/events/person-not-arrived/#eventId
-    person-departed-event-detail: http://localhost:3000/events/person-departed/#eventId
-    booking-not-made-event-detail: http://localhost:3000/events/booking-not-made/#eventId
-    booking-cancelled-event-detail: http://localhost:3000/events/booking-cancelled/#eventId
-    booking-changed-event-detail: http://localhost:3000/events/booking-changed/#eventId
-    application-withdrawn-event-detail: http://localhost:3000/events/application-withdrawn/#eventId
+    cas1:
+      application-submitted-event-detail: http://localhost:3000/events/application-submitted/#eventId
+      application-assessed-event-detail: http://localhost:3000/events/application-assessed/#eventId
+      booking-made-event-detail: http://localhost:3000/events/booking-made/#eventId
+      person-arrived-event-detail: http://localhost:3000/events/person-arrived/#eventId
+      person-not-arrived-event-detail: http://localhost:3000/events/person-not-arrived/#eventId
+      person-departed-event-detail: http://localhost:3000/events/person-departed/#eventId
+      booking-not-made-event-detail: http://localhost:3000/events/booking-not-made/#eventId
+      booking-cancelled-event-detail: http://localhost:3000/events/booking-cancelled/#eventId
+      booking-changed-event-detail: http://localhost:3000/events/booking-changed/#eventId
+      application-withdrawn-event-detail: http://localhost:3000/events/application-withdrawn/#eventId
+    cas3:
   frontend:
     application: http://localhost:3000/applications/#id
     assessment: http://localhost:3000/assessments/#id

--- a/src/main/resources/db/migration/all/20231009162205__add_support_for_cas3_to_domain_events_table.sql
+++ b/src/main/resources/db/migration/all/20231009162205__add_support_for_cas3_to_domain_events_table.sql
@@ -1,0 +1,9 @@
+ALTER TABLE domain_events ALTER COLUMN application_id DROP NOT NULL;
+
+ALTER TABLE domain_events ADD COLUMN booking_id UUID;
+ALTER TABLE domain_events ADD COLUMN service TEXT;
+
+UPDATE domain_events
+SET service = 'CAS1';
+
+ALTER TABLE domain_events ALTER COLUMN service SET NOT NULL;

--- a/src/main/resources/static/cas3-domain-events-api.yml
+++ b/src/main/resources/static/cas3-domain-events-api.yml
@@ -1,0 +1,94 @@
+openapi: '3.0.1'
+info:
+  version: '0.1.0'
+  title: 'CAS3 Domain events'
+  description: Get information about events in the CAS3 domain
+paths: {}
+components:
+  responses:
+    500Response:
+      description: unexpected error
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Problem'
+  schemas:
+    CAS3Event:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          $ref: '#/components/schemas/EventType'
+      required:
+        - id
+        - timestamp
+        - eventType
+      discriminator:
+        propertyName: eventType
+        mapping: {}
+
+    # Common domain schemas
+    PersonReference:
+      type: object
+      properties:
+        crn:
+          type: string
+        noms:
+          type: string
+      required:
+        - crn
+
+    Premises:
+      type: object
+      properties:
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        postcode:
+          type: string
+        town:
+          type: string
+        region:
+          type: string
+      required:
+        - addressLine1
+        - postcode
+        - region
+
+    # Utility schemas
+    EventId:
+      description: The UUID of an event
+      type: string
+      format: uuid
+      example: 364145f9-0af8-488e-9901-b4c46cd9ba37
+    EventType:
+      description: The type of an event
+      type: string
+      enum:
+        - example
+      x-enum-varnames:
+        - example
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+          example: https://example.net/validation-error
+        title:
+          type: string
+          example: Invalid request parameters
+        status:
+          type: integer
+          example: 400
+        detail:
+          type: string
+          example: You provided invalid request parameters
+        instance:
+          type: string
+          example: f7493e12-546d-42c3-b838-06c12671ab5b

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -2,21 +2,25 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationId: Yielded<UUID?> = { UUID.randomUUID() }
+  private var bookingId: Yielded<UUID?> = { null }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var type: Yielded<DomainEventType> = { DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
   private var occurredAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var data: Yielded<String> = { "{}" }
+  private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS3")) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -24,6 +28,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
+  }
+
+  fun withBookingId(bookingId: UUID) = apply {
+    this.bookingId = { bookingId }
   }
 
   fun withCrn(crn: String) = apply {
@@ -46,13 +54,25 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.data = { data }
   }
 
+  fun withService(service: ServiceName) = apply {
+    this.service = {
+      when (service) {
+        ServiceName.approvedPremises -> "CAS1"
+        ServiceName.cas2 -> "CAS2"
+        ServiceName.temporaryAccommodation -> "CAS3"
+      }
+    }
+  }
+
   override fun produce(): DomainEventEntity = DomainEventEntity(
     id = this.id(),
     applicationId = this.applicationId(),
+    bookingId = this.bookingId(),
     crn = this.crn(),
     type = this.type(),
     occurredAt = this.occurredAt(),
     createdAt = this.createdAt(),
     data = this.data(),
+    service = this.service(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3DomainEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3DomainEventFactory.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3Event
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.Instant
+import java.util.UUID
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
+
+class CAS3DomainEventFactory<T : CAS3Event, D : Any>(
+  private val eventClass: KClass<T>,
+  private val dataClass: KClass<D>,
+) : Factory<DomainEvent<T>> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var crn: Yielded<String> = { randomStringUpperCase(6) }
+  private var occurredAt: Yielded<Instant> = { Instant.now() }
+  private var timestamp: Yielded<Instant> = { Instant.now() }
+  private var data: Yielded<D?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withOccurredAt(occurredAt: Instant) = apply {
+    this.occurredAt = { occurredAt }
+  }
+
+  fun withTimestamp(timestamp: Instant) = apply {
+    this.timestamp = { timestamp }
+  }
+
+  fun withData(data: D) = apply {
+    this.data = { data }
+  }
+
+  override fun produce(): DomainEvent<T> {
+    val dataConstructor = getConstructor()
+    val eventType = getEventType()
+
+    return DomainEvent(
+      id = this.id(),
+      applicationId = this.applicationId(),
+      crn = this.crn(),
+      occurredAt = this.occurredAt(),
+      data = dataConstructor(
+        this.data() ?: throw RuntimeException("Must provide event data"),
+        this.id(),
+        this.timestamp(),
+        eventType,
+      ),
+    )
+  }
+
+  private fun getConstructor(): (D, UUID, Instant, EventType) -> T {
+    val primaryConstructor = eventClass.primaryConstructor!!
+
+    return { eventDetails: D, id: UUID, timestamp: Instant, eventType: EventType ->
+      primaryConstructor.call(eventDetails, id, timestamp, eventType)
+    }
+  }
+
+  private fun getEventType(): EventType = when (dataClass) {
+    else -> throw RuntimeException("Unknown event details type ${dataClass.qualifiedName}")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/PersonReferenceFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/PersonReferenceFactory.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+
+class PersonReferenceFactory : Factory<PersonReference> {
+  private var crn: Yielded<String> = { randomStringUpperCase(6) }
+  private var noms: Yielded<String?> = { randomStringUpperCase(10) }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withNoms(noms: String?) = apply {
+    this.noms = { noms }
+  }
+
+  override fun produce() = PersonReference(
+    crn = this.crn(),
+    noms = this.noms(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/PremisesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/PremisesFactory.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+
+class PremisesFactory : Factory<Premises> {
+  private var addressLine1: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var addressLine2: Yielded<String?> = { null }
+  private var postcode: Yielded<String> = { randomPostCode() }
+  private var town: Yielded<String?> = { null }
+  private var region: Yielded<String> = { randomStringUpperCase(16) }
+
+  fun withAddressLine1(addressLine1: String) = apply {
+    this.addressLine1 = { addressLine1 }
+  }
+
+  fun withAddressLine2(addressLine2: String?) = apply {
+    this.addressLine2 = { addressLine2 }
+  }
+
+  fun withPostcode(postcode: String) = apply {
+    this.postcode = { postcode }
+  }
+
+  fun withTown(town: String?) = apply {
+    this.town = { town }
+  }
+
+  fun withRegion(region: String) = apply {
+    this.region = { region }
+  }
+
+  override fun produce() = Premises(
+    addressLine1 = this.addressLine1(),
+    addressLine2 = this.addressLine2(),
+    postcode = this.postcode(),
+    town = this.town(),
+    region = this.region(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas3
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventBuilder
+
+class DomainEventBuilderTest {
+  private val domainEventBuilder = DomainEventBuilder()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas3
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.mockk.mockk
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventService
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+
+class DomainEventServiceTest {
+  private val domainEventRepositoryMock = mockk<DomainEventRepository>()
+  private val domainEventBuilderMock = mockk<DomainEventBuilder>()
+  private val hmppsQueueServiceMock = mockk<HmppsQueueService>()
+
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
+  private val domainEventService = DomainEventService(
+    objectMapper = objectMapper,
+    domainEventRepository = domainEventRepositoryMock,
+    domainEventBuilder = domainEventBuilderMock,
+    hmppsQueueService = hmppsQueueServiceMock,
+    emitDomainEventsEnabled = true,
+  )
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -50,7 +50,10 @@ hmpps.sqs:
       subscribeTopicId: domainevents
 
 domain-events:
-  emit-enabled: true
+  cas1:
+    emit-enabled: true
+  cas3:
+    emit-enabled: true
 
 hmpps:
   auth:
@@ -111,16 +114,18 @@ seed:
 
 url-templates:
   api:
-    application-submitted-event-detail: http://api/events/application-submitted/#eventId
-    application-assessed-event-detail: http://api/events/application-assessed/#eventId
-    booking-made-event-detail: http://api/events/booking-made/#eventId
-    person-arrived-event-detail: http://api/events/person-arrived/#eventId
-    person-not-arrived-event-detail: http://api/events/person-not-arrived/#eventId
-    person-departed-event-detail: http://api/events/person-departed/#eventId
-    booking-not-made-event-detail: http://api/events/booking-not-made/#eventId
-    booking-cancelled-event-detail: http://api/events/booking-cancelled/#eventId
-    booking-changed-event-detail: http://api/events/booking-changed/#eventId
-    application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
+    cas1:
+      application-submitted-event-detail: http://api/events/application-submitted/#eventId
+      application-assessed-event-detail: http://api/events/application-assessed/#eventId
+      booking-made-event-detail: http://api/events/booking-made/#eventId
+      person-arrived-event-detail: http://api/events/person-arrived/#eventId
+      person-not-arrived-event-detail: http://api/events/person-not-arrived/#eventId
+      person-departed-event-detail: http://api/events/person-departed/#eventId
+      booking-not-made-event-detail: http://api/events/booking-not-made/#eventId
+      booking-cancelled-event-detail: http://api/events/booking-cancelled/#eventId
+      booking-changed-event-detail: http://api/events/booking-changed/#eventId
+      application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
+    cas3:
   frontend:
     application: http://frontend/applications/#id
     assessment: http://frontend/assessments/#id


### PR DESCRIPTION
> See ticket [#1623 on the CAS3 Trello board](https://trello.com/c/JAHewQrO/1623-we-can-send-domain-events-without-requiring-an-application-id).

Following [this discussion](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1004#discussion_r1348479356) on #1004 where a need for a meaningful record identifier when the application ID is unavailable was raised, and [this Slack discussion with the probation integrations team](https://mojdt.slack.com/archives/C03KVQUFSER/p1696846088073159), we've reached an agreement to modify the structure of the domain events that we send, such that the `additionalInformation` section of the event can accept an optional `applicationId` and/or an optional `bookingId`.

While this change on its own is rather small, the above PR (#1004) at the time of writing already represents quite a large changeset, so we've decided to extract all of the setup work from that PR, apply the agreed changes to the domain event structure, and bundle it into a separate PR (this one) to be merged first, thus allowing the other PR to be solely focused on the implementation the 'person arrived' CAS3 domain event specifically.