### PR TITLE
Double memory allocation

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,9 +6,9 @@ generic-service:
 
   resources:
     limits:
-      memory: 1.5Gi
+      memory: 3Gi
     requests:
-      memory: 1Gi
+      memory: 2.5Gi
 
 
   ingress:
@@ -16,7 +16,7 @@ generic-service:
     tlsSecretName: hmpps-approved-premises-api-prod-cert
 
   env:
-    JAVA_OPTS: "-Xmx1000m"
+    JAVA_OPTS: "-Xmx2000m"
     SPRING_PROFILES_ACTIVE: prod
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
Double the memory limits  and double the maximum java heap allowancee in an effort to prevent out of memory exceptions being fired[1].

The CAS3 frontend[2] and CAS1 frontend[3] are exp seemingly random request timeouts after 30s.

There was another recent effort to increase memory size of spring[4] but without detail of what this was attempting to fix, it’s hard to know if this was a related attempt.

[1] https://ministryofjustice.sentry.io/issues/4087001141/?environment=prod&project=4503931792392192&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0
[2] https://ministryofjustice.sentry.io/issues/4383361316/events/?environment=prod&project=4504129156218880&referrer=issue-stream&statsPeriod=90d&stream_index=0
[3] https://ministryofjustice.sentry.io/issues/4379817471/events/?environment=prod&project=4503931667742720&referrer=issue-stream&statsPeriod=90d&stream_index=0
[4] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1065