### PR TITLE
Fix (pt 2) OAuth client registration and BASE URL config for Nomis-User-Roles API client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -234,7 +234,7 @@ class WebClientConfiguration(
   fun nomisUserRolesApiClient(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
-    @Value("\${services.nomis-user-roles.base-url}") nomisUserRolesBaseUrl: String,
+    @Value("\${services.nomis-user-roles-api.base-url}") nomisUserRolesBaseUrl: String,
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -238,7 +238,7 @@ class WebClientConfiguration(
   ): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
-    oauth2Client.setDefaultClientRegistrationId("nomis-user-roles")
+    oauth2Client.setDefaultClientRegistrationId("nomis-user-roles-api")
 
     return WebClient.builder()
       .baseUrl(nomisUserRolesBaseUrl)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,7 +132,7 @@ services:
     base-url: http://localhost:9004
   prisons-api:
     base-url: http://localhost:9570
-  nomis-user-roles:
+  nomis-user-roles-api:
     base-url: http://localhost:9575
   case-notes:
     base-url: http://localhost:9004

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -68,7 +68,7 @@ services:
     base-url: http://localhost:#WIREMOCK_PORT
   prisons-api:
     base-url: http://localhost:#WIREMOCK_PORT
-  nomis-user-roles:
+  nomis-user-roles-api:
     base-url: http://localhost:#WIREMOCK_PORT
   case-notes:
     base-url: http://localhost:#WIREMOCK_PORT


### PR DESCRIPTION
There were 2 further problems with our config which are addressed here, to give us the follow configs:

### 1. OAUTH CLIENT REGISTRATION

The OAuth client used to authenticate the system-to-system connection between the CAS and the new Nomis-User-Roles client must be configured with a key in `security.oauth2.client.registration` in `application.yml` which matches the environment variable defined in `helm_deploy/values.yaml` in the form `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_*`, in this case:

  - `nomis-user-roles-api` in `application.yml` and
  - `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_NOMIS-USER-ROLES-API_CLIENT-{ID,SECRET}` in `values.yaml`

Additionally, we need to tell our API client which OAuth client to use. This is done in `WebClientConfiguration.kt` using the value set in `security.oauth2.client.registration` in `application.yml`, in this case `"nomis-user-roles-api"`.

### 2. BASE_URL SETTINGS

The base URL of the API client is set in `WebClientConfiguration.kt` using the `@Value` annotation. We set the value `services.nomis-user-roles-api.base-url` which maps to the matching environment variable `SERVICES_NOMIS-USER-ROLES-API_BASE-URL` set in `helm/values-dev.yaml`.

In local and test environments these values are read from `application{.yml,-test.yml}` rather than from environment variables. 