### PR TITLE
Fix: adjust oauth client registration key to match spring env var

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,7 @@ spring:
             client-id: approved-premises-api
             client-secret: clientsecret
             authorization-grant-type: client_credentials
-          nomis-user-roles:
+          nomis-user-roles-api:
             provider: hmpps-auth
             client-id: approved-premises-api
             client-secret: clientsecret


### PR DESCRIPTION
This needs to match the
`SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_*` environment variables defined in the helm template `values.yaml` e.g.

`SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_NOMIS-USER-ROLES-API_CLIENT-ID`

The error this should fix is:

```
Failed to instantiate [org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository]: 
Factory method 'clientRegistrationRepository'threw exception; nested exception is java.lang.IllegalStateException:
 Provider ID must be specified for client registration 'nomis-user-roles-api
```