### PR TITLE
Make Bed info nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -265,8 +265,8 @@ interface BookingSummary {
   fun getArrivalDate(): LocalDate
   fun getDepartureDate(): LocalDate
   fun getCrn(): String
-  fun getBedId(): UUID
-  fun getBedName(): String
-  fun getBedCode(): String
+  fun getBedId(): UUID?
+  fun getBedName(): String?
+  fun getBedCode(): String?
   fun getStatus(): BookingStatus
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -37,11 +37,13 @@ class BookingTransformer(
       arrivalDate = jpa.getArrivalDate(),
       departureDate = jpa.getDepartureDate(),
       person = personTransformer.transformModelToPersonApi(personInfo),
-      bed = Bed(
-        id = jpa.getBedId(),
-        name = jpa.getBedName(),
-        code = jpa.getBedCode(),
-      ),
+      bed = jpa.getBedId()?.let {
+        Bed(
+          id = jpa.getBedId()!!,
+          name = jpa.getBedName()!!,
+          code = jpa.getBedCode(),
+        )
+      },
       status = jpa.getStatus(),
     )
   }


### PR DESCRIPTION
If a Booking is cancelled, it won’t have an associated bed.