### PR TITLE
Chore/enable detekt on ci

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -345,6 +345,6 @@ gatling {
 detekt {
   config = files("./detekt.yml")
   buildUponDefaultConfig = true
-  ignoreFailures = true
+  ignoreFailures = false
   baseline = file("./detekt-baseline.xml")
 }

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -15,7 +15,7 @@
     <ID>CyclomaticComplexMethod:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$private fun createBooking( row: ApprovedPremisesBookingSeedCsvRow, )</ID>
     <ID>CyclomaticComplexMethod:AssessmentService.kt$AssessmentService$fun acceptAssessment(user: UserEntity, assessmentId: UUID, document: String?, placementRequirements: PlacementRequirements?, placementDates: PlacementDates?, notes: String?): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
     <ID>CyclomaticComplexMethod:AssessmentService.kt$AssessmentService$fun rejectAssessment(user: UserEntity, assessmentId: UUID, document: String?, rejectionRationale: String): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesAdHocBooking( user: UserEntity? = null, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, bookingId: UUID? = null, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
+    <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesAdHocBooking( user: UserEntity? = null, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, eventNumber: String?, bookingId: UUID = UUID.randomUUID(), ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
     <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesBookingFromPlacementRequest( user: UserEntity, placementRequestId: UUID, bedId: UUID?, premisesId: UUID?, arrivalDate: LocalDate, departureDate: LocalDate, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
     <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$@Transactional fun createCas1Arrival( user: UserEntity? = null, booking: BookingEntity, arrivalDateTime: Instant, expectedDepartureDate: LocalDate, notes: String?, keyWorkerStaffCode: String?, )</ID>
     <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$fun createNonArrival( user: UserEntity?, booking: BookingEntity, date: LocalDate, reasonId: UUID, notes: String?, )</ID>
@@ -79,181 +79,24 @@
     <ID>ImplicitDefaultLocale:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$String.format("%.1f%%", percentage)</ID>
     <ID>ImplicitDefaultLocale:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$String.format("%.1f%%", percentage)</ID>
     <ID>InvalidPackageDeclaration:UserSpecifications.kt$package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.specification</ID>
-    <ID>LargeClass:ApplicationService.kt$ApplicationService</ID>
     <ID>LargeClass:ApplicationServiceTest.kt$ApplicationServiceTest</ID>
     <ID>LargeClass:ApplicationTest.kt$ApplicationTest : IntegrationTestBase</ID>
-    <ID>LargeClass:AssessmentService.kt$AssessmentService</ID>
     <ID>LargeClass:AssessmentServiceTest.kt$AssessmentServiceTest</ID>
     <ID>LargeClass:AssessmentTest.kt$AssessmentTest : IntegrationTestBase</ID>
-    <ID>LargeClass:BedSearchServiceTest.kt$BedSearchServiceTest</ID>
-    <ID>LargeClass:BedSearchTest.kt$BedSearchTest : IntegrationTestBase</ID>
     <ID>LargeClass:BookingService.kt$BookingService</ID>
     <ID>LargeClass:BookingServiceTest.kt$BookingServiceTest</ID>
-    <ID>LargeClass:BookingServiceTest.kt$BookingServiceTest$CreateApprovedPremisesBookingFromPlacementRequest</ID>
     <ID>LargeClass:BookingTest.kt$BookingTest : IntegrationTestBase</ID>
     <ID>LargeClass:BookingTransformerTest.kt$BookingTransformerTest</ID>
     <ID>LargeClass:DomainEventServiceTest.kt$DomainEventServiceTest</ID>
     <ID>LargeClass:LostBedsTest.kt$LostBedsTest : IntegrationTestBase</ID>
-    <ID>LargeClass:PremisesController.kt$PremisesController : PremisesApiDelegate</ID>
     <ID>LargeClass:PremisesTest.kt$PremisesTest : IntegrationTestBase</ID>
-    <ID>LargeClass:SeedBookingsTest.kt$SeedBookingsTest : SeedTestBase</ID>
-    <ID>LargeClass:UserAccessServiceTest.kt$UserAccessServiceTest</ID>
-    <ID>LongMethod:AcceptAssessmentTest.kt$AcceptAssessmentTest$@Test fun `acceptAssessment returns updated assessment, emits domain event, sends email, creates placement request when requirements provided`()</ID>
-    <ID>LongMethod:ApplicationReportsTest.kt$ApplicationReportsTest$private fun createAndSubmitApplication(apType: ApType): ApprovedPremisesApplicationEntity</ID>
-    <ID>LongMethod:ApplicationService.kt$ApplicationService$@Transactional fun submitApprovedPremisesApplication(applicationId: UUID, submitApplication: SubmitApprovedPremisesApplication, username: String, jwt: String): AuthorisableActionResult&lt;ValidatableActionResult&lt;ApplicationEntity&gt;&gt;</ID>
-    <ID>LongMethod:ApplicationService.kt$ApplicationService$@Transactional fun withdrawApprovedPremisesApplication( applicationId: UUID, user: UserEntity, withdrawalReason: String, otherReason: String?, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;Unit&gt;&gt;</ID>
-    <ID>LongMethod:ApplicationService.kt$ApplicationService$fun createApprovedPremisesApplication( offenderDetails: OffenderDetailSummary, user: UserEntity, jwt: String, convictionId: Long?, deliusEventNumber: String?, offenceId: String?, createWithRisks: Boolean? = true, )</ID>
-    <ID>LongMethod:ApplicationService.kt$ApplicationService$fun createTemporaryAccommodationApplication( crn: String, user: UserEntity, jwt: String, convictionId: Long?, deliusEventNumber: String?, offenceId: String?, createWithRisks: Boolean? = true, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;ApplicationEntity&gt;&gt;</ID>
-    <ID>LongMethod:ApplicationService.kt$ApplicationService$private fun createApplicationSubmittedEvent(application: ApprovedPremisesApplicationEntity, submitApplication: SubmitApprovedPremisesApplication, username: String, jwt: String)</ID>
-    <ID>LongMethod:ApplicationServiceTest.kt$ApplicationServiceTest$@Test fun `createApprovedPremisesApplication returns Success with created Application, persists Risk data and Offender name`()</ID>
-    <ID>LongMethod:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$@Test fun `submitApprovedPremisesApplication returns Success, creates assessment and stores event, sends confirmation email`()</ID>
-    <ID>LongMethod:ApplicationSummaryQueryTest.kt$ApplicationSummaryQueryTest$@Test fun `findAllTemporaryAccommodationSummariesCreatedByUser query works as described`()</ID>
-    <ID>LongMethod:ApplicationSummaryQueryTest.kt$ApplicationSummaryQueryTest$@Test fun `findNonWithdrawnApprovedPremisesSummariesForUser query works as described`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `Get all applications returns 200 with correct body - when user does not have roles returns applications managed by their teams`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `Get all applications returns 200 with correct body for Temporary Accommodation - when user has CAS3_ASSESSOR role then returns all submitted applications in region`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `Get single application returns 200 with correct body`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `Get single online application returns 200 with correct body, non-upgradable outdated application marked as such`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `Submit Temporary Accommodation application returns 200`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `Submit application returns 200, creates and allocates an assessment, saves a domain event, emits an SNS event`()</ID>
-    <ID>LongMethod:ApplicationTest.kt$ApplicationTest$@Test fun `When several concurrent submit application requests occur, only one is successful, all others return 400 without persisting domain events`()</ID>
-    <ID>LongMethod:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$@Test() fun `it returns application timeliness data`()</ID>
-    <ID>LongMethod:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$private fun createBooking( row: ApprovedPremisesBookingSeedCsvRow, )</ID>
-    <ID>LongMethod:AssessmentService.kt$AssessmentService$fun acceptAssessment(user: UserEntity, assessmentId: UUID, document: String?, placementRequirements: PlacementRequirements?, placementDates: PlacementDates?, notes: String?): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>LongMethod:AssessmentService.kt$AssessmentService$fun rejectAssessment(user: UserEntity, assessmentId: UUID, document: String?, rejectionRationale: String): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>LongMethod:AssessmentService.kt$AssessmentService$private fun reallocateApprovedPremisesAssessment( assigneeUser: UserEntity, currentAssessment: ApprovedPremisesAssessmentEntity, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>LongMethod:AssessmentServiceTest.kt$AssessmentServiceTest$@Test fun `reallocateAssessment for Approved Premises returns Success, deallocates old assessment and creates a new one, sends allocation email &amp; deallocation email`()</ID>
-    <ID>LongMethod:AssessmentServiceTest.kt$AssessmentServiceTest$@Test fun `rejectAssessment returns updated assessment, emits domain event, sends email`()</ID>
-    <ID>LongMethod:AssessmentTest.kt$AssessmentTest$@Test fun `Accept assessment returns 200, persists decision, creates and allocates a placement request, and emits SNS domain event message when requirements provided`()</ID>
-    <ID>LongMethod:AssessmentTest.kt$AssessmentTest$@Test fun `Accept assessment returns 200, persists decision, does not create a Placement Request, creates Placement Requirements and emits SNS domain event message when placement date information not provided`()</ID>
-    <ID>LongMethod:AssessmentTest.kt$AssessmentTest$@Test fun `Get Temporary Accommodation assessment by ID returns 200 with notes transformed correctly`()</ID>
-    <ID>LongMethod:AssessmentTest.kt$AssessmentTest$@Test fun `Get all assessments returns restricted person information for LAO`()</ID>
-    <ID>LongMethod:BedSearchRepository.kt$BedSearchRepository$fun findApprovedPremisesBeds( postcodeDistrictOutcode: String, maxDistanceMiles: Int, startDate: LocalDate, durationInDays: Int, requiredPremisesCharacteristics: List&lt;UUID&gt;, requiredRoomCharacteristics: List&lt;UUID&gt;, ): List&lt;ApprovedPremisesBedSearchResult&gt;</ID>
-    <ID>LongMethod:BedSearchRepository.kt$BedSearchRepository$fun findTemporaryAccommodationBeds( probationDeliveryUnit: String, startDate: LocalDate, endDate: LocalDate, probationRegionId: UUID, ): List&lt;TemporaryAccommodationBedSearchResult&gt;</ID>
     <ID>LongMethod:BedSearchRepositoryTest.kt$BedSearchRepositoryTest$@Test fun `Searching for a Temporary Accommodation Bed returns correct results`()</ID>
     <ID>LongMethod:BedSearchRepositoryTest.kt$BedSearchRepositoryTest$@Test fun `Searching for an Approved Premises Bed returns correct results`()</ID>
-    <ID>LongMethod:BedSearchResultTransformer.kt$BedSearchResultTransformer$private fun transformResult(result: DomainBedSearchResult)</ID>
-    <ID>LongMethod:BedSearchServiceTest.kt$BedSearchServiceTest$@Test fun `findApprovedPremisesBeds returns results from repository`()</ID>
-    <ID>LongMethod:BedSearchServiceTest.kt$BedSearchServiceTest$@Test fun `findTemporaryAccommodationBeds does not return results for beds that currently have turnarounds`()</ID>
-    <ID>LongMethod:BedSearchServiceTest.kt$BedSearchServiceTest$@Test fun `findTemporaryAccommodationBeds returns results from repository`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for a Temporary Accommodation Bed returns 200 with correct body`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for a Temporary Accommodation Bed returns results that do not include beds with current turnarounds`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for a Temporary Accommodation Bed returns results which do not consider cancelled bookings as overlapping`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for a Temporary Accommodation Bed returns results which do not include non-overlapping bookings`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for a Temporary Accommodation Bed returns results which include overlapping bookings across multiple premises`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for a Temporary Accommodation Bed returns results which include overlapping bookings for rooms in the same premises`()</ID>
-    <ID>LongMethod:BedSearchTest.kt$BedSearchTest$@Test fun `Searching for an Approved Premises Bed returns 200 with correct body`()</ID>
-    <ID>LongMethod:BedSummaryQueryTest.kt$BedSummaryQueryTest$@Test fun `summary works shows basic bed details and status`()</ID>
-    <ID>LongMethod:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$@Test fun `effectiveTurnaroundDays shows the total number of days (regardless of whether working days) in the month for the turnaround`()</ID>
-    <ID>LongMethod:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$@Test fun `scheduledTurnaroundDays shows the number of working days in the month for the turnaround`()</ID>
-    <ID>LongMethod:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$@Test fun `totalBookedDays shows the combined total days in the month of non-cancelled bookings, not non-cancelled voids or turnarounds - totalDaysInTheMonth, occupancyRate show correctly`()</ID>
-    <ID>LongMethod:BookingSearchRepository.kt$BookingSearchRepository$fun findBookings( serviceName: ServiceName, status: BookingStatus?, probationRegionId: UUID?, ): List&lt;BookingSearchResult&gt;</ID>
-    <ID>LongMethod:BookingSearchTest.kt$BookingSearchTest$@Test fun `Results are filtered by booking status when query parameter is supplied`()</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesAdHocBooking( user: UserEntity? = null, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, bookingId: UUID? = null, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesBookingFromPlacementRequest( user: UserEntity, placementRequestId: UUID, bedId: UUID?, premisesId: UUID?, arrivalDate: LocalDate, departureDate: LocalDate, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$@Transactional fun createCas1Arrival( user: UserEntity? = null, booking: BookingEntity, arrivalDateTime: Instant, expectedDepartureDate: LocalDate, notes: String?, keyWorkerStaffCode: String?, )</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$@Transactional fun createTemporaryAccommodationBooking( user: UserEntity, premises: TemporaryAccommodationPremisesEntity, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, assessmentId: UUID?, enableTurnarounds: Boolean, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$fun createNonArrival( user: UserEntity?, booking: BookingEntity, date: LocalDate, reasonId: UUID, notes: String?, )</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$private fun createCas1Cancellation( user: UserEntity?, booking: BookingEntity, cancelledAt: LocalDate, reasonId: UUID, notes: String?, )</ID>
-    <ID>LongMethod:BookingService.kt$BookingService$private fun createCas1Departure( user: UserEntity?, booking: BookingEntity, dateTime: OffsetDateTime, reasonId: UUID, moveOnCategoryId: UUID, destinationProviderId: UUID?, notes: String?, )</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@ParameterizedTest @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"]) fun `createApprovedPremisesAdHocBooking saves Booking and creates Domain Event when associated Application is an Online Application`(role: UserRole)</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@ParameterizedTest @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"]) fun `createApprovedPremisesAdHocBooking saves Booking and does not create Domain Event when associated Application is an Online Application and manualBookingsDomainEventsDisabled is true`(role: UserRole)</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createApprovedPremisesAdHocBooking succeeds when creating a double Booking`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createCancellation emits domain event when linked to Application`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createCancellation returns Success and creates new Placement Request when cancellation reason is 'Booking successfully appealed' and cancelled Booking was linked to Placement Request`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createCas1Arrival does not emit domain event when arrivedAndDepartedDomainEventsDisabled is true`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createDeparture for a CAS3 booking returns Success with correct result when validation passed and saves a domain event`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createDeparture for an Approved Premises booking does not emit domain event when associated with Application but arrivedAndDepartedDomainEventsDisabled is true`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createDeparture for an Approved Premises booking returns Success with correct result when validation passed, saves Domain Event when associated with Online Application`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createExtension emits domain event when Booking has associated Application`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest$@Test fun `createNonArrival returns Success with correct result when validation passed, saves Domain Event when associated with Online Application`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$@Test fun `createApprovedPremisesBookingFromPlacementRequest saves Booking, creates Domain Event and sends email when a premisesId is provided`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$@Test fun `createApprovedPremisesBookingFromPlacementRequest saves Booking, creates Domain Event and sends email`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$@Test fun `createApprovedPremisesBookingFromPlacementRequest saves successfully when the user is not assigned to the placement request and is a Workflow Manager`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest.CreateCas1Arrival$@Test fun `createCas1Arrival returns Success with correct result when validation passed, saves Domain Event when associated with Online Application`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$@Test fun `does not emit domain event when booking has associated application but was not created from placement request and manualBookingsDomainEventsDisabled is true`()</ID>
-    <ID>LongMethod:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$@Test fun `emits domain event when booking has associated application`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Approved Premises Booking returns OK with correct body emits domain event`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Approved Premises Booking returns OK with correct body when NOMS number is null`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Departure updates departure date for an Approved Premises booking`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Temporary Accommodation Booking returns OK with correct body when only cancelled bookings for the same bed overlap`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Temporary Accommodation Booking returns OK with correct body when only cancelled lost beds for the same bed overlap`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Temporary Accommodation Booking returns OK with correct body`()</ID>
-    <ID>LongMethod:BookingTest.kt$BookingTest$@Test fun `Create Temporary Accommodation Extension returns 409 Conflict when another booking for the same bed overlaps with the updated booking's turnaround time`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Approved Premises Arrived entity is correctly transformed`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Approved Premises Cancelled entity is correctly transformed`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Approved Premises Departed entity is correctly transformed`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Approved Premises Non Arrival entity is correctly transformed`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Approved Premises entity with application and assessment is correctly transformed`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Temporary Accommodation Confirmed entity is correctly transformed`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Temporary Accommodation Entity with edited cancellation is correctly transformed`()</ID>
     <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Temporary Accommodation Entity with edited departure is correctly transformed`()</ID>
     <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Temporary Accommodation entity with non-zero day turnaround period and departure with turnaround period in past is correctly transformed to closed status`()</ID>
     <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Temporary Accommodation entity with non-zero day turnaround period and departure within turnaround period is correctly transformed to departed status`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Temporary Accommodation entity with zero day turnaround period and departure is correctly transformed to closed status`()</ID>
-    <ID>LongMethod:BookingTransformerTest.kt$BookingTransformerTest$@Test fun `Turnarounds on a booking are correctly transformed`()</ID>
-    <ID>LongMethod:CalendarRepositoryTest.kt$CalendarRepositoryTest$@Test fun `Results are correct for a Premises with double-booked Bookings &amp; Lost Bed`()</ID>
-    <ID>LongMethod:CalendarRepositoryTest.kt$CalendarRepositoryTest$@Test fun `Results are correct for a Premises with non-double-booked Bookings &amp; Lost Bed`()</ID>
-    <ID>LongMethod:CalendarTransformerTest.kt$CalendarTransformerTest$@Test fun `transformDomainToApi transforms double-Booking and Lost Bed with gaps (for open entry) correctly`()</ID>
-    <ID>LongMethod:Cas2ApplicationTest.kt$Cas2ApplicationTest.GetToShow$@Test fun `Get single application returns 200 with correct body`()</ID>
-    <ID>LongMethod:Cas2ApplicationTest.kt$Cas2ApplicationTest.PostToSubmit$@Test fun `When several concurrent submit application requests occur, only one is successful, all others return 400`()</ID>
-    <ID>LongMethod:Cas2SubmissionTest.kt$Cas2SubmissionTest.GetToShow$@Test fun `Assessor can view single submitted application`()</ID>
-    <ID>LongMethod:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$@Test fun `it groups applications and domain events by date`()</ID>
-    <ID>LongMethod:DailyMetricsReportTest.kt$DailyMetricsReportTest$@Test fun `Get daily metrics report for returns a report for the given month`()</ID>
-    <ID>LongMethod:DocumentTransformerTest.kt$DocumentTransformerTest$@Test fun `transformToApi transforms correctly - filters out convictions other than one specified`()</ID>
-    <ID>LongMethod:DomainEventBuilderTest.kt$DomainEventBuilderTest$@Test fun `getPersonDepartedDomainEvent transforms the booking and departure information correctly`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getBookingCancelledEvent does not emit event to SNS if event fails to persist to database`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getBookingCancelledEvent persists event, emits event to SNS`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getBookingConfirmedEvent does not emit event to SNS if event fails to persist to database`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getBookingConfirmedEvent persists event, emits event to SNS`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getBookingProvisionallyMadeEvent does not emit event to SNS if event fails to persist to database`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getBookingProvisionallyMadeEvent persists event, emits event to SNS`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `getReferralSubmittedEvent persists event, emits event to SNS`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `savePersonArrivedEvent does not emit event to SNS if event fails to persist to database`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `savePersonArrivedEvent persists event, emits event to SNS`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `savePersonDepartedEvent does not emit event to SNS if event fails to persist to database`()</ID>
-    <ID>LongMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `savePersonDepartedEvent persists event, emits event to SNS`()</ID>
-    <ID>LongMethod:GivenAPlacementRequest.kt$fun IntegrationTestBase.`Given a Placement Request`( placementRequestAllocatedTo: UserEntity, assessmentAllocatedTo: UserEntity, createdByUser: UserEntity, crn: String? = null, name: String? = null, reallocated: Boolean = false, isWithdrawn: Boolean = false, isParole: Boolean = false, expectedArrival: LocalDate? = null, tier: String? = null, mappa: String? = null, applicationSubmittedAt: OffsetDateTime = OffsetDateTime.now(), ): Pair&lt;PlacementRequestEntity, ApplicationEntity&gt;</ID>
-    <ID>LongMethod:GivenAnOffender.kt$fun IntegrationTestBase.`Given an Offender`( offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -&gt; Unit)? = null, inmateDetailsConfigBlock: (InmateDetailFactory.() -&gt; Unit)? = null, mockServerErrorForCommunityApi: Boolean = false, mockServerErrorForPrisonApi: Boolean = false, ): Pair&lt;OffenderDetailSummary, InmateDetail&gt;</ID>
-    <ID>LongMethod:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$@Test fun `checkSchemaOutdated marks outdated correctly for Approved Premises applications`()</ID>
-    <ID>LongMethod:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$@Test fun `checkSchemaOutdated marks outdated correctly for CAS2 applications`()</ID>
-    <ID>LongMethod:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$@Test fun `checkSchemaOutdated marks outdated correctly for Temporary Accommodation applications`()</ID>
-    <ID>LongMethod:LostBedsTest.kt$LostBedsTest$@Test fun `Create Lost Bed on a Temporary Accommodation premises returns OK with correct body when only cancelled bookings for the same bed overlap`()</ID>
-    <ID>LongMethod:LostBedsTest.kt$LostBedsTest$@Test fun `Create Lost Bed on a Temporary Accommodation premises returns OK with correct body when only cancelled lost beds for the same bed overlap`()</ID>
-    <ID>LongMethod:LostBedsTest.kt$LostBedsTest$@Test fun `Update Lost Beds on Temporary Accommodation premises returns OK with correct body when only cancelled bookings for the same bed overlap`()</ID>
-    <ID>LongMethod:LostBedsTest.kt$LostBedsTest$@Test fun `Update Lost Beds on Temporary Accommodation premises returns OK with correct body when only cancelled lost beds for the same bed overlap`()</ID>
-    <ID>LongMethod:OASysSectionsTransformer.kt$OASysSectionsTransformer$private fun transformSupportingInformation(needsDetails: NeedsDetails, requestedOptionalSections: List&lt;Int&gt;): List&lt;OASysSupportingInformationQuestion&gt;</ID>
-    <ID>LongMethod:OASysSectionsTransformerTest.kt$OASysSectionsTransformerTest$@Test fun `transformRiskOfSeriousHarm transforms correctly`()</ID>
-    <ID>LongMethod:OASysSectionsTransformerTest.kt$OASysSectionsTransformerTest$@Test fun `transformToApi sections that are always present (offenceDetails, roshSummary, riskToSelf, riskManagementPlan) transform correctly`()</ID>
-    <ID>LongMethod:OASysSectionsTransformerTest.kt$OASysSectionsTransformerTest$@Test fun `transformToApi supportingInformation returns only sections explicitly requested, alcohol and drugs and those that are linked to harm`()</ID>
-    <ID>LongMethod:OffenderServiceTest.kt$OffenderServiceTest$@Test fun `getRisksByCrn returns Retrieved envelopes with expected contents for RoSH, Tier, Mappa &amp; flags when respective Clients return 200`()</ID>
-    <ID>LongMethod:PersonRisksTest.kt$PersonRisksTest$@Test fun `Getting risks for a CRN returns OK with correct body`()</ID>
-    <ID>LongMethod:PersonTransformerTest.kt$PersonTransformerTest$@Test fun `transformModelToPersonInfoApi transforms correctly for a full person info with prison info`()</ID>
-    <ID>LongMethod:PersonTransformerTest.kt$PersonTransformerTest$@Test fun `transformModelToPersonInfoApi transforms correctly for a full person info without prison info`()</ID>
-    <ID>LongMethod:PlacementApplicationsTest.kt$PlacementApplicationsTest.SubmitPlacementApplicationTest$@Test fun `submitting an in-progress placement request application returns successfully and updates the application`()</ID>
-    <ID>LongMethod:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$@Test fun `createBookingNotMade returns Success, saves Booking Not Made and saves domain event`()</ID>
-    <ID>LongMethod:PlacementRequestsTest.kt$PlacementRequestsTest.AllPlacementRequests$@Test fun `It returns all the placement requests for a user`()</ID>
-    <ID>LongMethod:PremisesService.kt$PremisesService$fun createNewPremises( addressLine1: String, addressLine2: String?, town: String?, postcode: String, latitude: Double?, longitude: Double?, service: String, localAuthorityAreaId: UUID?, probationRegionId: UUID, name: String, notes: String?, characteristicIds: List&lt;UUID&gt;, status: PropertyStatus, probationDeliveryUnitIdentifier: Either&lt;String, UUID&gt;?, turnaroundWorkingDayCount: Int?, )</ID>
-    <ID>LongMethod:PremisesService.kt$PremisesService$fun updatePremises( premisesId: UUID, addressLine1: String, addressLine2: String?, town: String?, postcode: String, localAuthorityAreaId: UUID?, probationRegionId: UUID, characteristicIds: List&lt;UUID&gt;, notes: String?, status: PropertyStatus, probationDeliveryUnitIdentifier: Either&lt;String, UUID&gt;?, turnaroundWorkingDayCount: Int?, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;PremisesEntity&gt;&gt;</ID>
-    <ID>LongMethod:PremisesServiceTest.kt$PremisesServiceTest$@Test fun `getAvailabilityForRange returns correctly for Temporary Accommodation premises`()</ID>
-    <ID>LongMethod:PremisesServiceTest.kt$PremisesServiceTest$@Test fun `getAvailabilityForRange returns correctly when there are bookings`()</ID>
-    <ID>LongMethod:PremisesTest.kt$PremisesTest$@ParameterizedTest @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"]) fun `Get Premises Summary by ID returns OK with correct body`(role: UserRole)</ID>
-    <ID>LongMethod:PremisesTest.kt$PremisesTest$@Test fun `Get Premises for a single region returns OK with correct body`()</ID>
-    <ID>LongMethod:ProblemResponsesTest.kt$ProblemResponsesTest$@Test fun `An invalid request body will return a 400 with details of all problems when the expected body root is an array and an array is provided`()</ID>
-    <ID>LongMethod:ProblemResponsesTest.kt$ProblemResponsesTest$@Test fun `An invalid request body will return a 400 with details of all problems when the expected body root is an object and an object is provided`()</ID>
-    <ID>LongMethod:ReferralsReportTest.kt$ReferralsReportTest$@ParameterizedTest @ValueSource(strings = ["referrals-by-tier", "referrals-by-ap-type"]) fun `Get referrals report returns the correct data`(reportType: String)</ID>
-    <ID>LongMethod:ReportsTest.kt$ReportsTest$@Test fun `Get bookings report returns OK with only Bookings with at least one day in month when year and month are specified`()</ID>
-    <ID>LongMethod:SeedApprovedPremisesRoomsTest.kt$SeedApprovedPremisesRoomsTest$@Test fun `Updating an existing AP room and beds persists correctly`()</ID>
-    <ID>LongMethod:SeedApprovedPremisesRoomsTest.kt$SeedApprovedPremisesRoomsTest$private fun approvedPremisesRoomsSeedCsvRowsToCsv(rows: List&lt;ApprovedPremisesRoomsSeedCsvRow&gt;): String</ID>
-    <ID>LongMethod:SeedApprovedPremisesTest.kt$SeedApprovedPremisesTest$private fun approvedPremisesSeedCsvRowsToCsv(rows: List&lt;ApprovedPremisesSeedCsvRow&gt;): String</ID>
-    <ID>LongMethod:SeedBookingsTest.kt$SeedBookingsTest$@Test fun `Creating a departed Booking (with Arrival, Departure without NonArrival or Cancellation) succeeds`()</ID>
-    <ID>LongMethod:SeedService.kt$SeedService$private fun seedData(seedFileType: SeedFileType, filename: String, resolveCsvPath: SeedJob&lt;*&gt;.() -&gt; String)</ID>
-    <ID>LongMethod:SeedUsersTest.kt$SeedUsersTest$@Test fun `Seeding same users multiple times works every time for AP user seed job`()</ID>
-    <ID>LongMethod:SeedUsersTest.kt$SeedUsersTest$@Test fun `Seeding same users multiple times works every time for base user seed job`()</ID>
     <ID>LongMethod:SeedUtils.kt$@Suppress("CyclomaticComplexMethod") fun getCanonicalLocalAuthorityName(localAuthorityName: String): String</ID>
-    <ID>LongMethod:TasksTest.kt$TasksTest.GetAllForUserTest$@Test fun `Get all tasks for a user returns the relevant tasks for a user`()</ID>
-    <ID>LongMethod:TasksTest.kt$TasksTest.GetAllReallocatableTest$@Test fun `Get all reallocatable tasks returns 200 with correct body, only returns Assessments from CAS1`()</ID>
     <ID>LongMethod:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$@BeforeEach fun setup()</ID>
-    <ID>LongMethod:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$private fun createUserForPlacementApplicationsQuery(deliusUsername: String, isMatcher: Boolean, qualifications: List&lt;UserQualification&gt;, numberOfPlacementApplications: Int, numberOfRecentCompletedPlacementApplications: Int, numberOfLessRecentCompletedPlacementApplications: Int, isActive: Boolean = true, isExcluded: Boolean = false): UserEntity</ID>
     <ID>LongParameterList:ApplicationEntity.kt$ApplicationEntity$( @Id val id: UUID, val crn: String, @ManyToOne @JoinColumn(name = "created_by_user_id") val createdByUser: UserEntity, @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType") var data: String?, @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType") var document: String?, @ManyToOne @JoinColumn(name = "schema_version") var schemaVersion: JsonSchemaEntity, val createdAt: OffsetDateTime, var submittedAt: OffsetDateTime?, @Transient var schemaUpToDate: Boolean, @OneToMany(mappedBy = "application") var assessments: MutableList&lt;AssessmentEntity&gt;, var nomsNumber: String?, )</ID>
     <ID>LongParameterList:ApplicationEntity.kt$ApprovedPremisesApplicationEntity$( id: UUID, crn: String, createdByUser: UserEntity, data: String?, document: String?, schemaVersion: JsonSchemaEntity, createdAt: OffsetDateTime, submittedAt: OffsetDateTime?, schemaUpToDate: Boolean, assessments: MutableList&lt;AssessmentEntity&gt;, var isWomensApplication: Boolean?, var isPipeApplication: Boolean?, var isEmergencyApplication: Boolean?, var isEsapApplication: Boolean?, var isInapplicable: Boolean?, var isWithdrawn: Boolean, var withdrawalReason: String?, var otherWithdrawalReason: String?, val convictionId: Long, val eventNumber: String, val offenceId: String, nomsNumber: String?, @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType") @Convert(disableConversion = true) val riskRatings: PersonRisks?, @OneToMany(mappedBy = "application") val teamCodes: MutableList&lt;ApplicationTeamCodeEntity&gt;, @OneToMany(mappedBy = "application") var placementRequests: MutableList&lt;PlacementRequestEntity&gt;, var releaseType: String?, var arrivalDate: OffsetDateTime?, var name: String, var targetLocation: String?, )</ID>
     <ID>LongParameterList:ApplicationEntity.kt$TemporaryAccommodationApplicationEntity$( id: UUID, crn: String, createdByUser: UserEntity, data: String?, document: String?, schemaVersion: JsonSchemaEntity, createdAt: OffsetDateTime, submittedAt: OffsetDateTime?, schemaUpToDate: Boolean, assessments: MutableList&lt;AssessmentEntity&gt;, nomsNumber: String?, val convictionId: Long, val eventNumber: String, val offenceId: String, @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType") @Convert(disableConversion = true) val riskRatings: PersonRisks?, @ManyToOne @JoinColumn(name = "probation_region_id") val probationRegion: ProbationRegionEntity, var arrivalDate: OffsetDateTime?, var isRegisteredSexOffender: Boolean?, var needsAccessibleProperty: Boolean?, var hasHistoryOfArson: Boolean?, var isDutyToReferSubmitted: Boolean?, var dutyToReferSubmissionDate: LocalDate?, var isEligible: Boolean?, var eligibilityReason: String?, )</ID>
@@ -279,12 +122,12 @@
     <ID>LongParameterList:BedSearchRepository.kt$BedSearchResult$( val premisesId: UUID, val premisesName: String, val premisesAddressLine1: String, val premisesAddressLine2: String?, val premisesTown: String?, val premisesPostcode: String, val premisesCharacteristics: MutableList&lt;CharacteristicNames&gt;, val premisesBedCount: Int, val roomId: UUID, val roomName: String, val bedId: UUID, val bedName: String, val roomCharacteristics: MutableList&lt;CharacteristicNames&gt;, )</ID>
     <ID>LongParameterList:BedSearchRepository.kt$TemporaryAccommodationBedSearchResult$( premisesId: UUID, premisesName: String, premisesAddressLine1: String, premisesAddressLine2: String?, premisesTown: String?, premisesPostcode: String, premisesCharacteristics: MutableList&lt;CharacteristicNames&gt;, premisesBedCount: Int, roomId: UUID, roomName: String, bedId: UUID, bedName: String, roomCharacteristics: MutableList&lt;CharacteristicNames&gt;, val overlaps: MutableList&lt;TemporaryAccommodationBedSearchResultOverlap&gt;, )</ID>
     <ID>LongParameterList:BedSearchService.kt$BedSearchService$( user: UserEntity, postcodeDistrictOutcode: String, maxDistanceMiles: Int, startDate: LocalDate, durationInDays: Int, requiredCharacteristics: List&lt;PlacementCriteria&gt;, )</ID>
-    <ID>LongParameterList:BookingService.kt$BookingService$( private val premisesService: PremisesService, private val staffMemberService: StaffMemberService, private val offenderService: OffenderService, private val domainEventService: DomainEventService, private val cas3DomainEventService: Cas3DomainEventService, private val cruService: CruService, private val applicationService: ApplicationService, private val workingDayCountService: WorkingDayCountService, private val emailNotificationService: EmailNotificationService, private val placementRequestService: PlacementRequestService, private val communityApiClient: CommunityApiClient, private val bookingRepository: BookingRepository, private val arrivalRepository: ArrivalRepository, private val cancellationRepository: CancellationRepository, private val confirmationRepository: ConfirmationRepository, private val extensionRepository: ExtensionRepository, private val dateChangeRepository: DateChangeRepository, private val departureRepository: DepartureRepository, private val departureReasonRepository: DepartureReasonRepository, private val moveOnCategoryRepository: MoveOnCategoryRepository, private val destinationProviderRepository: DestinationProviderRepository, private val nonArrivalRepository: NonArrivalRepository, private val nonArrivalReasonRepository: NonArrivalReasonRepository, private val cancellationReasonRepository: CancellationReasonRepository, private val bedRepository: BedRepository, private val placementRequestRepository: PlacementRequestRepository, private val lostBedsRepository: LostBedsRepository, private val turnaroundRepository: TurnaroundRepository, private val bedMoveRepository: BedMoveRepository, private val premisesRepository: PremisesRepository, private val assessmentRepository: AssessmentRepository, private val notifyConfig: NotifyConfig, @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String, @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: String, @Value("\${arrived-departed-domain-events-disabled}") private val arrivedAndDepartedDomainEventsDisabled: Boolean, @Value("\${manual-bookings-domain-events-disabled}") private val manualBookingsDomainEventsDisabled: Boolean, )</ID>
+    <ID>LongParameterList:BookingService.kt$BookingService$( private val premisesService: PremisesService, private val staffMemberService: StaffMemberService, private val offenderService: OffenderService, private val domainEventService: DomainEventService, private val cas3DomainEventService: Cas3DomainEventService, private val cruService: CruService, private val applicationService: ApplicationService, private val workingDayCountService: WorkingDayCountService, private val emailNotificationService: EmailNotificationService, private val placementRequestService: PlacementRequestService, private val communityApiClient: CommunityApiClient, private val bookingRepository: BookingRepository, private val arrivalRepository: ArrivalRepository, private val cancellationRepository: CancellationRepository, private val confirmationRepository: ConfirmationRepository, private val extensionRepository: ExtensionRepository, private val dateChangeRepository: DateChangeRepository, private val departureRepository: DepartureRepository, private val departureReasonRepository: DepartureReasonRepository, private val moveOnCategoryRepository: MoveOnCategoryRepository, private val destinationProviderRepository: DestinationProviderRepository, private val nonArrivalRepository: NonArrivalRepository, private val nonArrivalReasonRepository: NonArrivalReasonRepository, private val cancellationReasonRepository: CancellationReasonRepository, private val bedRepository: BedRepository, private val placementRequestRepository: PlacementRequestRepository, private val lostBedsRepository: LostBedsRepository, private val turnaroundRepository: TurnaroundRepository, private val bedMoveRepository: BedMoveRepository, private val premisesRepository: PremisesRepository, private val assessmentRepository: AssessmentRepository, private val notifyConfig: NotifyConfig, @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String, @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: String, @Value("\${arrived-departed-domain-events-disabled}") private val arrivedAndDepartedDomainEventsDisabled: Boolean, )</ID>
     <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity, placementRequestId: UUID, bedId: UUID?, premisesId: UUID?, arrivalDate: LocalDate, departureDate: LocalDate, )</ID>
     <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity, premises: TemporaryAccommodationPremisesEntity, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, assessmentId: UUID?, enableTurnarounds: Boolean, )</ID>
     <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity? = null, booking: BookingEntity, arrivalDate: LocalDate, expectedDepartureDate: LocalDate, notes: String?, keyWorkerStaffCode: String?, )</ID>
     <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity? = null, booking: BookingEntity, arrivalDateTime: Instant, expectedDepartureDate: LocalDate, notes: String?, keyWorkerStaffCode: String?, )</ID>
-    <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity? = null, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, bookingId: UUID? = null, )</ID>
+    <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity? = null, crn: String, nomsNumber: String?, arrivalDate: LocalDate, departureDate: LocalDate, bedId: UUID, eventNumber: String?, bookingId: UUID = UUID.randomUUID(), )</ID>
     <ID>LongParameterList:BookingService.kt$BookingService$( user: UserEntity?, booking: BookingEntity, dateTime: OffsetDateTime, reasonId: UUID, moveOnCategoryId: UUID, destinationProviderId: UUID?, notes: String?, )</ID>
     <ID>LongParameterList:BookingTransformer.kt$BookingTransformer$( private val personTransformer: PersonTransformer, private val staffMemberTransformer: StaffMemberTransformer, private val arrivalTransformer: ArrivalTransformer, private val departureTransformer: DepartureTransformer, private val nonArrivalTransformer: NonArrivalTransformer, private val cancellationTransformer: CancellationTransformer, private val confirmationTransformer: ConfirmationTransformer, private val extensionTransformer: ExtensionTransformer, private val bedTransformer: BedTransformer, private val turnaroundTransformer: TurnaroundTransformer, private val enumConverterFactory: EnumConverterFactory, private val workingDayCountService: WorkingDayCountService, )</ID>
     <ID>LongParameterList:DomainEventService.kt$DomainEventService$( domainEvent: DomainEvent&lt;*&gt;, typeName: String, typeDescription: String, detailUrl: String, crn: String, nomsNumber: String, )</ID>
@@ -313,7 +156,7 @@
     <ID>LongParameterList:PeopleController.kt$PeopleController$( private val httpAuthService: HttpAuthService, private val offenderService: OffenderService, private val personTransformer: PersonTransformer, private val risksTransformer: RisksTransformer, private val prisonCaseNoteTransformer: PrisonCaseNoteTransformer, private val adjudicationTransformer: AdjudicationTransformer, private val alertTransformer: AlertTransformer, private val needsDetailsTransformer: NeedsDetailsTransformer, private val oaSysSectionsTransformer: OASysSectionsTransformer, private val convictionTransformer: ConvictionTransformer, private val userService: UserService, )</ID>
     <ID>LongParameterList:PlacementRequestEntity.kt$PlacementRequestRepository$(status: PlacementRequestStatus?, crn: String?, crnOrName: String?, tier: String?, arrivalDateFrom: LocalDate?, arrivalDateTo: LocalDate?, pageable: Pageable?)</ID>
     <ID>LongParameterList:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest$(count: Int, isWithdrawn: Boolean, isReallocated: Boolean, isParole: Boolean, crn: String? = null, name: String? = null, expectedArrival: LocalDate? = null, tier: String? = null)</ID>
-    <ID>LongParameterList:PlacementRequestService.kt$PlacementRequestService$( private val placementRequestRepository: PlacementRequestRepository, private val userService: UserService, private val bookingNotMadeRepository: BookingNotMadeRepository, private val domainEventService: DomainEventService, private val offenderService: OffenderService, private val communityApiClient: CommunityApiClient, private val cruService: CruService, private val placementRequirementsRepository: PlacementRequirementsRepository, private val placementDateRepository: PlacementDateRepository, private val cancellationRepository: CancellationRepository, @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String, )</ID>
+    <ID>LongParameterList:PlacementRequestService.kt$PlacementRequestService$( private val placementRequestRepository: PlacementRequestRepository, private val userService: UserService, private val bookingNotMadeRepository: BookingNotMadeRepository, private val domainEventService: DomainEventService, private val emailNotificationService: EmailNotificationService, private val notifyConfig: NotifyConfig, private val offenderService: OffenderService, private val communityApiClient: CommunityApiClient, private val cruService: CruService, private val placementRequirementsRepository: PlacementRequirementsRepository, private val placementDateRepository: PlacementDateRepository, private val cancellationRepository: CancellationRepository, @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String, )</ID>
     <ID>LongParameterList:PlacementRequestService.kt$PlacementRequestService$(status: PlacementRequestStatus?, crn: String?, crnOrName: String?, tier: String?, arrivalDateStart: LocalDate?, arrivalDateEnd: LocalDate?, page: Int?, sortBy: PlacementRequestSortField, sortDirection: SortDirection?)</ID>
     <ID>LongParameterList:PlacementRequestsController.kt$PlacementRequestsController$( private val userService: UserService, private val placementRequestService: PlacementRequestService, private val placementRequestTransformer: PlacementRequestTransformer, private val placementRequestDetailTransformer: PlacementRequestDetailTransformer, private val offenderService: OffenderService, private val bookingService: BookingService, private val bookingConfirmationTransformer: NewPlacementRequestBookingConfirmationTransformer, private val bookingNotMadeTransformer: BookingNotMadeTransformer, )</ID>
     <ID>LongParameterList:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$(offenderDetails: OffenderDetailSummary, user: UserEntity, duration: Int = 12, expectedArrival: LocalDate = LocalDate.now(), createdAt: OffsetDateTime = OffsetDateTime.now(), applicationDate: OffsetDateTime = OffsetDateTime.now())</ID>
@@ -398,1323 +241,88 @@
     <ID>MagicNumber:ReportsController.kt$ReportsController$12</ID>
     <ID>MagicNumber:TaskTransformer.kt$TaskTransformer$10</ID>
     <ID>MagicNumber:UpdateAllUsersFromCommunityApiJob.kt$UpdateAllUsersFromCommunityApiJob$500</ID>
-    <ID>MaxLineLength:APDeliusContext.kt$editGetStubWithBodyAndJsonResponse(url, mockId, WireMock.equalToJson(objectMapper.writeValueAsString(requestBody), true, true), responseBody)</ID>
-    <ID>MaxLineLength:APDeliusContext.kt$fun</ID>
-    <ID>MaxLineLength:APDeliusContext.kt$val requestBody = objectMapper.readValue(existingMock.request.bodyPatterns[0].expected, object : TypeReference&lt;List&lt;String&gt;&gt;() {}).toMutableList()</ID>
-    <ID>MaxLineLength:APOASysContext.kt$fun</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$(it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$assertThat(generalValidationError.message).isEqualTo("The application has been reallocated, this assessment is read only")</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as TemporaryAccommodationAssessmentEntity }</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { communityApiClientMock.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns assessmentSchema</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) } returns schema</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) }</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername, any()) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes, false) }</ID>
     <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.GeneralValidationError("Couldn't create Placement Requirements")</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.Success(placementRequirementEntity)</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$fun</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$private</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null)</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, placementDates, notes)</ID>
-    <ID>MaxLineLength:AcceptAssessmentTest.kt$AcceptAssessmentTest$val updatedAssessment = (validationResult as ValidatableActionResult.Success).entity as TemporaryAccommodationAssessmentEntity</ID>
-    <ID>MaxLineLength:AdjudicationTransformer.kt$AdjudicationTransformer$establishment = adjudicationsPage.agencies.firstOrNull { it.agencyId == result.agencyId }?.description ?: throw RuntimeException("Agency ${result.agencyId} not found")</ID>
-    <ID>MaxLineLength:AdjudicationTransformer.kt$AdjudicationTransformer$fun</ID>
-    <ID>MaxLineLength:AdjudicationsAPI.kt$fun</ID>
-    <ID>MaxLineLength:ApplicationDocumentsTest.kt$ApplicationDocumentsTest$CommunityAPI_mockSuccessfulDocumentDownloadCall(offenderDetails.otherIds.crn, "457af8a5-82b1-449a-ad03-032b39435865", fileContents)</ID>
-    <ID>MaxLineLength:ApplicationEntity.kt$ApplicationRepository$"SELECT application.created_at as createdAt, CAST(application.created_by_user_id as TEXT) as createdByUserId FROM approved_premises_applications apa "</ID>
-    <ID>MaxLineLength:ApplicationEntity.kt$ApplicationRepository$fun</ID>
-    <ID>MaxLineLength:ApplicationReportGenerator.kt$ApplicationReportGenerator$)</ID>
-    <ID>MaxLineLength:ApplicationReportGenerator.kt$ApplicationReportGenerator$override</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$.</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$assertApplicationRowHasCorrectData(applicationWithBooking.id, applicationRowWithBooking, userEntity, hasBooking = true)</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$assertApplicationRowHasCorrectData(applicationWithCancelledBooking.id, applicationRowWithCancelledBooking, userEntity, hasBooking = true)</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$assertApplicationRowHasCorrectData(applicationWithDepartedBooking.id, applicationRowWithDepartedBooking, userEntity, hasBooking = true)</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$assertApplicationRowHasCorrectData(applicationWithNonArrivedBooking.id, applicationRowWithNonArrivedBooking, userEntity, hasBooking = true)</ID>
     <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$private</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$val applicationRowWithBooking = actual.find { reportRow -&gt; reportRow.id == applicationWithBooking.id.toString() }!!</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$val applicationRowWithCancelledBooking = actual.find { reportRow -&gt; reportRow.id == applicationWithCancelledBooking.id.toString() }!!</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$val applicationRowWithDepartedBooking = actual.find { reportRow -&gt; reportRow.id == applicationWithDepartedBooking.id.toString() }!!</ID>
-    <ID>MaxLineLength:ApplicationReportsTest.kt$ApplicationReportsTest$val applicationRowWithNonArrivedBooking = actual.find { reportRow -&gt; reportRow.id == applicationWithNonArrivedBooking.id.toString() }!!</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$TemporaryAccommodationApplicationAccessLevel.SELF -&gt; applicationRepository.findAllTemporaryAccommodationSummariesCreatedByUser(user.id)</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION -&gt; applicationRepository.findAllSubmittedTemporaryAccommodationSummariesByRegion(user.probationRegion.id)</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$arrivalDate = if (submitApplication.arrivalDate !== null) OffsetDateTime.of(submitApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC) else null</ID>
     <ID>MaxLineLength:ApplicationService.kt$ApplicationService$fun</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$if</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$is AuthorisableActionResult.NotFound -&gt; throw RuntimeException("Unable to get Offender Details when creating Application Submitted Domain Event: Not Found")</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$is AuthorisableActionResult.NotFound -&gt; throw RuntimeException("Unable to get Risks when creating Application Submitted Domain Event: Not Found")</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$is AuthorisableActionResult.Unauthorised -&gt; return@validated "$.crn" hasSingleValidationError "userPermission"</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$is AuthorisableActionResult.Unauthorised -&gt; throw RuntimeException("Unable to get Offender Details when creating Application Submitted Domain Event: Unauthorised")</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$is AuthorisableActionResult.Unauthorised -&gt; throw RuntimeException("Unable to get Risks when creating Application Submitted Domain Event: Unauthorised")</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$private</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$schemaVersion = jsonSchemaService.getNewestSchema(TemporaryAccommodationApplicationJsonSchemaEntity::class.java)</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$this.arrivalDate = if (arrivalDate !== null) OffsetDateTime.of(arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC) else null</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$this.otherWithdrawalReason = if (withdrawalReason == WithdrawalReason.other.value) { otherReason } else { null }</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$val</ID>
-    <ID>MaxLineLength:ApplicationService.kt$ApplicationService$var</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$@EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$applicationService.withdrawApprovedPremisesApplication(application.id, user, "alternative_identified_placement_no_longer_required", "Some other reason")</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getAllApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).containsAll(applicationSummaries)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getAllApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).isEmpty()</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getAllOfflineApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).containsAll(offlineApplicationEntities)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getAllOfflineApplicationsForUsername(distinguishedName, ServiceName.approvedPremises)).isEmpty()</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getOfflineApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(applicationService.getOfflineApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$assertThat(approvedPremisesApplication.name).isEqualTo("${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}")</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockApplicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(userId) } returns applicationSummaries</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockApplicationTeamCodeRepository.save(any()) } answers { it.invocation.args[0] as ApplicationTeamCodeEntity }</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockJsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns newestSchema</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockJsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns schema</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockJsonSchemaService.getNewestSchema(TemporaryAccommodationApplicationJsonSchemaEntity::class.java) } returns schema</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(riskRatings)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$every { mockUserAccessService.getApprovedPremisesApplicationAccessLevelForUser(userEntity) } returns ApprovedPremisesApplicationAccessLevel.TEAM</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$fun</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$listOf(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$val authorisableActionResult = applicationService.withdrawApprovedPremisesApplication(application.id, user, "alternative_identified_placement_no_longer_required", null)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$val authorisableActionResult = applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", "Some other reason")</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$val authorisableActionResult = applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", null)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$val result = applicationService.withdrawApprovedPremisesApplication(application.id, user, "alternative_identified_placement_no_longer_required", null)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$val result = applicationService.withdrawApprovedPremisesApplication(applicationId, user, "alternative_identified_placement_no_longer_required", null)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest$val validationMessages = (validatableActionResult as ValidatableActionResult.FieldValidationError).validationMessages</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.GetApplicationForUsername$assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.GetApplicationForUsername$assertThat(applicationService.getApplicationForUsername(applicationId, distinguishedName) is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$(it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(applicationService.submitApplication(applicationId, submitCas2Application) is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(applicationService.submitApplication(applicationId, submitCas2Application) is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(applicationService.submitApprovedPremisesApplication(applicationId, submitApprovedPremisesApplication, username, "jwt") is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(applicationService.submitApprovedPremisesApplication(applicationId, submitApprovedPremisesApplication, username, "jwt") is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(applicationService.submitTemporaryAccommodationApplication(applicationId, submitTemporaryAccommodationApplication) is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(applicationService.submitTemporaryAccommodationApplication(applicationId, submitTemporaryAccommodationApplication) is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$assertThat(persistedApplication.arrivalDate).isEqualTo(OffsetDateTime.of(submitTemporaryAccommodationApplication.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC))</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$every { mockApDeliusContextApiClient.getCaseDetail(application.crn) } returns ClientResult.Success(status = HttpStatus.OK, body = caseDetails)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$every { mockAssessmentService.createApprovedPremisesAssessment(application) }</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$every { mockObjectMapper.writeValueAsString(submitTemporaryAccommodationApplication.translatedDocument) } returns "{}"</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$every { mockObjectMapper.writeValueAsString(submitTemporaryAccommodationApplicationWithMiReportingData.translatedDocument) } returns "{}"</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) }</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$every { mockOffenderService.getRiskByCrn(application.crn, any(), user.deliusUsername) }</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$fun</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplication.summaryData!!)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplicationWithMiReportingData.summaryData!!)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$val result = applicationService.submitApprovedPremisesApplication(applicationId, submitApprovedPremisesApplication, username, "jwt")</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$val result = applicationService.submitTemporaryAccommodationApplication(applicationId, submitTemporaryAccommodationApplication)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$val result = applicationService.submitTemporaryAccommodationApplication(applicationId, submitTemporaryAccommodationApplicationWithMiReportingData)</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$verify(exactly = 1) { mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplication.summaryData!!) }</ID>
-    <ID>MaxLineLength:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$verify(exactly = 1) { mockAssessmentService.createTemporaryAccommodationAssessment(application, submitTemporaryAccommodationApplicationWithMiReportingData.summaryData!!) }</ID>
-    <ID>MaxLineLength:ApplicationSubmittedFactory.kt$ApplicationSubmittedFactory$private var gender: Yielded&lt;ApplicationSubmitted.Gender&gt; = { randomOf(listOf(ApplicationSubmitted.Gender.male, ApplicationSubmitted.Gender.female)) }</ID>
-    <ID>MaxLineLength:ApplicationSummaryQueryTest.kt$ApplicationSummaryQueryTest$assertThat(it.getLatestAssessmentSubmittedAt()?.toInstant()).isEqualTo(assessmentForSubmittedApplication.submittedAt?.toInstant())</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$CommunityAPI_mockOffenderUserAccessCall(assessorUser.deliusUsername, offenderDetails.otherIds.crn, false, false)</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$CommunityAPI_mockOffenderUserAccessCall(referrerUser.deliusUsername, offenderDetails.otherIds.crn, false, false)</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$CommunityAPI_mockOffenderUserAccessCall(userEntity.deliusUsername, offenderDetails.otherIds.crn, false, false)</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$`Given a User`</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$assertThat(emittedMessage.description).isEqualTo("An application has been submitted for an Approved Premises placement")</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$assertThat(emittedMessage.detailUrl).matches("http://api/events/application-submitted/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$fun</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$objectMapper.readValue(rawResponseBody, object : TypeReference&lt;List&lt;TemporaryAccommodationApplicationSummary&gt;&gt;() {})</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$private</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$val createdAssessment = approvedPremisesAssessmentRepository.findAll().first { it.application.id == applicationId }</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$val persistedApplication = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)!! as ApprovedPremisesApplicationEntity</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$val responseBody = objectMapper.readValue(rawResponseBody, object : TypeReference&lt;List&lt;ApprovedPremisesApplicationSummary&gt;&gt;() {})</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest.ApplicationTimeline$private</ID>
-    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest.GetAssessmentForApplication$fun</ID>
     <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest.GetAssessmentForApplication$private</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$assertThat(submittedAndAssessedApplicationTimelinessEntity.getApplicationSubmittedAt()!!.toInstant()).isEqualTo(submittedDate.toInstant())</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$assertThat(submittedAndBookedApplicationTimelinessEntity.getApplicationSubmittedAt()!!.toInstant()).isEqualTo(submittedDate.toInstant())</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$assertThat(submittedAndBookedApplicationTimelinessEntity.getBookingMadeAt()!!.toInstant()).isEqualTo(submittedDate.plusDays(22).toInstant())</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$assertThat(submittedAndUnassessedApplicationTimelinessEntity.getApplicationSubmittedAt()!!.toInstant()).isEqualTo(submittedDate.toInstant())</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$val submittedAndAssessedApplicationTimelinessEntity = result.find { it.getId() == submittedAndAssessedApplication.id.toString() }</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$val submittedAndBookedApplicationTimelinessEntity = result.find { it.getId() == submittedAndBookedApplication.id.toString() }</ID>
-    <ID>MaxLineLength:ApplicationTimelinessTest.kt$ApplicationTimelinessTest$val submittedAndUnassessedApplicationTimelinessEntity = result.find { it.getId() == submittedAndUnassessedApplication.id.toString() }</ID>
     <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$ServiceName.approvedPremises -&gt; applicationService.createApprovedPremisesApplication(personInfo.offenderDetailSummary, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$if</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is SubmitApprovedPremisesApplication -&gt; applicationService.submitApprovedPremisesApplication(applicationId, submitApplication, username, deliusPrincipal.token.tokenValue)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is SubmitTemporaryAccommodationApplication -&gt; applicationService.submitTemporaryAccommodationApplication(applicationId, submitApplication)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = applicationResult.conflictingEntityId, conflictReason = applicationResult.message)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = applicationResult.validationMessages)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validationResult.validationMessages)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = applicationResult.message)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validationResult.message)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$override</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$private</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$val</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$val offenderDetailsResult = offenderService.getOffenderByCrn(placementApplication.application.crn, user.deliusUsername)</ID>
-    <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$val placementApplicationEntities = placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(applicationId)</ID>
     <ID>MaxLineLength:ApplicationsController.kt$ApplicationsController$when</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$AssessmentDecision.ACCEPTED -&gt; uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision.accepted</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$AssessmentDecision.REJECTED -&gt; uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision.rejected</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -&gt; APITimelineEventType.approvedPremisesApplicationSubmitted</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -&gt; APITimelineEventType.approvedPremisesApplicationWithdrawn</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$entity.getLatestAssessmentHasClarificationNotesWithoutResponse() -&gt; ApplicationStatus.requestedFurtherInformation</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$entity.getSubmittedAt() != null &amp;&amp; entity.getLatestAssessmentDecision() == AssessmentDecision.ACCEPTED &amp;&amp; !entity.getHasBooking() -&gt; ApplicationStatus.awaitingPlacement</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$entity.getSubmittedAt() != null &amp;&amp; entity.getLatestAssessmentDecision() == AssessmentDecision.ACCEPTED &amp;&amp; !entity.getHasPlacementRequest() -&gt; ApplicationStatus.pending</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$entity.getSubmittedAt() != null &amp;&amp; entity.getLatestAssessmentDecision() == AssessmentDecision.ACCEPTED &amp;&amp; entity.getHasBooking() -&gt; ApplicationStatus.placed</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$entity.getSubmittedAt() != null &amp;&amp; entity.getLatestAssessmentDecision() == AssessmentDecision.REJECTED -&gt; ApplicationStatus.rejected</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$fun</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$latestAssessment?.clarificationNotes?.any { it.response == null } == true -&gt; ApplicationStatus.requestedFurtherInformation</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$latestAssessment?.submittedAt != null &amp;&amp; latestAssessment.decision == AssessmentDecision.ACCEPTED &amp;&amp; entity.getLatestBooking() != null -&gt; ApplicationStatus.placed</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$latestAssessment?.submittedAt != null &amp;&amp; latestAssessment.decision == AssessmentDecision.ACCEPTED &amp;&amp; entity.getLatestBooking() == null -&gt; ApplicationStatus.awaitingPlacement</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$latestAssessment?.submittedAt != null &amp;&amp; latestAssessment.decision == AssessmentDecision.ACCEPTED &amp;&amp; entity.getLatestPlacementRequest() == null -&gt; ApplicationStatus.pending</ID>
-    <ID>MaxLineLength:ApplicationsTransformer.kt$ApplicationsTransformer$latestAssessment?.submittedAt != null &amp;&amp; latestAssessment.decision == AssessmentDecision.REJECTED -&gt; ApplicationStatus.rejected</ID>
-    <ID>MaxLineLength:ApplicationsTransformerTest.kt$ApplicationsTransformerTest$fun</ID>
-    <ID>MaxLineLength:ApplicationsTransformerTest.kt$ApplicationsTransformerTest$val exception = assertThrows&lt;RuntimeException&gt; { applicationsTransformer.transformDomainEventTypeToTimelineEventType(cas2DomainEventType) }</ID>
-    <ID>MaxLineLength:ApplicationsTransformerTest.kt$ApplicationsTransformerTest$val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as ApprovedPremisesApplicationSummary</ID>
-    <ID>MaxLineLength:ApplicationsTransformerTest.kt$ApplicationsTransformerTest$val result = applicationsTransformer.transformDomainToApiSummary(application, mockk()) as TemporaryAccommodationApplicationSummary</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$is ValidatableActionResult.ConflictError -&gt; throw RuntimeException("Conflict trying to create Cancellation: ${validationResult.message}")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$is ValidatableActionResult.FieldValidationError -&gt; throw RuntimeException("Field error trying to create Cancellation: ${validationResult.validationMessages}")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$is ValidatableActionResult.GeneralValidationError -&gt; throw RuntimeException("General error trying to create Cancellation: ${validationResult.message}")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (cancellationReason == null) throw RuntimeException("If cancellationDate is provided, cancellationReason must also be provided")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (departureReason == null) throw RuntimeException("If departureDateTime is provided, departureReason must also be provided")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (destinationProvider == null) throw RuntimeException("If departureDateTime is provided, destinationProvider must also be provided")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (keyWorker == null) throw RuntimeException("If arrivalDate is provided, keyWorkerDeliusUsername must also be provided.")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (moveOnCategory == null) throw RuntimeException("If departureDateTime is provided, moveOnCategory must also be provided")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (nonArrivalReason == null) throw RuntimeException("If nonArrivalDate is provided, nonArrivalReason must also be provided")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$if (row.arrivalDate == null) throw RuntimeException("If departureDateTime is provided, arrivalDate must also be provided.")</ID>
-    <ID>MaxLineLength:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$moveOnCategoryRepository.findByNameAndServiceScope(row.departureMoveOnCategory, ServiceName.approvedPremises.value)</ID>
-    <ID>MaxLineLength:ApprovedPremisesEntityFactory.kt$ApprovedPremisesEntityFactory$fun withCharacteristicsList(characteristics: List&lt;CharacteristicEntity&gt;)</ID>
-    <ID>MaxLineLength:ApprovedPremisesEntityFactory.kt$ApprovedPremisesEntityFactory$localAuthorityArea = this.localAuthorityArea?.invoke() ?: throw RuntimeException("Must provide a local authority area")</ID>
-    <ID>MaxLineLength:ApprovedPremisesOfflineApplicationsSeedJob.kt$ApprovedPremisesOfflineApplicationsSeedJob$val existingOfflineApplications = offlineApplicationRepository.findAllByServiceAndCrn(ServiceName.approvedPremises.value, row.crn)</ID>
-    <ID>MaxLineLength:ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory.kt$ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory$class</ID>
-    <ID>MaxLineLength:ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory.kt$ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory$override</ID>
-    <ID>MaxLineLength:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$characteristicRepository.findByPropertyNameAndScopes(propertyName = it.propertyName, serviceName = "approved-premises", modelName = "room")</ID>
-    <ID>MaxLineLength:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$hasArsonInsuranceConditions = parseBooleanStringOrThrow(columns["hasArsonInsuranceConditions"]!!, "hasArsonInsuranceConditions")</ID>
-    <ID>MaxLineLength:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$isSuitedForSexOffenders = parseBooleanStringOrThrow(columns["isSuitedForSexOffenders"]!!, "isSuitedForSexOffenders")</ID>
-    <ID>MaxLineLength:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$private</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$acceptsChildSexOffenders = parseBooleanStringOrThrow(columns["acceptsChildSexOffenders"]!!, "acceptsChildSexOffenders")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$acceptsHateCrimeOffenders = parseBooleanStringOrThrow(columns["acceptsHateCrimeOffenders"]!!, "acceptsHateCrimeOffenders")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$acceptsNonSexualChildOffenders = parseBooleanStringOrThrow(columns["acceptsNonSexualChildOffenders"]!!, "acceptsNonSexualChildOffenders")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$characteristicRepository.findByPropertyNameAndScopes(propertyName = it.propertyName, serviceName = "approved-premises", modelName = "premises")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$hasStepFreeAccessToCommunalAreas = parseBooleanStringOrThrow(columns["hasStepFreeAccessToCommunalAreas"]!!, "hasStepFreeAccessToCommunalAreas")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$hasWheelChairAccessibleBathrooms = parseBooleanStringOrThrow(columns["hasWheelChairAccessibleBathrooms"]!!, "hasWheelChairAccessibleBathrooms")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$hasWideAccessToCommunalAreas = parseBooleanStringOrThrow(columns["hasWideAccessToCommunalAreas"]!!, "hasWideAccessToCommunalAreas")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$if</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$isSemiSpecialistMentalHealth = parseBooleanStringOrThrow(columns["isSemiSpecialistMentalHealth"]!!, "isSemiSpecialistMentalHealth")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$isSuitableForVulnerable = parseBooleanStringOrThrow(columns["isSuitableForVulnerable"]!!, "isSuitableForVulnerable")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$point = if (row.longitude != null &amp;&amp; row.latitude != null) geometryFactory.createPoint(Coordinate(row.latitude, row.longitude)) else null</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$this.point = if (row.longitude != null &amp;&amp; row.latitude != null) geometryFactory.createPoint(Coordinate(row.latitude, row.longitude)) else null</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$throw RuntimeException("Premises ${row.apCode} is of type ${existingPremises::class.qualifiedName}, cannot be updated with Approved Premises Seed Job")</ID>
-    <ID>MaxLineLength:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$updateExistingApprovedPremises(row, existingPremises as ApprovedPremisesEntity, probationRegion, localAuthorityArea, characteristics)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = assessmentValidationResult.conflictingEntityId, conflictReason = assessmentValidationResult.message)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = assessmentValidationResult.validationMessages)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = assessmentValidationResult.message)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$override</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$val</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$val assessmentAuthResult = assessmentService.rejectAssessment(user, assessmentId, serializedData, assessmentRejection.rejectionRationale)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$val clarificationNoteResult = assessmentService.addAssessmentClarificationNote(user, assessmentId, newClarificationNote.query)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$xServiceName == ServiceName.temporaryAccommodation &amp;&amp; crn != null -&gt; assessmentService.getAssessmentSummariesByCrnForUser(user, crn, xServiceName)</ID>
-    <ID>MaxLineLength:AssessmentController.kt$AssessmentController$xServiceName == ServiceName.temporaryAccommodation &amp;&amp; sortField == null -&gt; AssessmentSortField.assessmentArrivalDate</ID>
-    <ID>MaxLineLength:AssessmentEntity.kt$AssessmentRepository$@Query("SELECT a FROM AssessmentEntity a WHERE a.reallocatedAt IS NULL AND a.isWithdrawn != true AND a.submittedAt IS NULL AND TYPE(a) = :type")</ID>
-    <ID>MaxLineLength:AssessmentEntity.kt$AssessmentRepository$fun</ID>
-    <ID>MaxLineLength:AssessmentReferralHistoryNoteTransformer.kt$AssessmentReferralHistoryNoteTransformer$private</ID>
-    <ID>MaxLineLength:AssessmentReferralHistorySystemNoteTestRepository.kt$AssessmentReferralHistorySystemNoteTestRepository$interface</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$ServiceName.approvedPremises -&gt; assessmentRepository.findAllApprovedPremisesAssessmentSummariesNotReallocated(user.id.toString())</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$ServiceName.temporaryAccommodation -&gt; assessmentRepository.findAllTemporaryAccommodationAssessmentSummariesForRegion(user.probationRegion.id)</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$ServiceName.temporaryAccommodation -&gt; assessmentRepository.findTemporaryAccommodationAssessmentSummariesForRegionAndCrn(user.probationRegion.id, crn)</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingAssessorRole" })</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingQualifications" })</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$ValidatableActionResult.GeneralValidationError("The application has been reallocated, this assessment is read only")</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$else -&gt; throw RuntimeException("Reallocating an assessment of type '${currentAssessment::class.qualifiedName}' has not been implemented.")</ID>
     <ID>MaxLineLength:AssessmentService.kt$AssessmentService$fun</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$is ApprovedPremisesAssessmentEntity -&gt; jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$is AuthorisableActionResult.NotFound -&gt; throw RuntimeException("Unable to get Offender Details when creating Application Assessed Domain Event: Not Found")</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$is AuthorisableActionResult.Unauthorised -&gt; throw RuntimeException("Unable to get Offender Details when creating Application Assessed Domain Event: Unauthorised")</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$is TemporaryAccommodationAssessmentEntity -&gt; jsonSchemaService.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java)</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$is TemporaryAccommodationAssessmentEntity -&gt; reallocateTemporaryAccommodationAssessment(assigneeUser, currentAssessment)</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$val</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$val assessments = assessmentRepository.findAllByReallocatedAtNullAndSubmittedAtNullAndType(ApprovedPremisesAssessmentEntity::class.java)</ID>
-    <ID>MaxLineLength:AssessmentService.kt$AssessmentService$val offenderResult = offenderService.getOffenderByCrn(assessment.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$(it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$(it["assessmentUrl"] as String).matches(Regex("http://frontend/assessments/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$.</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$assertThat(generalValidationError.message).isEqualTo("The application has been reallocated, this assessment is read only")</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { assessmentRepositoryMock.findAllApprovedPremisesAssessmentSummariesNotReallocated(any()) } returns emptyList()</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { assessmentRepositoryMock.findAllTemporaryAccommodationAssessmentSummariesForRegion(any()) } returns emptyList()</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { assessmentRepositoryMock.findByIdOrNull(assessmentId) }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { assessmentRepositoryMock.findTemporaryAccommodationAssessmentSummariesForRegionAndCrn(any(), any()) } returns emptyList()</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as TemporaryAccommodationAssessmentEntity }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { communityApiClientMock.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) } returns TemporaryAccommodationApplicationJsonSchemaEntityFactory().produce()</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) } returns schema</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername, any()) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$fun</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$val updatedAssessment = (validationResult as ValidatableActionResult.Success).entity as TemporaryAccommodationAssessmentEntity</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$verify(exactly = 1) { assessmentRepositoryMock.findAllApprovedPremisesAssessmentSummariesNotReallocated(user.id.toString()) }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$verify(exactly = 1) { assessmentRepositoryMock.findAllTemporaryAccommodationAssessmentSummariesForRegion(user.probationRegion.id) }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$verify(exactly = 1) { assessmentRepositoryMock.findTemporaryAccommodationAssessmentSummariesForRegionAndCrn(user.probationRegion.id, "SOMECRN") }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$(it["assessmentUrl"] as String).matches(Regex("http://frontend/assessments/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$every { assessmentClarificationNoteRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentClarificationNoteEntity }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as TemporaryAccommodationAssessmentEntity }</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns apSchema</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) } returns taSchema</ID>
-    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.UpdateAssessmentClarificationNote$every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) }</ID>
-    <ID>MaxLineLength:AssessmentStateTest.kt$AssessmentStateTest$private</ID>
-    <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$apAssessment.id -&gt; fail("Did not expect an Approved Premises Assessment when fetching Temporary Accommodation Assessment summaries")</ID>
-    <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$assertThat(summary.completed).isEqualTo((assessment as TemporaryAccommodationAssessmentEntity).completedAt != null)</ID>
     <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$assertThat(summary.riskRatings).isEqualTo("""{"roshRisks":{"status":"NotFound","value":null},"mappa":{"status":"NotFound","value":null},"tier":{"status":"NotFound","value":null},"flags":{"status":"NotFound","value":null}}""")</ID>
-    <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$private</ID>
-    <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$realAssessmentRepository.findAllTemporaryAccommodationAssessmentSummariesForRegion(user1.probationRegion.id)</ID>
-    <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$taAssessment.id -&gt; fail("Did not expect a Temporary Accommodation Assessment when fetching Approved Premises Assessment summaries")</ID>
-    <ID>MaxLineLength:AssessmentSummaryQueryTest.kt$AssessmentSummaryQueryTest$val results: List&lt;DomainAssessmentSummary&gt; = realAssessmentRepository.findAllApprovedPremisesAssessmentSummariesNotReallocated(user1.id.toString())</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$.</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$// Simulate https://ministryofjustice.sentry.io/issues/4479884804 by deleting the data key from the cache while</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$AssessmentSortField.assessmentArrivalDate -&gt; assessments.sortedByDescending { (it.assessment.application as TemporaryAccommodationApplicationEntity).arrivalDate }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$AssessmentSortField.personName -&gt; assessments.sortedByDescending { "${it.offenderDetails.firstName} ${it.offenderDetails.surname}" }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$PersonInfoResult.Success.Restricted(otherOffender.first.otherIds.crn, otherOffender.first.otherIds.nomsNumber)</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$ServiceName.approvedPremises</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$ServiceName.temporaryAccommodation</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(notes).anyMatch { it is ReferralHistorySystemNote &amp;&amp; it.category == ReferralHistorySystemNote.Category.completed }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(notes).anyMatch { it is ReferralHistorySystemNote &amp;&amp; it.category == ReferralHistorySystemNote.Category.inReview }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(notes).anyMatch { it is ReferralHistorySystemNote &amp;&amp; it.category == ReferralHistorySystemNote.Category.readyToPlace }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(notes).anyMatch { it is ReferralHistorySystemNote &amp;&amp; it.category == ReferralHistorySystemNote.Category.rejected }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(notes).anyMatch { it is ReferralHistorySystemNote &amp;&amp; it.category == ReferralHistorySystemNote.Category.submitted }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(notes).anyMatch { it is ReferralHistorySystemNote &amp;&amp; it.category == ReferralHistorySystemNote.Category.unallocated }</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(persistedPlacementRequirements.desirableCriteria.map { it.propertyName }).containsExactlyInAnyOrderElementsOf(placementRequirements.desirableCriteria.map { it.toString() })</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(persistedPlacementRequirements.essentialCriteria.map { it.propertyName }).containsExactlyInAnyOrderElementsOf(placementRequirements.essentialCriteria.map { it.toString() })</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)</ID>
     <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$fun</ID>
     <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$listOf(assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(assessment), PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails)))</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$objectMapper.readValue(objectMapper.writeValueAsString(it), object : TypeReference&lt;ReferralHistoryNote&gt;() {})</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$val desirableCriteria = listOf(PlacementCriteria.acceptsNonSexualChildOffenders, PlacementCriteria.acceptsSexOffenders)</ID>
-    <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$val persistedPlacementRequirements = placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(application)!!</ID>
     <ID>MaxLineLength:AssessmentTest.kt$AssessmentTest$}</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$allocatedToStaffMember = jpa.allocatedToUser?.let { userTransformer.transformJpaToApi(it, ServiceName.temporaryAccommodation) as TemporaryAccommodationUser }</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$allocatedToStaffMember = userTransformer.transformJpaToApi(jpa.allocatedToUser!!, ServiceName.approvedPremises) as ApprovedPremisesUser</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$application = applicationsTransformer.transformJpaToApi(jpa.application, personInfo) as ApprovedPremisesApplication</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$application = applicationsTransformer.transformJpaToApi(jpa.application, personInfo) as TemporaryAccommodationApplication</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$else -&gt; throw RuntimeException("Unsupported Application type when transforming Assessment: ${jpa.application::class.qualifiedName}")</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$entity.decision == AssessmentDecision.ACCEPTED &amp;&amp; (entity as TemporaryAccommodationAssessmentEntity).completedAt != null</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$fun</ID>
-    <ID>MaxLineLength:AssessmentTransformer.kt$AssessmentTransformer$risks = ase.riskRatings?.let { risksTransformer.transformDomainToApi(objectMapper.readValue&lt;PersonRisks&gt;(it), ase.crn) }</ID>
-    <ID>MaxLineLength:AssessmentTransformerTest.kt$AssessmentTransformerTest$every { mockUserTransformer.transformJpaToApi(any(), ServiceName.temporaryAccommodation) } returns temporaryAccommodationUser</ID>
-    <ID>MaxLineLength:AssessmentTransformerTest.kt$AssessmentTransformerTest$fun</ID>
-    <ID>MaxLineLength:AssessmentUtils.kt$AssessmentSortField.personName -&gt; compareValues((a.person as? FullPerson)?.name, (b.person as? FullPerson)?.name)</ID>
-    <ID>MaxLineLength:AssessmentUtils.kt$a is ApprovedPremisesAssessmentSummary &amp;&amp; b is ApprovedPremisesAssessmentSummary -&gt; compareValues(a.status, b.status)</ID>
-    <ID>MaxLineLength:AssessmentUtils.kt$a is TemporaryAccommodationAssessmentSummary &amp;&amp; b is TemporaryAccommodationAssessmentSummary -&gt; compareValues(a.status, b.status)</ID>
-    <ID>MaxLineLength:AssessmentUtils.kt$else -&gt; throw RuntimeException("Cannot compare values of types ${a::class.qualifiedName} and ${b::class.qualifiedName} due to incomparable status types.")</ID>
-    <ID>MaxLineLength:AssessmentUtils.kt$else -&gt; throw RuntimeException("Unknown assessment summary type '${it::class.qualifiedName}'; could not narrow AssessmentStatus enum to its corresponding service-specific enum.")</ID>
-    <ID>MaxLineLength:AuthTest.kt$AuthTest$.</ID>
     <ID>MaxLineLength:AuthTest.kt$AuthTest$val jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhcHByb3ZlZC1wcmVtaXNlcy1hcGkiLCJncmFudF90eXBlIjoiY2xpZW50X2NyZWRlbnRpYWxzIiwic2NvcGUiOlsicmVhZCJdLCJhdXRoX3NvdXJjZSI6Im5vbmUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjkwOTEvYXV0aC9pc3N1ZXIiLCJleHAiOjI2NTk3MDQ5NDAsImF1dGhvcml0aWVzIjpbIlJPTEVfSU5URVJWRU5USU9OUyIsIlJPTEVfT0FTWVNfUkVBRF9PTkxZIiwiUk9MRV9DT01NVU5JVFkiLCJST0xFX0dMT0JBTF9TRUFSQ0giLCJST0xFX0NPTU1VTklUWV9VU0VSUyIsIlJPTEVfUklTS19TVU1NQVJZIl0sImp0aSI6ImlTSEtsTXJ1aXFUNjF0dTNXVFFqckE2WWJfTSIsImNsaWVudF9pZCI6ImFwcHJvdmVkLXByZW1pc2VzLWFwaSJ9.Cr7Nl09vjUpyieddsJwyQF02nmqhR6PbM4xePA47ukkyhhctE4SwqpOAO5D5OIstr9ePnlmF_Tug7HZ6-SLF8lBnN9C_M2-74d8127gPkQxjWsGnAKIxAGDnwLjtwV1UpSvS0p-Phg3cBTGiq6_HABEuh2JSD67eJS0ZaqNPUXXp2kTfi1ZJXA1ysxFKvAP5qYHbBpYWfvFq9Wkpsrq4sM41yjzS7hmkpaEUAYvKUdYefeRAT6nMCU6pfkEOoCmXkMTf6n6rJ1HxxTvkucZwEQk1dOKZUH0d_AOjZy5RAXiSRzgiYsMfB02gvn2T0FfOyjkjKXgVDsFc2yf3bd6P0g"</ID>
-    <ID>MaxLineLength:AuthorisableActionResult.kt$AuthorisableActionResult$NotFound&lt;EntityType&gt; : AuthorisableActionResult</ID>
-    <ID>MaxLineLength:AuthorisableActionResult.kt$fun &lt;T, U&gt; AuthorisableActionResult.NotFound&lt;T&gt;.into(): AuthorisableActionResult.NotFound&lt;U&gt;</ID>
-    <ID>MaxLineLength:BadRequestProblem.kt$BadRequestProblem$AbstractThrowableProblem(null, "Bad Request", Status.BAD_REQUEST, errorDetail ?: "There is a problem with your request")</ID>
-    <ID>MaxLineLength:BadRequestProblem.kt$BadRequestProblem$class</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$BaseHMPPSClient$fun</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$BaseHMPPSClient$protected</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$BaseHMPPSClient$protected inline</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$BaseHMPPSClient$return ClientResult.Failure.StatusCode(method, requestBuilder.path ?: "", exception.statusCode, exception.responseBodyAsString, false)</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$ClientResult$Success&lt;ResponseType&gt; : ClientResult</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$ClientResult.Failure.Other$class</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$ClientResult.Failure.PreemptiveCacheTimeout$class</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$ClientResult.Failure.PreemptiveCacheTimeout$override fun toException(): Throwable</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$ClientResult.Failure.StatusCode$class</ID>
-    <ID>MaxLineLength:BaseHMPPSClient.kt$ClientResult.Failure.StatusCode$inline fun &lt;reified ResponseType&gt; deserializeTo(): ResponseType</ID>
-    <ID>MaxLineLength:BedSearchController.kt$BedSearchController$else -&gt; throw RuntimeException("Unsupported BedSearchParameters type: ${bedSearchParameters::class.qualifiedName}")</ID>
-    <ID>MaxLineLength:BedSearchController.kt$BedSearchController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)</ID>
-    <ID>MaxLineLength:BedSearchController.kt$BedSearchController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validationResult.validationMessages)</ID>
-    <ID>MaxLineLength:BedSearchController.kt$BedSearchController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validationResult.message)</ID>
-    <ID>MaxLineLength:BedSearchRepository.kt$BedSearchRepository$premisesCharacteristics</ID>
-    <ID>MaxLineLength:BedSearchRepository.kt$BedSearchRepository$roomCharacteristics</ID>
-    <ID>MaxLineLength:BedSearchRepositoryTest.kt$BedSearchRepositoryTest$// Premises isn't in the PDU which has a room/bed which matches everything else - this should not be returned in the results</ID>
-    <ID>MaxLineLength:BedSearchRepositoryTest.kt$BedSearchRepositoryTest$// one of these beds has a conflicting booking that has been cancelled (so booking should not prevent bed appearing in search results)</ID>
-    <ID>MaxLineLength:BedSearchRepositoryTest.kt$BedSearchRepositoryTest$// one of these beds has a conflicting lost beds entry that has been cancelled (so lost bed should not prevent bed appearing in results)</ID>
-    <ID>MaxLineLength:BedSearchResultTransformerTest.kt$BedSearchResultTransformerTest$assertThat(domainResult.distance.toBigDecimal()).isEqualTo((it as ApiApprovedPremisesBedSearchResult).distanceMiles)</ID>
-    <ID>MaxLineLength:BedSearchResultTransformerTest.kt$BedSearchResultTransformerTest$assertThat(domainResult.premisesCharacteristics).isEqualTo(it.premises.characteristics.map { c -&gt; CharacteristicNames(c.propertyName, c.name) })</ID>
-    <ID>MaxLineLength:BedSearchResultTransformerTest.kt$BedSearchResultTransformerTest$assertThat(domainResult.roomCharacteristics).isEqualTo(it.room.characteristics.map { c -&gt; CharacteristicNames(c.propertyName, c.name) })</ID>
-    <ID>MaxLineLength:BedSearchService.kt$BedSearchService$.</ID>
-    <ID>MaxLineLength:BedSearchService.kt$BedSearchService$characteristic.matches(ServiceName.approvedPremises.value, "premises") -&gt; premisesCharacteristicIds += characteristic.id</ID>
-    <ID>MaxLineLength:BedSearchService.kt$BedSearchService$characteristic.matches(ServiceName.approvedPremises.value, "room") -&gt; roomCharacteristicIds += characteristic.id</ID>
-    <ID>MaxLineLength:BedSearchService.kt$BedSearchService$fun</ID>
-    <ID>MaxLineLength:BedSearchService.kt$BedSearchService$val overlappedBookings = bookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(distinctIds, startDate, endDate)</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$assertThat(fieldValidationError.validationMessages["$.requiredCharacteristics"]).isEqualTo("$premisesCharacteristicPropertyName doesNotExist")</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$assertThat(fieldValidationError.validationMessages["$.requiredCharacteristics"]).isEqualTo("$roomCharacteristicPropertyName doesNotExist")</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$assertThat(fieldValidationError.validationMessages["$.requiredCharacteristics"]).isEqualTo("${premisesCharacteristic.propertyName} scopeInvalid")</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$assertThat(fieldValidationError.validationMessages["$.requiredCharacteristics"]).isEqualTo("${roomCharacteristic.propertyName} scopeInvalid")</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$every { mockBookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(any(), any(), any()) } returns listOf()</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$every { mockCharacteristicService.getCharacteristicByPropertyName(roomCharacteristic.propertyName!!) } returns roomCharacteristic</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf("isESAP", premisesCharacteristicPropertyName)) } returns listOf(roomCharacteristic)</ID>
     <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf(premisesCharacteristic.propertyName!!, roomCharacteristic.propertyName!!)) } returns listOf(premisesCharacteristic, roomCharacteristic)</ID>
-    <ID>MaxLineLength:BedSearchServiceTest.kt$BedSearchServiceTest$every { mockCharacteristicService.getCharacteristicsByPropertyNames(listOf(premisesCharacteristic.propertyName!!, roomCharacteristicPropertyName)) } returns listOf(premisesCharacteristic)</ID>
-    <ID>MaxLineLength:BedSearchTest.kt$BedSearchTest$fun</ID>
-    <ID>MaxLineLength:BedService.kt$BedService$fun</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$assertThat(result[0][BedUsageReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$assertThat(result[1][BedUsageReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.name)</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$assertThat(result[1][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$assertThat(result[1][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()</ID>
     <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationBooking)</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()</ID>
     <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)</ID>
     <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)</ID>
     <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)</ID>
-    <ID>MaxLineLength:BedUsageReportGeneratorTest.kt$BedUsageReportGeneratorTest$every { mockWorkingDayCountService.addWorkingDays(LocalDate.parse("2023-04-07"), 2) } returns LocalDate.parse("2023-04-09")</ID>
-    <ID>MaxLineLength:BedUtilisationReportGenerator.kt$BedUtilisationReportGenerator$)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGenerator.kt$BedUtilisationReportGenerator$override</ID>
-    <ID>MaxLineLength:BedUtilisationReportGenerator.kt$BedUtilisationReportGenerator$scheduledTurnaroundDays += workingDayCountService.getWorkingDaysCount(firstDayOfTurnaroundInMonth, lastDayOfTurnaroundInMonth)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGenerator.kt$BedUtilisationReportGenerator$val turnaroundEndDate = workingDayCountService.addWorkingDays(booking.departureDate, booking.turnaround!!.workingDayCount)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$assertThat(result[1][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.name)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$assertThat(result[1][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.id.toShortBase58())</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()</ID>
     <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns emptyList()</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()</ID>
     <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantVoidStraddlingStartOfMonth, relevantVoidStraddlingEndOfMonth)</ID>
     <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)</ID>
     <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)</ID>
     <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockWorkingDayCountService.getWorkingDaysCount(LocalDate.parse("2023-04-05"), LocalDate.parse("2023-04-09")) } returns 4</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockWorkingDayCountService.getWorkingDaysCount(LocalDate.parse("2023-04-05"), LocalDate.parse("2023-04-10")) } returns 4</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockWorkingDayCountService.getWorkingDaysCount(LocalDate.parse("2023-04-05"), LocalDate.parse("2023-04-10")) } returns 5</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$every { mockWorkingDayCountService.getWorkingDaysCount(LocalDate.parse("2023-04-28"), LocalDate.parse("2023-04-30")) } returns 1</ID>
-    <ID>MaxLineLength:BedUtilisationReportGeneratorTest.kt$BedUtilisationReportGeneratorTest$fun</ID>
-    <ID>MaxLineLength:BookingEntity.kt$BookingEntity$override fun hashCode()</ID>
-    <ID>MaxLineLength:BookingEntity.kt$BookingRepository$@Query("SELECT b FROM BookingEntity b WHERE b.arrivalDate &lt;= :endDate AND b.departureDate &gt;= :startDate AND b.bed = :bed")</ID>
     <ID>MaxLineLength:BookingEntity.kt$BookingRepository$@Query("SELECT b FROM BookingEntity b WHERE b.bed.id = :bedId AND b.arrivalDate &lt;= :endDate AND b.departureDate &gt;= :startDate AND SIZE(b.cancellations) = 0 AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)")</ID>
-    <ID>MaxLineLength:BookingEntity.kt$BookingRepository$@Query("SELECT b FROM BookingEntity b WHERE b.premises.id = :premisesId AND b.arrivalDate &lt;= :endDate AND b.departureDate &gt;= :startDate")</ID>
-    <ID>MaxLineLength:BookingEntity.kt$BookingRepository$@Query("SELECT b FROM BookingEntity b WHERE b.premises.id IN :premisesIds AND b.arrivalDate &lt;= :endDate AND b.departureDate &gt;= :startDate AND SIZE(b.cancellations) = 0")</ID>
-    <ID>MaxLineLength:BookingEntity.kt$BookingRepository$fun</ID>
-    <ID>MaxLineLength:BookingEntityFactory.kt$BookingEntityFactory$private var serviceName: Yielded&lt;ServiceName&gt; = { randomOf(listOf(ServiceName.approvedPremises, ServiceName.temporaryAccommodation)) }</ID>
-    <ID>MaxLineLength:BookingSearchController.kt$BookingSearchController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)</ID>
-    <ID>MaxLineLength:BookingSearchController.kt$BookingSearchController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validationResult.validationMessages)</ID>
-    <ID>MaxLineLength:BookingSearchController.kt$BookingSearchController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validationResult.message)</ID>
-    <ID>MaxLineLength:BookingSearchResultTransformer.kt$BookingSearchResultTransformer$status = BookingStatus.values().find { it.value == result.bookingStatus } ?: throw RuntimeException("Unknown booking status ${result.bookingStatus}")</ID>
-    <ID>MaxLineLength:BookingSearchService.kt$BookingSearchService$val</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$every { mockOffenderService.getOffenderByCrn(any(), any()) } returns AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce())</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$fun</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, SortOrder.ascending, BookingSearchSortField.bookingCreatedAt)</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, sortOrder, BookingSearchSortField.bookingCreatedAt)</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, sortOrder, BookingSearchSortField.bookingEndDate)</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, sortOrder, BookingSearchSortField.bookingStartDate)</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, sortOrder, BookingSearchSortField.personCrn)</ID>
-    <ID>MaxLineLength:BookingSearchServiceTest.kt$BookingSearchServiceTest$val result = bookingSearchService.findBookings(ServiceName.temporaryAccommodation, null, sortOrder, BookingSearchSortField.personName)</ID>
-    <ID>MaxLineLength:BookingSearchTest.kt$BookingSearchTest$private</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$(newestOfflineApplication != null &amp;&amp; newestSubmittedOnlineApplication != null &amp;&amp; newestOfflineApplication.createdAt &gt; newestSubmittedOnlineApplication.submittedAt)</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; (!manualBookingsDomainEventsDisabled || booking.placementRequest != null)</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$getBookingWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, booking.id, booking.bed!!.id)</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$if</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$is AuthorisableActionResult.NotFound -&gt; throw RuntimeException("Unable to get Offender Details when creating Booking Cancelled Domain Event: Not Found")</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$is AuthorisableActionResult.NotFound -&gt; throw RuntimeException("Unable to get Offender Details when creating Booking Made Domain Event: Not Found")</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$is AuthorisableActionResult.Unauthorised -&gt; throw RuntimeException("Unable to get Offender Details when creating Booking Cancelled Domain Event: Unauthorised")</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$is AuthorisableActionResult.Unauthorised -&gt; throw RuntimeException("Unable to get Offender Details when creating Booking Made Domain Event: Unauthorised")</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates"</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$return@validated placementRequest.booking!!.id hasConflictError "A Booking has already been made for this Placement Request"</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$val</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$val approvedPremisesBookingAppealedCancellationReasonId: UUID = UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$val expectedLastUnavailableDate = workingDayCountService.addWorkingDays(departureDate, premises.turnaroundWorkingDayCount)</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$val expectedLastUnavailableDate = workingDayCountService.addWorkingDays(effectiveNewDepartureDate, booking.turnaround?.workingDayCount ?: 0)</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$val expectedLastUnavailableDate = workingDayCountService.addWorkingDays(newDepartureDate, booking.turnaround?.workingDayCount ?: 0)</ID>
-    <ID>MaxLineLength:BookingService.kt$BookingService$val newBed = bedRepository.findByIdOrNull(bedId) ?: return AuthorisableActionResult.NotFound("Bed", bedId.toString())</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$(it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$(it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has a Cancellation set")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has a Confirmation set")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has a Departure set")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has a Non Arrival set")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$assertThat(runtimeException.message).isEqualTo("Unable to complete GET request to /staff-details/${user.deliusUsername}: 404 NOT_FOUND")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(existingApplication)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(existingApplication)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/staff-details/${user.deliusUsername}", HttpStatus.NOT_FOUND, null)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockDepartureReasonRepository.findByIdOrNull(departureReasonId) } returns DepartureReasonEntityFactory().produce()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockDestinationProviderRepository.findByIdOrNull(destinationProviderId) } returns DestinationProviderEntityFactory().produce()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bedId, arrivalDate, departureDate, null) } returns listOf()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockMoveOnCategoryRepository.findByIdOrNull(moveOnCategoryId) } returns MoveOnCategoryEntityFactory().produce()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockOffenderService.getOffenderByCrn(crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, "QCODE") } returns AuthorisableActionResult.Success(keyWorker)</ID>
     <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$fun</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bedId)</ID>
     <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", LocalDate.parse("2023-02-23"), LocalDate.parse("2023-02-22"), bedId, assessmentId, false)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, application.id, false)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, application.id, true)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, assessmentId, false)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bed.id, null, false)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingService.createTemporaryAccommodationBooking(user, premises, crn, "NOMS123", arrivalDate, departureDate, bedId, assessmentId, false)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val authorisableResult = bookingServiceWithManualBookingsDomainEventsDisabled.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest$val result = bookingService.createApprovedPremisesAdHocBooking(user, "CRN", "NOMS123", LocalDate.parse("2023-02-22"), LocalDate.parse("2023-02-24"), UUID.randomUUID())</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$every { mockApplicationService.getApplicationsForCrn(crn, ServiceName.approvedPremises) } returns listOf(application)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$every { mockApplicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises) } returns emptyList()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$fun</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, bed.id)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$(it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
+    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesAdHocBooking$(it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
+    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesAdHocBooking$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Failure.StatusCode(HttpMethod.GET, "/staff-details/${user.deliusUsername}", HttpStatus.NOT_FOUND, null)</ID>
     <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$(it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$assertThat(conflictError.message).isEqualTo("A Booking already exists for dates from $arrivalDate to $departureDate which overlaps with the desired dates")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$assertThat(conflictError.message).isEqualTo("A Lost Bed already exists for dates from $arrivalDate to $departureDate which overlaps with the desired dates")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$every { mockCommunityApiClient.getStaffUserDetails(workflowManager.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) }</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$every { mockOffenderService.getOffenderByCrn(application.crn, workflowManager.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesBookingFromPlacementRequest$fun</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateArrival$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has an Arrival set")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateArrival$fun</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateCas1Arrival$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("CAS1 Arrivals cannot be set on non-CAS1 premises")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateCas1Arrival$assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has an Arrival set")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateCas1Arrival$every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateCas1Arrival$every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, "QCODE") } returns AuthorisableActionResult.Success(keyWorker)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateCas1Arrival$fun</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$assertThat(result.validationMessages).containsEntry("$.newArrivalDate", "arrivalDateCannotBeChangedOnArrivedBooking")</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-14"), booking.id) } returns emptyList()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-14"), booking.id) } returns listOf(conflictingBooking)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)</ID>
     <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-12"), LocalDate.parse("2023-07-14"), null) } returns listOf(conflictingLostBed)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$every { mockLostBedsRepository.findByBedIdAndOverlappingDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-16"), LocalDate.parse("2023-07-14"), null) } returns emptyList()</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:BookingServiceTest.kt$BookingServiceTest.CreateDateChange$fun</ID>
-    <ID>MaxLineLength:BookingTest.kt$BookingTest$.</ID>
-    <ID>MaxLineLength:BookingTest.kt$BookingTest$assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")</ID>
-    <ID>MaxLineLength:BookingTest.kt$BookingTest$fun</ID>
-    <ID>MaxLineLength:BookingTest.kt$BookingTest$probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }</ID>
-    <ID>MaxLineLength:BookingTest.kt$BookingTest$withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }</ID>
-    <ID>MaxLineLength:BookingTransformer.kt$BookingTransformer$effectiveEndDate = if (hasNonZeroDayTurnaround) workingDayCountService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount) else jpa.departureDate</ID>
-    <ID>MaxLineLength:BookingTransformer.kt$BookingTransformer$serviceName = enumConverterFactory.getConverter(ServiceName::class.java).convert(jpa.service) ?: throw InternalServerErrorProblem("Could not convert '${jpa.service}' to a ServiceName")</ID>
-    <ID>MaxLineLength:BookingTransformer.kt$BookingTransformer$turnaroundStartDate = if (hasNonZeroDayTurnaround) workingDayCountService.addWorkingDays(jpa.departureDate, 1) else null</ID>
-    <ID>MaxLineLength:BookingTransformer.kt$BookingTransformer$workingDayCountService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount).isBefore(LocalDate.now())</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$every { mockPersonTransformer.transformModelToPersonApi(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) }</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$every { mockStaffMemberTransformer.transformDomainToApi(staffMember) }</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$every { mockWorkingDayCountService.addWorkingDays(LocalDate.parse("2022-08-30"), 1) } returns LocalDate.parse("2022-08-31")</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$every { mockWorkingDayCountService.addWorkingDays(LocalDate.parse("2022-08-30"), 4) } returns LocalDate.parse("2022-09-05")</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$every { mockWorkingDayCountService.addWorkingDays(departedAt.toLocalDate(), 1) } returns departedAt.toLocalDate().plusDays(1)</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$fun</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises")</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value)</ID>
     <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = CancellationReason(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value)</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises")</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value)</ID>
     <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = CancellationReasonEntity(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value)</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = NonArrivalReason(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true)</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$reason = NonArrivalReasonEntity(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true, legacyDeliusReasonCode = "A")</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$val</ID>
-    <ID>MaxLineLength:BookingTransformerTest.kt$BookingTransformerTest$val awaitingArrivalBooking = baseBookingEntity.copy(id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"), application = application)</ID>
-    <ID>MaxLineLength:BookingsReportGenerator.kt$BookingsReportGenerator$actualNightsStayed = if (this.arrival?.arrivalDate == null) null else this.departure?.dateTime?.let { ChronoUnit.DAYS.between(this.arrival?.arrivalDate, it.toLocalDate()).toInt() }</ID>
-    <ID>MaxLineLength:BookingsReportGenerator.kt$BookingsReportGenerator$class</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$fun</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$val actual = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, probationRegionId, 2023, 4))</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$val actual = reportGenerator.createReport(expectedBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$val actual1 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))</ID>
-    <ID>MaxLineLength:BookingsReportGeneratorTest.kt$BookingsReportGeneratorTest$val actual2 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))</ID>
-    <ID>MaxLineLength:CacheClearTest.kt$CacheClearTest$wiremockServer.verify(WireMock.exactly(times), WireMock.getRequestedFor(WireMock.urlEqualTo("/approved-premises/$qCode/staff")))</ID>
-    <ID>MaxLineLength:CacheClearTest.kt$CacheClearTest$wiremockServer.verify(WireMock.exactly(times), WireMock.getRequestedFor(WireMock.urlEqualTo("/secure/offenders/crn/$crn")))</ID>
-    <ID>MaxLineLength:CalendarRepository.kt$CalendarRepository$fun</ID>
-    <ID>MaxLineLength:CalendarService.kt$CalendarService$fun</ID>
-    <ID>MaxLineLength:CalendarService.kt$CalendarService$val offenderResult = offenderService.getOffenderByCrn(it.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:CalendarServiceTest.kt$CalendarServiceTest$every { offenderServiceMock.getOffenderByCrn(crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()</ID>
-    <ID>MaxLineLength:CalendarServiceTest.kt$CalendarServiceTest$fun</ID>
-    <ID>MaxLineLength:CalendarTest.kt$CalendarTest$fun</ID>
-    <ID>MaxLineLength:CalendarTransformer.kt$CalendarTransformer$fun</ID>
-    <ID>MaxLineLength:CalendarTransformer.kt$CalendarTransformer$val dateIsOpen = bedCalendarInfo.value.none { it.startDate.getDaysUntilInclusive(it.endDate).contains(dateInRange) }</ID>
-    <ID>MaxLineLength:CapacityTest.kt$CapacityTest$fun</ID>
-    <ID>MaxLineLength:CapacityTest.kt$CapacityTest$probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }</ID>
-    <ID>MaxLineLength:Cas2PersonOASysRiskToSelfTest.kt$Cas2PersonOASysRiskToSelfTest$APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, risksToTheIndividual, 2500)</ID>
-    <ID>MaxLineLength:CaseNotesAPI.kt$fun</ID>
-    <ID>MaxLineLength:CharacteristicEntity.kt$CharacteristicEntity$fun matches(entityServiceScope: String, entityModelScope: String)</ID>
-    <ID>MaxLineLength:ClientResultRedisSerializerTest.kt$ClientResultRedisSerializerTest$private val clientResponseRedisSerializer = ClientResultRedisSerializer(objectMapper, object : TypeReference&lt;ClientResponseBody&gt;() {})</ID>
-    <ID>MaxLineLength:CommunityAPI.kt$fun</ID>
-    <ID>MaxLineLength:ConflictProblem.kt$ConflictProblem$class</ID>
-    <ID>MaxLineLength:ConnectionPoolConfiguration.kt$ConnectionPoolConfiguration$fun</ID>
-    <ID>MaxLineLength:ConvictionTransformer.kt$ConvictionTransformer$private</ID>
     <ID>MaxLineLength:DailyMetricReportRow.kt$// Date	Applications Started	Unique Users starting applications	Applications Submitted	Unique Users submitting applications	Assessments completed	Unique Users completing assessments	Bookings made	Unique Users making bookings</ID>
-    <ID>MaxLineLength:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator$uniqueUsersCompletingAssessments = assessmentsCompletedToday.groupBy { domainEvent -&gt; domainEvent.data.eventDetails.assessedBy.staffMember!!.staffIdentifier }.size</ID>
-    <ID>MaxLineLength:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator$uniqueUsersMakingBookings = bookingsMadeToday.groupBy { domainEvent -&gt; domainEvent.data.eventDetails.bookedBy }.size</ID>
-    <ID>MaxLineLength:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator$uniqueUsersStartingApplications = applicationsCreatedToday.groupBy { application -&gt; application.createdByUserId }.size</ID>
-    <ID>MaxLineLength:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator$uniqueUsersSubmittingApplications = applicationsSubmittedToday.groupBy { domainEvent -&gt; domainEvent.data.eventDetails.submittedBy.staffMember.staffIdentifier }.size</ID>
-    <ID>MaxLineLength:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$assertThat(results[i]["uniqueUsersCompletingAssessments"]).isEqualTo(countUniqueUsersForDate(assessmentCompletedEvents, date))</ID>
-    <ID>MaxLineLength:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$assertThat(results[i]["uniqueUsersSubmittingApplications"]).isEqualTo(countUniqueUsersForDate(applicationSubmittedEvents, date))</ID>
-    <ID>MaxLineLength:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$private</ID>
-    <ID>MaxLineLength:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$private fun &lt;T&gt; countEntitiesForDate(events: Map&lt;LocalDate, Map&lt;UserEntity, List&lt;T&gt;&gt;&gt;, date: LocalDate)</ID>
-    <ID>MaxLineLength:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$private fun &lt;T&gt; countUniqueUsersForDate(events: Map&lt;LocalDate, Map&lt;UserEntity, List&lt;T&gt;&gt;&gt;, date: LocalDate)</ID>
-    <ID>MaxLineLength:DailyMetricsReportGeneratorTest.kt$DailyMetricsReportGeneratorTest$val allApplicationSubmittedEvents = applicationSubmittedEvents.flatMap { events -&gt; events.value.flatMap { it.value } }</ID>
-    <ID>MaxLineLength:DailyMetricsReportTest.kt$DailyMetricsReportTest$fun</ID>
-    <ID>MaxLineLength:Dates.kt$fun LocalDate.toLocalDateTime(zoneOffset: ZoneOffset = ZoneOffset.UTC)</ID>
-    <ID>MaxLineLength:DbExtension.kt$DbExtension$connection.prepareStatement("ALTER TABLE ${table.fullyQualifiedTableName} ALTER CONSTRAINT $fk DEFERRABLE INITIALLY IMMEDIATE;")</ID>
-    <ID>MaxLineLength:DeleteBookingTest.kt$DeleteBookingTest$every { realExtensionRepository.delete(match { it.id == extensions.last().id }) } throws RuntimeException("Database Exception")</ID>
-    <ID>MaxLineLength:DeleteBookingTest.kt$DeleteBookingTest$fun</ID>
-    <ID>MaxLineLength:DeletePremisesController.kt$DeletePremisesController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = result.validationMessages)</ID>
-    <ID>MaxLineLength:DeletePremisesTest.kt$DeletePremisesTest$fun</ID>
-    <ID>MaxLineLength:DeleteRoomController.kt$DeleteRoomController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = result.validationMessages)</ID>
-    <ID>MaxLineLength:DeleteRoomTest.kt$DeleteRoomTest$fun</ID>
-    <ID>MaxLineLength:DepartureReasonEntity.kt$DepartureReasonRepository$@Query("SELECT d FROM DepartureReasonEntity d WHERE d.serviceScope = :serviceName OR d.serviceScope = '*' AND d.isActive = true")</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$fun</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$private</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$result.putAll(validateArray("$path.${it.name}", genericType, jsonObject.get(it.name) as ArrayNode, it.returnType.arguments.first().type!!.isMarkedNullable))</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$result["$path.${it.name}"] = "expected${expectedJsonPrimitiveType!!.name.lowercase().replaceFirstChar(Char::uppercase)}"</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$result["$path[$index]"] = "expected${expectedJsonPrimitiveType!!.name.lowercase().replaceFirstChar(Char::uppercase)}"</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$val expectedSpecialHandlingJsonPrimitiveType = getExpectedSpecialHandlingJsonPrimitiveTypeChecker(it.returnType.jvmErasure.java, jsonNode)</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$val expectedSpecialHandlingJsonPrimitiveType = getExpectedSpecialHandlingJsonPrimitiveTypeChecker(targetType.java, jsonNode)</ID>
-    <ID>MaxLineLength:DeserializationValidationService.kt$DeserializationValidationService$validateObject("$path.${it.name}", it.returnType.jvmErasure.java.kotlin, jsonObject.get(it.name) as ObjectNode)</ID>
-    <ID>MaxLineLength:DocumentsController.kt$DocumentsController$@RequestMapping(method = [RequestMethod.GET], value = ["/documents/{crn}/{documentId}"], produces = ["application/octet-stream"])</ID>
-    <ID>MaxLineLength:DocumentsController.kt$DocumentsController$fun</ID>
-    <ID>MaxLineLength:DocumentsController.kt$DocumentsController$val offenderDetailsResult = offenderService.getOffenderByCrn(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:DomainEventBuilder.kt$DomainEventBuilder$URI(bookingUrlTemplate.replace("#premisesId", this.premises.id.toString()).replace("#bookingId", this.id.toString()))</ID>
-    <ID>MaxLineLength:DomainEventEntity.kt$DomainEventEntity$T::class == ApplicationAssessedEnvelope::class &amp;&amp; this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED</ID>
-    <ID>MaxLineLength:DomainEventEntity.kt$DomainEventEntity$T::class == ApplicationSubmittedEnvelope::class &amp;&amp; this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED</ID>
-    <ID>MaxLineLength:DomainEventEntity.kt$DomainEventEntity$T::class == ApplicationWithdrawnEnvelope::class &amp;&amp; this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN</ID>
-    <ID>MaxLineLength:DomainEventEntity.kt$DomainEventEntity$T::class == PersonNotArrivedEnvelope::class &amp;&amp; this.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED</ID>
     <ID>MaxLineLength:DomainEventEntity.kt$DomainEventRepository$@Query("SELECT new uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary(cast(d.id as string), d.type, d.occurredAt) FROM DomainEventEntity d WHERE d.applicationId = :applicationId")</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$.</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas1.application-assessed-event-detail}") private val applicationAssessedDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas1.application-submitted-event-detail}") private val applicationSubmittedDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas1.application-withdrawn-event-detail}") private val applicationWithdrawnDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas1.booking-cancelled-event-detail}") private val bookingCancelledDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas1.booking-not-made-event-detail}") private val bookingNotMadeDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas1.person-not-arrived-event-detail}") private val personNotArrivedDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas2.application-submitted-event-detail}") private val cas2ApplicationSubmittedDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas3.booking-cancelled-event-detail}") private val bookingCancelledDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas3.booking-confirmed-event-detail}") private val bookingConfirmedDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas3.booking-provisionally-made-event-detail}") private val bookingProvisionallyMadeDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$@Value("\${url-templates.api.cas3.referral-submitted-event-detail}") private val referralSubmittedDetailUrlTemplate: String</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$else -&gt; throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${domainEventEntity.type.name}")</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$fun getAllDomainEventsForApplication(applicationId: UUID)</ID>
-    <ID>MaxLineLength:DomainEventService.kt$DomainEventService$log.info("Emitted SNS event (Message Id: ${publishResult.messageId}, Sequence Id: ${publishResult.sequenceNumber}) for Domain Event: ${domainEvent.id} of type: ${snsEvent.eventType}")</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.description == "A booking for a Transitional Accommodation premises has been cancelled"</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.description == "A booking has been confirmed for a Transitional Accommodation premises"</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.description == "A booking has been provisionally made for a Transitional Accommodation premises"</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.description == "Someone has arrived at a Transitional Accommodation premises for their booking"</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.description == "Someone has failed to arrive at an Approved Premises for their Booking"</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.personReference.identifiers.any { it.type == "CRN" &amp;&amp; it.value == domainEventToSave.data.eventDetails.personReference.crn }</ID>
-    <ID>MaxLineLength:DomainEventServiceTest.kt$DomainEventServiceTest$deserializedMessage.personReference.identifiers.any { it.type == "NOMS" &amp;&amp; it.value == domainEventToSave.data.eventDetails.personReference.noms }</ID>
-    <ID>MaxLineLength:DomainEventsController.kt$DomainEventsController$override</ID>
-    <ID>MaxLineLength:EmailNotificationServiceTest.kt$EmailNotificationServiceTest$fun</ID>
-    <ID>MaxLineLength:EntityUtils.kt$fun</ID>
-    <ID>MaxLineLength:EntityUtils.kt$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)</ID>
-    <ID>MaxLineLength:EnumConverterFactory.kt$EnumConverterFactory.EnumConverter$val valueProperty = this::class.declaredMemberProperties.firstOrNull { it.name == "value" } as KProperty1&lt;T, String&gt;?</ID>
-    <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$errorDetail = "Invalid type for query parameter ${throwable.parameter.parameterName} expected ${throwable.parameter.parameterType.name}"</ID>
-    <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$private fun expectedArrayButGotObject(jsonNode: JsonNode, mismatchedInputException: MismatchedInputException)</ID>
-    <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$private fun expectedObjectButGotArray(jsonNode: JsonNode, mismatchedInputException: MismatchedInputException)</ID>
     <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$private fun logBadRequestProblem(problem: BadRequestProblem)</ID>
-    <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$private fun logInternalServerErrorProblem(problem: InternalServerErrorProblem)</ID>
-    <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$private fun rootIsArray(mismatchedInputException: MismatchedInputException)</ID>
-    <ID>MaxLineLength:ForbiddenProblem.kt$ForbiddenProblem$class</ID>
-    <ID>MaxLineLength:GroupedDocuments.kt$GroupedDocuments$fun findDocument(documentId: String)</ID>
-    <ID>MaxLineLength:HealthDetailsFactory.kt$HealthDetailsFactory$fun</ID>
-    <ID>MaxLineLength:InmateDetailsCacheRefreshWorker.kt$InmateDetailsCacheRefreshWorker$val distinctNomsNumbers = (applicationRepository.getDistinctNomsNumbers() + bookingRepository.getDistinctNomsNumbers()).distinct()</ID>
-    <ID>MaxLineLength:InmateDetailsCacheRefreshWorkerTest.kt$InmateDetailsCacheRefreshWorkerTest$every { mockPrisonsApiClient.getInmateDetailsCacheEntryStatus(it.offenderNo) } returns PreemptiveCacheEntryStatus.EXISTS</ID>
-    <ID>MaxLineLength:InmateDetailsCacheRefreshWorkerTest.kt$InmateDetailsCacheRefreshWorkerTest$every { mockPrisonsApiClient.getInmateDetailsCacheEntryStatus(it.offenderNo) } returns PreemptiveCacheEntryStatus.MISS</ID>
-    <ID>MaxLineLength:InmateDetailsCacheRefreshWorkerTest.kt$InmateDetailsCacheRefreshWorkerTest$every { mockPrisonsApiClient.getInmateDetailsCacheEntryStatus(it.offenderNo) } returns PreemptiveCacheEntryStatus.REQUIRES_REFRESH</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesApplicationJsonSchemaEntityFactory() }, approvedPremisesApplicationJsonSchemaRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$approvedPremisesAssessmentEntityFactory = PersistedFactory({ ApprovedPremisesAssessmentEntityFactory() }, approvedPremisesAssessmentRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$approvedPremisesAssessmentJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesAssessmentJsonSchemaEntityFactory() }, approvedPremisesAssessmentJsonSchemaRepository)</ID>
     <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$approvedPremisesPlacementApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory() }, approvedPremisesPlacementApplicationJsonSchemaRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$assessmentClarificationNoteEntityFactory = PersistedFactory({ AssessmentClarificationNoteEntityFactory() }, assessmentClarificationNoteRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$assessmentReferralHistorySystemNoteEntityFactory = PersistedFactory({ AssessmentReferralHistorySystemNoteEntityFactory() }, assessmentReferralSystemNoteRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$assessmentReferralHistoryUserNoteEntityFactory = PersistedFactory({ AssessmentReferralHistoryUserNoteEntityFactory() }, assessmentReferralUserNoteRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$cancellationReasonEntityFactory = PersistedFactory({ CancellationReasonEntityFactory() }, cancellationReasonRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$cas2ApplicationJsonSchemaEntityFactory = PersistedFactory({ Cas2ApplicationJsonSchemaEntityFactory() }, cas2ApplicationJsonSchemaRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$destinationProviderEntityFactory = PersistedFactory({ DestinationProviderEntityFactory() }, destinationProviderRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$fun</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var applicationTeamCodeFactory: PersistedFactory&lt;ApplicationTeamCodeEntity, UUID, ApplicationTeamCodeEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory&lt;ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory&lt;ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var approvedPremisesAssessmentEntityFactory: PersistedFactory&lt;ApprovedPremisesAssessmentEntity, UUID, ApprovedPremisesAssessmentEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var approvedPremisesAssessmentJsonSchemaEntityFactory: PersistedFactory&lt;ApprovedPremisesAssessmentJsonSchemaEntity, UUID, ApprovedPremisesAssessmentJsonSchemaEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var approvedPremisesEntityFactory: PersistedFactory&lt;ApprovedPremisesEntity, UUID, ApprovedPremisesEntityFactory&gt;</ID>
     <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var approvedPremisesPlacementApplicationJsonSchemaEntityFactory: PersistedFactory&lt;ApprovedPremisesPlacementApplicationJsonSchemaEntity, UUID, ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var assessmentClarificationNoteEntityFactory: PersistedFactory&lt;AssessmentClarificationNoteEntity, UUID, AssessmentClarificationNoteEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var assessmentReferralHistorySystemNoteEntityFactory: PersistedFactory&lt;AssessmentReferralHistorySystemNoteEntity, UUID, AssessmentReferralHistorySystemNoteEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var assessmentReferralHistoryUserNoteEntityFactory: PersistedFactory&lt;AssessmentReferralHistoryUserNoteEntity, UUID, AssessmentReferralHistoryUserNoteEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var cancellationReasonEntityFactory: PersistedFactory&lt;CancellationReasonEntity, UUID, CancellationReasonEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var cas2ApplicationJsonSchemaEntityFactory: PersistedFactory&lt;Cas2ApplicationJsonSchemaEntity, UUID, Cas2ApplicationJsonSchemaEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var destinationProviderEntityFactory: PersistedFactory&lt;DestinationProviderEntity, UUID, DestinationProviderEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var localAuthorityEntityFactory: PersistedFactory&lt;LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var lostBedCancellationEntityFactory: PersistedFactory&lt;LostBedCancellationEntity, UUID, LostBedCancellationEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var nonArrivalReasonEntityFactory: PersistedFactory&lt;NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var offlineApplicationEntityFactory: PersistedFactory&lt;OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var placementApplicationFactory: PersistedFactory&lt;PlacementApplicationEntity, UUID, PlacementApplicationEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var placementRequirementsFactory: PersistedFactory&lt;PlacementRequirementsEntity, UUID, PlacementRequirementsEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var probationAreaProbationRegionMappingFactory: PersistedFactory&lt;ProbationAreaProbationRegionMappingEntity, UUID, ProbationAreaProbationRegionMappingEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var probationDeliveryUnitFactory: PersistedFactory&lt;ProbationDeliveryUnitEntity, UUID, ProbationDeliveryUnitEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory&lt;TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory&gt;</ID>
     <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var temporaryAccommodationApplicationJsonSchemaEntityFactory: PersistedFactory&lt;TemporaryAccommodationApplicationJsonSchemaEntity, UUID, TemporaryAccommodationApplicationJsonSchemaEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var temporaryAccommodationAssessmentEntityFactory: PersistedFactory&lt;TemporaryAccommodationAssessmentEntity, UUID, TemporaryAccommodationAssessmentEntityFactory&gt;</ID>
     <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var temporaryAccommodationAssessmentJsonSchemaEntityFactory: PersistedFactory&lt;TemporaryAccommodationAssessmentJsonSchemaEntity, UUID, TemporaryAccommodationAssessmentJsonSchemaEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var temporaryAccommodationPremisesEntityFactory: PersistedFactory&lt;TemporaryAccommodationPremisesEntity, UUID, TemporaryAccommodationPremisesEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var userQualificationAssignmentEntityFactory: PersistedFactory&lt;UserQualificationAssignmentEntity, UUID, UserQualificationAssignmentEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lateinit var userRoleAssignmentEntityFactory: PersistedFactory&lt;UserRoleAssignmentEntity, UUID, UserRoleAssignmentEntityFactory&gt;</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$lostBedCancellationEntityFactory = PersistedFactory({ LostBedCancellationEntityFactory() }, lostBedCancellationRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$offlineApplicationEntityFactory = PersistedFactory({ OfflineApplicationEntityFactory() }, offlineApplicationRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$placementApplicationFactory = PersistedFactory({ PlacementApplicationEntityFactory() }, placementApplicationRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$placementRequirementsFactory = PersistedFactory({ PlacementRequirementsEntityFactory() }, placementRequirementsRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$probationAreaProbationRegionMappingFactory = PersistedFactory({ ProbationAreaProbationRegionMappingEntityFactory() }, probationAreaProbationRegionMappingRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$probationDeliveryUnitFactory = PersistedFactory({ ProbationDeliveryUnitEntityFactory() }, probationDeliveryUnitRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$temporaryAccommodationApplicationEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationEntityFactory() }, temporaryAccommodationApplicationRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$temporaryAccommodationApplicationJsonSchemaEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationJsonSchemaEntityFactory() }, temporaryAccommodationApplicationJsonSchemaRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$temporaryAccommodationAssessmentEntityFactory = PersistedFactory({ TemporaryAccommodationAssessmentEntityFactory() }, temporaryAccommodationAssessmentRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$temporaryAccommodationAssessmentJsonSchemaEntityFactory = PersistedFactory({ TemporaryAccommodationAssessmentJsonSchemaEntityFactory() }, temporaryAccommodationAssessmentJsonSchemaRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$temporaryAccommodationPremisesEntityFactory = PersistedFactory({ TemporaryAccommodationPremisesEntityFactory() }, temporaryAccommodationPremisesRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$userQualificationAssignmentEntityFactory = PersistedFactory({ UserQualificationAssignmentEntityFactory() }, userQualificationAssignmentRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$IntegrationTestBase$userRoleAssignmentEntityFactory = PersistedFactory({ UserRoleAssignmentEntityFactory() }, userRoleAssignmentRepository)</ID>
-    <ID>MaxLineLength:IntegrationTestBase.kt$WiremockPortHolder$val lockFilePath = Paths.get("${System.getProperty("java.io.tmpdir")}${System.getProperty("file.separator")}ap-int-port-lock-$portToTry.lock")</ID>
-    <ID>MaxLineLength:InternalServerErrorProblem.kt$InternalServerErrorProblem$class</ID>
-    <ID>MaxLineLength:JsonSchemaService.kt$JsonSchemaService$fun &lt;T : JsonSchemaEntity&gt; getNewestSchema(type: Class&lt;T&gt;): JsonSchemaEntity</ID>
-    <ID>MaxLineLength:JsonSchemaService.kt$JsonSchemaService$log.warn("Validation errors whilst validating schema: \n\t${validationErrors.joinToString("\n\t,") { "Schema Path: ${it.schemaPath} -&gt; Path: ${it.path}: ${it.message}" }}")</ID>
-    <ID>MaxLineLength:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$every { mockApplicationRepository.findAllByCreatedByUser_Id(userId, ApprovedPremisesApplicationEntity::class.java) } returns applicationEntities</ID>
-    <ID>MaxLineLength:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$every { mockApplicationRepository.findAllByCreatedByUser_Id(userId, TemporaryAccommodationApplicationEntity::class.java) } returns applicationEntities</ID>
-    <ID>MaxLineLength:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$every { mockJsonSchemaRepository.getSchemasForType(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns listOf(newestJsonSchema)</ID>
-    <ID>MaxLineLength:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$every { mockJsonSchemaRepository.getSchemasForType(Cas2ApplicationJsonSchemaEntity::class.java) } returns listOf(newestJsonSchema)</ID>
-    <ID>MaxLineLength:JsonSchemaServiceTest.kt$JsonSchemaServiceTest$every { mockJsonSchemaRepository.getSchemasForType(TemporaryAccommodationApplicationJsonSchemaEntity::class.java) } returns listOf(newestJsonSchema)</ID>
-    <ID>MaxLineLength:JsonSchemaTestRepository.kt$ApprovedPremisesApplicationJsonSchemaTestRepository$interface</ID>
-    <ID>MaxLineLength:JsonSchemaTestRepository.kt$ApprovedPremisesAssessmentJsonSchemaTestRepository$interface</ID>
-    <ID>MaxLineLength:JsonSchemaTestRepository.kt$ApprovedPremisesPlacementApplicationJsonSchemaTestRepository$interface</ID>
-    <ID>MaxLineLength:JsonSchemaTestRepository.kt$TemporaryAccommodationApplicationJsonSchemaTestRepository$interface</ID>
-    <ID>MaxLineLength:JsonSchemaTestRepository.kt$TemporaryAccommodationAssessmentJsonSchemaTestRepository$interface</ID>
-    <ID>MaxLineLength:LocalAuthorityAreaTransformer.kt$LocalAuthorityAreaTransformer$fun transformJpaToApi(jpa: LocalAuthorityAreaEntity)</ID>
-    <ID>MaxLineLength:LostBedReportGeneratorTest.kt$LostBedReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)</ID>
     <ID>MaxLineLength:LostBedReportGeneratorTest.kt$LostBedReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)</ID>
     <ID>MaxLineLength:LostBedReportGeneratorTest.kt$LostBedReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)</ID>
     <ID>MaxLineLength:LostBedReportGeneratorTest.kt$LostBedReportGeneratorTest$every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)</ID>
-    <ID>MaxLineLength:LostBedsEntity.kt$LostBedsRepository$@Query("SELECT lb FROM LostBedsEntity lb LEFT JOIN lb.cancellation c WHERE lb.premises.id = :premisesId AND c is NULL")</ID>
-    <ID>MaxLineLength:LostBedsEntity.kt$LostBedsRepository$@Query("SELECT lb FROM LostBedsEntity lb WHERE lb.premises.id = :premisesId AND lb.startDate &lt;= :endDate AND lb.endDate &gt;= :startDate")</ID>
-    <ID>MaxLineLength:LostBedsEntity.kt$LostBedsRepository$@Query("SELECT lb FROM LostBedsEntity lb WHERE lb.startDate &lt;= :endDate AND lb.endDate &gt;= :startDate AND lb.bed = :bed")</ID>
-    <ID>MaxLineLength:LostBedsEntity.kt$LostBedsRepository$fun</ID>
-    <ID>MaxLineLength:LostBedsReportGenerator.kt$LostBedsReportGenerator$lengthDays = latestDateOf(startOfMonth, it.startDate).getDaysUntilInclusive(earliestDateOf(endOfMonth, it.endDate)).size</ID>
-    <ID>MaxLineLength:LostBedsTest.kt$LostBedsTest$.</ID>
-    <ID>MaxLineLength:LostBedsTest.kt$LostBedsTest$fun</ID>
-    <ID>MaxLineLength:LostBedsTest.kt$LostBedsTest$probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }</ID>
-    <ID>MaxLineLength:MDCHandlerInterceptor.kt$MDCHandlerInterceptor$Sentry.configureScope { scope: Scope -&gt; scope.setTag("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified") }</ID>
-    <ID>MaxLineLength:MoveOnCategoryEntity.kt$MoveOnCategoryRepository$@Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*' AND m.isActive = true")</ID>
-    <ID>MaxLineLength:NeedsDetailsFactory.kt$NeedsDetailsFactory$fun</ID>
-    <ID>MaxLineLength:NeedsDetailsTransformerTest.kt$NeedsDetailsTransformerTest$OASysSection(section = 4, name = "Education, Training and Employment", linkedToHarm = null, linkedToReOffending = null)</ID>
-    <ID>MaxLineLength:NotAllowedProblem.kt$NotAllowedProblem$class</ID>
     <ID>MaxLineLength:NotFoundProblem.kt$NotFoundProblem$class</ID>
-    <ID>MaxLineLength:NotImplementedProblem.kt$NotImplementedProblem$class</ID>
-    <ID>MaxLineLength:NotifyConfig.kt$NotifyClientConfig$fun</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$assessmentState = if (offenceDetails.dateCompleted != null) OASysAssessmentState.completed else OASysAssessmentState.incomplete</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$if</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Additional comments", "RM35", riskManagementPlan.riskManagementPlan?.additionalComments)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Contingency plans", "RM34", riskManagementPlan.riskManagementPlan?.contingencyPlans)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Current concerns about Coping in Custody or Hostel", "R8.2.1", risksToTheIndividual.riskToTheIndividual?.currentCustodyHostelCoping)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Current concerns about Vulnerability", "R8.3.1", risksToTheIndividual.riskToTheIndividual?.currentVulnerability)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Current concerns about self-harm or suicide", "R8.1.1", risksToTheIndividual.riskToTheIndividual?.currentConcernsSelfHarmSuicide)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Further considerations", "RM28", riskManagementPlan.riskManagementPlan?.furtherConsiderations)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Interventions and treatment", "RM32", riskManagementPlan.riskManagementPlan?.interventionsAndTreatment)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Issues contributing to risks", "2.98", offenceDetails.offence?.issueContributingToRisk)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Key information about current situation", "RM28.1", riskManagementPlan.riskManagementPlan?.keyInformationAboutCurrentSituation)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Monitoring and control", "RM31", riskManagementPlan.riskManagementPlan?.monitoringAndControl)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Previous concerns about self-harm or suicide", "R8.1.4", risksToTheIndividual.riskToTheIndividual?.previousConcernsSelfHarmSuicide)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Victim - perpetrator relationship", "2.4.1", offenceDetails.offence?.victimPerpetratorRel)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("Victim safety planning", "RM33", riskManagementPlan.riskManagementPlan?.victimSafetyPlanning)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("What circumstances are likely to increase risk", "R10.4", roshSummary.roshSummary?.riskIncreaseLikelyTo)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("What circumstances are likely to reduce the risk", "R10.5", roshSummary.roshSummary?.riskReductionLikelyTo)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$oASysQuestionWithSingleAnswer("When is the risk likely to be the greatest", "R10.3", roshSummary.roshSummary?.riskGreatest)</ID>
-    <ID>MaxLineLength:OASysSectionsTransformer.kt$OASysSectionsTransformer$private</ID>
-    <ID>MaxLineLength:OASysSectionsTransformerTest.kt$OASysSectionsTransformerTest$.</ID>
-    <ID>MaxLineLength:OASysSectionsTransformerTest.kt$OASysSectionsTransformerTest$fun</ID>
-    <ID>MaxLineLength:OAuth2ResourceServerSecurityConfiguration.kt$AuthorizedClientServiceConfiguration$if (logClintCredentialsJwtInfo) return LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository, objectMapper)</ID>
-    <ID>MaxLineLength:OAuth2ResourceServerSecurityConfiguration.kt$LoggingInMemoryOAuth2AuthorizedClientService$class</ID>
     <ID>MaxLineLength:OAuth2ResourceServerSecurityConfiguration.kt$LoggingInMemoryOAuth2AuthorizedClientService$log.info("Retrieved a client_credentials JWT for service-&gt;service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")</ID>
-    <ID>MaxLineLength:OAuth2ResourceServerSecurityConfiguration.kt$LoggingInMemoryOAuth2AuthorizedClientService$override fun removeAuthorizedClient(clientRegistrationId: String?, principalName: String?)</ID>
-    <ID>MaxLineLength:OffenderDetailsCacheRefreshWorker.kt$OffenderDetailsCacheRefreshWorker$log.info("No upstream call made when refreshing Offender Details for $it, stored result still within soft TTL")</ID>
-    <ID>MaxLineLength:OffenderDetailsCacheRefreshWorkerTest.kt$OffenderDetailsCacheRefreshWorkerTest$every { mockCommunityApiClient.getOffenderDetailsCacheEntryStatus(it.otherIds.crn) } returns PreemptiveCacheEntryStatus.EXISTS</ID>
-    <ID>MaxLineLength:OffenderDetailsCacheRefreshWorkerTest.kt$OffenderDetailsCacheRefreshWorkerTest$every { mockCommunityApiClient.getOffenderDetailsCacheEntryStatus(it.otherIds.crn) } returns PreemptiveCacheEntryStatus.MISS</ID>
-    <ID>MaxLineLength:OffenderDetailsCacheRefreshWorkerTest.kt$OffenderDetailsCacheRefreshWorkerTest$every { mockCommunityApiClient.getOffenderDetailsCacheEntryStatus(it.otherIds.crn) } returns PreemptiveCacheEntryStatus.REQUIRES_REFRESH</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$adjudicationsApiPageSize = adjudicationsConfigBindingModel.prisonApiPageSize ?: throw RuntimeException("No prison-adjudications.adjudications-api-page-size configuration provided")</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$category = categoryConfig.category ?: throw RuntimeException("No category provided for prison-case-notes.excluded-categories at index $index")</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$false -&gt; log.warn("Could not get inmate details for $crn as an unsuccessful response was cached", inmateDetailResponse.toException())</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$fun</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$fun getDocument(crn: String, documentId: String, outputStream: OutputStream)</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$is ClientResult.Failure.StatusCode -&gt; if (offenderResponse.status == HttpStatus.NOT_FOUND) return AuthorisableActionResult.NotFound() else offenderResponse.throwException()</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$lastUpdated = registration.registrationReviews?.filter { it.completed }?.maxOfOrNull { it.reviewDate } ?: registration.startDate</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$lookbackDays = prisonCaseNotesConfigBindingModel.lookbackDays ?: throw RuntimeException("No prison-case-notes.lookback-days configuration provided")</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$prisonApiPageSize = prisonCaseNotesConfigBindingModel.prisonApiPageSize ?: throw RuntimeException("No prison-api-page-size configuration provided")</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$true -&gt; log.warn("Could not get inmate details for $crn after cache timed out", inmateDetailResponse.toException())</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$val adjudicationsPageResponse = adjudicationsApiClient.getAdjudicationsPage(nomsNumber, currentPageIndex, adjudicationsConfig.adjudicationsApiPageSize)</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$val caseNotesPageResponse = caseNotesClient.getCaseNotesPage(nomsNumber, fromDate, currentPageIndex, prisonCaseNotesConfig.prisonApiPageSize)</ID>
-    <ID>MaxLineLength:OffenderService.kt$OffenderService$value = registrationsResponse.body.registrations.filter { !ignoredRegisterTypesForFlags.contains(it.type.code) }.map { it.type.description }</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/crn/a-crn/user/distinguished.name/userAccess: 403 FORBIDDEN")</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/a-crn: 400 BAD_REQUEST")</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name", true) is AuthorisableActionResult.Success).isTrue</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(offenderService.getPrisonCaseNotesByNomsNumber(nomsNumber) is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(offenderDetails.otherIds.crn) }</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.FORBIDDEN, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.NOT_FOUND, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$fun</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock200Registrations(crn: String, body: Registrations)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock200RoSH(crn: String, body: RoshRatings)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock200RoSH(crn: String, jwt: String, body: RoshRatings)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock200Tier(crn: String, body: Tier)</ID>
     <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock404Registrations(crn: String)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock404RoSH(crn: String)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock404RoSH(crn: String, jwt: String)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock404Tier(crn: String)</ID>
     <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock500Registrations(crn: String)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock500RoSH(crn: String)</ID>
     <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock500RoSH(crn: String, jwt: String)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$private fun mock500Tier(crn: String)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest$val exception = assertThrows&lt;RuntimeException&gt; { offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") }</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetInfoForPerson$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/ABC123", HttpStatus.INTERNAL_SERVER_ERROR, null, true)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetInfoForPerson$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait(crn) } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/ABC123", HttpStatus.NOT_FOUND, null, true)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetInmateDetailByNomsNumber$every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.FORBIDDEN, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetInmateDetailByNomsNumber$every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns StatusCode(HttpMethod.GET, "/api/offenders/$nomsNumber", HttpStatus.NOT_FOUND, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetOffenderByCrn$assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/a-crn: 400 BAD_REQUEST")</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetOffenderByCrn$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetOffenderByCrn$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetOffenderSummariesByCrns$every { mockApDeliusContextApiClient.getUserAccessForCrns(user.deliusUsername, crns) }</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetRisksByCrn$assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/a-crn: 400 BAD_REQUEST")</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetRisksByCrn$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)</ID>
-    <ID>MaxLineLength:OffenderServiceTest.kt$OffenderServiceTest.GetRisksByCrn$every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)</ID>
-    <ID>MaxLineLength:PeopleController.kt$PeopleController$is PersonInfoResult.Unknown -&gt; throw personInfo.throwable ?: RuntimeException("Could not retrieve person info for CRN: $crn")</ID>
-    <ID>MaxLineLength:PeopleController.kt$PeopleController$private</ID>
-    <ID>MaxLineLength:PeopleController.kt$PeopleController$val</ID>
-    <ID>MaxLineLength:PeopleController.kt$PeopleController$val personInfo = offenderService.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
     <ID>MaxLineLength:PersistedFactory.kt$PersistedFactory$class</ID>
-    <ID>MaxLineLength:PersonAdjudicationsTest.kt$PersonAdjudicationsTest$AdjudicationsAPI_mockSuccessfulAdjudicationsCall(offenderDetails.otherIds.nomsNumber!!, 0, 30, adjudicationsResponse)</ID>
-    <ID>MaxLineLength:PersonDepartedFactory.kt$PersonDepartedFactory$private var personDepartedDestination: Yielded&lt;PersonDepartedDestination&gt; = { PersonDepartedDestinationFactory().produce() }</ID>
-    <ID>MaxLineLength:PersonInfoResult.kt$PersonInfoResult.Success$Full : Success</ID>
-    <ID>MaxLineLength:PersonOASysRiskToSelfTest.kt$PersonOASysRiskToSelfTest$APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, risksToTheIndividual, 2500)</ID>
-    <ID>MaxLineLength:PersonOffencesTest.kt$PersonOffencesTest$CommunityAPI_mockSuccessfulConvictionsCall(offenderDetails.otherIds.crn, listOf(activeConviction, inactiveConviction))</ID>
-    <ID>MaxLineLength:PersonTransformer.kt$PersonTransformer$isRestricted = (personInfoResult.offenderDetailSummary.currentExclusion || personInfoResult.offenderDetailSummary.currentRestriction)</ID>
-    <ID>MaxLineLength:PersonTransformer.kt$PersonTransformer$isRestricted = (personInfoResult.summary.currentRestriction == true || personInfoResult.summary.currentExclusion == true)</ID>
-    <ID>MaxLineLength:PersonTransformer.kt$PersonTransformer$personInfoResult.inmateDetail?.assignedLivingUnit?.agencyName ?: personInfoResult.inmateDetail?.assignedLivingUnit?.agencyId</ID>
-    <ID>MaxLineLength:PersonTransformer.kt$PersonTransformer$prisonName</ID>
-    <ID>MaxLineLength:PersonUtils.kt$fun</ID>
-    <ID>MaxLineLength:PersonUtils.kt$return</ID>
-    <ID>MaxLineLength:PersonUtils.kt$val</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingMatcherRole" })</ID>
     <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$fun</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$private</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$schemaVersion = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java)</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java)</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$val placementApplication = placementApplicationRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$val placementApplicationEntity = placementApplicationRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$val placementApplicationValidationResult = confirmApplicationCanBeUpdatedOrSubmitted(placementApplicationAuthorisationResult.entity)</ID>
-    <ID>MaxLineLength:PlacementApplicationService.kt$PlacementApplicationService$val placementRequestResult = placementRequestService.createPlacementRequestsFromPlacementApplication(placementApplicationEntity, placementApplicationDecisionEnvelope.decisionSummary)</ID>
-    <ID>MaxLineLength:PlacementApplicationServiceTest.kt$PlacementApplicationServiceTest.ReallocateApplicationTest$every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication</ID>
-    <ID>MaxLineLength:PlacementApplicationServiceTest.kt$PlacementApplicationServiceTest.ReallocateApplicationTest$every { placementApplicationRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementApplicationEntity }</ID>
-    <ID>MaxLineLength:PlacementApplicationServiceTest.kt$PlacementApplicationServiceTest.ReallocateApplicationTest$every { placementApplicationRepository.save(previousPlacementApplication) } answers { it.invocation.args[0] as PlacementApplicationEntity }</ID>
-    <ID>MaxLineLength:PlacementApplicationServiceTest.kt$PlacementApplicationServiceTest.ReallocateApplicationTest$fun</ID>
-    <ID>MaxLineLength:PlacementApplicationServiceTest.kt$PlacementApplicationServiceTest.ReallocateApplicationTest$match { it.first().expectedArrival == placementDates[0].expectedArrival &amp;&amp; it.first().duration == placementDates[0].duration }</ID>
-    <ID>MaxLineLength:PlacementApplicationsController.kt$PlacementApplicationsController$override</ID>
-    <ID>MaxLineLength:PlacementApplicationsController.kt$PlacementApplicationsController$val offenderResult = offenderService.getOffenderByCrn(placementApplication.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:PlacementApplicationsController.kt$PlacementApplicationsController$val result = placementApplicationService.submitApplication(id, serializedData, submitPlacementApplication.placementType, submitPlacementApplication.placementDates)</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$`Given a submitted Placement Application`</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$`Given placement requirements`</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$assertThat(createdPlacementApplication.allocatedToUser!!.id).isIn(listOf(matcher1.id, matcher2.id))</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$assertThat(createdPlacementApplication.application.id).isEqualTo(placementApplicationEntity.application.id)</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$assertThat(createdPlacementApplication.placementRequirements.id).isEqualTo(placementRequirements.id)</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$assertThat(updatedPlacementApplication.decision).isEqualTo(JpaPlacementApplicationDecision.ACCEPTED)</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationDecisionTest$fun</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.CreatePlacementApplicationTest$`Given an Assessment for Approved Premises`</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.GetPlacementApplicationTest$fun</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.SubmitPlacementApplicationTest$serializableToJsonNode(expectedUpdatedPlacementApplication.document) == serializableToJsonNode(it.document)</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.SubmitPlacementApplicationTest$val createdPlacementDates = placementDateRepository.findAllByPlacementApplication(placementApplicationEntity)</ID>
-    <ID>MaxLineLength:PlacementApplicationsTest.kt$PlacementApplicationsTest.WithdrawPlacementApplicationTest$assertThat(updatedPlacementApplication.decision).isEqualTo(uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.WITHDRAWN_BY_PP)</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$)</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$override</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$private</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$timeliness366PlusCalendarDays = successfulRequests.count { it.overallTimeliness != null &amp;&amp; it.overallTimeliness &gt;= 366 }</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$val averagePlacementMatchingTimeliness = successfulRequests.map { row -&gt; row.placementMatchingTimeliness!! }.average()</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$.</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$Duration.between(LocalDateTime.of(firstArg(), LocalTime.MIDNIGHT), LocalDateTime.of(secondArg(), LocalTime.MIDNIGHT)).toDays().toInt()</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness121To150CalendarDays]).isEqualTo(timeliness121To150CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness151To180CalendarDays]).isEqualTo(timeliness151To180CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness16To30CalendarDays]).isEqualTo(timeliness16To30CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness181To275CalendarDays]).isEqualTo(timeliness181To275CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness1To2WorkingDays]).isEqualTo(timeliness1To2WorkingDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness276To365CalendarDays]).isEqualTo(timeliness276To365CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness31To60CalendarDays]).isEqualTo(timeliness31To60CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness366PlusCalendarDays]).isEqualTo(timeliness366PlusCalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness3To5WorkingDays]).isEqualTo(timeliness3To5WorkingDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness61To90CalendarDays]).isEqualTo(timeliness61To90CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness8To15CalendarDays]).isEqualTo(timeliness8To15CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timeliness91To120CalendarDays]).isEqualTo(timeliness91To120CalendarDaysEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$assertThat(results[0][PlacementMetricsReportRow::timelinessSameDayAdmission]).isEqualTo(timelinessSameDayAdmissionEntities.count())</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$createTimelinessEntity(tier, applicationSubmittedAt, applicationSubmittedAt.plusDays(timeliness.toLong()), timeliness, timeliness + 5)</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$private</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$val successfulRequests = (1..5).toList().map { createTimelinessEntity("A1", LocalDateTime.now(), LocalDateTime.now(), 1, 1) }</ID>
-    <ID>MaxLineLength:PlacementMetricsReportGeneratorTest.kt$PlacementMetricsReportGeneratorTest$val unSuccessfulRequests = (1..7).toList().map { createTimelinessEntity("A1", LocalDateTime.now(), null, null, null) }</ID>
-    <ID>MaxLineLength:PlacementMetricsTest.kt$PlacementMetricsTest$fun</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformer.kt$PlacementRequestDetailTransformer$fun</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformerTest.kt$PlacementRequestDetailTransformerTest$every { mockApplicationsTransformer.transformJpaToApi(mockApplicationEntity, mockPersonInfoResult) } returns mockApplication</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformerTest.kt$PlacementRequestDetailTransformerTest$every { mockAssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns AssessmentDecision.accepted</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformerTest.kt$PlacementRequestDetailTransformerTest$every { mockPlacementRequestTransformer.transformJpaToApi(mockPlacementRequestEntity, mockPersonInfoResult) } returns transformedPlacementRequest</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformerTest.kt$PlacementRequestDetailTransformerTest$every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockk&lt;PersonRisks&gt;()</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformerTest.kt$PlacementRequestDetailTransformerTest$every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockk&lt;ApprovedPremisesUser&gt;()</ID>
-    <ID>MaxLineLength:PlacementRequestDetailTransformerTest.kt$PlacementRequestDetailTransformerTest$val result = placementRequestDetailTransformer.transformJpaToApi(mockPlacementRequestEntity, mockPersonInfoResult, mockCancellationEntities)</ID>
     <ID>MaxLineLength:PlacementRequestEntity.kt$PlacementRequestRepository$fun</ID>
-    <ID>MaxLineLength:PlacementRequestEntity.kt$PlacementRequestRepository$fun findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(isParole: Boolean, pageable: Pageable?): Page&lt;PlacementRequestEntity&gt;</ID>
-    <ID>MaxLineLength:PlacementRequestEntityFactory.kt$PlacementRequestEntityFactory$placementRequirements = this.placementRequirements?.invoke() ?: throw RuntimeException("Must provide Placement Requirements")</ID>
     <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest$`Given a Placement Request`(user, user, user, reallocated = isReallocated, isWithdrawn = isWithdrawn, isParole = isParole, crn = crn, name = name, expectedArrival = expectedArrival, tier = tier).first</ID>
     <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest$private</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$assertThat(matchedPlacementRequests.content.map { it.id }).isEqualTo(listOf(placementRequestsWithBooking[2], placementRequestsWithBooking[3]).map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$assertThat(notMatchedPlacementRequests.content.map { it.id }).isEqualTo(expectedNotMatchedPlacementRequests.map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$assertThat(notMatchedPlacementRequests.content.map { it.id }).isEqualTo(listOf(expectedNotMatchedPlacementRequests[2], expectedNotMatchedPlacementRequests[3]).map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$assertThat(unableToMatchPlacementRequests.content.map { it.id }).isEqualTo(listOf(placementRequestsWithABookingNotMade[2]).map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$assertThat(unableToMatchPlacementRequests.content.map { it.id }).isEqualTo(placementRequestsWithABookingNotMade.map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$expectedNotMatchedPlacementRequests = listOf(placementRequestsWithNoBooking, placementRequestsWithACancelledBooking).flatten()</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$fun</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$placementRequestsWithABookingNotMade = createPlacementRequests(3, isWithdrawn = false, isReallocated = false, isParole = true)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$placementRequestsWithACancelledBooking = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = false)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$placementRequestsWithBooking = createPlacementRequests(4, isWithdrawn = false, isReallocated = false, isParole = false)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$placementRequestsWithNoBooking = createPlacementRequests(4, isWithdrawn = false, isReallocated = false, isParole = true)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val allPlacementRequests = realPlacementRequestRepository.allForDashboard(null, null, null, null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, null, null)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, null, null, null, null, null)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, null, null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, crn = crn)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, name = name)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, tier = tier)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, "crN456", null, null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, crn, null, null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, "%$name%", null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, null, tier, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val unableToMatchPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.unableToMatch, null, null, null, null, null, null)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboard$val unableToMatchPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.unableToMatch, null, null, null, null, null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboardArrivalDate$val requestsForDate = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, expectedArrival = expectedArrival)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboardArrivalDate$val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, null, null, expectedArrival.minusDays(1), null, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.AllForDashboardArrivalDate$val results = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched, null, null, null, null, expectedArrival.plusDays(1), pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$assertThat(nonParoleResults.content.map { it.id }).isEqualTo(listOf(nonParolePlacementRequests[2], nonParolePlacementRequests[3]).map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$assertThat(paroleResults.content.map { it.id }).isEqualTo(listOf(parolePlacementRequests[2], parolePlacementRequests[3]).map { it.id })</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$nonParolePlacementRequests = createPlacementRequests(4, isWithdrawn = false, isReallocated = false, isParole = false)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$val nonParoleResults = realPlacementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(false, null)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$val nonParoleResults = realPlacementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(false, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$val paroleResults = realPlacementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(true, null)</ID>
-    <ID>MaxLineLength:PlacementRequestRepositoryTest.kt$PlacementRequestRepositoryTest.FindAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse$val paroleResults = realPlacementRequestRepository.findAllByIsParoleAndReallocatedAtNullAndIsWithdrawnFalse(true, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$)</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$ValidatableActionResult.FieldValidationError(ValidationErrors().apply { this["$.userId"] = "lackingMatcherRole" })</ID>
     <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$fun</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$is AuthorisableActionResult.NotFound -&gt; throw RuntimeException("Unable to get Offender Details when creating Booking Not Made Domain Event: Not Found")</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$is AuthorisableActionResult.Unauthorised -&gt; throw RuntimeException("Unable to get Offender Details when creating Booking Not Made Domain Event: Unauthorised")</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$return AuthorisableActionResult.NotFound("Placement Dates for Placement Application", placementApplicationEntity.id.toString())</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$val</ID>
-    <ID>MaxLineLength:PlacementRequestService.kt$PlacementRequestService$val response = placementRequestRepository.allForDashboard(status, crn, crnOrName, tier, arrivalDateStart, arrivalDateEnd, pageable)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$assertThat(newPlacementRequest.placementRequirements.apType).isEqualTo(previousPlacementRequest.placementRequirements.apType)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$assertThat(newPlacementRequest.placementRequirements.desirableCriteria).isEqualTo(previousPlacementRequest.placementRequirements.desirableCriteria)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$assertThat(newPlacementRequest.placementRequirements.essentialCriteria).isEqualTo(previousPlacementRequest.placementRequirements.essentialCriteria)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$assertThat(newPlacementRequest.placementRequirements.gender).isEqualTo(previousPlacementRequest.placementRequirements.gender)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$assertThat(newPlacementRequest.placementRequirements.postcodeDistrict).isEqualTo(previousPlacementRequest.placementRequirements.postcodeDistrict)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$assertThat(newPlacementRequest.placementRequirements.radius).isEqualTo(previousPlacementRequest.placementRequirements.radius)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { offenderService.getOffenderByCrn(application.crn, requestingUser.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, null, null) } returns page</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { placementRequestRepository.allForDashboard(PlacementRequestStatus.matched, null, null, null, null, null, pageRequest) } returns page</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { placementRequestRepository.allForDashboard(null, null, null, null, endDate, null, pageRequest) } returns page</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { placementRequestRepository.allForDashboard(null, null, null, null, startDate, null, pageRequest) } returns page</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementRequestEntity }</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$every { placementRequestRepository.save(previousPlacementRequest) } answers { it.invocation.args[0] as PlacementRequestEntity }</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$fun</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$private</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, null, null, null, 1, PlacementRequestSortField.createdAt, null)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, null, null, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(PlacementRequestStatus.matched, null, null, null, null, null, null, PlacementRequestSortField.createdAt, null)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(null, crn, null, null, null, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(null, null, null, null, endDate, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(null, null, null, null, startDate, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$val (requests, metadata) = placementRequestService.getAllActive(null, null, null, tier, null, null, 1, PlacementRequestSortField.expectedArrival, SortDirection.desc)</ID>
-    <ID>MaxLineLength:PlacementRequestServiceTest.kt$PlacementRequestServiceTest$verify(exactly = 1) { bookingNotMadeRepository.save(match { it.notes == "some notes" &amp;&amp; it.placementRequest == placementRequest }) }</ID>
-    <ID>MaxLineLength:PlacementRequestTransformer.kt$PlacementRequestTransformer$assessor = userTransformer.transformJpaToApi(jpa.assessment.allocatedToUser!!, ServiceName.approvedPremises) as ApprovedPremisesUser</ID>
-    <ID>MaxLineLength:PlacementRequestTransformerTest.kt$PlacementRequestTransformerTest$desirableCriteria = listOf(PlacementCriteria.isWheelchairDesignated, PlacementCriteria.isSingle, PlacementCriteria.hasEnSuite)</ID>
-    <ID>MaxLineLength:PlacementRequestTransformerTest.kt$PlacementRequestTransformerTest$essentialCriteria = listOf(PlacementCriteria.isSemiSpecialistMentalHealth, PlacementCriteria.isRecoveryFocussed)</ID>
-    <ID>MaxLineLength:PlacementRequestTransformerTest.kt$PlacementRequestTransformerTest$private val personInfo = PersonInfoResult.Success.Full(offenderDetailSummary.otherIds.crn, offenderDetailSummary, inmateDetail)</ID>
-    <ID>MaxLineLength:PlacementRequestTransformerTest.kt$PlacementRequestTransformerTest$val result = placementRequestTransformer.transformJpaToApi(placementRequestEntity, PersonInfoResult.Success.Full(offenderDetailSummary.otherIds.crn, offenderDetailSummary, inmateDetail))</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${it.application.crn}")</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$is AuthorisableActionResult.NotFound -&gt; throw NotFoundProblem(authorisableResult.id!!, authorisableResult.entityType!!)</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validatableResult.conflictingEntityId, conflictReason = validatableResult.message)</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validatableResult.validationMessages)</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validatableResult.message)</ID>
     <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$override</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$private</ID>
     <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$val (requests, metadata) = placementRequestService.getAllActive(status, crn, crnOrName, tier?.value, arrivalDateStart, arrivalDateEnd, page, sortBy ?: PlacementRequestSortField.createdAt, sortDirection)</ID>
-    <ID>MaxLineLength:PlacementRequestsController.kt$PlacementRequestsController$val personInfo = offenderService.getInfoForPerson(it.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.CreateBookingFromPlacementRequest$fun</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.CreateBookingFromPlacementRequest$probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$PersonInfoResult.Success.Full(unableToMatchOffender.otherIds.crn, unableToMatchOffender, unableToMatchInmate)</ID>
     <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$private</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$val placementRequestCreatedFiveDaysAgo = createPlacementRequest(offenderDetails, user, createdAt = OffsetDateTime.now().minusDays(5))</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$val placementRequestCreatedThirtyDaysAgo = createPlacementRequest(offenderDetails, user, createdAt = OffsetDateTime.now().minusDays(30))</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$val placementRequestWithApplicationCreatedThirtyDaysAgo = createPlacementRequest(offenderDetails, user, applicationDate = OffsetDateTime.now().minusDays(30))</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$val placementRequestWithApplicationCreatedTwelveDaysAgo = createPlacementRequest(offenderDetails, user, applicationDate = OffsetDateTime.now().minusDays(12))</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$val placementRequestWithExpectedArrivalInThirtyDays = createPlacementRequest(offenderDetails, user, expectedArrival = LocalDate.now().plusDays(30))</ID>
-    <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.Dashboard$val placementRequestWithExpectedArrivalInTwelveDays = createPlacementRequest(offenderDetails, user, expectedArrival = LocalDate.now().plusDays(12))</ID>
     <ID>MaxLineLength:PlacementRequestsTest.kt$PlacementRequestsTest.SinglePlacementRequest$fun</ID>
-    <ID>MaxLineLength:PlacementRequirementsEntityFactory.kt$PlacementRequirementsEntityFactory$private var desirableCriteria: Yielded&lt;List&lt;CharacteristicEntity&gt;&gt; = { listOf(CharacteristicEntityFactory().produce(), CharacteristicEntityFactory().produce()) }</ID>
-    <ID>MaxLineLength:PlacementRequirementsEntityFactory.kt$PlacementRequirementsEntityFactory$private var essentialCriteria: Yielded&lt;List&lt;CharacteristicEntity&gt;&gt; = { listOf(CharacteristicEntityFactory().produce()) }</ID>
-    <ID>MaxLineLength:PlacementRequirementsService.kt$PlacementRequirementsService$fun</ID>
-    <ID>MaxLineLength:PreemptiveCacheTest.kt$PreemptiveCacheTest$// Subsequent calls up to the first amount of seconds in failureSoftTtlBackoffSeconds should return the cached value without making an upstream request</ID>
-    <ID>MaxLineLength:PreemptiveCacheTest.kt$PreemptiveCacheTest$// The next call after successSoftTtlSeconds should make an upstream request and replace the original cached value, attempt number in metadata should increase to 2</ID>
-    <ID>MaxLineLength:PreemptiveCacheTest.kt$PreemptiveCacheTest$wiremockServer.verify(exactly(1), getRequestedFor(urlEqualTo("/secure/offenders/crn/${offenderDetailsResponse.otherIds.crn}")))</ID>
-    <ID>MaxLineLength:PreemptiveCacheTest.kt$PreemptiveCacheTest$wiremockServer.verify(exactly(1), getRequestedFor(urlEqualTo("/secure/offenders/crn/${offenderDetailsResponseOne.otherIds.crn}")))</ID>
-    <ID>MaxLineLength:PreemptiveCacheTest.kt$PreemptiveCacheTest$wiremockServer.verify(exactly(2), getRequestedFor(urlEqualTo("/secure/offenders/crn/${offenderDetailsResponseOne.otherIds.crn}")))</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$// TODO: Bookings will need to be specialised in a similar way to Premises so that TA Bookings do not have a keyWorkerStaffCode field</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$if</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${body.crn}")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$if (premises !is ApprovedPremisesEntity) throw RuntimeException("Booking ${it.id} has a Key Worker specified but Premises ${premises.id} is not an ApprovedPremises")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$if (premises !is ApprovedPremisesEntity) throw RuntimeException("Booking has a Key Worker specified but Premises is not an ApprovedPremises")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is AuthorisableActionResult.NotFound -&gt; throw InternalServerErrorProblem("No team found for QCode: ${premises.qCode}")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = cancelLostBedResult.conflictingEntityId, conflictReason = cancelLostBedResult.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validatableResult.conflictingEntityId, conflictReason = validatableResult.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = cancelLostBedResult.validationMessages)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = result.validationMessages)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validatableResult.validationMessages)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validationResult.validationMessages)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = cancelLostBedResult.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validatableResult.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validationResult.message)</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$override</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$private</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$throw ConflictProblem(it.id, "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$throw ConflictProblem(it.id, "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$throw InternalServerErrorProblem("Unable to get Key Worker via Staff Code: $keyWorkerStaffCode / Q Code: ${premises.qCode}")</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$val</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$val personInfo = offenderService.getInfoForPerson(body.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$val personInfo = offenderService.getInfoForPerson(booking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$val personInfo = personSummary.find { personSummary -&gt; personSummary.crn == it.getCrn() } ?: PersonSummaryInfoResult.NotFound(it.getCrn())</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$val personSummary = offenderService.getOffenderSummariesByCrns(crns, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$val staffMemberResult = async { staffMemberService.getStaffMemberByCode(keyWorkerStaffCode, premises.qCode) }.await()</ID>
-    <ID>MaxLineLength:PremisesController.kt$PremisesController$xServiceName != null &amp;&amp; xUserRegion != null -&gt; premisesService.getAllPremisesInRegionForService(xUserRegion, xServiceName)</ID>
     <ID>MaxLineLength:PremisesEntity.kt$PremisesRepository$@Query("SELECT new uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesSummary(p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.status, CAST(COUNT(b) as int), p.apCode) FROM ApprovedPremisesEntity p LEFT JOIN p.rooms r LEFT JOIN r.beds b GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status")</ID>
-    <ID>MaxLineLength:PremisesEntity.kt$PremisesRepository$fun</ID>
-    <ID>MaxLineLength:PremisesService.kt$PremisesService$fun getAllPremisesInRegion(probationRegionId: UUID): List&lt;PremisesEntity&gt;</ID>
-    <ID>MaxLineLength:PremisesService.kt$PremisesService$fun getPremisesSummary(premisesId: UUID): List&lt;BookingSummary&gt;</ID>
-    <ID>MaxLineLength:PremisesService.kt$PremisesService$if (endDate.isBefore(startDate)) throw RuntimeException("startDate must be before endDate when calculating availability for range")</ID>
-    <ID>MaxLineLength:PremisesService.kt$PremisesService$pendingBookings = bookingsOnDay.count { it.arrival == null &amp;&amp; it.nonArrival == null &amp;&amp; it.cancellation == null }</ID>
-    <ID>MaxLineLength:PremisesService.kt$PremisesService$val</ID>
-    <ID>MaxLineLength:PremisesService.kt$PremisesService$val lostBedsOnDay = lostBeds.filter { lostBed -&gt; lostBed.startDate &lt;= date &amp;&amp; lostBed.endDate &gt; date &amp;&amp; lostBed.cancellation == null }</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate, pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate, pendingBookings = 0, arrivedBookings = 1, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(1), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(1), pendingBookings = 1, arrivedBookings = 1, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 1)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(1), pendingBookings = 1, arrivedBookings = 1, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 2)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(2), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(2), pendingBookings = 1, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(3), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(3), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 1, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(4), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(4), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 1, cancelledBookings = 1, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 0, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$Availability(date = startDate.plusDays(5), pendingBookings = 0, arrivedBookings = 0, nonArrivedBookings = 0, cancelledBookings = 1, lostBeds = 0)</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) }</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf()</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) }</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf()</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$every { premisesRepositoryMock.nameIsUniqueForType&lt;TemporaryAccommodationPremisesEntity&gt;(any(), any()) } returns false</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$every { premisesRepositoryMock.nameIsUniqueForType&lt;TemporaryAccommodationPremisesEntity&gt;(any(), any()) } returns true</ID>
-    <ID>MaxLineLength:PremisesServiceTest.kt$PremisesServiceTest$fun</ID>
-    <ID>MaxLineLength:PremisesSummaryTest.kt$PremisesSummaryTest$probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }</ID>
-    <ID>MaxLineLength:PremisesSummaryTransformer.kt$PremisesSummaryTransformer$fun</ID>
-    <ID>MaxLineLength:PremisesSummaryTransformerTest.kt$PremisesSummaryTransformerTest$fun</ID>
-    <ID>MaxLineLength:PremisesTest.kt$PremisesTest$@ParameterizedTest(name = "Trying to create a new Temporary Accommodation premises with turnaround working day count = {0} returns 400 and errorType = {1}")</ID>
-    <ID>MaxLineLength:PremisesTest.kt$PremisesTest$fun</ID>
-    <ID>MaxLineLength:PremisesTest.kt$PremisesTest$probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }</ID>
-    <ID>MaxLineLength:PrisonCaseNotesConfig.kt$ExcludedCategory$fun excluded(otherCategory: String, otherSubcategory: String)</ID>
-    <ID>MaxLineLength:PrisonsApiClient.kt$PrisonsApiClient$fun getInmateDetailsCacheEntryStatus(nomsNumber: String)</ID>
-    <ID>MaxLineLength:ProbationAreaProbationRegionMappingEntity.kt$ProbationAreaProbationRegionMappingRepository$interface</ID>
-    <ID>MaxLineLength:ProbationAreaProbationRegionMappingTestRepository.kt$ProbationAreaProbationRegionMappingTestRepository$interface</ID>
-    <ID>MaxLineLength:ProblemResponsesTest.kt$DeserializationTestController$fun</ID>
-    <ID>MaxLineLength:ProblemResponsesTest.kt$ProblemResponsesTest$fun</ID>
-    <ID>MaxLineLength:ProfileTest.kt$ProfileTest$qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe)</ID>
-    <ID>MaxLineLength:RandomData.kt$fun Instant.randomDateTimeAfter(maxDays: Int = 14): Instant</ID>
-    <ID>MaxLineLength:RandomData.kt$fun Instant.randomDateTimeBefore(maxDays: Int = 14): Instant</ID>
-    <ID>MaxLineLength:RandomData.kt$fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime</ID>
-    <ID>MaxLineLength:RandomData.kt$fun OffsetDateTime.randomDateTimeAfter(maxDays: Int = 14): OffsetDateTime</ID>
-    <ID>MaxLineLength:RandomData.kt$fun OffsetDateTime.randomDateTimeBefore(maxDays: Int = 14): OffsetDateTime</ID>
-    <ID>MaxLineLength:RandomData.kt$fun randomEmailAddress()</ID>
-    <ID>MaxLineLength:ReallocationAtomicTest.kt$ReallocationAtomicTest$every { realAssessmentRepository.save(match { it.id != existingAssessment.id }) } throws RuntimeException("I am a database error")</ID>
-    <ID>MaxLineLength:RedisConfiguration.kt$RedisConfiguration$.</ID>
-    <ID>MaxLineLength:RedisConfiguration.kt$RedisConfiguration$builder.clientCacheFor&lt;StaffMembersPage&gt;("qCodeStaffMembersCache", Duration.ofSeconds(staffMembersExpirySeconds), time, objectMapper)</ID>
-    <ID>MaxLineLength:RedisConfiguration.kt$RedisConfiguration$private inline</ID>
-    <ID>MaxLineLength:RedisConfiguration.kt$const val IS_NOT_SUCCESSFUL = "!(#result instanceof T(uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult\$Success))"</ID>
-    <ID>MaxLineLength:ReferenceDataController.kt$ReferenceDataController$override</ID>
-    <ID>MaxLineLength:ReferenceDataTest.kt$ReferenceDataTest$fun</ID>
-    <ID>MaxLineLength:ReferralHistoryNoteHelper.kt$fun</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$private</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedAccommodationNeedOnly = referralsWithRejectionReason(referrals, "Reject, not suitable for an AP: Accommodation need only")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedInsufficientContingencyPlan = referralsWithRejectionReason(referrals, "Reject, insufficient information: Insufficient contingency plan")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedInsufficientMoveOnPlan = referralsWithRejectionReason(referrals, "Reject, insufficient information: Insufficient move on plan")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedNeedsCannotBeMet = referralsWithRejectionReason(referrals, "Reject, not suitable for an AP: Health / social care / disability needs cannot be met")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedOtherReasons = referralsWithRejectionReason(referrals, "Reject, not suitable for an AP: Not suitable for other reasons")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedRequestedInformationNotProvided = referralsWithRejectionReason(referrals, "Reject, insufficient information: Requested information not provided by probation practitioner")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedRiskToHighToStaff = referralsWithRejectionReason(referrals, "Reject, risk too high (must be approved by an AP Area Manager (APAM): Risk to staff")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedRiskTooHighToCommunity = referralsWithRejectionReason(referrals, "Reject, risk too high (must be approved by an AP Area Manager (APAM): Risk to community")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedRiskTooHighToOtherPeopleInAP = referralsWithRejectionReason(referrals, "Reject, risk too high (must be approved by an AP Area Manager (APAM): Risk to other people in AP")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedRiskTooLow = referralsWithRejectionReason(referrals, "Reject, not suitable for an AP: Risk too low")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsRejectedSupervisionPeriodTooShort = referralsWithRejectionReason(referrals, "Reject, not suitable for an AP: Remaining supervision period too short")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$referralsWithdrawn = referralsWithRejectionReason(referrals, "Application withdrawn: Application withdrawn by the probation practitioner")</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsByReleaseTypeHdc]).isEqualTo(assessmentsWithHdcReleaseType.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsByReleaseTypeLicence]).isEqualTo(assessmentsWithLicenceReleaseType.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsByReleaseTypePSS]).isEqualTo(assessmentsWithPssReleaseType.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsByReleaseTypeParole]).isEqualTo(assessmentsWithRotlReleaseType.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedAccommodationNeedOnly]).isEqualTo(assessmentsRejectedAccommodationNeedOnly.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedInsufficientContingencyPlan]).isEqualTo(assessmentsRejectedInsufficientContingencyPlan.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedInsufficientMoveOnPlan]).isEqualTo(assessmentsRejectedInsufficientMoveOnPlan.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedNeedsCannotBeMet]).isEqualTo(assessmentsRejectedNeedsCannotBeMet.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedOtherReasons]).isEqualTo(assessmentsRejectedOtherReasons.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedRequestedInformationNotProvided]).isEqualTo(assessmentsRejectedRequestedInformationNotProvided.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedRiskToHighToStaff]).isEqualTo(assessmentsRejectedRiskToHighToStaff.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedRiskTooHighToCommunity]).isEqualTo(assessmentsRejectedRiskTooHighToCommunity.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedRiskTooHighToOtherPeopleInAP]).isEqualTo(assessmentsRejectedRiskTooHighToOtherPeopleInAP.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedRiskTooLow]).isEqualTo(assessmentsRejectedRiskTooLow.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsRejectedSupervisionPeriodTooShort]).isEqualTo(assessmentsRejectedSupervisionPeriodTooShort.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$assertThat(results[0][ReferralsMetricsReportRow::referralsWithInformationRequests]).isEqualTo(assessmentsWithInformationRequests.size)</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$createDto(tier = "A0", applicationSubmittedAt = LocalDate.of(2023, 1, 2), assessmentSubmittedAt = LocalDate.of(2023, 1, 5))</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$createDto(tier = "A0", applicationSubmittedAt = LocalDate.of(2023, 1, 3), assessmentSubmittedAt = LocalDate.of(2023, 1, 15))</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$createDto(tier = "A0", applicationSubmittedAt = LocalDate.of(2023, 1, 3), assessmentSubmittedAt = LocalDate.of(2023, 1, 7))</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$createDto(tier = "A0", applicationSubmittedAt = LocalDate.of(2023, 1, 4), assessmentSubmittedAt = LocalDate.of(2023, 1, 7))</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedAccommodationNeedOnly = (1..1).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, not suitable for an AP: Accommodation need only") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedInsufficientContingencyPlan = (1..7).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, insufficient information: Insufficient contingency plan") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedInsufficientMoveOnPlan = (1..8).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, insufficient information: Insufficient move on plan") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedNeedsCannotBeMet = (1..2).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, not suitable for an AP: Health / social care / disability needs cannot be met") }</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedOtherReasons = (1..5).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, not suitable for an AP: Not suitable for other reasons") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedRequestedInformationNotProvided = (1..6).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, insufficient information: Requested information not provided by probation practitioner") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedRiskToHighToStaff = (1..11).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, risk too high (must be approved by an AP Area Manager (APAM): Risk to staff") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedRiskTooHighToCommunity = (1..9).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, risk too high (must be approved by an AP Area Manager (APAM): Risk to community") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedRiskTooHighToOtherPeopleInAP = (1..10).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, risk too high (must be approved by an AP Area Manager (APAM): Risk to other people in AP") }</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedRiskTooLow = (1..4).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, not suitable for an AP: Risk too low") }</ID>
     <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsRejectedSupervisionPeriodTooShort = (1..3).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Reject, not suitable for an AP: Remaining supervision period too short") }</ID>
-    <ID>MaxLineLength:ReferralsMetricsReportGeneratorTest.kt$ReferralsMetricsReportGeneratorTest$val assessmentsWithdrawn = (1..12).map { createDto("A0", decision = AssessmentDecision.REJECTED, rejectionReason = "Application withdrawn: Application withdrawn by the probation practitioner") }</ID>
-    <ID>MaxLineLength:ReferralsReportTest.kt$ReferralsReportTest$fun</ID>
-    <ID>MaxLineLength:ReportService.kt$ReportService$.</ID>
-    <ID>MaxLineLength:ReportService.kt$ReportService$fun</ID>
-    <ID>MaxLineLength:ReportService.kt$ReportService$val</ID>
-    <ID>MaxLineLength:ReportsController.kt$ReportsController$override</ID>
-    <ID>MaxLineLength:ReportsController.kt$ReportsController$private</ID>
-    <ID>MaxLineLength:ReportsController.kt$ReportsController$probationRegionId != null &amp;&amp; !userAccessService.currentUserCanAccessRegion(probationRegionId) -&gt; throw ForbiddenProblem()</ID>
-    <ID>MaxLineLength:ReportsTest.kt$ReportsTest$.</ID>
-    <ID>MaxLineLength:ReportsTest.kt$ReportsTest$fun</ID>
-    <ID>MaxLineLength:RisksTransformer.kt$RisksTransformer$fun</ID>
-    <ID>MaxLineLength:RoomEntityFactory.kt$RoomEntityFactory$fun withCharacteristicsList(characteristics: List&lt;CharacteristicEntity&gt;)</ID>
-    <ID>MaxLineLength:RoomServiceTest.kt$RoomServiceTest$private val roomService = RoomService(roomRepository, bedRepository, bookingRepository, lostBedsRepository, characteristicService)</ID>
-    <ID>MaxLineLength:RoshRatings.kt$RoshRatingsInner$fun anyRisksAreNull()</ID>
-    <ID>MaxLineLength:RoshRatings.kt$RoshRatingsInner$val allLevels = listOf(riskChildrenCommunity, riskPrisonersCustody, riskStaffCommunity, riskStaffCustody, riskKnownAdultCommunity, riskKnownAdultCustody, riskPublicCommunity, riskPublicCustody)</ID>
-    <ID>MaxLineLength:SeedApprovedPremisesTest.kt$SeedApprovedPremisesTest$"[addressLine2, postcode, totalBeds, notes, emailAddress, characteristics, isIAP, isPIPE, isESAP, isSemiSpecialistMentalHealth, "</ID>
-    <ID>MaxLineLength:SeedBookingsTest.kt$SeedBookingsTest$it.throwable.message!!.contains("Unable to complete GET request to /secure/staff/username/USERNAME: 404 NOT_FOUND")</ID>
-    <ID>MaxLineLength:SeedJob.kt$SeedJob$throw RuntimeException("Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied")</ID>
-    <ID>MaxLineLength:SeedScaffoldingTest.kt$SeedScaffoldingTest$"Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied"</ID>
-    <ID>MaxLineLength:SeedService.kt$SeedService$errors += "Unable to deserialize CSV at row: $rowNumber: ${exception.message} ${exception.stackTrace.joinToString("\n")}"</ID>
-    <ID>MaxLineLength:SeedService.kt$SeedService$errors.add("Error on row $rowNumber: ${exception.message} ${if (rootCauseException != null) rootCauseException.message else "no exception cause"}")</ID>
-    <ID>MaxLineLength:SeedService.kt$SeedService$fun seedData(seedFileType: SeedFileType, filename: String)</ID>
-    <ID>MaxLineLength:SeedServiceTest.kt$SeedServiceTest$every { mockApplicationContext.getBean(LocalAuthorityAreaRepository::class.java) } returns mockLocalAuthorityAreaRepository</ID>
-    <ID>MaxLineLength:SeedServiceTest.kt$SeedServiceTest$every { mockApplicationContext.getBean(ProbationRegionRepository::class.java) } returns mockProbationRegionRepository</ID>
-    <ID>MaxLineLength:SeedServiceTest.kt$SeedServiceTest$every { spy["seedData"](SeedFileType.approvedPremises, "approved_premises", capture(approvedPremisesLambda)) } returns Unit</ID>
-    <ID>MaxLineLength:SeedServiceTest.kt$SeedServiceTest$every { spy["seedData"](SeedFileType.approvedPremisesRooms, "approved_premises_rooms", capture(approvedPremisesRoomLambda)) } returns Unit</ID>
-    <ID>MaxLineLength:SeedServiceTest.kt$SeedServiceTest$it.message.contains("/db/seed/unknown-job-type/unknown_seed_file.csv does not have a known job type; skipping.")</ID>
-    <ID>MaxLineLength:SeedServiceTest.kt$SeedServiceTest$it.message.contains("\\db\\seed\\unknown-job-type\\unknown_seed_file.csv does not have a known job type; skipping.")</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationBedspaceTest.kt$SeedTemporaryAccommodationBedspaceTest$private</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationPremisesTest.kt$SeedTemporaryAccommodationPremisesTest$private</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"APP,78 Applemill Court,Pudding Lane,Hereford,HR6 7ZP,West Midlands,Herefordshire,\"Herefordshire, Shropshire and Telford\",TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,app@emailaddress.com"</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"CHE,1 CherryTree Lane,,Sheffield,SH7 4PB,Yorkshire and the Humber,Sheffield,Sheffield,FALSE,FALSE,FALSE,TRUE,TRUE,FALSE,TRUE,TRUE,FALSE,\"Property is located on the same road as a primary school and a park.\",che@emailaddress.com\n"</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"CHE,CHE-1,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,TRUE,FALSE,\"Property is located on the same road as a primary school and a park.\",che@emailaddress.com\n"</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"Property reference,Address Line 1,Address Line 2 (optional),City/Town,Postcode,Region,Local authority / Borough,Probation delivery unit (PDU),Floor level access?,Wheelchair accessible?,Pub nearby?,Park nearby?,School nearby?,Women only?,Men only?,Not suitable for RSO?,Not suitable for arson offenders?,Optional notes,Email Address\n"</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"Property reference,Bedspace reference,Single bed?,Double bed?,Shared kitchen?,Floor level access?,Lift access?,Wheelchair accessible?,Not suitable for RSO?,Not suitable for arson offenders?,Optional notes about the bedspace,Email address\n"</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"SIL,12 Silverhill Lane,Broadheath,Bath,BA3 0EZ,South West,Bath and North East Somerset,Bath and North Somerset (Bath and North East Somerset and North Somerset),FALSE,FALSE,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,TRUE,\"This property has 3 bedspaces, with shared kitchen facilities.\",sil@emailaddress.com\n"</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"SIL,SIL-1,TRUE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,\"Bedspace is 1 of 3 in the property, with access to a shared kitchen.\",sil@email.com\n"</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"SIL,SIL-2,TRUE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,\"Bedspace is 2 of 3 in the property, with access to a shared kitchen.\",sil@email.com\n"</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"SIL,SIL-3,TRUE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,\"Bedspace is 3 of 3 in the property, with access to a shared kitchen.\",sil@email.com\n"</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"STR,24 Strawberry Road,City Centre,Newport,NP1 0PA,Wales,Newport,\"Gwent (Blaenau Gwent, Caerphilly, Monmouthshire, Newport, Torfaen)\",FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,\"Not suitable to those who hold addictive behaviours.\",str@emailaddress.com\n"</ID>
     <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"WED,1 Wednesday Street,,Westminster,SE19 4EP,London,Lewisham,Lewisham and Bromley,TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,\"Property is located in a block of flats. Bedspace is accessible for wheelchair users, as has ground floor access and a lift up to the property. Cleaning turn around is 7 days.\",wed@emailaddress.com\n"</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"WED,WED-1,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,FALSE,FALSE,\"Bedspace is accessible for wheelchair users, as has ground floor access and a lift up to the property.\",wed@email.com\n"</ID>
-    <ID>MaxLineLength:SeedTemporaryAccommodationSmokeTest.kt$SeedTemporaryAccommodationSmokeTest$"WED,WED-2,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,FALSE,FALSE,\"Bedspace is accessible for wheelchair users, as has ground floor access and a lift up to the property.\",wed@email.com\n"</ID>
-    <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$assertThat(persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification))</ID>
-    <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$expectedRoles = listOf(UserRole.CAS1_ADMIN, UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR)</ID>
-    <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$expectedRoles = listOf(UserRole.CAS1_ADMIN, UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER)</ID>
-    <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Unrecognised User Qualifications(s): [PIPEE]")</ID>
-    <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Unrecognised User Role(s): [WORKFLOW_MANAGEF]")</ID>
     <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$println("${it.staffUserDetails.username}\n" + it.iterationValidations.mapIndexed { index, validation -&gt; " Run $index: roles correct = ${validation.rolesCorrect}, qalifications correct = ${validation.qualificationsCorrect}" }.joinToString("\n"))</ID>
-    <ID>MaxLineLength:SeedUsersTest.kt$SeedUsersTest$qualificationsCorrect = persistedUser.qualifications.map(UserQualificationAssignmentEntity::qualification).containsAll(it.expectedQualifications)</ID>
-    <ID>MaxLineLength:StaffMemberService.kt$StaffMemberService$fun</ID>
-    <ID>MaxLineLength:StaffMemberService.kt$StaffMemberService$is ClientResult.Failure.StatusCode -&gt; if (staffMembersResponse.status == HttpStatus.NOT_FOUND) AuthorisableActionResult.NotFound() else staffMembersResponse.throwException()</ID>
-    <ID>MaxLineLength:StringHelpers.kt$return replace(pattern) { it.value.last().uppercase() }.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }</ID>
-    <ID>MaxLineLength:TaskService.kt$TaskService$fun</ID>
-    <ID>MaxLineLength:TaskService.kt$TaskService$is ValidatableActionResult.ConflictError -&gt; AuthorisableActionResult.Success(ValidatableActionResult.ConflictError(validationResult.conflictingEntityId, validationResult.message))</ID>
-    <ID>MaxLineLength:TaskService.kt$TaskService$is ValidatableActionResult.FieldValidationError -&gt; AuthorisableActionResult.Success(ValidatableActionResult.FieldValidationError(validationResult.validationMessages))</ID>
-    <ID>MaxLineLength:TaskService.kt$TaskService$is ValidatableActionResult.GeneralValidationError -&gt; AuthorisableActionResult.Success(ValidatableActionResult.GeneralValidationError(validationResult.message))</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$every { assessmentServiceMock.reallocateAssessment(assigneeUser, assessment.id) }</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$every { placementApplicationServiceMock.reallocateApplication(assigneeUser, placementApplication.id) }</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$every { placementRequestServiceMock.reallocatePlacementRequest(assigneeUser, placementRequest.id) }</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUser.id, assessment.id)</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUserId, UUID.randomUUID())</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$val result = taskService.reallocateTask(requestUserWithPermission, TaskType.placementApplication, assigneeUser.id, placementApplication.id)</ID>
-    <ID>MaxLineLength:TaskServiceTest.kt$TaskServiceTest$val result = taskService.reallocateTask(requestUserWithPermission, TaskType.placementRequest, assigneeUser.id, placementRequest.id)</ID>
-    <ID>MaxLineLength:TaskTransformer.kt$TaskTransformer$fun</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$async { tasks += getPlacementApplicationTasks(placementApplicationService.getVisiblePlacementApplicationsForUser(user), user) }</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$async { tasks += getPlacementRequestTasks(placementRequestService.getVisiblePlacementRequestsForUser(user), user) }</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$body?.userId == null -&gt; throw BadRequestProblem(invalidParams = ValidationErrors(mutableMapOf("$.userId" to "empty")))</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$is ValidatableActionResult.ConflictError -&gt; throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$is ValidatableActionResult.FieldValidationError -&gt; throw BadRequestProblem(invalidParams = validationResult.validationMessages)</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$is ValidatableActionResult.GeneralValidationError -&gt; throw BadRequestProblem(errorDetail = validationResult.message)</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$private</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$private suspend</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$private suspend fun getPlacementRequestTasks(placementRequests: List&lt;PlacementRequestEntity&gt;, user: UserEntity)</ID>
     <ID>MaxLineLength:TasksController.kt$TasksController$transformedAllocatableUsers</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$userService.getUsersWithQualificationsAndRolesPassingLAO(placementRequest.application.crn, emptyList(), listOf(UserRole.CAS1_MATCHER))</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$val offenderDetailsResult = offenderService.getOffenderByCrn(assessment.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$val offenderDetailsResult = offenderService.getOffenderByCrn(placementApplication.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$val offenderDetailsResult = offenderService.getOffenderByCrn(placementRequest.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))</ID>
-    <ID>MaxLineLength:TasksController.kt$TasksController$val placementApplicationTasks = getPlacementApplicationTasks(placementApplicationService.getAllReallocatable(), user)</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.DeallocateTaskTest$val assessment = temporaryAccommodationAssessmentRepository.findAll().first { it.id == existingAssessment.id }</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.GetAllReallocatableTest$fun</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.GetTaskTest$task = taskTransformer.transformAssessmentToTask(assessment, "${offenderDetails.firstName} ${offenderDetails.surname}")</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.GetTaskTest$task = taskTransformer.transformPlacementApplicationToTask(placementApplication, "${offenderDetails.firstName} ${offenderDetails.surname}")</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.GetTaskTest$task = taskTransformer.transformPlacementRequestToTask(placementRequest, "${offenderDetails.firstName} ${offenderDetails.surname}")</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.GetTaskTest$users = listOf(userTransformer.transformJpaToApi(allocatableUser, ServiceName.approvedPremises))</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$Assertions.assertThat(desirableCriteria).isEqualTo(existingPlacementRequest.placementRequirements.desirableCriteria.map { it.propertyName })</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$Assertions.assertThat(essentialCriteria).isEqualTo(existingPlacementRequest.placementRequirements.essentialCriteria.map { it.propertyName })</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$Assertions.assertThat(placementApplications.first { it.id == placementApplication.id }.reallocatedAt).isNotNull</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$Assertions.assertThat(placementRequests.first { it.id == existingPlacementRequest.id }.reallocatedAt).isNotNull</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$fun</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$user = userTransformer.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) as ApprovedPremisesUser</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$val allocatedPlacementApplication = placementApplications.find { it.allocatedToUser!!.id == assigneeUser.id }</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$val desirableCriteria = allocatedPlacementRequest!!.placementRequirements.desirableCriteria.map { it.propertyName }</ID>
-    <ID>MaxLineLength:TasksTest.kt$TasksTest.ReallocateTaskTest$val essentialCriteria = allocatedPlacementRequest!!.placementRequirements.essentialCriteria.map { it.propertyName }</ID>
-    <ID>MaxLineLength:TemporaryAccommodationApplicationJsonSchemaEntityFactory.kt$TemporaryAccommodationApplicationJsonSchemaEntityFactory$class</ID>
-    <ID>MaxLineLength:TemporaryAccommodationAssessmentJsonSchemaEntityFactory.kt$TemporaryAccommodationAssessmentJsonSchemaEntityFactory$class</ID>
-    <ID>MaxLineLength:TemporaryAccommodationAssessmentJsonSchemaEntityFactory.kt$TemporaryAccommodationAssessmentJsonSchemaEntityFactory$override</ID>
-    <ID>MaxLineLength:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$.</ID>
-    <ID>MaxLineLength:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$log.info("Updating existing Temporary Accommodation bedspace '${row.bedspaceName}' on premises '${row.premisesName}'")</ID>
-    <ID>MaxLineLength:TemporaryAccommodationPremisesEntityFactory.kt$TemporaryAccommodationPremisesEntityFactory$localAuthorityArea = this.localAuthorityArea?.invoke() ?: throw RuntimeException("Must provide a local authority area")</ID>
-    <ID>MaxLineLength:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$log.warn("'${row.localAuthorityArea}' is not the canonical local authority name, correcting to '$canonicalLocalAuthorityName'")</ID>
-    <ID>MaxLineLength:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$updateExistingPremises(row, existingPremises, probationRegion, localAuthorityArea, probationDeliveryUnit, characteristics)</ID>
-    <ID>MaxLineLength:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$val</ID>
-    <ID>MaxLineLength:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$val existingPremises = premisesRepository.findByName(row.name, TemporaryAccommodationPremisesEntity::class.java) as TemporaryAccommodationPremisesEntity?</ID>
-    <ID>MaxLineLength:TestPropertiesInitializer.kt$TestPropertiesInitializer$"hmpps.sqs.topics.domainevents.arn" to "arn:aws:sns:eu-west-2:000000000000:domainevents-int-test-${randomStringLowerCase(10)}"</ID>
-    <ID>MaxLineLength:TestPropertiesInitializer.kt$TestPropertiesInitializer$upstreamServiceUrlsToOverride[propertyName] = ((propertyValue as OriginTrackedValue).value as String).replace("#WIREMOCK_PORT", wiremockPort.toString())</ID>
-    <ID>MaxLineLength:TurnaroundTest.kt$TurnaroundTest$.</ID>
     <ID>MaxLineLength:UnauthenticatedProblem.kt$UnauthenticatedProblem$class</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$)</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$ServiceName.approvedPremises.value -&gt; user.hasAnyRole(UserRole.CAS1_REPORT_VIEWER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ADMIN)</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$fun</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$is ApprovedPremisesApplicationEntity -&gt; userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application)</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$is ApprovedPremisesEntity -&gt; user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$is TemporaryAccommodationApplicationEntity -&gt; userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(user, application)</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$is TemporaryAccommodationPremisesEntity -&gt; userCanAccessRegion(user, premises.probationRegion.id) &amp;&amp; user.hasRole(UserRole.CAS3_ASSESSOR)</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER) -&gt; ApprovedPremisesApplicationAccessLevel.ALL</ID>
-    <ID>MaxLineLength:UserAccessService.kt$UserAccessService$userCanAccessRegion(user, (assessment.application as TemporaryAccommodationApplicationEntity).probationRegion.id)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$@EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$@EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_REPORT_VIEWER", "CAS1_ADMIN"], mode = EnumSource.Mode.EXCLUDE)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesInUserRegion)).isTrue</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesNotInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanManagePremisesLostBeds(temporaryAccommodationPremisesInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanManagePremisesLostBeds(temporaryAccommodationPremisesInUserRegion)).isTrue</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanManagePremisesLostBeds(temporaryAccommodationPremisesNotInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.currentUserCanViewPremisesCapacity(temporaryAccommodationPremisesNotInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForCurrentUser()).isEqualTo(ApprovedPremisesApplicationAccessLevel.ALL)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForCurrentUser()).isEqualTo(ApprovedPremisesApplicationAccessLevel.TEAM)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForUser(user)).isEqualTo(ApprovedPremisesApplicationAccessLevel.ALL)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForUser(user)).isEqualTo(ApprovedPremisesApplicationAccessLevel.TEAM)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForCurrentUser()).isEqualTo(TemporaryAccommodationApplicationAccessLevel.NONE)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForCurrentUser()).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SELF)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForCurrentUser()).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.NONE)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SELF)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION)</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.userCanManagePremisesBookings(user, temporaryAccommodationPremisesInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.userCanManagePremisesBookings(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.userCanManagePremisesLostBeds(user, temporaryAccommodationPremisesInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.userCanManagePremisesLostBeds(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$assertThat(userAccessService.userCanViewPremisesCapacity(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$every { offenderService.getOffenderByCrn(application.crn, user.deliusUsername) }</ID>
-    <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$every { offenderService.getOffenderByCrn(application.crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()</ID>
     <ID>MaxLineLength:UserAccessServiceTest.kt$UserAccessServiceTest$fun</ID>
-    <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$.</ID>
-    <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$AllocationType.PlacementApplication -&gt; userRepository.findUserWithLeastPendingOrCompletedInLastWeekPlacementApplications(userIds)</ID>
-    <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$AllocationType.PlacementRequest -&gt; userRepository.findUserWithLeastPendingOrCompletedInLastWeekPlacementRequests(userIds)</ID>
     <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$class</ID>
-    <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$private</ID>
-    <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$private fun allActiveUsers(criteriaBuilder: CriteriaBuilder, root: Root&lt;UserEntity&gt;)</ID>
-    <ID>MaxLineLength:UserAllocationsEngine.kt$UserAllocationsEngine$userQualifications.get&lt;UserQualificationAssignmentEntity&gt;(UserQualificationAssignmentEntity::qualification.name)</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$"Assessor with both Qualifications, zero pending allocated Assessments and one complete Assessment from the last week"</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$"Matcher with both Qualifications, zero pending allocated Placement Applications and one complete Placement Application from the last week"</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$"Matcher with both Qualifications, zero pending allocated Placement Requests and one complete Placement Request from the last week"</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$fun</ID>
     <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$private</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$val allocationEngine = UserAllocationsEngine(realUserRepository, AllocationType.Assessment, listOf(UserQualification.PIPE, UserQualification.WOMENS), false)</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$val allocationEngine = UserAllocationsEngine(realUserRepository, AllocationType.PlacementApplication, listOf(UserQualification.PIPE, UserQualification.WOMENS), false)</ID>
-    <ID>MaxLineLength:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$val allocationEngine = UserAllocationsEngine(realUserRepository, AllocationType.PlacementRequest, listOf(UserQualification.PIPE, UserQualification.WOMENS), false)</ID>
-    <ID>MaxLineLength:UserEntity.kt$UserEntity$fun hasAllQualifications(requiredQualifications: List&lt;UserQualification&gt;)</ID>
-    <ID>MaxLineLength:UserEntity.kt$UserEntity$fun hasQualification(userQualification: UserQualification)</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$!isLao || it.hasQualification(UserQualification.LAO) || offenderService.getOffenderByCrn(crn, it.deliusUsername) is AuthorisableActionResult.Success</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$@Value("\${assign-default-region-to-users-with-unknown-region}") private val assignDefaultRegionToUsersWithUnknownRegion: Boolean</ID>
     <ID>MaxLineLength:UserService.kt$UserService$fun</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$log.warn("Unknown probation region code '${staffUserDetails.probationArea.code}' for user '$normalisedUsername', assigning a default region of 'North West'.")</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$return</ID>
     <ID>MaxLineLength:UserService.kt$UserService$return (deliusUser.email !== user.email) || (deliusUser.telephoneNumber !== user.telephoneNumber) || (deliusUser.staff.fullName != user.name) || (deliusUser.staffCode != user.deliusStaffCode) || (deliusUser.probationArea.code != user.probationRegion.deliusCode)</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$throw BadRequestProblem(errorDetail = "Unknown probation region code '${staffUserDetails.probationArea.code}' for user '$normalisedUsername'")</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$val allocationsEngine = UserAllocationsEngine(this.userRepository, AllocationType.PlacementApplication, emptyList(), isLao)</ID>
-    <ID>MaxLineLength:UserService.kt$UserService$val allocationsEngine = UserAllocationsEngine(this.userRepository, AllocationType.PlacementRequest, emptyList(), isLao)</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest$every { mockProbationAreaProbationRegionMappingRepository.findByProbationAreaDeliusCode("AREACODE") }</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest$fun</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest.DeleteUsersOnAPI$private val mockProbationAreaProbationRegionMappingRepository = mockk&lt;ProbationAreaProbationRegionMappingRepository&gt;()</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest.SearchUsersOnAPI$private val mockProbationAreaProbationRegionMappingRepository = mockk&lt;ProbationAreaProbationRegionMappingRepository&gt;()</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest.UpdateUserFromCommunityApiById$every { mockProbationAreaProbationRegionMappingRepository.findByProbationAreaDeliusCode(newProbationRegion.deliusCode) }</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest.UpdateUserFromCommunityApiById$every { mockProbationAreaProbationRegionMappingRepository.findByProbationAreaDeliusCode(user.probationRegion.deliusCode) }</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest.UpdateUserFromCommunityApiById$fun</ID>
-    <ID>MaxLineLength:UserServiceTest.kt$UserServiceTest.UpdateUserFromCommunityApiById$private val mockProbationAreaProbationRegionMappingRepository = mockk&lt;ProbationAreaProbationRegionMappingRepository&gt;()</ID>
-    <ID>MaxLineLength:UserServiceUtils.kt$ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation -&gt; UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION</ID>
-    <ID>MaxLineLength:UserSpecifications.kt$fun</ID>
-    <ID>MaxLineLength:UserTransformer.kt$UserTransformer$UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION -&gt; ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation</ID>
-    <ID>MaxLineLength:UserTransformer.kt$UserTransformer$private</ID>
-    <ID>MaxLineLength:UsersController.kt$UsersController$ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation -&gt; JpaUserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION</ID>
-    <ID>MaxLineLength:UsersController.kt$UsersController$UserQualification.emergency -&gt; uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.EMERGENCY</ID>
-    <ID>MaxLineLength:UsersController.kt$UsersController$if</ID>
     <ID>MaxLineLength:UsersController.kt$UsersController$override</ID>
     <ID>MaxLineLength:UsersController.kt$UsersController$private</ID>
-    <ID>MaxLineLength:UsersController.kt$UsersController$val (users, metadata) = userService.getUsersWithQualificationsAndRoles(qualifications, roles, sortBy, sortDirection, page)</ID>
-    <ID>MaxLineLength:UsersSeedJob.kt$UsersSeedJob$log.info("Setting roles for ${row.deliusUsername} to exactly ${row.roles.joinToString(",")}, qualifications to exactly: ${row.qualifications.joinToString(",")}")</ID>
-    <ID>MaxLineLength:UsersSeedJob.kt$UsersSeedJob$qualifications = parseAllQualificationsOrThrow(columns["qualifications"]!!.split(",").filter(String::isNotBlank).map(String::trim))</ID>
-    <ID>MaxLineLength:UsersTest.kt$UsersTest.GetUsers$`Given a User`</ID>
-    <ID>MaxLineLength:UsersTest.kt$UsersTest.GetUsers$fun</ID>
-    <ID>MaxLineLength:UsersTest.kt$UsersTest.SearchByDeliusUserName$fun</ID>
-    <ID>MaxLineLength:UsersTest.kt$UsersTest.UpdateUser$fun</ID>
-    <ID>MaxLineLength:ValidatableActionResult.kt$ValidatableActionResult$ConflictError&lt;EntityType&gt; : ValidatableActionResult</ID>
-    <ID>MaxLineLength:ValidationErrors.kt$ValidatedScope$infix fun String.hasSingleValidationError(message: String)</ID>
-    <ID>MaxLineLength:ValidationErrors.kt$ValidatedScope$val fieldValidationError: ValidatableActionResult.FieldValidationError&lt;EntityType&gt; = ValidatableActionResult.FieldValidationError(validationErrors)</ID>
-    <ID>MaxLineLength:ValidationErrors.kt$ValidationErrors$value</ID>
-    <ID>MaxLineLength:ValidationErrors.kt$inline</ID>
-    <ID>MaxLineLength:ValidationErrors.kt$private fun singleValidationErrorOf(propertyNameToMessage: Pair&lt;String, String&gt;)</ID>
-    <ID>MaxLineLength:WebClientCache.kt$WebClientCache$private</ID>
-    <ID>MaxLineLength:WebClientConfiguration.kt$WebClientConfiguration$.</ID>
-    <ID>MaxLineLength:WorkingDayCountServiceTest.kt$WorkingDayCountServiceTest$@ParameterizedTest(name = "getWorkingDaysCount returns 0 if from and to are the same date = {0} and it is a weekend day")</ID>
-    <ID>MaxLineLength:WorkingDayCountServiceTest.kt$WorkingDayCountServiceTest$fun</ID>
     <ID>NestedBlockDepth:CalendarService.kt$CalendarService$fun getCalendarInfo(user: UserEntity, premisesId: UUID, startDate: LocalDate, endDate: LocalDate): Map&lt;CalendarBedInfo, List&lt;CalendarOccupancyInfo&gt;&gt;</ID>
     <ID>NestedBlockDepth:DbExtension.kt$DbExtension$private fun setInitialDatabaseState(dataSource: DataSource)</ID>
     <ID>NestedBlockDepth:DeserializationValidationService.kt$DeserializationValidationService$fun validateObject(path: String = "$", targetType: KClass&lt;*&gt;, jsonObject: ObjectNode): Map&lt;String, String&gt;</ID>
@@ -1723,85 +331,21 @@
     <ID>NestedBlockDepth:SeedService.kt$SeedService$@PostConstruct fun autoSeed()</ID>
     <ID>PrintStackTrace:DbExtension.kt$DbExtension$e</ID>
     <ID>ProtectedMemberInFinalClass:PreemptiveCacheRefresher.kt$PreemptiveCacheRefresher$protected val log = LoggerFactory.getLogger(this::class.java)</ID>
-    <ID>ReturnCount:ApplicationService.kt$ApplicationService$@Transactional fun submitApplication( applicationId: UUID, submitApplication: SubmitCas2Application, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;Cas2ApplicationEntity&gt;&gt;</ID>
+    <ID>ReturnCount:ApplicationService.kt$ApplicationService$@Transactional fun submitApplication( submitApplication: SubmitCas2Application, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;Cas2ApplicationEntity&gt;&gt;</ID>
     <ID>ReturnCount:ApplicationService.kt$ApplicationService$@Transactional fun submitApprovedPremisesApplication(applicationId: UUID, submitApplication: SubmitApprovedPremisesApplication, username: String, jwt: String): AuthorisableActionResult&lt;ValidatableActionResult&lt;ApplicationEntity&gt;&gt;</ID>
     <ID>ReturnCount:ApplicationService.kt$ApplicationService$@Transactional fun submitTemporaryAccommodationApplication( applicationId: UUID, submitApplication: SubmitTemporaryAccommodationApplication, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;ApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:ApplicationService.kt$ApplicationService$@Transactional fun withdrawApprovedPremisesApplication( applicationId: UUID, user: UserEntity, withdrawalReason: String, otherReason: String?, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;Unit&gt;&gt;</ID>
-    <ID>ReturnCount:ApplicationService.kt$ApplicationService$fun getOfflineApplicationForUsername(applicationId: UUID, deliusUsername: String): AuthorisableActionResult&lt;OfflineApplicationEntity&gt;</ID>
     <ID>ReturnCount:ApplicationService.kt$ApplicationService$fun updateApplication(applicationId: UUID, data: String?, username: String?): AuthorisableActionResult&lt;ValidatableActionResult&lt;Cas2ApplicationEntity&gt;&gt;</ID>
     <ID>ReturnCount:ApplicationService.kt$ApplicationService$fun updateApprovedPremisesApplication( applicationId: UUID, isWomensApplication: Boolean?, isPipeApplication: Boolean?, isEmergencyApplication: Boolean?, isEsapApplication: Boolean?, releaseType: String?, arrivalDate: LocalDate?, data: String, isInapplicable: Boolean?, username: String, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;ApplicationEntity&gt;&gt;</ID>
     <ID>ReturnCount:ApplicationService.kt$ApplicationService$fun updateTemporaryAccommodationApplication( applicationId: UUID, data: String, username: String, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;ApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:ApplicationTest.kt$ApplicationTest$private fun serializableToJsonNode(serializable: Any?): JsonNode</ID>
-    <ID>ReturnCount:ApplicationsTransformer.kt$ApplicationsTransformer$private fun getStatusFromSummary(entity: DomainApplicationSummary): ApplicationStatus</ID>
     <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun acceptAssessment(user: UserEntity, assessmentId: UUID, document: String?, placementRequirements: PlacementRequirements?, placementDates: PlacementDates?, notes: String?): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun addAssessmentClarificationNote(user: UserEntity, assessmentId: UUID, text: String): AuthorisableActionResult&lt;AssessmentClarificationNoteEntity&gt;</ID>
-    <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun addAssessmentReferralHistoryUserNote(user: UserEntity, assessmentId: UUID, text: String): AuthorisableActionResult&lt;AssessmentReferralHistoryUserNoteEntity&gt;</ID>
     <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun closeAssessment( user: UserEntity, assessmentId: UUID, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun getAssessmentForUser(user: UserEntity, assessmentId: UUID): AuthorisableActionResult&lt;AssessmentEntity&gt;</ID>
-    <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun getAssessmentForUserAndApplication(user: UserEntity, applicationID: UUID): AuthorisableActionResult&lt;AssessmentEntity&gt;</ID>
     <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun rejectAssessment(user: UserEntity, assessmentId: UUID, document: String?, rejectionRationale: String): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
     <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun updateAssessment(user: UserEntity, assessmentId: UUID, data: String?): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
     <ID>ReturnCount:AssessmentService.kt$AssessmentService$fun updateAssessmentClarificationNote(user: UserEntity, assessmentId: UUID, id: UUID, response: String, responseReceivedOn: LocalDate): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentClarificationNoteEntity&gt;&gt;</ID>
-    <ID>ReturnCount:AssessmentService.kt$AssessmentService$private fun reallocateApprovedPremisesAssessment( assigneeUser: UserEntity, currentAssessment: ApprovedPremisesAssessmentEntity, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;AssessmentEntity&gt;&gt;</ID>
-    <ID>ReturnCount:BaseHMPPSClient.kt$BaseHMPPSClient$fun &lt;ResponseType : Any&gt; doRequest(typeReference: TypeReference&lt;ResponseType&gt;, method: HttpMethod, requestBuilderConfiguration: HMPPSRequestConfiguration.() -&gt; Unit): ClientResult&lt;ResponseType&gt;</ID>
-    <ID>ReturnCount:BedSummaryTransformer.kt$BedSummaryTransformer$private fun getStatus(summary: DomainBedSummary): BedStatus</ID>
-    <ID>ReturnCount:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesBookingFromPlacementRequest( user: UserEntity, placementRequestId: UUID, bedId: UUID?, premisesId: UUID?, arrivalDate: LocalDate, departureDate: LocalDate, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
-    <ID>ReturnCount:BookingService.kt$BookingService$@Transactional fun moveBooking( booking: BookingEntity, bedId: UUID, notes: String?, user: UserEntity, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
-    <ID>ReturnCount:BookingService.kt$BookingService$fun getBookingForPremises(premisesId: UUID, bookingId: UUID): GetBookingForPremisesResult</ID>
-    <ID>ReturnCount:Cas2ApplicationTest.kt$Cas2ApplicationTest$private fun serializableToJsonNode(serializable: Any?): JsonNode</ID>
-    <ID>ReturnCount:Cas2SubmissionTest.kt$Cas2SubmissionTest$private fun serializableToJsonNode(serializable: Any?): JsonNode</ID>
-    <ID>ReturnCount:CharacteristicService.kt$CharacteristicService$fun serviceScopeMatches(characteristic: CharacteristicEntity, target: Any): Boolean</ID>
-    <ID>ReturnCount:ExceptionHandling.kt$ExceptionHandling$override fun handleMessageNotReadableException( exception: HttpMessageNotReadableException, request: NativeWebRequest, ): ResponseEntity&lt;Problem&gt;</ID>
     <ID>ReturnCount:ExceptionHandling.kt$ExceptionHandling$override fun toProblem(throwable: Throwable, status: StatusType): ThrowableProblem?</ID>
-    <ID>ReturnCount:ExceptionHandling.kt$ExceptionHandling$private fun isInputTypeArray(mismatchedInputException: MismatchedInputException): Boolean</ID>
-    <ID>ReturnCount:HttpAuthService.kt$HttpAuthService$fun getDeliusPrincipalOrNull(): AuthAwareAuthenticationToken?</ID>
-    <ID>ReturnCount:Matchers.kt$&lt;no name provided&gt;$override fun matches(actual: Any?): Boolean</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getAcctAlertsByNomsNumber(nomsNumber: String): AuthorisableActionResult&lt;List&lt;Alert&gt;&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getAdjudicationsByNomsNumber(nomsNumber: String): AuthorisableActionResult&lt;AdjudicationsPage&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getConvictions(crn: String): AuthorisableActionResult&lt;List&lt;Conviction&gt;&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getDocuments(crn: String): AuthorisableActionResult&lt;GroupedDocuments&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getInfoForPerson(crn: String): PersonInfoResult</ID>
     <ID>ReturnCount:OffenderService.kt$OffenderService$fun getInfoForPerson(crn: String, deliusUsername: String, ignoreLao: Boolean): PersonInfoResult</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getInmateDetailByNomsNumber(crn: String, nomsNumber: String): AuthorisableActionResult&lt;InmateDetail?&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getOASysNeeds(crn: String): AuthorisableActionResult&lt;NeedsDetails&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getOASysOffenceDetails(crn: String): AuthorisableActionResult&lt;OffenceDetails&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getOASysRiskManagementPlan(crn: String): AuthorisableActionResult&lt;RiskManagementPlan&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getOASysRiskToTheIndividual(crn: String): AuthorisableActionResult&lt;RisksToTheIndividual&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getOASysRoshSummary(crn: String): AuthorisableActionResult&lt;RoshSummary&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getOffenderByCrn(crn: String, userDistinguishedName: String, ignoreLao: Boolean = false): AuthorisableActionResult&lt;OffenderDetailSummary&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getPrisonCaseNotesByNomsNumber(nomsNumber: String): AuthorisableActionResult&lt;List&lt;CaseNote&gt;&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$private fun getFlagsEnvelope(registrationsResponse: ClientResult&lt;Registrations&gt;): RiskWithStatus&lt;List&lt;String&gt;&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$private fun getMappaEnvelope(registrationsResponse: ClientResult&lt;Registrations&gt;): RiskWithStatus&lt;Mappa&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$private fun getRiskTierEnvelope(crn: String): RiskWithStatus&lt;RiskTier&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$private fun getRoshRisksEnvelope(crn: String): RiskWithStatus&lt;RoshRisks&gt;</ID>
-    <ID>ReturnCount:OffenderService.kt$OffenderService$private fun getRoshRisksEnvelope(crn: String, jwt: String): RiskWithStatus&lt;RoshRisks&gt;</ID>
-    <ID>ReturnCount:PersonUtils.kt$fun tryGetPersonDetailsForCrn( log: Logger, crn: String, deliusUsername: String, offenderService: OffenderService, ignoreLao: Boolean, ): AuthorisableActionResult&lt;Pair&lt;OffenderDetailSummary, InmateDetail?&gt;&gt;</ID>
     <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$@Transactional fun recordDecision(id: UUID, placementApplicationDecisionEnvelope: PlacementApplicationDecisionEnvelope): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$fun reallocateApplication(assigneeUser: UserEntity, id: UUID): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$fun submitApplication(id: UUID, translatedDocument: String, apiPlacementType: ApiPlacementType, apiPlacementDates: List&lt;ApiPlacementDates&gt;): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$fun updateApplication(id: UUID, data: String): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$fun withdrawPlacementApplication(id: UUID): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementApplicationEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$private fun confirmApplicationCanBeUpdatedOrSubmitted(placementApplicationEntity: PlacementApplicationEntity): ValidatableActionResult&lt;PlacementApplicationEntity&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationService.kt$PlacementApplicationService$private fun getApplicationForUpdateOrSubmit(id: UUID): AuthorisableActionResult&lt;PlacementApplicationEntity&gt;</ID>
-    <ID>ReturnCount:PlacementApplicationsTest.kt$PlacementApplicationsTest$private fun serializableToJsonNode(serializable: Any?): JsonNode</ID>
-    <ID>ReturnCount:PlacementRequestService.kt$PlacementRequestService$fun createPlacementRequestsFromPlacementApplication(placementApplicationEntity: PlacementApplicationEntity, notes: String?): AuthorisableActionResult&lt;List&lt;PlacementRequestEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementRequestService.kt$PlacementRequestService$fun getPlacementRequestForUser(user: UserEntity, id: UUID): AuthorisableActionResult&lt;Pair&lt;PlacementRequestEntity, List&lt;CancellationEntity&gt;&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementRequestService.kt$PlacementRequestService$fun reallocatePlacementRequest(assigneeUser: UserEntity, id: UUID): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementRequestEntity&gt;&gt;</ID>
-    <ID>ReturnCount:PlacementRequestService.kt$PlacementRequestService$fun withdrawPlacementRequest(placementRequestId: UUID, user: UserEntity): AuthorisableActionResult&lt;Unit&gt;</ID>
-    <ID>ReturnCount:PlacementRequestTransformer.kt$PlacementRequestTransformer$fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus</ID>
-    <ID>ReturnCount:PremisesService.kt$PremisesService$fun updatePremises( premisesId: UUID, addressLine1: String, addressLine2: String?, town: String?, postcode: String, localAuthorityAreaId: UUID?, probationRegionId: UUID, characteristicIds: List&lt;UUID&gt;, notes: String?, status: PropertyStatus, probationDeliveryUnitIdentifier: Either&lt;String, UUID&gt;?, turnaroundWorkingDayCount: Int?, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;PremisesEntity&gt;&gt;</ID>
-    <ID>ReturnCount:RedisConfiguration.kt$ClientResultRedisSerializer$override fun deserialize(bytes: ByteArray?): ClientResult&lt;Any&gt;?</ID>
-    <ID>ReturnCount:RoomService.kt$RoomService$fun renameRoom( premises: PremisesEntity, roomId: UUID, name: String, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;RoomEntity&gt;&gt;</ID>
-    <ID>ReturnCount:RoomService.kt$RoomService$fun updateRoom( premises: PremisesEntity, roomId: UUID, notes: String?, characteristicIds: List&lt;UUID&gt;, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;RoomEntity&gt;&gt;</ID>
-    <ID>ReturnCount:RoshRatings.kt$RoshRatingsInner$fun determineOverallRiskLevel(): RiskLevel</ID>
-    <ID>ReturnCount:StaffMemberService.kt$StaffMemberService$fun getStaffMemberByCode(code: String, qCode: String): AuthorisableActionResult&lt;StaffMember&gt;</ID>
-    <ID>ReturnCount:TaskService.kt$TaskService$fun deallocateTask( requestUser: UserEntity, taskType: TaskType, id: UUID, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;Unit&gt;&gt;</ID>
     <ID>ReturnCount:TaskService.kt$TaskService$fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, id: UUID): AuthorisableActionResult&lt;ValidatableActionResult&lt;Reallocation&gt;&gt;</ID>
-    <ID>ReturnCount:TasksController.kt$TasksController$override fun tasksReallocatableGet(type: String?): ResponseEntity&lt;List&lt;Task&gt;&gt;</ID>
-    <ID>ReturnCount:ThrowableUtils.kt$fun findRootCause(throwable: Throwable, topMost: Boolean = true): Throwable?</ID>
-    <ID>ReturnCount:TracesSamplerCallback.kt$TracesSamplerCallback$override fun sample(context: SamplingContext): Double?</ID>
-    <ID>ReturnCount:WebClientCache.kt$WebClientCache$fun &lt;ResponseType : Any&gt; tryGetCachedValue( typeReference: TypeReference&lt;ResponseType&gt;, requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration, cacheConfig: PreemptiveCacheConfig, attempt: AtomicInteger, ): ClientResult&lt;ResponseType&gt;?</ID>
-    <ID>ReturnCount:WebClientCache.kt$WebClientCache$private fun &lt;ResponseType&gt; resultFromCacheMetadata(cacheEntry: PreemptiveCacheMetadata, cacheKeySet: CacheKeySet, typeReference: TypeReference&lt;ResponseType&gt;): ClientResult&lt;ResponseType&gt;</ID>
     <ID>SpreadOperator:ReportGenerator.kt$ReportGenerator$(*sorted.toTypedArray())</ID>
     <ID>SpreadOperator:UserAllocationsEngine.kt$UserAllocationsEngine$(*predicates.toTypedArray())</ID>
     <ID>SpreadOperator:UserService.kt$UserService$(*UserRole.getAllRolesForService(ServiceName.temporaryAccommodation).toTypedArray())</ID>
@@ -2017,20 +561,13 @@
     <ID>TooGenericExceptionThrown:WebClientCache.kt$WebClientCache$throw RuntimeException("Must provide a preemptiveCacheKey")</ID>
     <ID>TooManyFunctions:ApplicationEntity.kt$ApplicationRepository : JpaRepository</ID>
     <ID>TooManyFunctions:ApplicationEntityReportRow.kt$ApplicationEntityReportRow</ID>
-    <ID>TooManyFunctions:ApplicationService.kt$ApplicationService</ID>
-    <ID>TooManyFunctions:ApplicationsController.kt$ApplicationsController : ApplicationsApiDelegate</ID>
-    <ID>TooManyFunctions:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob : SeedJob</ID>
     <ID>TooManyFunctions:AssessmentService.kt$AssessmentService</ID>
     <ID>TooManyFunctions:BookingEntity.kt$BookingRepository : JpaRepository</ID>
     <ID>TooManyFunctions:BookingService.kt$BookingService</ID>
     <ID>TooManyFunctions:DomainEventService.kt$DomainEventService</ID>
     <ID>TooManyFunctions:OffenderService.kt$OffenderService</ID>
-    <ID>TooManyFunctions:PeopleController.kt$PeopleController : PeopleApiDelegate</ID>
-    <ID>TooManyFunctions:PlacementApplicationService.kt$PlacementApplicationService</ID>
     <ID>TooManyFunctions:PremisesController.kt$PremisesController : PremisesApiDelegate</ID>
     <ID>TooManyFunctions:PremisesService.kt$PremisesService</ID>
-    <ID>TooManyFunctions:ReportsController.kt$ReportsController : ReportsApiDelegate</ID>
-    <ID>TooManyFunctions:TasksController.kt$TasksController : TasksApiDelegate</ID>
     <ID>TooManyFunctions:UserAccessService.kt$UserAccessService</ID>
     <ID>TooManyFunctions:UserService.kt$UserService</ID>
     <ID>TopLevelPropertyNaming:BedEntity.kt$const val bedSummaryQuery = """ select cast(b.id as text) as id, cast(b.name as text) as name, cast(r.name as text) as roomName, r.id as roomId, ( select count(booking.id) from bookings booking left join cancellations cancellation on booking.id = cancellation.booking_id left join non_arrivals non_arrival on non_arrival.booking_id = booking.id where booking.bed_id = b.id and booking.arrival_date &lt;= CURRENT_DATE and booking.departure_date &gt;= CURRENT_DATE and cancellation IS NULL and non_arrival IS NULL ) &gt; 0 as bedBooked, ( select count(lost_bed.id) from lost_beds lost_bed left join lost_bed_cancellations cancellation on lost_bed.id = cancellation.lost_bed_id where lost_bed.bed_id = b.id and lost_bed.start_date &lt;= CURRENT_DATE and lost_bed.end_date &gt;= CURRENT_DATE and cancellation IS NULL ) &gt; 0 as bedOutOfService from beds b join rooms r on b.room_id = r.id """</ID>
@@ -2044,6 +581,7 @@
     <ID>UnusedParameter:BookingService.kt$BookingService$keyWorkerStaffCode: String?</ID>
     <ID>UnusedParameter:BookingService.kt$BookingService$user: UserEntity</ID>
     <ID>UnusedParameter:BookingService.kt$BookingService$user: UserEntity? = null</ID>
+    <ID>UnusedParameter:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesAdHocBooking$role: UserRole</ID>
     <ID>UnusedParameter:GivenAPlacementRequest.kt$assessmentAllocatedTo: UserEntity</ID>
     <ID>UnusedParameter:MigrationJobService.kt$MigrationJobService$pageSize: Int = 50</ID>
     <ID>UnusedParameter:OAuth2ResourceServerSecurityConfiguration.kt$JwksCacheConfig$applicationContext: ApplicationContext</ID>
@@ -2059,14 +597,13 @@
     <ID>UnusedParameter:ProblemResponsesTest.kt$DeserializationTestController$@RequestBody body: List&lt;DeserializationTestBody&gt;</ID>
     <ID>UnusedParameter:ProblemResponsesTest.kt$DeserializationTestController$@RequestParam(value = "requiredProperty", required = true) requiredProperty: Int</ID>
     <ID>UnusedParameter:RedisConfiguration.kt$RedisConfiguration$@Value("\${caches.staffMember.expiry-seconds}") staffMemberExpirySeconds: Long</ID>
-    <ID>UnusedParameter:UserAccessService.kt$UserAccessService$user: UserEntity</ID>
     <ID>UnusedParameter:WebClientConfiguration.kt$WebClientConfiguration$authorizedClients: OAuth2AuthorizedClientRepository</ID>
     <ID>UnusedParameter:WebClientConfiguration.kt$WebClientConfiguration$clientRegistrations: ClientRegistrationRepository</ID>
     <ID>UnusedPrivateMember:ApplicationsController.kt$ApplicationsController$private fun getAssessmentTask(assessment: AssessmentEntity, user: UserEntity): AssessmentTask</ID>
     <ID>UnusedPrivateMember:ApplicationsController.kt$ApplicationsController$private fun getPersonDetail(crn: String, forceFullLaoCheck: Boolean = false): Pair&lt;OffenderDetailSummary, InmateDetail?&gt;</ID>
     <ID>UnusedPrivateMember:ApplicationsController.kt$ApplicationsController$private fun getPlacementApplicationTask(placementApplication: PlacementApplicationEntity, user: UserEntity): PlacementApplicationTask</ID>
     <ID>UnusedPrivateMember:ApplicationsController.kt$ApplicationsController$private fun getPlacementRequestTask(placementRequest: PlacementRequestEntity, user: UserEntity): PlacementRequestTask</ID>
-    <ID>UnusedPrivateMember:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremiseAdHocsBookingFromPlacementRequest$@BeforeEach private fun getAdHocEverys()</ID>
+    <ID>UnusedPrivateMember:BookingServiceTest.kt$BookingServiceTest.CreateApprovedPremisesAdHocBooking$@BeforeEach private fun setup()</ID>
     <ID>UnusedPrivateMember:OAuth2ResourceServerSecurityConfiguration.kt$AuthAwareTokenConverter$private fun extractAuthSource(claims: Map&lt;String, Any?&gt;): String</ID>
     <ID>UnusedPrivateMember:UserService.kt$UserService$private fun updateUserFromCommunityApi(user: UserEntity): UserEntity</ID>
     <ID>UnusedPrivateProperty:ApplicationReportGenerator.kt$ApplicationReportGenerator$private val offenderService: OffenderService</ID>

--- a/detekt.yml
+++ b/detekt.yml
@@ -9,3 +9,19 @@ performance:
     active: true
   UnnecessaryPartOfBinaryExpression:
     active: true
+
+style:
+  MaxLineLength:
+    maxLineLength: 200
+  ReturnCount:
+    max: 4
+
+complexity:
+  LongMethod:
+    threshold: 200
+  LargeClass:
+    threshold: 1000
+  LongParameterList:
+    threshold: 12
+  TooManyFunctions:
+    thresholdInClasses: 20


### PR DESCRIPTION
[We recently installed detekt and turned off checks so we didn't cause too much disruption](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1092).

We now want to turn these rules on so the team have to react to the feedback which should hopefully push us towards better quality code.

In between the install of the packages there have been some changes which have caused a fair few rule violations. Given these things are indicative of lots of disruption to the team, we include a few more changes to thresholds in an attempt to limit the harshness of these new rules.

We then update the baseline with these rules so they should only apply to new changes.