### PR TITLE
(518) External NACRO assessor logs in to view submitted CAS2 applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -59,6 +59,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/application-submitted/*", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
+        authorize(HttpMethod.GET, "/cas2/applications/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -106,6 +106,10 @@ class AuthAwareTokenConverter() : Converter<Jwt, AbstractAuthenticationToken> {
     return AuthAwareAuthenticationToken(jwt, principal, authorities)
   }
 
+  private fun extractAuthSource(claims: Map<String, Any?>): String {
+    return claims[CLAIM_AUTH_SOURCE] as String
+  }
+
   private fun findPrincipal(claims: Map<String, Any?>): String {
     return if (claims.containsKey(CLAIM_USERNAME)) {
       claims[CLAIM_USERNAME] as String
@@ -135,6 +139,7 @@ class AuthAwareTokenConverter() : Converter<Jwt, AbstractAuthenticationToken> {
   companion object {
     const val CLAIM_USERNAME = "user_name"
     const val CLAIM_USER_ID = "user_id"
+    const val CLAIM_AUTH_SOURCE = "auth_source"
     const val CLAIM_CLIENT_ID = "client_id"
     const val CLAIM_AUTHORITY = "authorities"
   }
@@ -145,8 +150,15 @@ class AuthAwareAuthenticationToken(
   private val aPrincipal: String,
   authorities: Collection<GrantedAuthority>,
 ) : JwtAuthenticationToken(jwt, authorities) {
+
+  private val jwt = jwt
+
   override fun getPrincipal(): String {
     return aPrincipal
+  }
+
+  fun isExternalUser(): Boolean {
+    return jwt.claims["auth_source"] == "auth"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -49,7 +49,7 @@ class ApplicationsController(
 
     return if (authenticatedPrincipal.isExternalUser()) {
       ensureExternalUserPersisted()
-      val applications = applicationService.getAllApplicationsForAssessor()
+      val applications = applicationService.getAllSubmittedApplicationsForAssessor()
       ResponseEntity.ok(applications.map { getPersonDetailAndTransformToSummary(it) })
     } else {
       val user = userService.getUserForRequest()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/PeopleController.kt
@@ -37,7 +37,7 @@ class PeopleController(
   override fun peopleSearchGet(crn: String): ResponseEntity<Person> {
     val user = userService.getUserForRequest()
 
-    val personInfo = offenderService.getInfoForPerson(crn, user.nomisUsername)
+    val personInfo = offenderService.getInfoForPerson(crn)
 
     when (personInfo) {
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -49,6 +49,12 @@ WHERE a.submitted_at IS NOT NULL
   )
   fun findAllSubmittedCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
 
+  @Query(
+    "SELECT a FROM Cas2ApplicationEntity a WHERE a.id = :id AND " +
+      "a.submittedAt IS NOT NULL",
+  )
+  fun findSubmittedApplicationById(id: UUID): Cas2ApplicationEntity?
+
   @Query("SELECT a FROM Cas2ApplicationEntity a WHERE a.createdByUser.id = :id")
   fun findAllByCreatedByUser_Id(id: UUID): List<Cas2ApplicationEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -43,10 +43,11 @@ SELECT
     a.created_at as createdAt,
     a.submitted_at as submittedAt
 FROM cas_2_applications a
+WHERE a.submitted_at IS NOT NULL
 """,
     nativeQuery = true,
   )
-  fun findAllCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
+  fun findAllSubmittedCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
 
   @Query("SELECT a FROM Cas2ApplicationEntity a WHERE a.createdByUser.id = :id")
   fun findAllByCreatedByUser_Id(id: UUID): List<Cas2ApplicationEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -34,6 +34,20 @@ WHERE a.created_by_user_id = :userId
   fun findAllCas2ApplicationSummariesCreatedByUser(userId: UUID):
     List<Cas2ApplicationSummary>
 
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt
+FROM cas_2_applications a
+""",
+    nativeQuery = true,
+  )
+  fun findAllCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
+
   @Query("SELECT a FROM Cas2ApplicationEntity a WHERE a.createdByUser.id = :id")
   fun findAllByCreatedByUser_Id(id: UUID): List<Cas2ApplicationEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExternalUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExternalUserEntity.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface ExternalUserRepository : JpaRepository<ExternalUserEntity, UUID> {
+  fun findByUsername(userName: String): ExternalUserEntity?
+}
+
+@Entity
+@Table(name = "external_users")
+data class ExternalUserEntity(
+  @Id
+  val id: UUID,
+  val username: String,
+  var isEnabled: Boolean,
+  var origin: String,
+
+  @CreationTimestamp
+  private val createdAt: OffsetDateTime? = null,
+) {
+  override fun toString() = "External user $id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ExternalUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ExternalUserService.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserRepository
+import java.util.UUID
+
+@Service
+class ExternalUserService(
+  private val httpAuthService: HttpAuthService,
+  private val userRepository: ExternalUserRepository,
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getUserForRequest(): ExternalUserEntity {
+    val authenticatedPrincipal = httpAuthService.getCas2AuthenticatedPrincipalOrThrow()
+    val username = authenticatedPrincipal.name
+
+    return getUserForUsername(username)
+  }
+
+  fun getUserForUsername(username: String): ExternalUserEntity {
+    val normalisedUsername = username.uppercase()
+
+    val existingUser = userRepository.findByUsername(normalisedUsername)
+    if (existingUser != null) return existingUser
+
+    // We will obtain some further user details from the Manage-Users API
+    // e.g. name, email, phone number
+
+    return userRepository.save(
+      ExternalUserEntity(
+        id = UUID.randomUUID(),
+        username = username,
+        isEnabled = true,
+        origin = "NACRO",
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/HttpAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/HttpAuthService.kt
@@ -17,6 +17,15 @@ class HttpAuthService {
     return principal
   }
 
+  fun getCas2AuthenticatedPrincipalOrThrow(): AuthAwareAuthenticationToken {
+    val principal = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
+    if (!listOf("nomis", "auth").contains(principal.token.claims["auth_source"])) {
+      throw ForbiddenProblem()
+    }
+
+    return principal
+  }
+
   fun getDeliusPrincipalOrThrow(): AuthAwareAuthenticationToken {
     val principal = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -45,8 +45,8 @@ class ApplicationService(
     return applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id)
   }
 
-  fun getAllApplicationsForAssessor(): List<Cas2ApplicationSummary> {
-    return applicationRepository.findAllCas2ApplicationSummaries()
+  fun getAllSubmittedApplicationsForAssessor(): List<Cas2ApplicationSummary> {
+    return applicationRepository.findAllSubmittedCas2ApplicationSummaries()
   }
 
   fun getApplicationForUsername(applicationId: UUID, userDistinguishedName: String): AuthorisableActionResult<Cas2ApplicationEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -45,6 +45,10 @@ class ApplicationService(
     return applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id)
   }
 
+  fun getAllApplicationsForAssessor(): List<Cas2ApplicationSummary> {
+    return applicationRepository.findAllCas2ApplicationSummaries()
+  }
+
   fun getApplicationForUsername(applicationId: UUID, userDistinguishedName: String): AuthorisableActionResult<Cas2ApplicationEntity> {
     val applicationEntity = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -49,6 +49,16 @@ class ApplicationService(
     return applicationRepository.findAllSubmittedCas2ApplicationSummaries()
   }
 
+  fun getSubmittedApplicationForAssessor(applicationId: UUID):
+    AuthorisableActionResult<Cas2ApplicationEntity> {
+    val applicationEntity = applicationRepository.findSubmittedApplicationById(applicationId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    return AuthorisableActionResult.Success(
+      jsonSchemaService.checkSchemaOutdated(applicationEntity),
+    )
+  }
+
   fun getApplicationForUsername(applicationId: UUID, userDistinguishedName: String): AuthorisableActionResult<Cas2ApplicationEntity> {
     val applicationEntity = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -25,7 +25,7 @@ class OffenderService(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getInfoForPerson(crn: String, nomisUsername: String): PersonInfoResult {
+  fun getInfoForPerson(crn: String): PersonInfoResult {
     var offenderResponse = communityApiClient.getOffenderDetailSummaryWithWait(crn)
 
     if (offenderResponse is ClientResult.Failure.PreemptiveCacheTimeout) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/cas2/PersonUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/cas2/PersonUtils.kt
@@ -1,26 +1,22 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 
-fun OffenderService.getInfoForPersonOrThrowInternalServerError(
-  crn: String,
-  user: NomisUserEntity,
-):
+fun OffenderService.getInfoForPersonOrThrowInternalServerError(crn: String):
   PersonInfoResult.Success {
-  val personInfo = this.getInfoForPerson(crn, user.nomisUsername)
+  val personInfo = this.getInfoForPerson(crn)
   if (personInfo is PersonInfoResult.NotFound) throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
 
   return personInfo as PersonInfoResult.Success
 }
 
-fun OffenderService.getFullInfoForPersonOrThrow(crn: String, user: NomisUserEntity):
+fun OffenderService.getFullInfoForPersonOrThrow(crn: String):
   PersonInfoResult.Success.Full {
-  val personInfo = this.getInfoForPerson(crn, user.nomisUsername)
+  val personInfo = this.getInfoForPerson(crn)
   if (personInfo is PersonInfoResult.NotFound) throw NotFoundProblem(crn, "Offender")
   if (personInfo is PersonInfoResult.Success.Restricted) throw ForbiddenProblem()
 

--- a/src/main/resources/db/migration/all/20231017175537__create_table_for_external_users.sql
+++ b/src/main/resources/db/migration/all/20231017175537__create_table_for_external_users.sql
@@ -1,0 +1,12 @@
+-- create new table for external users
+CREATE TABLE external_users (
+    id              UUID                        NOT NULL,
+    username        TEXT                        NOT NULL,
+    origin          TEXT                        NOT NULL,
+    is_enabled      BOOLEAN                     NOT NULL,
+    created_at      TIMESTAMP WITH TIME ZONE    NOT NULL,
+    updated_at      TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY (id),
+    UNIQUE (username)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserEntityFactory.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class ExternalUserEntityFactory : Factory<ExternalUserEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var username: Yielded<String> = { randomStringUpperCase(12) }
+  private var isEnabled: Yielded<Boolean> = { true }
+  private var origin: Yielded<String> = { "NACRO" }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withUsername(username: String) = apply {
+    this.username = { username }
+  }
+
+  override fun produce(): ExternalUserEntity = ExternalUserEntity(
+    id = this.id(),
+    username = this.username(),
+    isEnabled = this.isEnabled(),
+    origin = this.origin(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
@@ -110,6 +111,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
@@ -173,6 +175,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DomainEventTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExtensionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExternalUserTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedReasonTestRepository
@@ -386,6 +389,9 @@ abstract class IntegrationTestBase {
   lateinit var nomisUserRepository: NomisUserTestRepository
 
   @Autowired
+  lateinit var externalUserRepository: ExternalUserTestRepository
+
+  @Autowired
   lateinit var userRoleAssignmentRepository: UserRoleAssignmentTestRepository
 
   @Autowired
@@ -481,6 +487,7 @@ abstract class IntegrationTestBase {
   lateinit var temporaryAccommodationAssessmentJsonSchemaEntityFactory: PersistedFactory<TemporaryAccommodationAssessmentJsonSchemaEntity, UUID, TemporaryAccommodationAssessmentJsonSchemaEntityFactory>
   lateinit var userEntityFactory: PersistedFactory<UserEntity, UUID, UserEntityFactory>
   lateinit var nomisUserEntityFactory: PersistedFactory<NomisUserEntity, UUID, NomisUserEntityFactory>
+  lateinit var externalUserEntityFactory: PersistedFactory<ExternalUserEntity, UUID, ExternalUserEntityFactory>
   lateinit var userRoleAssignmentEntityFactory: PersistedFactory<UserRoleAssignmentEntity, UUID, UserRoleAssignmentEntityFactory>
   lateinit var userQualificationAssignmentEntityFactory: PersistedFactory<UserQualificationAssignmentEntity, UUID, UserQualificationAssignmentEntityFactory>
   lateinit var approvedPremisesAssessmentEntityFactory: PersistedFactory<ApprovedPremisesAssessmentEntity, UUID, ApprovedPremisesAssessmentEntityFactory>
@@ -562,6 +569,7 @@ abstract class IntegrationTestBase {
     temporaryAccommodationAssessmentJsonSchemaEntityFactory = PersistedFactory({ TemporaryAccommodationAssessmentJsonSchemaEntityFactory() }, temporaryAccommodationAssessmentJsonSchemaRepository)
     approvedPremisesPlacementApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory() }, approvedPremisesPlacementApplicationJsonSchemaRepository)
     nomisUserEntityFactory = PersistedFactory({ NomisUserEntityFactory() }, nomisUserRepository)
+    externalUserEntityFactory = PersistedFactory({ ExternalUserEntityFactory() }, externalUserRepository)
     userEntityFactory = PersistedFactory({ UserEntityFactory() }, userRepository)
     userRoleAssignmentEntityFactory = PersistedFactory({ UserRoleAssignmentEntityFactory() }, userRoleAssignmentRepository)
     userQualificationAssignmentEntityFactory = PersistedFactory({ UserQualificationAssignmentEntityFactory() }, userQualificationAssignmentRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -49,6 +49,57 @@ class Cas2ApplicationTest : IntegrationTestBase() {
   }
 
   @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `creating an application is forbidden to external users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/applications")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `updating an application is forbidden to external users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.put()
+        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `submitting an application is forbidden to external users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd/submission")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
   inner class MissingJwt {
     @Test
     fun `Get all applications without JWT returns 401`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -463,6 +463,61 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `Assessor can NOT view single in-progress application`() {
+      `Given a CAS2 Assessor` { _, jwt ->
+        `Given a CAS2 User` { user, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            cas2ApplicationJsonSchemaRepository.deleteAll()
+
+            val newestJsonSchema = cas2ApplicationJsonSchemaEntityFactory
+              .produceAndPersist {
+                withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+                withSchema(
+                  """
+          {
+            "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+            "${"\$id"}": "https://example.com/product.schema.json",
+            "title": "Thing",
+            "description": "A thing",
+            "type": "object",
+            "properties": {
+              "thingId": {
+                "description": "The unique identifier for a thing",
+                "type": "integer"
+              }
+            },
+            "required": [ "thingId" ]
+          }
+          """,
+                )
+              }
+
+            val applicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(newestJsonSchema)
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(user)
+              withSubmittedAt(null)
+              withData(
+                """
+            {
+               "thingId": 123
+            }
+            """,
+              )
+            }
+
+            val rawResponseBody = webTestClient.get()
+              .uri("/cas2/applications/${applicationEntity.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isNotFound
+          }
+        }
+      }
+    }
+
+    @Test
     fun `Get single application returns successfully when the person cannot be fetched from the prisons API`() {
       `Given a CAS2 User`() { userEntity, jwt ->
         val crn = "X1234"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserDetailF
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -110,6 +111,20 @@ fun IntegrationTestBase.`Given a CAS2 User`(
   }
 
   val jwt = jwtAuthHelper.createValidNomisAuthorisationCodeJwt(nomisUserDetails.username)
+
+  block(user, jwt)
+}
+
+fun IntegrationTestBase.`Given a CAS2 Assessor`(
+  id: UUID = UUID.randomUUID(),
+  block: (externalUserEntity: ExternalUserEntity, jwt: String) -> Unit,
+) {
+  val user = externalUserEntityFactory.produceAndPersist {
+    withId(id)
+    withUsername("CAS2_ASSESSOR_USER")
+  }
+
+  val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt("CAS2_ASSESSOR_USER")
 
   block(user, jwt)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ExternalUserTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ExternalUserTestRepository.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
+import java.util.UUID
+
+@Repository
+interface ExternalUserTestRepository : JpaRepository<ExternalUserEntity, UUID> {
+  fun findByUsername(username: String): ExternalUserEntity?
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/OffenderServiceTest.kt
@@ -244,11 +244,10 @@ class OffenderServiceTest {
     @Test
     fun `returns NotFound if Community API responds with a 404`() {
       val crn = "ABC123"
-      val nomisUsername = "USER"
 
       every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/ABC123", HttpStatus.NOT_FOUND, null, true)
 
-      val result = offenderService.getInfoForPerson(crn, nomisUsername)
+      val result = offenderService.getInfoForPerson(crn)
 
       assertThat(result is PersonInfoResult.NotFound).isTrue
     }
@@ -256,11 +255,10 @@ class OffenderServiceTest {
     @Test
     fun `returns Unknown if Community API responds with a 500`() {
       val crn = "ABC123"
-      val nomisUsername = "USER"
 
       every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/ABC123", HttpStatus.INTERNAL_SERVER_ERROR, null, true)
 
-      val result = offenderService.getInfoForPerson(crn, nomisUsername)
+      val result = offenderService.getInfoForPerson(crn)
 
       assertThat(result is PersonInfoResult.Unknown).isTrue
       result as PersonInfoResult.Unknown
@@ -271,7 +269,6 @@ class OffenderServiceTest {
     fun `returns Full for CRN with both Community API and Prison API data where Community API links to Prison API`() {
       val crn = "ABC123"
       val nomsNumber = "NOMSABC"
-      val nomisUsername = "USER"
 
       val offenderDetails = OffenderDetailsSummaryFactory()
         .withCrn(crn)
@@ -292,7 +289,7 @@ class OffenderServiceTest {
         body = inmateDetail,
       )
 
-      val result = offenderService.getInfoForPerson(crn, nomisUsername)
+      val result = offenderService.getInfoForPerson(crn)
 
       assertThat(result is PersonInfoResult.Success.Full).isTrue
       result as PersonInfoResult.Success.Full

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -70,6 +70,13 @@ class JwtAuthHelper {
       roles = listOf("ROLE_PRISON"),
     )
 
+  internal fun createValidExternalAuthorisationCodeJwt(username: String = "username") =
+    createAuthorizationCodeJwt(
+      subject = username,
+      authSource = "auth",
+      roles = listOf("ROLE_CAS2_ASSESSOR"),
+    )
+
   internal fun createValidAuthorizationCodeJwt(username: String = "username") = createAuthorizationCodeJwt(
     subject = username,
     authSource = "delius",


### PR DESCRIPTION
External users from NACRO will be logging into CAS to perform specific operations on *submitted* CAS2 applications only.

The users are managed on HMPPS auth and will have the role `CAS2_ASSESSOR` (the JWT 'authority' `ROLE_CAS2_ASSESSOR`). The `auth_source` of their claim will be `auth`. 

See AP-Tools [PR 48](https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/48) for a CAS2_ASSESSOR user for use in local development.

In this PR we:

- allow an external user to authenticate and create a representation for each one in a new `external_users` table
- allow holders of the `CAS2_ASSESSOR` role to `GET` a list of submitted applications or an individual submitted application.

#### A note on ApplicationStatus versus 'has been submitted'
  
Note that for "submitted" we test for the presence of a  
value in the `Cas2Application.submittedAt` timestamp. An  
application can be submitted exactly once and can never  
become "unsubmitted".  
  
i.e. "submitted" is an event rather than a status which  
changes from time to time. This is contrary to what is  
currently implied by ApplicationStatus:  
  
```  
ApplicationStatus:  
  type: string  
  enum:  
    - inProgress  
    - submitted  
    - requestedFurtherInformation  
    - pending  
    - rejected  
    - awaitingPlacement  
    - placed  
    - inapplicable  
    - withdrawn  
```  
  
In CAS2 we will be requiring external users from NACRO  
(logging in with the `CAS2_ASSESSOR` role) to provide updates on  
their progress in taking submitted applications through the  
assessment and placement process which they manage in their  
own NACRO / OpenHousing systems.  
  
So it will be clearer for CAS2 to model something  
like a `CAS2ExternalWorkflowStatus` which can go though  
states such as:  
  
- `pendingAssessment`  
- `furtherInfoRequested`  
- `applicationWithdrawn`  
- `accepted / rejected`  
- `placed`  
- `bookingCancelled`  
  
We probably need to implement a lightweight state-machine to  
ensure that only valid transitions are made. e.g. that an  
application isn't moved from `pendingAssessment` to  
`bookingCancelled` without having been first `accepted`.  
  
As these workflow updates will be made by NACRO outside of  
their actual workflow perhaps it will be necessary for us to  
ask for the date on which the status change occurred. e.g.  
"When was this application accepted?" as this is not  
necessarily when the event is being reported in our  
service...
