### PR TITLE
Backfill cas3 referrals so they have eligibility reasons

### DIFF
--- a/src/main/resources/db/migration/all/20231019120235__backfill_new_eligibility_reason_field_on_cas3_referrals.sql
+++ b/src/main/resources/db/migration/all/20231019120235__backfill_new_eligibility_reason_field_on_cas3_referrals.sql
@@ -1,0 +1,7 @@
+UPDATE temporary_accommodation_applications AS ta
+SET eligibility_reason = (
+    SELECT app.data->'eligibility'->'eligibility-reason'->>'reason'
+    FROM applications AS app
+    WHERE app.id = ta.id AND service ='temporary-accommodation'
+)
+WHERE eligibility_reason IS NULL;


### PR DESCRIPTION
We’ll need this historic data for referrals created so far in production.