### PR TITLE
(485) Retire “Error in Booking” reason

### DIFF
--- a/src/main/resources/db/migration/all/20231019112844__retire_error_in_booking_reason.sql
+++ b/src/main/resources/db/migration/all/20231019112844__retire_error_in_booking_reason.sql
@@ -1,0 +1,2 @@
+-- Retire "Error in booking" reason
+UPDATE cancellation_reasons SET is_active = false WHERE id = '3a5afbfc-3c0f-11ee-be56-0242ac120002';


### PR DESCRIPTION
This is a duplicate, so we should retire it.