### PR TITLE
Feature/1644 expect a eligibility reason for cas3 referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -308,6 +308,7 @@ class TemporaryAccommodationApplicationEntity(
   var isDutyToReferSubmitted: Boolean?,
   var dutyToReferSubmissionDate: LocalDate?,
   var isEligible: Boolean?,
+  var eligibilityReason: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -324,6 +324,7 @@ class ApplicationService(
             isDutyToReferSubmitted = null,
             dutyToReferSubmissionDate = null,
             isEligible = null,
+            eligibilityReason = null,
           ),
         )
 
@@ -670,6 +671,7 @@ class ApplicationService(
       isDutyToReferSubmitted = submitApplication.isDutyToReferSubmitted
       dutyToReferSubmissionDate = submitApplication.dutyToReferSubmissionDate
       isEligible = submitApplication.isApplicationEligible
+      eligibilityReason = submitApplication.eligibilityReason
     }
 
     assessmentService.createTemporaryAccommodationAssessment(application, submitApplication.summaryData ?: {})

--- a/src/main/resources/db/migration/all/20231018164717__add_elibility_reason_to_cas3_applications.sql
+++ b/src/main/resources/db/migration/all/20231018164717__add_elibility_reason_to_cas3_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE temporary_accommodation_applications ADD COLUMN eligibility_reason TEXT;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1863,6 +1863,8 @@ components:
               format: date
             isApplicationEligible:
               type: boolean
+            eligibilityReason:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5778,6 +5778,8 @@ components:
               format: date
             isApplicationEligible:
               type: boolean
+            eligibilityReason:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2166,6 +2166,8 @@ components:
               format: date
             isApplicationEligible:
               type: boolean
+            eligibilityReason:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -43,6 +43,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var isDutyToReferSubmitted: Yielded<Boolean?> = { null }
   private var dutyToReferSubmissionDate: Yielded<LocalDate?> = { null }
   private var isEligible: Yielded<Boolean?> = { null }
+  private var eligibilityReason: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -140,6 +141,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.isEligible = { isEligible }
   }
 
+  fun withEligiblilityReason(eligibilityReason: String?) = apply {
+    this.eligibilityReason = { eligibilityReason }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -164,5 +169,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     isDutyToReferSubmitted = this.isDutyToReferSubmitted(),
     dutyToReferSubmissionDate = this.dutyToReferSubmissionDate(),
     isEligible = this.isEligible(),
+    eligibilityReason = this.eligibilityReason(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1026,6 +1026,7 @@ class ApplicationServiceTest {
       isDutyToReferSubmitted = true,
       dutyToReferSubmissionDate = LocalDate.now().minusDays(7),
       isApplicationEligible = true,
+      eligibilityReason = "homelessFromApprovedPremises",
     )
 
     private val submitCas2Application = SubmitCas2Application(
@@ -1465,6 +1466,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.isDutyToReferSubmitted).isEqualTo(true)
       assertThat(persistedApplication.dutyToReferSubmissionDate).isEqualTo(LocalDate.now().minusDays(7))
       assertThat(persistedApplication.isEligible).isEqualTo(true)
+      assertThat(persistedApplication.eligibilityReason).isEqualTo("homelessFromApprovedPremises")
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) { mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplicationWithMiReportingData.summaryData!!) }


### PR DESCRIPTION
The `eligiblityReason` is a new field we have to put into our MI reports. This sits alongside the `isEligible` which we leave as it is since it's already been released.

[I used this earlier PR as a reference.](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/966)

[We will need to migrate the data out of the blob and into this field as a separate operation.](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1059)

Frontend changes: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/693