### PR TITLE
Add missing CAS2 domain event feature flag for local env

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,8 @@ hmpps.sqs:
 domain-events:
   cas1:
     emit-enabled: true
+  cas2:
+    emit-enabled: true
   cas3:
     emit-enabled: true
 


### PR DESCRIPTION
In the Cloud Platform deployed environments these flags are set with environment variables set in the Helm 'values.yaml' e.g.

```
DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
```