### PR TITLE
Add application URL and booking URL to CAS3 domain events

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -49,6 +49,8 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/applications/#applicationId
+    URL-TEMPLATES_API_CAS3_BOOKING: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_API_CAS3_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/person-arrived/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/person-departed/#eventId
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -44,6 +44,8 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/applications/#applicationId
+    URL-TEMPLATES_API_CAS3_BOOKING: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_API_CAS3_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/person-arrived/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/person-departed/#eventId
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -54,6 +54,8 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api.hmpps.service.justice.gov.uk/applications/#applicationId
+    URL-TEMPLATES_API_CAS3_BOOKING: https://approved-premises-api.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_API_CAS3_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/person-arrived/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/person-departed/#eventId
     ARRIVED-DEPARTED-DOMAIN-EVENTS-DISABLED: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -44,6 +44,8 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-test.hmpps.service.justice.gov.uk/applications/#applicationId
+    URL-TEMPLATES_API_CAS3_BOOKING: https://approved-premises-api-test.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_API_CAS3_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/person-arrived/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/person-departed/#eventId
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -202,6 +202,8 @@ url-templates:
       booking-changed-event-detail: http://localhost:3000/events/booking-changed/#eventId
       application-withdrawn-event-detail: http://localhost:3000/events/application-withdrawn/#eventId
     cas3:
+      application: http://localhost:3000/applications/#applicationId
+      booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
       person-arrived-event-detail: http://localhost:3000/events/cas3/person-arrived/#eventId
       person-departed-event-detail: http://localhost:3000/events/cas3/person-departed/#eventId
   frontend:

--- a/src/main/resources/static/cas3-domain-events-api.yml
+++ b/src/main/resources/static/cas3-domain-events-api.yml
@@ -106,9 +106,15 @@ components:
         applicationId:
           type: string
           format: uuid
+        applicationUrl:
+          type: string
+          format: uri
         bookingId:
           type: string
           format: uuid
+        bookingUrl:
+          type: string
+          format: uri
         premises:
           $ref: '#/components/schemas/Premises'
         arrivedAt:
@@ -123,6 +129,7 @@ components:
         - personReference
         - deliusEventNumber
         - bookingId
+        - bookingUrl
         - premises
         - arrivedAt
         - expectedDepartureOn
@@ -146,9 +153,15 @@ components:
         applicationId:
           type: string
           format: uuid
+        applicationUrl:
+          type: string
+          format: uri
         bookingId:
           type: string
           format: uuid
+        bookingUrl:
+          type: string
+          format: uri
         premises:
           $ref: '#/components/schemas/Premises'
         departedAt:
@@ -166,6 +179,7 @@ components:
         - personReference
         - deliusEventNumber
         - bookingId
+        - bookingUrl
         - premises
         - departedAt
         - reason

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3PersonDepartedEventDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3PersonDepartedEventDetailsFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.Pe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.net.URI
 import java.time.Instant
 import java.util.UUID
 
@@ -15,6 +16,7 @@ class CAS3PersonDepartedEventDetailsFactory : Factory<CAS3PersonDepartedEventDet
   private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
   private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
+  private var premisesId: Yielded<UUID> = { UUID.randomUUID() }
   private var premises: Yielded<Premises> = { PremisesFactory().produce() }
   private var departedAt: Yielded<Instant> = { Instant.now() }
   private var reason: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
@@ -33,6 +35,10 @@ class CAS3PersonDepartedEventDetailsFactory : Factory<CAS3PersonDepartedEventDet
 
   fun withBookingId(bookingId: UUID) = apply {
     this.bookingId = { bookingId }
+  }
+
+  fun withPremisesId(premisesId: UUID) = apply {
+    this.premisesId = { premisesId }
   }
 
   fun withPremises(configuration: PremisesFactory.() -> Unit) = apply {
@@ -63,16 +69,23 @@ class CAS3PersonDepartedEventDetailsFactory : Factory<CAS3PersonDepartedEventDet
     this.reasonDetail = { reasonDetail }
   }
 
-  override fun produce() = CAS3PersonDepartedEventDetails(
-    personReference = this.personReference(),
-    deliusEventNumber = this.deliusEventNumber(),
-    bookingId = this.bookingId(),
-    premises = this.premises(),
-    departedAt = this.departedAt(),
-    reason = this.reason(),
-    notes = this.notes(),
-    moveOnCategory = this.moveOnCategory(),
-    applicationId = this.applicationId(),
-    reasonDetail = this.reasonDetail(),
-  )
+  override fun produce(): CAS3PersonDepartedEventDetails {
+    val bookingId = this.bookingId()
+    val applicationId = this.applicationId()
+
+    return CAS3PersonDepartedEventDetails(
+      personReference = this.personReference(),
+      deliusEventNumber = this.deliusEventNumber(),
+      bookingId = bookingId,
+      bookingUrl = URI("http://api/premises/${this.premisesId()}/bookings/$bookingId"),
+      premises = this.premises(),
+      departedAt = this.departedAt(),
+      reason = this.reason(),
+      notes = this.notes(),
+      moveOnCategory = this.moveOnCategory(),
+      applicationId = applicationId,
+      reasonDetail = this.reasonDetail(),
+      applicationUrl = applicationId?.let { URI("http://api/applications/$it") },
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
@@ -19,7 +19,10 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class DomainEventBuilderTest {
-  private val domainEventBuilder = DomainEventBuilder()
+  private val domainEventBuilder = DomainEventBuilder(
+    applicationUrlTemplate = "http://api/applications/#applicationId",
+    bookingUrlTemplate = "http://api/premises/#premisesId/bookings/#bookingId",
+  )
 
   @Test
   fun `getPersonArrivedDomainEvent transforms the booking and arrival information correctly`() {
@@ -73,6 +76,7 @@ class DomainEventBuilderTest {
         data.personReference.noms == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
         data.bookingId == booking.id &&
+        data.bookingUrl.toString() == "http://api/premises/${premises.id}/bookings/${booking.id}" &&
         data.premises.addressLine1 == premises.addressLine1 &&
         data.premises.addressLine2 == premises.addressLine2 &&
         data.premises.postcode == premises.postcode &&
@@ -81,7 +85,8 @@ class DomainEventBuilderTest {
         data.arrivedAt == arrivalDateTime &&
         data.expectedDepartureOn == expectedDepartureDate &&
         data.notes == notes &&
-        data.applicationId == application.id
+        data.applicationId == application.id &&
+        data.applicationUrl.toString() == "http://api/applications/${application.id}"
     }
   }
 
@@ -149,6 +154,7 @@ class DomainEventBuilderTest {
         data.personReference.noms == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
         data.bookingId == booking.id &&
+        data.bookingUrl.toString() == "http://api/premises/${premises.id}/bookings/${booking.id}" &&
         data.premises.addressLine1 == premises.addressLine1 &&
         data.premises.addressLine2 == premises.addressLine2 &&
         data.premises.postcode == premises.postcode &&
@@ -159,7 +165,8 @@ class DomainEventBuilderTest {
         data.notes == notes &&
         data.moveOnCategory.description == moveOnCategoryDescription &&
         data.moveOnCategory.label == moveOnCategoryLabel &&
-        data.applicationId == application.id
+        data.applicationId == application.id &&
+        data.applicationUrl.toString() == "http://api/applications/${application.id}"
     }
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -126,6 +126,8 @@ url-templates:
       booking-changed-event-detail: http://api/events/booking-changed/#eventId
       application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
     cas3:
+      application: http://api/applications/#applicationId
+      booking: http://api/premises/#premisesId/bookings/#bookingId
       person-arrived-event-detail: http://api/events/cas3/person-arrived/#eventId
       person-departed-event-detail: http://api/events/cas3/person-departed/#eventId
   frontend:


### PR DESCRIPTION
> See [ticket #1639 on the CAS3 Trello board](https://trello.com/c/sPimu5Mx/1639-add-urls-to-the-person-arrived-and-departed-domain-event-endpoints).

Following a discussion with the integrations team, we've come to the agreement to provide URLs to the relevant booking and application (if available) associated with the event. This PR introduces `applicationUrl` and `bookingUrl` as properties on the two existing CAS3 domain events, as well as the infrastructure to generate appropriate URLs for future event types.