### PR TITLE
Bump Guava version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("com.github.ben-manes.caffeine:caffeine")
+  implementation("com.google.guava:guava:32.1.3-jre")
 
   runtimeOnly("org.postgresql:postgresql:42.6.0")
 


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2023-2976

This is used by kotlinx/dataframe, but is not included directly.