### PR TITLE
(413) Add sentence type to Application Report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -29,6 +29,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
           ELSE 'normal'
         END
       ) as premisesType,
+      application.data -> 'basic-information' -> 'sentence-type' ->> 'sentenceType' as sentenceType,
       submission_event.data -> 'eventDetails' ->> 'releaseType' as releaseType,
       cast(submission_event.data -> 'eventDetails' ->> 'submittedAt' as date) as applicationSubmissionDate,
       submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'ldu' ->> 'name' as referralLdu,
@@ -93,6 +94,8 @@ interface ApplicationEntityReportRow {
   fun getOffenceId(): String
   fun getNoms(): String
   fun getPremisesType(): String?
+
+  fun getSentenceType(): String?
 
   fun getReleaseType(): String?
   fun getApplicationSubmissionDate(): Date?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -28,6 +28,7 @@ class ApplicationReportGenerator(
         noms = this.getNoms(),
         premisesType = this.getPremisesType(),
         releaseType = this.getReleaseType(),
+        sentenceType = this.getSentenceType(),
         applicationSubmissionDate = this.getApplicationSubmissionDate()?.toLocalDate(),
         referralLdu = this.getReferralLdu(),
         referralRegion = this.getReferralRegion(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -16,6 +16,7 @@ data class ApplicationReportRow(
   val noms: String?,
   val premisesType: String?,
   val releaseType: String?,
+  val sentenceType: String?,
   val applicationSubmissionDate: LocalDate?,
   val referralLdu: String?,
   val referralRegion: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -307,6 +307,19 @@ class ApplicationReportsTest : IntegrationTestBase() {
       withCrn(offenderDetails.otherIds.crn)
       withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
       withApplicationSchema(applicationSchema)
+      withData(
+        objectMapper.writeValueAsString(
+          mapOf(
+            "basic-information" to
+              mapOf(
+                "sentence-type"
+                  to mapOf(
+                    "sentenceType" to "Some Sentence Type",
+                  ),
+              ),
+          ),
+        ),
+      )
       withRiskRatings(
         PersonRisksFactory()
           .withMappa(


### PR DESCRIPTION
This is needed for performance reporting. The original plan was to have a breakddown by release type and sentence type, but we’ve agreed that adding this to the application report was sufficient.