### PR TITLE
Add debug info for manual bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import arrow.core.Either
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -123,6 +124,8 @@ class BookingService(
   @Value("\${arrived-departed-domain-events-disabled}") private val arrivedAndDepartedDomainEventsDisabled: Boolean,
 ) {
   val approvedPremisesBookingAppealedCancellationReasonId: UUID = UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")
+
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   fun updateBooking(bookingEntity: BookingEntity): BookingEntity = bookingRepository.save(bookingEntity)
   fun getBooking(id: UUID) = bookingRepository.findByIdOrNull(id)
@@ -333,6 +336,14 @@ class BookingService(
       val onlineApplication = if (application is Either.Left<ApprovedPremisesApplicationEntity>) application.value else null
       val offlineApplication = if (application is Either.Right<OfflineApplicationEntity>) application.value else null
 
+      if (onlineApplication != null) {
+        log.info("Found online application: ${onlineApplication.id}")
+      }
+
+      if (offlineApplication != null) {
+        log.info("Found offline application: ${offlineApplication.id}")
+      }
+
       val bookingCreatedAt = OffsetDateTime.now()
 
       val booking = bookingRepository.save(
@@ -366,9 +377,15 @@ class BookingService(
       associateBookingWithPlacementRequest(onlineApplication, booking)
 
       if (!isCalledFromSeeder) {
+        val applicationId = (onlineApplication?.id ?: offlineApplication?.id)
+        val eventNumberForDomainEvent = (onlineApplication?.eventNumber ?: offlineApplication?.eventNumber)
+
+        log.info("Using application ID: $applicationId")
+        log.info("Using Event Number: $eventNumber")
+
         saveBookingMadeDomainEvent(
-          applicationId = (onlineApplication?.id ?: offlineApplication?.id)!!,
-          eventNumber = (onlineApplication?.eventNumber ?: offlineApplication?.eventNumber)!!,
+          applicationId = applicationId!!,
+          eventNumber = eventNumberForDomainEvent!!,
           booking = booking,
           user = user!!,
           bookingCreatedAt = bookingCreatedAt,
@@ -430,6 +447,7 @@ class BookingService(
       .maxByOrNull { it.createdAt }
 
     if (newestSubmittedOnlineApplication == null && newestOfflineApplication == null) {
+      log.info("No online or offline application, so we create a new offline application")
       newestOfflineApplication = applicationService.createOfflineApplication(
         OfflineApplicationEntity(
           id = UUID.randomUUID(),
@@ -442,10 +460,13 @@ class BookingService(
     }
 
     return if (newestOfflineApplication != null && newestSubmittedOnlineApplication != null && newestOfflineApplication.createdAt.isBefore(newestSubmittedOnlineApplication.submittedAt)) {
+      log.info("Offline application is created before the online application, so returning the offline application")
       Either.Right(newestOfflineApplication)
     } else if (newestSubmittedOnlineApplication != null) {
+      log.info("Returning online application")
       Either.Left(newestSubmittedOnlineApplication)
     } else {
+      log.info("Returning offline application")
       Either.Right(newestOfflineApplication!!)
     }
   }


### PR DESCRIPTION
We have some nullability issues (see https://ministryofjustice.sentry.io/issues/4590242455/?project=4503931667742720&project=4503931792392192&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=0) when running the e2e tests, so adding some logging to see what’s going on.