### PR TITLE
Add an `isRestricted` argument to a `FullPerson`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -30,6 +30,7 @@ class PersonTransformer {
       prisonName = inOutStatusToPersonInfoApiStatus(personInfoResult.inmateDetail?.inOutStatus).takeIf { it == FullPerson.Status.inCustody }?.let {
         personInfoResult.inmateDetail?.assignedLivingUnit?.agencyName ?: personInfoResult.inmateDetail?.assignedLivingUnit?.agencyId
       },
+      isRestricted = (personInfoResult.offenderDetailSummary.currentExclusion || personInfoResult.offenderDetailSummary.currentRestriction),
     )
     is PersonInfoResult.Success.Restricted -> RestrictedPerson(
       type = PersonType.restrictedPerson,
@@ -55,6 +56,7 @@ class PersonTransformer {
       religionOrBelief = personInfoResult.summary.profile?.religion,
       genderIdentity = personInfoResult.summary.profile?.genderIdentity,
       prisonName = null,
+      isRestricted = (personInfoResult.summary.currentRestriction == true || personInfoResult.summary.currentExclusion == true),
     )
     is PersonSummaryInfoResult.Success.Restricted -> RestrictedPerson(
       type = PersonType.restrictedPerson,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -683,6 +683,8 @@ components:
                 - Unknown
             prisonName:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
             - dateOfBirth

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4598,6 +4598,8 @@ components:
                 - Unknown
             prisonName:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
             - dateOfBirth

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -986,6 +986,8 @@ components:
                 - Unknown
             prisonName:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
             - dateOfBirth

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -157,6 +157,7 @@ class PersonSearchTest : IntegrationTestBase() {
                 religionOrBelief = "Judaism",
                 genderIdentity = "This is a self described identity",
                 prisonName = "HMP Bristol",
+                isRestricted = false,
               ),
             ),
           )
@@ -204,6 +205,7 @@ class PersonSearchTest : IntegrationTestBase() {
                 religionOrBelief = "Judaism",
                 genderIdentity = "This is a self described identity",
                 prisonName = null,
+                isRestricted = false,
               ),
             ),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -129,6 +129,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
                 religionOrBelief = "Judaism",
                 genderIdentity = "This is a self described identity",
                 prisonName = "HMP Bristol",
+                isRestricted = false,
               ),
             ),
           )
@@ -176,6 +177,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
                 religionOrBelief = "Judaism",
                 genderIdentity = "This is a self described identity",
                 prisonName = null,
+                isRestricted = false,
               ),
             ),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -135,6 +135,7 @@ class PersonTransformerTest {
         religionOrBelief = "Sikh",
         genderIdentity = null,
         prisonName = null,
+        isRestricted = false,
       ),
     )
   }
@@ -226,6 +227,7 @@ class PersonTransformerTest {
         religionOrBelief = "Sikh",
         genderIdentity = null,
         prisonName = "HMP Bristol",
+        isRestricted = false,
       ),
     )
   }
@@ -251,6 +253,52 @@ class PersonTransformerTest {
     assertThat(result is FullPerson).isTrue
     result as FullPerson
     assertThat(result.genderIdentity).isEqualTo(null)
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly with an exclusion`() {
+    val crn = "CRN123"
+
+    val offenderDetailSummary = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withCurrentExclusion(true)
+      .produce()
+
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
+    )
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
+    result as FullPerson
+    assertThat(result.isRestricted).isTrue()
+  }
+
+  @Test
+  fun `transformModelToPersonInfoApi transforms correctly with a restriction`() {
+    val crn = "CRN123"
+
+    val offenderDetailSummary = OffenderDetailsSummaryFactory()
+      .withCrn(crn)
+      .withCurrentRestriction(true)
+      .produce()
+
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
+    )
+
+    val result = personTransformer.transformModelToPersonApi(personInfoResult)
+
+    assertThat(result.crn).isEqualTo(crn)
+    assertThat(result is FullPerson).isTrue
+    result as FullPerson
+    assertThat(result.isRestricted).isTrue()
   }
 
   @Test
@@ -325,6 +373,7 @@ class PersonTransformerTest {
         religionOrBelief = caseSummary.profile!!.religion,
         genderIdentity = caseSummary.profile!!.genderIdentity,
         prisonName = null,
+        isRestricted = false,
       ),
     )
   }


### PR DESCRIPTION
This will allow us to tell a user that the Person they have accessed is a Limited Access Offender, meaning even though they may be able to acces this offender’s details, other users may not be able to.