### PR TITLE
(APS-13) Use provided event number if application has none

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -378,10 +378,10 @@ class BookingService(
 
       if (!isCalledFromSeeder) {
         val applicationId = (onlineApplication?.id ?: offlineApplication?.id)
-        val eventNumberForDomainEvent = (onlineApplication?.eventNumber ?: offlineApplication?.eventNumber)
+        val eventNumberForDomainEvent = (onlineApplication?.eventNumber ?: offlineApplication?.eventNumber ?: eventNumber)
 
         log.info("Using application ID: $applicationId")
-        log.info("Using Event Number: $eventNumber")
+        log.info("Using Event Number: $eventNumberForDomainEvent")
 
         saveBookingMadeDomainEvent(
           applicationId = applicationId!!,


### PR DESCRIPTION
In some cases an offline application may have already been created for a CRN. If this is the case, we’ll use the eventNumber that has been provided, rather than the one from the offline application.