### PR TITLE
Add maxResponseInMemorySize config to PrisonsAPI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -135,6 +135,11 @@ class WebClientConfiguration(
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
         ),
       )
+      .exchangeStrategies(
+        ExchangeStrategies.builder().codecs {
+          it.defaultCodecs().maxInMemorySize(maxResponseInMemorySizeBytes)
+        }.build(),
+      )
       .filter(oauth2Client)
       .build()
   }


### PR DESCRIPTION
Following on from #1066 - the config we set was only used in the Community API previously, so we'll use this setting for Prisons API too.