### PR TITLE
Fix memory errors on Daily Metrics and Referrals report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -40,14 +40,14 @@ interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
   fun <T : ApplicationEntity> findAllForServiceAndNameNull(type: Class<T>, pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
 
   @Query(
-    "SELECT * FROM approved_premises_applications apa " +
+    "SELECT application.created_at as createdAt, CAST(application.created_by_user_id as TEXT) as createdByUserId FROM approved_premises_applications apa " +
       "LEFT JOIN applications application ON application.id = apa.id " +
       "where date_part('month', application.created_at) = :month " +
       "AND date_part('year', application.created_at) = :year " +
       "AND application.service = 'approved-premises'",
     nativeQuery = true,
   )
-  fun findAllApprovedPremisesApplicationsCreatedInMonth(month: Int, year: Int): List<ApprovedPremisesApplicationEntity>
+  fun findAllApprovedPremisesApplicationsCreatedInMonth(month: Int, year: Int): List<ApprovedPremisesApplicationMetricsSummary>
 
   @Query(
     "SELECT a FROM ApplicationEntity a " +
@@ -349,4 +349,9 @@ interface ApprovedPremisesApplicationSummary : ApplicationSummary {
 
 interface TemporaryAccommodationApplicationSummary : ApplicationSummary {
   fun getRiskRatings(): String?
+}
+
+interface ApprovedPremisesApplicationMetricsSummary {
+  fun getCreatedAt(): Timestamp
+  fun getCreatedByUserId(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApprovedPremisesApplicationMetricsSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApprovedPremisesApplicationMetricsSummaryDto.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import java.time.LocalDate
+
+data class ApprovedPremisesApplicationMetricsSummaryDto(
+  val createdAt: LocalDate,
+  val createdByUserId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ReferralsDataDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ReferralsDataDto.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import java.time.LocalDate
+
+data class ReferralsDataDto(
+  val tier: String?,
+  val isEsapApplication: Boolean?,
+  val isPipeApplication: Boolean?,
+  val decision: String?,
+  val applicationSubmittedAt: LocalDate?,
+  val assessmentSubmittedAt: LocalDate?,
+  val rejectionRationale: String?,
+  val releaseType: String?,
+  val clarificationNoteCount: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Dail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.LostBedsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.PlacementMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ReferralsMetricsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TierCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
@@ -95,7 +96,12 @@ class ReportService(
   }
 
   fun createDailyMetricsReport(properties: DailyMetricReportProperties, outputStream: OutputStream) {
-    val applications = applicationRepository.findAllApprovedPremisesApplicationsCreatedInMonth(properties.month, properties.year)
+    val applications = applicationRepository.findAllApprovedPremisesApplicationsCreatedInMonth(properties.month, properties.year).map {
+      ApprovedPremisesApplicationMetricsSummaryDto(
+        it.getCreatedAt().toLocalDateTime().toLocalDate(),
+        it.getCreatedByUserId(),
+      )
+    }
     val domainEvents = domainEventRepository.findAllCreatedInMonth(properties.month, properties.year)
 
     val startDate = LocalDate.of(properties.year, properties.month, 1)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Lost
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.PlacementMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ReferralsMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ReferralsDataDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TierCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
@@ -117,7 +118,19 @@ class ReportService(
   }
 
   fun <T : Any> createReferralsMetricsReport(properties: ReferralsMetricsProperties, outputStream: OutputStream, categories: List<T>) {
-    val referrals = assessmentRepository.findAllCreatedInMonthAndYear(properties.month, properties.year)
+    val referrals = assessmentRepository.findAllReferralsDataForMonthAndYear(properties.month, properties.year).map {
+      ReferralsDataDto(
+        it.getTier(),
+        it.getIsEsapApplication(),
+        it.getIsPipeApplication(),
+        it.getDecision(),
+        it.getApplicationSubmittedAt()?.toLocalDateTime()?.toLocalDate(),
+        it.getAssessmentSubmittedAt()?.toLocalDateTime()?.toLocalDate(),
+        it.getRejectionRationale(),
+        it.getReleaseType(),
+        it.getClarificationNoteCount(),
+      )
+    }
 
     ReferralsMetricsReportGenerator<T>(referrals, workingDayCountService)
       .createReport(categories, properties)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.DailyMetricReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.DailyMetricReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
@@ -216,7 +217,14 @@ class DailyMetricsReportTest : IntegrationTestBase() {
         LocalDate.of(year, month, 30),
       )
 
-      val expectedDataFrame = DailyMetricsReportGenerator(domainEvents, applications, objectMapper)
+      val expectedApplications = applications.map {
+        ApprovedPremisesApplicationMetricsSummaryDto(
+          it.createdAt.toLocalDate(),
+          it.createdByUser.id.toString(),
+        )
+      }
+
+      val expectedDataFrame = DailyMetricsReportGenerator(domainEvents, expectedApplications, objectMapper)
         .createReport(
           datesForMonth,
           DailyMetricReportProperties(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -24,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemb
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.DailyMetricReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -76,28 +76,16 @@ class DailyMetricsReportGeneratorTest {
   fun `it groups applications and domain events by date`() {
     val applications = mapOf(
       dates[0] to mapOf(
-        user1 to ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(user1)
-          .withCreatedAt(dates[0].toLocalDateTime()).produceMany().take(4).toList(),
-        user2 to ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(user2)
-          .withCreatedAt(dates[0].toLocalDateTime()).produceMany().take(1).toList(),
-        user3 to ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(user3)
-          .withCreatedAt(dates[0].toLocalDateTime()).produceMany().take(3).toList(),
+        user1 to (1..4).map { ApprovedPremisesApplicationMetricsSummaryDto(dates[0], user1.id.toString()) },
+        user2 to (1..2).map { ApprovedPremisesApplicationMetricsSummaryDto(dates[0], user2.id.toString()) },
+        user3 to (1..3).map { ApprovedPremisesApplicationMetricsSummaryDto(dates[0], user3.id.toString()) },
       ),
       dates[1] to mapOf(
-        user1 to ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(user1)
-          .withCreatedAt(dates[1].toLocalDateTime()).produceMany().take(3).toList(),
+        user1 to (1..4).map { ApprovedPremisesApplicationMetricsSummaryDto(dates[1], user2.id.toString()) },
       ),
       dates[2] to mapOf(
-        user2 to ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(user2)
-          .withCreatedAt(dates[2].toLocalDateTime()).produceMany().take(3).toList(),
-        user3 to ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(user3)
-          .withCreatedAt(dates[2].toLocalDateTime()).produceMany().take(3).toList(),
+        user2 to (1..3).map { ApprovedPremisesApplicationMetricsSummaryDto(dates[2], user2.id.toString()) },
+        user3 to (1..2).map { ApprovedPremisesApplicationMetricsSummaryDto(dates[2], user3.id.toString()) },
       ),
     )
 


### PR DESCRIPTION
The Daily Metrics and Referrals reports wer erroring as we were loading all the application JSON in memory. This tweaks the queries we use to only return what we need, cast it as a DTO in the service, and then pass the list of DTOs to the Generators.