### PR TITLE
HAAR-1778: update nomis-user-roles-api dev url

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,7 @@ generic-service:
     SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL: https://approved-premises-and-delius-dev.hmpps.service.justice.gov.uk
     SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
     SERVICES_PRISONS-API_BASE-URL: https://prison-api-dev.prison.service.justice.gov.uk
-    SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
+    SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://dev.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
from https://nomis-user-dev.aks-dev-1.studio-hosting.service.justice.gov.uk to https://nomis-user-roles-api-dev.prison.service.justice.gov.uk