### PR TITLE
Implement submissions endpoint for assessors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -60,6 +60,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/events/cas2/application-submitted/*", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(HttpMethod.GET, "/cas2/applications/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
+        authorize(HttpMethod.GET, "/cas2/submissions/**", hasRole("CAS2_ASSESSOR"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -59,7 +59,6 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/application-submitted/*", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
-        authorize(HttpMethod.GET, "/cas2/applications/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasRole("CAS2_ASSESSOR"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.SubmissionsCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getFullInfoForPersonOrThrow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getInfoForPersonOrThrowInternalServerError
+import java.util.UUID
+
+@Service("Cas2SubmissionsController")
+class SubmissionsController(
+  private val httpAuthService: HttpAuthService,
+  private val applicationService: ApplicationService,
+  private val applicationsTransformer: ApplicationsTransformer,
+  private val offenderService: OffenderService,
+  private val externalUserService: ExternalUserService,
+) : SubmissionsCas2Delegate {
+
+  override fun submissionsGet(): ResponseEntity<List<Cas2SubmittedApplicationSummary>> {
+    httpAuthService.getCas2AuthenticatedPrincipalOrThrow()
+    ensureExternalUserPersisted()
+    val applications = applicationService.getAllSubmittedApplicationsForAssessor()
+    return ResponseEntity.ok(applications.map { getPersonDetailAndTransformToSummary(it) })
+  }
+
+  override fun submissionsApplicationIdGet(applicationId: UUID): ResponseEntity<Cas2SubmittedApplication> {
+    httpAuthService.getCas2AuthenticatedPrincipalOrThrow()
+
+    val application = when (
+      val applicationResult = applicationService.getSubmittedApplicationForAssessor(applicationId)
+    ) {
+      is AuthorisableActionResult.NotFound -> null
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> applicationResult.entity
+    }
+
+    if (application != null) {
+      return ResponseEntity.ok(getPersonDetailAndTransform(application))
+    }
+    throw NotFoundProblem(applicationId, "Application")
+  }
+
+  private fun ensureExternalUserPersisted() {
+    externalUserService.getUserForRequest()
+  }
+
+  private fun getPersonDetailAndTransformToSummary(
+    application: Cas2ApplicationSummary,
+  ):
+    Cas2SubmittedApplicationSummary {
+    val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
+
+    return applicationsTransformer.transformJpaSummaryToCas2SubmittedSummary(
+      application,
+      personInfo,
+    )
+  }
+
+  private fun getPersonDetailAndTransform(
+    application: Cas2ApplicationEntity,
+  ): Cas2SubmittedApplication {
+    val personInfo = offenderService.getFullInfoForPersonOrThrow(application.crn)
+
+    return applicationsTransformer.transformJpaToSubmittedApplication(
+      application,
+      personInfo,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -32,6 +34,26 @@ class ApplicationsTransformer(
     )
   }
 
+  fun transformJpaToSubmittedApplication(
+    jpa: Cas2ApplicationEntity,
+    personInfo:
+      PersonInfoResult
+      .Success,
+  ):
+    Cas2SubmittedApplication {
+    return Cas2SubmittedApplication(
+      id = jpa.id,
+      person = personTransformer.transformModelToPersonApi(personInfo),
+      createdByUserId = jpa.createdByUser.id,
+      schemaVersion = jpa.schemaVersion.id,
+      outdatedSchema = !jpa.schemaUpToDate,
+      createdAt = jpa.createdAt.toInstant(),
+      submittedAt = jpa.submittedAt?.toInstant(),
+      document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
+      status = getStatus(jpa),
+    )
+  }
+
   fun transformJpaSummaryToSummary(
     jpaSummary: Cas2ApplicationSummary,
     personInfo:
@@ -47,6 +69,21 @@ class ApplicationsTransformer(
         status = getStatusFromSummary(jpaSummary),
         type = "CAS2",
       )
+  }
+
+  fun transformJpaSummaryToCas2SubmittedSummary(
+    jpaSummary: Cas2ApplicationSummary,
+    personInfo:
+      PersonInfoResult.Success,
+  ): Cas2SubmittedApplicationSummary {
+    return Cas2SubmittedApplicationSummary(
+      id = jpaSummary.getId(),
+      person = personTransformer.transformModelToPersonApi(personInfo),
+      createdByUserId = jpaSummary.getCreatedByUserId(),
+      createdAt = jpaSummary.getCreatedAt().toInstant(),
+      submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
+      status = getStatusFromSummary(jpaSummary),
+    )
   }
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1589,6 +1589,40 @@ components:
             - schemaVersion
             - outdatedSchema
             - status
+    Cas2SubmittedApplication:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - person
+        - createdAt
+        - createdByUserId
+        - schemaVersion
+        - outdatedSchema
+        - status
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -1711,6 +1745,31 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2SubmittedApplicationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - status
+        - id
+        - person
+        - createdAt
     ApplicationStatus:
       type: string
       enum:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -163,6 +163,52 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /submissions:
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: List summaries of all submitted CAS2 applications
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Cas2SubmittedApplicationSummary'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /submissions/{applicationId}:
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Gets a single submitted CAS2 application by its ID
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2SubmittedApplication'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /people/search:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5504,6 +5504,40 @@ components:
             - schemaVersion
             - outdatedSchema
             - status
+    Cas2SubmittedApplication:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - person
+        - createdAt
+        - createdByUserId
+        - schemaVersion
+        - outdatedSchema
+        - status
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -5626,6 +5660,31 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2SubmittedApplicationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - status
+        - id
+        - person
+        - createdAt
     ApplicationStatus:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -165,6 +165,52 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /submissions:
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: List summaries of all submitted CAS2 applications
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas2SubmittedApplicationSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /submissions/{applicationId}:
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Gets a single submitted CAS2 application by its ID
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2SubmittedApplication'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /people/search:
     get:
       tags:
@@ -1892,6 +1938,40 @@ components:
             - schemaVersion
             - outdatedSchema
             - status
+    Cas2SubmittedApplication:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - person
+        - createdAt
+        - createdByUserId
+        - schemaVersion
+        - outdatedSchema
+        - status
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -2014,6 +2094,31 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2SubmittedApplicationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - status
+        - id
+        - person
+        - createdAt
     ApplicationStatus:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -1,0 +1,298 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2SubmissionTest : IntegrationTestBase() {
+  @SpykBean
+  lateinit var realApplicationRepository: ApplicationRepository
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realApplicationRepository)
+  }
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `viewing submitted applications is forbidden to internal users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_PRISON"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/submissions")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `viewing a single submitted application is forbidden to internal users based on     role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_PRISON"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/submissions/66911cf0-75b1-4361-84bd-501b176fd4fd")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class MissingJwt {
+    @Test
+    fun `Get all submitted applications without JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas2/submissions")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get single submitted application without JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas2/submissions/9b785e59-b85c-4be0-b271-d9ac287684b6")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+  }
+
+  @Nested
+  inner class GetToIndex {
+
+    @Test
+    fun `Assessor can view ALL submitted applications`() {
+      `Given a CAS2 Assessor` { _externalUserEntity, jwt ->
+        `Given a CAS2 User` { user, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            cas2ApplicationJsonSchemaRepository.deleteAll()
+
+            val applicationSchema =
+              cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withAddedAt(OffsetDateTime.now())
+                withId(UUID.randomUUID())
+              }
+
+            val submittedCas2ApplicationEntity = cas2ApplicationEntityFactory
+              .produceAndPersist {
+                withApplicationSchema(applicationSchema)
+                withCreatedByUser(user)
+                withCrn(offenderDetails.otherIds.crn)
+                withSubmittedAt(OffsetDateTime.parse("2023-01-01T09:00:00+01:00"))
+                withData("{}")
+              }
+
+            val inProgressCas2ApplicationEntity = cas2ApplicationEntityFactory
+              .produceAndPersist {
+                withApplicationSchema(applicationSchema)
+                withCreatedByUser(user)
+                withCrn(offenderDetails.otherIds.crn)
+                withSubmittedAt(null)
+                withData("{}")
+              }
+
+            val rawResponseBody = webTestClient.get()
+              .uri("/cas2/submissions")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.cas2.value)
+              .exchange()
+              .expectStatus()
+              .isOk
+              .returnResult<String>()
+              .responseBody
+              .blockFirst()
+
+            val responseBody =
+              objectMapper.readValue(
+                rawResponseBody,
+                object : TypeReference<List<Cas2SubmittedApplicationSummary>>() {},
+              )
+
+            Assertions.assertThat(responseBody).anyMatch {
+              submittedCas2ApplicationEntity.id == it.id &&
+                submittedCas2ApplicationEntity.crn == it.person.crn &&
+                submittedCas2ApplicationEntity.createdAt.toInstant() == it.createdAt &&
+                submittedCas2ApplicationEntity.createdByUser.id == it.createdByUserId &&
+                submittedCas2ApplicationEntity.submittedAt?.toInstant() == it.submittedAt
+            }
+
+            Assertions.assertThat(responseBody).noneMatch {
+              inProgressCas2ApplicationEntity.id == it.id
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class GetToShow {
+    @Test
+    fun `Assessor can view single submitted application`() {
+      `Given a CAS2 Assessor` { _, jwt ->
+        `Given a CAS2 User` { user, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            cas2ApplicationJsonSchemaRepository.deleteAll()
+
+            val newestJsonSchema = cas2ApplicationJsonSchemaEntityFactory
+              .produceAndPersist {
+                withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+                withSchema(
+                  """
+          {
+            "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+            "${"\$id"}": "https://example.com/product.schema.json",
+            "title": "Thing",
+            "description": "A thing",
+            "type": "object",
+            "properties": {
+              "thingId": {
+                "description": "The unique identifier for a thing",
+                "type": "integer"
+              }
+            },
+            "required": [ "thingId" ]
+          }
+          """,
+                )
+              }
+
+            val applicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(newestJsonSchema)
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(user)
+              withSubmittedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+              withData(
+                """
+            {
+               "thingId": 123
+            }
+            """,
+              )
+            }
+
+            val rawResponseBody = webTestClient.get()
+              .uri("/cas2/submissions/${applicationEntity.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .returnResult<String>()
+              .responseBody
+              .blockFirst()
+
+            val responseBody = objectMapper.readValue(
+              rawResponseBody,
+              Cas2SubmittedApplication::class.java,
+            )
+
+            Assertions.assertThat(responseBody).matches {
+              applicationEntity.id == it.id &&
+                applicationEntity.crn == it.person.crn &&
+                applicationEntity.createdAt.toInstant() == it.createdAt &&
+                applicationEntity.createdByUser.id == it.createdByUserId &&
+                applicationEntity.submittedAt?.toInstant() == it.submittedAt &&
+                serializableToJsonNode(applicationEntity.document) ==
+                  serializableToJsonNode(it.document) &&
+                newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Assessor can NOT view single in-progress application`() {
+      `Given a CAS2 Assessor` { _, jwt ->
+        `Given a CAS2 User` { user, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            cas2ApplicationJsonSchemaRepository.deleteAll()
+
+            val newestJsonSchema = cas2ApplicationJsonSchemaEntityFactory
+              .produceAndPersist {
+                withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+                withSchema(
+                  """
+          {
+            "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+            "${"\$id"}": "https://example.com/product.schema.json",
+            "title": "Thing",
+            "description": "A thing",
+            "type": "object",
+            "properties": {
+              "thingId": {
+                "description": "The unique identifier for a thing",
+                "type": "integer"
+              }
+            },
+            "required": [ "thingId" ]
+          }
+          """,
+                )
+              }
+
+            val applicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(newestJsonSchema)
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(user)
+              withSubmittedAt(null)
+              withData(
+                """
+            {
+               "thingId": 123
+            }
+            """,
+              )
+            }
+
+            val rawResponseBody = webTestClient.get()
+              .uri("/cas2/submissions/${applicationEntity.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isNotFound
+          }
+        }
+      }
+    }
+  }
+
+  private fun serializableToJsonNode(serializable: Any?): JsonNode {
+    if (serializable == null) return NullNode.instance
+    if (serializable is String) return objectMapper.readTree(serializable)
+
+    return objectMapper.readTree(objectMapper.writeValueAsString(serializable))
+  }
+}


### PR DESCRIPTION
## Add a new `/cas2/submissions` endpoint to represent submitted applications

In this PR I make a case for introducing a new REST resource to represent applications 
which have been submitted.

The other CAS services introduce a new DB entity (`Assessment`), but I think this is
overkill for our needs. We can achieve the "separation of concerns" which we need
by introducing a new API model (REST representation) to present the existing application
record in the post-submission world.

### In detail

When the UI asks that API for a list of applications, what is the appropriate
range of filtering which should be implicitly applied by the API?

`GET /applications`
  - APPLICANT: all applications which I've created (filter on associated user)
  - ASSESSOR: all application which have been submitted (filter on submittedAt
    presence)
  - ADMIN: all applications (no filter)

`GET /application/{applicationId}`
  - APPLICANT: 403 if I didn't create the application
  - ASSESSOR: 404 if the application hasn't yet been submitted

I think it's reasonable to implicitly filter a list of resources according to
some access rules, which could become slightly complex, such as:

- APPLICANT can see applications they've created
- APPLICANT can see applications made to their region
- APPLICANT can see applications where an assessor has named them in a request
  for further information

It becomes more opaque if we combine this with rules which are based on the
**state of the application** as well as on the **role of the user**, e.g.

- ASSESSOR can see only applications which have been submitted

### Beyond "apply"

The submission of an application is an important milestone (consider the
`application.submitted` domain event). The mutable form `data` is stored in a
permanent read-only `document` as a full and reliable record of the risks and
needs at the time of application.

The lifecycle of the accommodation workflow moves to a new stage on submission
of the application. It's not a  stage out which the application can transition,
it's an event which cannot be undone.

If we agree that the API should not handle filtering submitted applications
implicitly, how should the UI request them explicitly? Two options:

1. url params, e.g. `GET /cas2/applications?filters=[submitted]`. In this
   approach the complexity at the API is retained: the controller actions still
   needs to handle the logic of whether to return all applications or just those
   which have been submitted.
2. dedicated url e.g. `GET /cas2/submissions`. In this approach a new endpoint
   and controller (and API representation) can be used.

### Re-presenting Application as Submission / SubmittedApplication

I believe that by giving this different entity its own name e.g. **submission**
we can make our code simpler.

The new `cas2/submissions` endpoint can return a new representation of an
application which has been through the submission process. This
SubmittedApplication or SubmittedApplicationSummary can do a much better (more
specialised) job of meeting our needs as we leave the "apply" journey behind.
e.g.

- `data` is no longer relevant or helpful. Only exposing `document` is clearer
  and less error prone in displaying a submitted application.
- we can add in a list of `StatusUpdates` to our new `SubmittedApplication`
  representations


![submissions_endpoints](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/206b4f32-411e-4ba5-8438-e3898af2a9bf)

![cas2_submitted_application](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/1255215a-da68-428f-a6b3-0c117347e591)

![cas2_submitted_application_summary](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/ebd8ff31-c1a5-417d-a387-f410db2eb22b)

### Not included

This PR does not include moving `POST /cas2/applications/submission` to the new controller as 
`POST /cas2/submissions` -- but this would now be the correct way to "submit an application":
i.e. "create a submission".

