### PR TITLE
(APS-14) Hide withdrawn assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -102,6 +102,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
            join applications ap on a.application_id = ap.id
            left outer join approved_premises_applications apa on ap.id = apa.id
      where a.reallocated_at is null
+           and a.is_withdrawn is false
            and (?1 is null or a.allocated_to_user_id = cast(?1 as UUID))
     """,
   resultSetMapping = "DomainAssessmentSummaryMapping",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -37,7 +37,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   @Query(nativeQuery = true)
   fun findTemporaryAccommodationAssessmentSummariesForRegionAndCrn(probationRegionId: UUID, crn: String): List<DomainAssessmentSummary>
 
-  @Query("SELECT a FROM AssessmentEntity a WHERE a.reallocatedAt IS NULL AND a.submittedAt IS NULL AND TYPE(a) = :type")
+  @Query("SELECT a FROM AssessmentEntity a WHERE a.reallocatedAt IS NULL AND a.isWithdrawn != true AND a.submittedAt IS NULL AND TYPE(a) = :type")
   fun <T : AssessmentEntity> findAllByReallocatedAtNullAndSubmittedAtNullAndType(type: Class<T>): List<AssessmentEntity>
 
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -116,6 +116,16 @@ class AssessmentTest : IntegrationTestBase() {
 
         reallocatedAssessment.schemaUpToDate = true
 
+        val withdrawnAssessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
+          withAllocatedToUser(user)
+          withApplication(application)
+          withAssessmentSchema(assessmentSchema)
+          withDecision(assessmentDecision)
+          withIsWithdrawn(true)
+        }
+
+        withdrawnAssessment.schemaUpToDate = true
+
         webTestClient.get()
           .uri("/assessments")
           .header("Authorization", "Bearer $jwt")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -74,6 +74,14 @@ class TasksTest : IntegrationTestBase() {
               reallocated = true,
             )
 
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              reallocated = true,
+              isWithdrawn = true,
+            )
+
             `Given an Assessment for Temporary Accommodation`(
               allocatedToUser = otherUser,
               createdByUser = otherUser,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -18,6 +18,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   decision: AssessmentDecision? = null,
   submittedAt: OffsetDateTime? = null,
   createdAt: OffsetDateTime? = null,
+  isWithdrawn: Boolean = false,
 ): Pair<AssessmentEntity, ApprovedPremisesApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -34,6 +35,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withApplicationSchema(applicationSchema)
     withSubmittedAt(OffsetDateTime.now())
     withReleaseType("licence")
+    withIsWithdrawn(isWithdrawn)
   }
 
   val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
@@ -49,6 +51,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     if (reallocated) {
       withReallocatedAt(OffsetDateTime.now())
     }
+    withIsWithdrawn(isWithdrawn)
   }
 
   assessment.schemaUpToDate = true


### PR DESCRIPTION
Now assessments can be withdrawn, we need to hide them on the assessments and application listing pages.