### PR TITLE
Include referral columns in booking report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import java.time.LocalDate
@@ -9,8 +10,20 @@ import java.time.temporal.ChronoUnit
 class BookingsReportGenerator : ReportGenerator<BookingEntity, BookingsReportRow, BookingsReportProperties>(BookingsReportRow::class) {
 
   override val convert: BookingEntity.(properties: BookingsReportProperties) -> List<BookingsReportRow> = {
+    val application = this.application as? TemporaryAccommodationApplicationEntity
+
     listOf(
       BookingsReportRow(
+        referralId = application?.id?.toString(),
+        referralDate = application?.submittedAt?.toLocalDate(),
+        riskOfSeriousHarm = application?.riskRatings?.roshRisks?.value?.overallRisk,
+        sexOffender = application?.isRegisteredSexOffender,
+        needForAccessibleProperty = application?.needsAccessibleProperty,
+        historyOfArsonOffence = application?.hasHistoryOfArson,
+        dutyToReferMade = application?.isDutyToReferSubmitted,
+        dateDutyToReferMade = application?.dutyToReferSubmissionDate,
+        isReferralEligibleForCas3 = application?.isEligible,
+        referralEligibilityReason = application?.eligibilityReason,
         probationRegion = this.premises.probationRegion.name,
         crn = this.crn,
         offerAccepted = this.confirmation != null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
@@ -3,6 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
 import java.time.LocalDate
 
 data class BookingsReportRow(
+  val referralId: String?,
+  val referralDate: LocalDate?,
+  val riskOfSeriousHarm: String?,
+  val sexOffender: Boolean?,
+  val needForAccessibleProperty: Boolean?,
+  val historyOfArsonOffence: Boolean?,
+  val dutyToReferMade: Boolean?,
+  val dateDutyToReferMade: LocalDate?,
+  val isReferralEligibleForCas3: Boolean?,
+  val referralEligibilityReason: String?,
   val probationRegion: String,
   val crn: String,
   val offerAccepted: Boolean,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -145,6 +145,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.eligibilityReason = { eligibilityReason }
   }
 
+  fun withRiskRatings(configuration: PersonRisksFactory.() -> Unit) = apply {
+    this.riskRatings = { PersonRisksFactory().apply(configuration).produce() }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),


### PR DESCRIPTION
> See [ticket #1516 on the CAS3 Trello board](https://trello.com/c/fixhLvcQ/1516-include-new-referral-columns-in-the-mi-report-download).

There are several columns that are now required for MI reporting for bookings that have applications. For bookings not associated with an application these must be empty, but otherwise should be included in the booking report.