### PR TITLE
Increase max-response-in-memory-size-bytes

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -227,5 +227,5 @@ manual-bookings-domain-events-disabled: true
 upstream-timeout-ms: 10000
 case-notes-service-upstream-timeout-ms: 30000
 
-max-response-in-memory-size-bytes: 512000
+max-response-in-memory-size-bytes: 750000
 


### PR DESCRIPTION
Attempted fix for https://ministryofjustice.sentry.io/issues/4401628845/?project=4503931792392192&query=is%3Aunresolved+N013922&referrer=issue-stream&statsPeriod=90d&stream_index=0 

We initially tried to increase max-in-memory-size, but this setting overrides that