### PR TITLE
Move CAS2 application submission endpoint to /cas2/submissions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.ApplicationsCas2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
@@ -126,29 +124,6 @@ class ApplicationsController(
     }
 
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication, user))
-  }
-
-  override fun applicationsApplicationIdSubmissionPost(
-    applicationId: UUID,
-    submitApplication: SubmitCas2Application,
-  ): ResponseEntity<Unit> {
-    httpAuthService.getNomisPrincipalOrThrow()
-    val submitResult = applicationService.submitApplication(applicationId, submitApplication)
-
-    val validationResult = when (submitResult) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.Success -> submitResult.entity
-    }
-
-    when (validationResult) {
-      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
-      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
-      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
-      is ValidatableActionResult.Success -> Unit
-    }
-
-    return ResponseEntity(HttpStatus.OK)
   }
 
   private fun getPersonDetailAndTransformToSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -1,15 +1,20 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.SubmissionsCas2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
@@ -50,6 +55,28 @@ class SubmissionsController(
       return ResponseEntity.ok(getPersonDetailAndTransform(application))
     }
     throw NotFoundProblem(applicationId, "Application")
+  }
+
+  override fun submissionsPost(
+    submitApplication: SubmitCas2Application,
+  ): ResponseEntity<Unit> {
+    httpAuthService.getNomisPrincipalOrThrow()
+    val submitResult = applicationService.submitApplication(submitApplication)
+
+    val validationResult = when (submitResult) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(submitApplication.applicationId, "Application")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> submitResult.entity
+    }
+
+    when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.Success -> Unit
+    }
+
+    return ResponseEntity(HttpStatus.OK)
   }
 
   private fun ensureExternalUserPersisted() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -156,10 +156,9 @@ class ApplicationService(
 
   @Transactional
   fun submitApplication(
-    applicationId: UUID,
     submitApplication: SubmitCas2Application,
   ): AuthorisableActionResult<ValidatableActionResult<Cas2ApplicationEntity>> {
-    var application = applicationRepository.findByIdOrNullWithWriteLock(applicationId)
+    var application = applicationRepository.findByIdOrNullWithWriteLock(submitApplication.applicationId)
       ?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1901,8 +1901,17 @@ components:
             - targetLocation
             - releaseType
     SubmitCas2Application:
-      allOf:
-        - $ref: '#/components/schemas/SubmitApplication'
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+        applicationId:
+          type: string
+          format: uuid
+          description: Id of the application being submitted
+      required:
+        - translatedDocument
+        - applicationId
     SubmitTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/SubmitApplication'

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -128,19 +128,30 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
-  /applications/{applicationId}/submission:
+  /submissions:
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: List summaries of all submitted CAS2 applications
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Cas2SubmittedApplicationSummary'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
     post:
       tags:
         - Operations on CAS2 applications
-      summary: Submits a CAS2 Application
-      parameters:
-        - in: path
-          name: applicationId
-          required: true
-          description: Id of the application
-          schema:
-            type: string
-            format: uuid
+      summary: Submits a CAS2 Application (creates a SubmittedApplication)
       requestBody:
         description: Information needed to submit an application
         content:
@@ -157,26 +168,6 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
-  /submissions:
-    get:
-      tags:
-        - Operations on submitted CAS2 applications (Assessors)
-      summary: List summaries of all submitted CAS2 applications
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '_shared.yml#/components/schemas/Cas2SubmittedApplicationSummary'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5888,8 +5888,17 @@ components:
             - targetLocation
             - releaseType
     SubmitCas2Application:
-      allOf:
-        - $ref: '#/components/schemas/SubmitApplication'
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+        applicationId:
+          type: string
+          format: uuid
+          description: Id of the application being submitted
+      required:
+        - translatedDocument
+        - applicationId
     SubmitTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/SubmitApplication'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -130,13 +130,32 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
-  /applications/{applicationId}/submission:
+  /submissions:
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: List summaries of all submitted CAS2 applications
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas2SubmittedApplicationSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
     post:
       tags:
         - Operations on CAS2 applications
       summary: Submits a CAS2 Application
       parameters:
-        - in: path
+        - in: query
           name: applicationId
           required: true
           description: Id of the application
@@ -159,26 +178,6 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
-  /submissions:
-    get:
-      tags:
-        - Operations on submitted CAS2 applications (Assessors)
-      summary: List summaries of all submitted CAS2 applications
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Cas2SubmittedApplicationSummary'
         401:
           $ref: '#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -153,15 +153,7 @@ paths:
     post:
       tags:
         - Operations on CAS2 applications
-      summary: Submits a CAS2 Application
-      parameters:
-        - in: query
-          name: applicationId
-          required: true
-          description: Id of the application
-          schema:
-            type: string
-            format: uuid
+      summary: Submits a CAS2 Application (creates a SubmittedApplication)
       requestBody:
         description: Information needed to submit an application
         content:
@@ -2249,8 +2241,17 @@ components:
             - targetLocation
             - releaseType
     SubmitCas2Application:
-      allOf:
-        - $ref: '#/components/schemas/SubmitApplication'
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+        applicationId:
+          type: string
+          format: uuid
+          description: Id of the application being submitted
+      required:
+        - translatedDocument
+        - applicationId
     SubmitTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/SubmitApplication'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -5,18 +5,22 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.NullNode
 import com.ninjasquad.springmockk.SpykBean
 import io.mockk.clearMocks
+import io.mockk.every
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -35,6 +39,22 @@ class Cas2SubmissionTest : IntegrationTestBase() {
 
   @Nested
   inner class ControlsOnExternalUsers {
+    @Test
+    fun `submitting an application is forbidden to external users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/submissions?applicationId=de6512fc-a225-4109-bdcd-86c6307a5237")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
     @Test
     fun `viewing submitted applications is forbidden to internal users based on role`() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
@@ -284,6 +304,141 @@ class Cas2SubmissionTest : IntegrationTestBase() {
               .expectStatus()
               .isNotFound
           }
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class PostToCreate {
+    @Test
+    fun `Submit Cas2 application returns 200`() {
+      `Given a CAS2 User`() { submittingUser, jwt ->
+        `Given a CAS2 User` { userEntity, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+            val applicationSchema =
+              cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withAddedAt(OffsetDateTime.now())
+                withId(UUID.randomUUID())
+                withSchema(
+                  """
+                {
+                  "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+                  "${"\$id"}": "https://example.com/product.schema.json",
+                  "title": "Thing",
+                  "description": "A thing",
+                  "type": "object",
+                  "properties": {},
+                  "required": []
+                }
+              """,
+                )
+              }
+
+            cas2ApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails.otherIds.crn)
+              withId(applicationId)
+              withApplicationSchema(applicationSchema)
+              withCreatedByUser(submittingUser)
+              withData(
+                """
+                {}
+              """,
+              )
+            }
+
+            webTestClient.post()
+              .uri("/cas2/submissions")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.cas2.value)
+              .bodyValue(
+                SubmitCas2Application(
+                  applicationId = applicationId,
+                  translatedDocument = {},
+                ),
+              )
+              .exchange()
+              .expectStatus()
+              .isOk
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `When several concurrent submit application requests occur, only one is successful, all others return 400`() {
+      `Given a CAS2 User`() { submittingUser, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+          val applicationSchema = cas2ApplicationJsonSchemaEntityFactory
+            .produceAndPersist {
+              withAddedAt(OffsetDateTime.now())
+              withId(UUID.randomUUID())
+              withSchema(
+                """
+            {
+              "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+              "${"\$id"}": "https://example.com/product.schema.json",
+              "title": "Thing",
+              "description": "A thing",
+              "type": "object",
+              "properties": {}
+              },
+              "required": [  ]
+            }
+          """,
+              )
+            }
+
+          cas2ApplicationEntityFactory.produceAndPersist {
+            withCrn(offenderDetails.otherIds.crn)
+            withId(applicationId)
+            withApplicationSchema(applicationSchema)
+            withCreatedByUser(submittingUser)
+            withData(
+              """
+                {}
+              """,
+            )
+          }
+
+          every { realApplicationRepository.save(any()) } answers {
+            Thread.sleep(1000)
+            it.invocation.args[0] as ApplicationEntity
+          }
+
+          val responseStatuses = mutableListOf<HttpStatus>()
+
+          (1..10).map {
+            val thread = Thread {
+              webTestClient.post()
+                .uri("/cas2/submissions")
+                .header("Authorization", "Bearer $jwt")
+                .bodyValue(
+                  SubmitCas2Application(
+                    applicationId = applicationId,
+                    translatedDocument = {},
+                  ),
+                )
+                .exchange()
+                .returnResult<String>()
+                .consumeWith {
+                  synchronized(responseStatuses) {
+                    responseStatuses += it.status
+                  }
+                }
+            }
+
+            thread.start()
+
+            thread
+          }.forEach(Thread::join)
+
+          Assertions.assertThat(responseStatuses.count { it.value() == 200 }).isEqualTo(1)
+          Assertions.assertThat(responseStatuses.count { it.value() == 400 }).isEqualTo(9)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1032,17 +1032,11 @@ class ApplicationServiceTest {
       eligibilityReason = "homelessFromApprovedPremises",
     )
 
-    private val submitCas2Application = SubmitCas2Application(
-      translatedDocument = {},
-      type = "CAS2",
-    )
-
     @BeforeEach
     fun setup() {
       every { mockObjectMapper.writeValueAsString(submitApprovedPremisesApplication.translatedDocument) } returns "{}"
       every { mockObjectMapper.writeValueAsString(submitTemporaryAccommodationApplication.translatedDocument) } returns "{}"
       every { mockObjectMapper.writeValueAsString(submitTemporaryAccommodationApplicationWithMiReportingData.translatedDocument) } returns "{}"
-      every { mockObjectMapper.writeValueAsString(submitCas2Application.translatedDocument) } returns "{}"
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -390,7 +390,7 @@ class ApplicationServiceTest {
 
     private val submitCas2Application = SubmitCas2Application(
       translatedDocument = {},
-      type = "CAS2",
+      applicationId = applicationId
     )
 
     @BeforeEach
@@ -405,7 +405,7 @@ class ApplicationServiceTest {
 
       every { mockApplicationRepository.findByIdOrNullWithWriteLock(applicationId) } returns null
 
-      assertThat(applicationService.submitApplication(applicationId, submitCas2Application) is AuthorisableActionResult.NotFound).isTrue
+      assertThat(applicationService.submitApplication(submitCas2Application) is AuthorisableActionResult.NotFound).isTrue
     }
 
     @Test
@@ -425,7 +425,7 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns
         application
 
-      assertThat(applicationService.submitApplication(applicationId, submitCas2Application) is AuthorisableActionResult.Unauthorised).isTrue
+      assertThat(applicationService.submitApplication(submitCas2Application) is AuthorisableActionResult.Unauthorised).isTrue
     }
 
     @Test
@@ -445,7 +445,7 @@ class ApplicationServiceTest {
       } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-      val result = applicationService.submitApplication(applicationId, submitCas2Application)
+      val result = applicationService.submitApplication(submitCas2Application)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       result as AuthorisableActionResult.Success
@@ -476,7 +476,7 @@ class ApplicationServiceTest {
       } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
-      val result = applicationService.submitApplication(applicationId, submitCas2Application)
+      val result = applicationService.submitApplication(submitCas2Application)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       result as AuthorisableActionResult.Success
@@ -524,7 +524,7 @@ class ApplicationServiceTest {
 
       val _schema = application.schemaVersion as Cas2ApplicationJsonSchemaEntity
 
-      val result = applicationService.submitApplication(applicationId, submitCas2Application)
+      val result = applicationService.submitApplication(submitCas2Application)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       result as AuthorisableActionResult.Success


### PR DESCRIPTION
**This should be merged with the corresponding change at the UI https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/273**

CAS2 Applications are now submitted using a POST to the submissions endpoint:

`POST /cas2/submissions` with
  `{ translatedDocument: JSON, applicationId: UUID}`

rather than

`POST /cas2/applications/{applicationId}/submission` with
  `{ translatedDocument: JSON, type: 'CAS2'}`

Representing a submitted application as a "submission" resource with a type of `CAS2SubmittedApplication`
allows us to avoid adding to complexity to the `ApplicationsController`.

Note also that:

- the `applicationId` is now received as the `applicationId`
  form data param rather than being in the path.

- the `type` param is no longer part of the interface, as this was not being used.

![post_submissions](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/5f3360ef-0f6c-4a38-a1cd-206e8e4fb113)
