### PR TITLE
(454) Bulk fetch CRNs on Premises Summary request

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,13 @@ services:
       - COMMUNITY-API_BASE-URL=http://community-api:8080
 
   wiremock:
-    image: rodolpheche/wiremock
+    image: wiremock/wiremock
     container_name: wiremock
     ports:
       - "9004:8080"
     volumes:
       - ./wiremock:/home/wiremock
+    command: "--global-response-templating"
 
   prison-api:
     image: quay.io/hmpps/prison-api:latest

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.UserAccess
 
 @Component
 class ApDeliusContextApiClient(
@@ -29,5 +31,15 @@ class ApDeliusContextApiClient(
   @Cacheable(value = ["crnGetCaseDetailCache"], unless = IS_NOT_SUCCESSFUL)
   fun getCaseDetail(crn: String) = getRequest<CaseDetail> {
     path = "/probation-cases/$crn/details"
+  }
+
+  fun getSummariesForCrns(crns: List<String>) = getRequest<CaseSummaries> {
+    path = "/probation-cases/summaries"
+    body = crns
+  }
+
+  fun getUserAccessForCrns(deliusUsername: String, crns: List<String>) = getRequest<UserAccess> {
+    path = "/users/access?username=$deliusUsername"
+    body = crns
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonSummaryInfoResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonSummaryInfoResult.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
+
+sealed interface PersonSummaryInfoResult {
+  val crn: String
+
+  sealed interface Success : PersonSummaryInfoResult {
+    data class Full(override val crn: String, val summary: CaseSummary) : Success
+    data class Restricted(override val crn: String, val nomsNumber: String?) : Success
+  }
+
+  data class NotFound(override val crn: String) : PersonSummaryInfoResult
+  data class Unknown(override val crn: String, val throwable: Throwable? = null) : PersonSummaryInfoResult
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -70,3 +70,7 @@ data class MappaDetail(
   val startDate: LocalDate,
   val lastUpdated: ZonedDateTime,
 )
+
+data class CaseSummaries(
+  var cases: List<CaseSummary>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/UserAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/UserAccess.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext
+
+data class UserAccess(
+  var access: List<CaseAccess>,
+)
+
+data class CaseAccess(
+  val crn: String,
+  val userExcluded: Boolean,
+  val userRestricted: Boolean,
+  val exclusionMessage: String?,
+  val restrictionMessage: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
@@ -31,12 +32,12 @@ class BookingTransformer(
   private val workingDayCountService: WorkingDayCountService,
 ) {
 
-  fun transformBookingSummary(jpa: BookingSummary, personInfo: PersonInfoResult): PremisesBooking {
+  fun transformBookingSummary(jpa: BookingSummary, personInfo: PersonSummaryInfoResult): PremisesBooking {
     return PremisesBooking(
       id = jpa.getID(),
       arrivalDate = jpa.getArrivalDate(),
       departureDate = jpa.getDepartureDate(),
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.transformSummaryToPersonApi(personInfo),
       bed = jpa.getBedId()?.let {
         Bed(
           id = jpa.getBedId()!!,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
 
 @Component
@@ -35,6 +36,31 @@ class PersonTransformer {
       crn = personInfoResult.crn,
     )
     is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> UnknownPerson(
+      type = PersonType.unknownPerson,
+      crn = personInfoResult.crn,
+    )
+  }
+
+  fun transformSummaryToPersonApi(personInfoResult: PersonSummaryInfoResult) = when (personInfoResult) {
+    is PersonSummaryInfoResult.Success.Full -> FullPerson(
+      type = PersonType.fullPerson,
+      crn = personInfoResult.crn,
+      name = "${personInfoResult.summary.name.forename} ${personInfoResult.summary.name.surname}",
+      dateOfBirth = personInfoResult.summary.dateOfBirth,
+      sex = personInfoResult.summary.gender ?: "Not Found",
+      status = FullPerson.Status.unknown,
+      nomsNumber = personInfoResult.summary.nomsId,
+      ethnicity = personInfoResult.summary.profile.ethnicity,
+      nationality = personInfoResult.summary.profile.nationality,
+      religionOrBelief = personInfoResult.summary.profile.religion,
+      genderIdentity = personInfoResult.summary.profile.genderIdentity,
+      prisonName = null,
+    )
+    is PersonSummaryInfoResult.Success.Restricted -> RestrictedPerson(
+      type = PersonType.restrictedPerson,
+      crn = personInfoResult.crn,
+    )
+    is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> UnknownPerson(
       type = PersonType.unknownPerson,
       crn = personInfoResult.crn,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseAccessFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseAccessFactory.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+
+class CaseAccessFactory : Factory<CaseAccess> {
+  var crn: Yielded<String> = { randomStringUpperCase(10) }
+  var userExcluded: Yielded<Boolean> = { false }
+  var userRestricted: Yielded<Boolean> = { false }
+  var exclusionMessage: Yielded<String?> = { null }
+  var restrictionMessage: Yielded<String?> = { null }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+  fun withUserExcluded(userExcluded: Boolean) = apply {
+    this.userExcluded = { userExcluded }
+  }
+  fun withUserRestricted(userRestricted: Boolean) = apply {
+    this.userRestricted = { userRestricted }
+  }
+  fun withExclusionMessage(exclusionMessage: String?) = apply {
+    this.exclusionMessage = { exclusionMessage }
+  }
+  fun withRestrictionMessage(restrictionMessage: String?) = apply {
+    this.restrictionMessage = { restrictionMessage }
+  }
+
+  override fun produce(): CaseAccess = CaseAccess(
+    crn = this.crn(),
+    userExcluded = this.userExcluded(),
+    userRestricted = this.userRestricted(),
+    exclusionMessage = this.exclusionMessage(),
+    restrictionMessage = this.restrictionMessage(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -743,6 +744,35 @@ abstract class IntegrationTestBase {
           ),
       )
     }
+
+  fun mockSuccessfulGetCallWithBodyAndJsonResponse(url: String, requestBody: StringValuePattern, responseBody: Any, responseStatus: Int = 200) =
+    mockOAuth2ClientCredentialsCallIfRequired {
+      wiremockServer.stubFor(
+        WireMock.get(urlEqualTo(url))
+          .withRequestBody(requestBody)
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(responseStatus)
+              .withBody(
+                objectMapper.writeValueAsString(responseBody),
+              ),
+          ),
+      )
+    }
+
+  fun editGetStubWithBodyAndJsonResponse(url: String, uuid: UUID, requestBody: StringValuePattern, responseBody: Any) = wiremockServer.editStub(
+    WireMock.get(WireMock.urlEqualTo(url)).withId(uuid)
+      .withRequestBody(requestBody)
+      .willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200)
+          .withBody(
+            objectMapper.writeValueAsString(responseBody),
+          ),
+      ),
+  )
 
   fun mockUnsuccessfulGetCall(url: String, responseStatus: Int) =
     mockOAuth2ClientCredentialsCallIfRequired {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -19,9 +19,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
@@ -1548,9 +1552,9 @@ class PremisesTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER" ])
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
   fun `Get Premises Summary by ID returns OK with correct body`(role: UserRole) {
-    `Given a User`(roles = listOf(role)) { _, jwt ->
+    `Given a User`(roles = listOf(role)) { user, jwt ->
 
       val premises = approvedPremisesEntityFactory.produceAndPersist() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1574,11 +1578,37 @@ class PremisesTest : IntegrationTestBase() {
         )
       }
 
+      bookings.forEach {
+        ApDeliusContext_addCaseSummaryToBulkResponse(
+          CaseSummaryFactory()
+            .withCrn(it.crn)
+            .produce(),
+        )
+        ApDeliusContext_addResponseToUserAccessCall(
+          CaseAccessFactory()
+            .withCrn(it.crn)
+            .produce(),
+          user.deliusUsername,
+        )
+      }
+
       val cancelledBooking = bookingEntityFactory.produceAndPersist() {
         withNomsNumber("1234")
         withPremises(premises)
         withBed(null)
       }
+
+      ApDeliusContext_addCaseSummaryToBulkResponse(
+        CaseSummaryFactory()
+          .withCrn(cancelledBooking.crn)
+          .produce(),
+      )
+      ApDeliusContext_addResponseToUserAccessCall(
+        CaseAccessFactory()
+          .withCrn(cancelledBooking.crn)
+          .produce(),
+        user.deliusUsername,
+      )
 
       cancellationEntityFactory.produceAndPersist {
         withBooking(cancelledBooking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
@@ -8,6 +9,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProfileFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockServerErrorOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockServerErrorInmateDetailsCall
@@ -73,6 +76,17 @@ fun IntegrationTestBase.`Given an Offender`(
   ).produce()
 
   APDeliusContext_mockSuccessfulCaseDetailCall(offenderDetails.otherIds.crn, caseDetail)
+
+  ApDeliusContext_addCaseSummaryToBulkResponse(
+    caseDetail.case,
+  )
+  ApDeliusContext_addResponseToUserAccessCall(
+    CaseAccessFactory()
+      .withCrn(offenderDetails.otherIds.crn)
+      .withUserExcluded(offenderDetails.currentExclusion)
+      .withUserRestricted(offenderDetails.currentRestriction)
+      .produce(),
+  )
 
   loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
 

--- a/wiremock/__files/caseSummary
+++ b/wiremock/__files/caseSummary
@@ -1,0 +1,35 @@
+{
+  "cases": [
+    {{#each (jsonPath request.body '$[*]') as |crn|}}
+        {
+            "crn": "{{crn}}",
+            "nomsId": "A7779DY",
+            "name": {
+              "forename": "Ben",
+              "surname": "Davies",
+              "middleNames": []
+            },
+            "dateOfBirth": "1993-04-24",
+            "gender": "Male",
+            "profile": {
+              "ethnicity": "White: British/English/Welsh/Scottish/Northern Irish",
+              "genderIdentity": "Male",
+              "nationality": "British",
+              "religion": "Apostolic"
+            },
+            "manager": {
+              "team": {
+                "code": "N07UAT",
+                "name": "Unallocated Team(N07)",
+                "ldu": {
+                  "code": "N07UAT",
+                  "name": "Unallocated Level 3(N07)"
+                }
+              }
+            },
+            "currentExclusion": false,
+            "currentRestriction": false
+        }{{#if @last}}{{else}},{{/if}}
+    {{/each}}
+  ]
+}

--- a/wiremock/__files/userAccess
+++ b/wiremock/__files/userAccess
@@ -1,0 +1,11 @@
+{
+  "access": [
+    {{#each (jsonPath request.body '$[*]') as |crn|}}
+        {
+            "crn": "{{crn}}",
+            "userExcluded": false,
+            "userRestricted": false
+        }{{#if @last}}{{else}},{{/if}}
+    {{/each}}
+  ]
+}

--- a/wiremock/mappings/ApDeliusContext_GetCaseSummaries.json
+++ b/wiremock/mappings/ApDeliusContext_GetCaseSummaries.json
@@ -1,0 +1,15 @@
+{
+  "id": "7f55eb9e-21ee-4ad4-a4c8-5c749ecf770a",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/probation-cases/summaries"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "bodyFileName": "caseSummary",
+    "transformers": ["response-template"]
+  }
+}

--- a/wiremock/mappings/ApDeliusContext_GetUserAccess.json
+++ b/wiremock/mappings/ApDeliusContext_GetUserAccess.json
@@ -1,0 +1,16 @@
+{
+  "id": "914913d6-2258-4e19-ae5e-20f95079822e",
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/user/access"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "bodyFileName": "userAccess",
+    "transformers": ["response-template"]
+  }
+}


### PR DESCRIPTION
The integrations team have built us two endpoints to fetch information for multiple CRNs in one API call. One fetches the basic information about the case, and the other checks if the logged in user has permissions to view those cases. This should significantly speed up requests when we have to fetch multiple cases on one endpoint (for example when listing multiple entities). By way of a trial, I've added all the necessary wiring to call these new endpoints on the Premises summary endpoint. If we're happy, it should be fairly trivial to roll the endpoint out on other listings pages.