### PR TITLE
Include personal data for bookings report

### DIFF
--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
@@ -12,11 +12,13 @@ import io.gatling.javaapi.http.HttpDsl.status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import java.time.LocalDate
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -50,7 +52,7 @@ class ApplyJourneyStressSimulation : Simulation() {
         .body(
           toJson(
             UpdateTemporaryAccommodationApplication(
-              type = "CAS3",
+              type = UpdateApplicationType.CAS3,
               data = mapOf(),
             ),
           ),
@@ -65,6 +67,7 @@ class ApplyJourneyStressSimulation : Simulation() {
       .body(
         toJson(
           SubmitTemporaryAccommodationApplication(
+            arrivalDate = LocalDate.now().plusWeeks(3),
             type = "CAS3",
             translatedDocument = "{}",
           ),

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
@@ -1,79 +1,43 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
 
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
-import io.gatling.javaapi.core.CoreDsl.exec
-import io.gatling.javaapi.core.CoreDsl.jsonPath
 import io.gatling.javaapi.core.CoreDsl.repeat
 import io.gatling.javaapi.core.CoreDsl.scenario
 import io.gatling.javaapi.core.CoreDsl.stressPeakUsers
+import io.gatling.javaapi.core.Session
 import io.gatling.javaapi.core.Simulation
-import io.gatling.javaapi.http.HttpDsl.http
-import io.gatling.javaapi.http.HttpDsl.status
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.submitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.updateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
-import java.time.LocalDate
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 class ApplyJourneyStressSimulation : Simulation() {
-  private val createTemporaryAccommodationApplication = exec(
-    http("Create Application")
-      .post("/applications")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .body(
-        toJson(
-          NewApplication(
-            crn = "X320741",
-            convictionId = 0L,
-            deliusEventNumber = "",
-            offenceId = "",
-          ),
-        ),
-      )
-      .check(status().`is`(201))
-      .check(jsonPath("$.id").saveAs("application_id")),
+  private val applicationIdKey = "application_id"
+  private val getApplicationId = { session: Session -> session.getUUID(applicationIdKey) }
+
+  private val createTemporaryAccommodationApplication = createTemporaryAccommodationApplication(
+    saveApplicationIdAs = applicationIdKey,
   )
     .exitHereIfFailed()
     .pause(1.seconds.toJavaDuration())
 
   private val updateTemporaryAccommodationApplication = repeat({ randomInt(1, 20) }, "n").on(
-    exec(
-      http("Update Application")
-        .put("/applications/#{application_id}")
-        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-        .body(
-          toJson(
-            UpdateTemporaryAccommodationApplication(
-              type = UpdateApplicationType.CAS3,
-              data = mapOf(),
-            ),
-          ),
-        ),
-    ).pause(5.seconds.toJavaDuration()),
+    updateTemporaryAccommodationApplication(
+      applicationId = getApplicationId,
+    )
+      .pause(5.seconds.toJavaDuration()),
   )
 
-  private val submitTemporaryAccommodationApplication = exec(
-    http("Submit Application")
-      .post("/applications/#{application_id}/submission")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .body(
-        toJson(
-          SubmitTemporaryAccommodationApplication(
-            arrivalDate = LocalDate.now().plusWeeks(3),
-            type = "CAS3",
-            translatedDocument = "{}",
-          ),
-        ),
-      ),
-  ).pause(10.seconds.toJavaDuration())
+  private val submitTemporaryAccommodationApplication = submitTemporaryAccommodationApplication(
+    applicationId = getApplicationId,
+  )
+    .pause(10.seconds.toJavaDuration())
 
   private val temporaryAccommodationApplyJourney = scenario("Apply journey for Temporary Accommodation")
     .exec(

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/BookingsReportGenerationTimeSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/BookingsReportGenerationTimeSimulation.kt
@@ -1,0 +1,150 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
+
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.exec
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.getProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.getUserProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.submitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.updateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAround
+import java.time.LocalDate
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class BookingsReportGenerationTimeSimulation : Simulation() {
+  private val arrivalDateKey = "arrival_date"
+  private val getArrivalDate = { session: Session -> session.get<LocalDate>(arrivalDateKey)!! }
+
+  private val reportDateKey = "report_date"
+
+  private val probationRegionIdKey = "probation_region_id"
+  private val getProbationRegionId = { session: Session -> session.getUUID(probationRegionIdKey) }
+
+  private val probationDeliveryUnitIdKey = "probation_delivery_unit_id"
+  private val getProbationDeliveryUnitId = { session: Session -> session.getUUID(probationDeliveryUnitIdKey) }
+
+  private val premisesIdKey = "premises_id"
+  private val getPremisesId = { session: Session -> session.getUUID(premisesIdKey) }
+
+  private val bedIdKey = "bed_id"
+  private val getBedId = { session: Session -> session.getUUID(bedIdKey) }
+
+  private val applicationIdKey = "application_id"
+  private val getApplicationId = { session: Session -> session.getUUID(applicationIdKey) }
+
+  private val createArrivalDate = exec { session ->
+    session.set(arrivalDateKey, LocalDate.now().randomDateAround(60))
+  }
+
+  private val createReportDate = exec { session ->
+    session.set(reportDateKey, LocalDate.now().randomDateAround(60))
+  }
+
+  private val getUserProbationRegion = getUserProbationRegion(probationRegionIdKey)
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val getProbationDeliveryUnit = getProbationDeliveryUnit(
+    probationRegionId = getProbationRegionId,
+    saveProbationDeliveryUnitIdAs = probationDeliveryUnitIdKey,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationPremises = createTemporaryAccommodationPremises(
+    probationRegionId = getProbationRegionId,
+    probationDeliveryUnitId = getProbationDeliveryUnitId,
+    savePremisesIdAs = premisesIdKey,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationRoom = createTemporaryAccommodationRoom(
+    premisesId = getPremisesId,
+    saveBedIdAs = bedIdKey,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationApplication = createTemporaryAccommodationApplication(
+    saveApplicationIdAs = applicationIdKey,
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val updateTemporaryAccommodationApplication = updateTemporaryAccommodationApplication(
+    applicationId = getApplicationId,
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val submitTemporaryAccommodationApplication = submitTemporaryAccommodationApplication(
+    applicationId = getApplicationId,
+    arrivalDate = getArrivalDate,
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationBooking = createTemporaryAccommodationBooking(
+    bedId = getBedId,
+    arrivalDate = getArrivalDate,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val setupBooking = scenario("Setup booking")
+    .exec(
+      authorizeUser(),
+      createArrivalDate,
+      getUserProbationRegion,
+      getProbationDeliveryUnit,
+      createTemporaryAccommodationPremises,
+      createTemporaryAccommodationRoom,
+      createTemporaryAccommodationApplication,
+      updateTemporaryAccommodationApplication,
+      submitTemporaryAccommodationApplication,
+      createTemporaryAccommodationBooking,
+    )
+
+  private val downloadBookingsReport = exec(
+    http("Download Booking Report")
+      .get("/reports/bookings/")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+      .queryParam("year") { session -> session.get<LocalDate>(reportDateKey)!!.year }
+      .queryParam("month") { session -> session.get<LocalDate>(reportDateKey)!!.monthValue }
+      .queryParam("probationRegionId", getProbationRegionId)
+      .check(status().`is`(200)),
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val bookingsReportDownloadJourney = scenario("Bookings report journey")
+    .exec(
+      authorizeUser(),
+      createReportDate,
+      getUserProbationRegion,
+      downloadBookingsReport,
+    )
+
+  init {
+    setUp(
+      setupBooking.injectOpen(
+        constantUsersPerSec(20.0).during(60.seconds.toJavaDuration()),
+      )
+        .andThen(
+          bookingsReportDownloadJourney.injectOpen(
+            constantUsersPerSec(0.25).during(400.seconds.toJavaDuration()),
+          ),
+        ),
+    ).withAuthorizedUserHttpProtocol()
+  }
+}

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Applications.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Applications.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import java.time.LocalDate
+import java.util.UUID
+
+fun createTemporaryAccommodationApplication(
+  crn: (Session) -> String = { _ -> "X320741" },
+  saveApplicationIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Application")
+    .post("/applications")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        NewApplication(
+          crn = crn(session),
+          convictionId = 0L,
+          deliusEventNumber = "",
+          offenceId = "",
+        )
+      },
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (saveApplicationIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveApplicationIdAs))
+      }
+    },
+)
+
+fun updateTemporaryAccommodationApplication(
+  applicationId: (Session) -> UUID,
+) = CoreDsl.exec(
+  HttpDsl.http("Update Application")
+    .put { session -> "/applications/${applicationId(session)}" }
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson(
+        UpdateTemporaryAccommodationApplication(
+          type = UpdateApplicationType.CAS3,
+          data = mapOf(),
+        ),
+      ),
+    ),
+)
+
+fun submitTemporaryAccommodationApplication(
+  applicationId: (Session) -> UUID,
+  arrivalDate: (Session) -> LocalDate = { _ -> LocalDate.now() },
+) = CoreDsl.exec(
+  HttpDsl.http("Submit Application")
+    .post { session -> "/applications/${applicationId(session)}/submission" }
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        SubmitTemporaryAccommodationApplication(
+          arrivalDate = arrivalDate(session),
+          type = "CAS3",
+          translatedDocument = "{}",
+          summaryData = "{}",
+        )
+      },
+    ),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Bookings.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Bookings.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import java.time.LocalDate
+import java.util.UUID
+
+fun createTemporaryAccommodationBooking(
+  bedId: (Session) -> UUID,
+  crn: (Session) -> String = { _ -> "X320741" },
+  arrivalDate: (Session) -> LocalDate = { _ -> LocalDate.now() },
+  departureDate: (Session) -> LocalDate = { session -> arrivalDate(session).plusDays(84) },
+  saveBookingIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Booking")
+    .post("/premises/#{premises_id}/bookings")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        NewBooking(
+          crn = crn(session),
+          arrivalDate = arrivalDate(session),
+          departureDate = departureDate(session),
+          bedId = bedId(session),
+          serviceName = ServiceName.temporaryAccommodation,
+          enableTurnarounds = true,
+          assessmentId = null,
+        )
+      },
+    )
+    .let {
+      when (saveBookingIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveBookingIdAs))
+      }
+    },
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Premises.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Premises.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+fun createTemporaryAccommodationPremises(
+  probationRegionId: (Session) -> UUID,
+  probationDeliveryUnitId: (Session) -> UUID,
+  savePremisesIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Premises")
+    .post("/premises")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        NewPremises(
+          name = randomStringMultiCaseWithNumbers(16),
+          addressLine1 = randomStringMultiCaseWithNumbers(16),
+          postcode = randomPostCode(),
+          probationRegionId = probationRegionId(session),
+          characteristicIds = listOf(),
+          status = PropertyStatus.active,
+          probationDeliveryUnitId = probationDeliveryUnitId(session),
+        )
+      },
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (savePremisesIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(savePremisesIdAs))
+      }
+    },
+)
+
+fun createTemporaryAccommodationRoom(
+  premisesId: (Session) -> UUID,
+  saveRoomIdAs: String? = null,
+  saveBedIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Room")
+    .post { session -> "/premises/${premisesId(session)}/rooms" }
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson(
+        NewRoom(
+          name = randomStringUpperCase(8),
+          characteristicIds = listOf(),
+          notes = randomStringMultiCaseWithNumbers(20),
+        ),
+      ),
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (saveRoomIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveRoomIdAs))
+      }
+    }
+    .let {
+      when (saveBedIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.beds[0].id").saveAs(saveBedIdAs))
+      }
+    },
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/ReferenceData.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/ReferenceData.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import java.util.UUID
+
+fun getProbationDeliveryUnit(
+  probationRegionId: (Session) -> UUID,
+  saveProbationDeliveryUnitIdAs: String,
+) = CoreDsl.exec(
+
+  HttpDsl.http("Get Probation Delivery Unit")
+    .get("/reference-data/probation-delivery-units")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .queryParam("probationRegionId") { session -> probationRegionId(session) }
+    .check(HttpDsl.status().`is`(200))
+    .check(CoreDsl.jsonPath("$[0].id").saveAs(saveProbationDeliveryUnitIdAs)),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Users.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Users.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+
+fun getUserProbationRegion(
+  saveProbationRegionIdAs: String,
+) = CoreDsl.exec(
+  HttpDsl.http("Get User's Probation Region")
+    .get("/profile")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .check(HttpDsl.status().`is`(200))
+    .check(CoreDsl.jsonPath("$.region.id").saveAs(saveProbationRegionIdAs)),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
@@ -23,7 +23,7 @@ fun authorizeUser(): ChainBuilder {
 fun Simulation.SetUp.withAuthorizedUserHttpProtocol() = apply {
   val protocol = http
     .baseUrl(BASE_URL)
-    .acceptHeader("application/json")
+    .acceptHeader("*/*")
     .contentTypeHeader("application/json")
     .authorizationHeader("Bearer #{access_token}")
 

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.gatling.javaapi.core.CoreDsl.StringBody
+import io.gatling.javaapi.core.Session
 
 private val objectMapper = lazy { ObjectMapper().findAndRegisterModules() }
 
 fun toJson(value: Any) = StringBody(objectMapper.value.writeValueAsString(value))
+
+fun toJson(f: (Session) -> Any) = StringBody { session -> objectMapper.value.writeValueAsString(f(session)) }

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
@@ -3,4 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.gatling.javaapi.core.CoreDsl.StringBody
 
-fun toJson(value: Any) = StringBody(ObjectMapper().writeValueAsString(value))
+private val objectMapper = lazy { ObjectMapper().findAndRegisterModules() }
+
+fun toJson(value: Any) = StringBody(objectMapper.value.writeValueAsString(value))

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Session.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Session.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
+
+import io.gatling.javaapi.core.Session
+import java.util.UUID
+
+fun Session.getUUID(key: String) = UUID.fromString(this.getString(key))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportData.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 
 data class BookingsReportData(
   val booking: BookingEntity,
-  val personInfoResult: PersonInfoResult,
+  val personInfoResult: PersonSummaryInfoResult,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportData.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+
+data class BookingsReportData(
+  val booking: BookingEntity,
+  val personInfoResult: PersonInfoResult,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
@@ -5,6 +5,11 @@ import java.time.LocalDate
 data class BookingsReportRow(
   val referralId: String?,
   val referralDate: LocalDate?,
+  val personName: String?,
+  val pncNumber: String?,
+  val gender: String?,
+  val ethnicity: String?,
+  val dateOfBirth: LocalDate?,
   val riskOfSeriousHarm: String?,
   val sexOffender: Boolean?,
   val needForAccessibleProperty: Boolean?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
@@ -59,13 +60,12 @@ class ReportService(
 
     val bookingsInScope = bookingRepository.findAllByOverlappingDate(startOfMonth, endOfMonth)
 
-    val reportData = bookingsInScope.map {
-      val personInfo = offenderService.getInfoForPerson(
-        it.crn,
-        userService.getUserForRequest().deliusUsername,
-        false,
-      )
+    val crns = bookingsInScope.map { it.crn }.distinct().sorted()
+    val personInfos = offenderService.getOffenderSummariesByCrns(crns, userService.getUserForRequest().deliusUsername)
+      .associateBy { it.crn }
 
+    val reportData = bookingsInScope.map {
+      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
       BookingsReportData(it, personInfo)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Ldu
@@ -114,6 +115,30 @@ class CaseSummaryFactory : Factory<CaseSummary> {
   }
   fun withCurrentRestriction(currentRestriction: Boolean) = apply {
     this.currentRestriction = { currentRestriction }
+  }
+
+  fun fromOffenderDetails(offenderDetails: OffenderDetailSummary) = apply {
+    withCrn(offenderDetails.otherIds.crn)
+    withNomsId(offenderDetails.otherIds.nomsNumber)
+    withName(
+      NameFactory()
+        .withForename(offenderDetails.firstName)
+        .withMiddleNames(offenderDetails.middleNames ?: listOf())
+        .withSurname(offenderDetails.surname)
+        .produce(),
+    )
+    withDateOfBirth(offenderDetails.dateOfBirth)
+    withGender(offenderDetails.gender)
+    withProfile(
+      ProfileFactory()
+        .withEthnicity(offenderDetails.offenderProfile.ethnicity)
+        .withGenderIdentity(offenderDetails.offenderProfile.genderIdentity)
+        .withNationality(offenderDetails.offenderProfile.nationality)
+        .withReligion(offenderDetails.offenderProfile.religion)
+        .produce(),
+    )
+    withCurrentExclusion(offenderDetails.currentExclusion)
+    withCurrentRestriction(offenderDetails.currentRestriction)
   }
 
   override fun produce(): CaseSummary = CaseSummary(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
@@ -19,6 +19,7 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
   private var lastName: Yielded<String> = { randomStringUpperCase(10) }
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
+  private var pncNumber: Yielded<String?> = { null }
   private var gender: Yielded<String> = { randomOf(listOf("Male", "Female", "Other")) }
   private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore() }
   private var currentRestriction: Yielded<Boolean> = { false }
@@ -55,6 +56,10 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
 
   fun withoutNomsNumber() = apply {
     this.nomsNumber = { null }
+  }
+
+  fun withPncNumber(pncNumber: String?) = apply {
+    this.pncNumber = { pncNumber }
   }
 
   fun withGender(gender: String) = apply {
@@ -110,7 +115,7 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
       mostRecentPrisonNumber = null,
       niNumber = null,
       nomsNumber = this.nomsNumber(),
-      pncNumber = null,
+      pncNumber = this.pncNumber(),
     ),
     offenderProfile = OffenderProfile(
       ethnicity = this.ethnicity(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.Bed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toBookingsReportData
 import java.time.LocalDate
 import java.util.UUID
 
@@ -138,7 +140,12 @@ class ReportsTest : IntegrationTestBase() {
         }
 
         val expectedDataFrame = BookingsReportGenerator()
-          .createReport(bookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+          .createReport(
+            bookings.toBookingsReportData { crn ->
+              PersonInfoResult.Success.Full(crn, offenderDetails, inmateDetails)
+            },
+            BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+          )
 
         webTestClient.get()
           .uri("/reports/bookings?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -363,7 +370,12 @@ class ReportsTest : IntegrationTestBase() {
         }
 
         val expectedDataFrame = BookingsReportGenerator()
-          .createReport(shouldBeIncludedBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+          .createReport(
+            shouldBeIncludedBookings.toBookingsReportData { crn ->
+              PersonInfoResult.Success.Full(crn, offenderDetails, inmateDetails)
+            },
+            BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+          )
 
         webTestClient.get()
           .uri("/reports/bookings?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -8,14 +8,17 @@ import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
@@ -139,10 +142,21 @@ class ReportsTest : IntegrationTestBase() {
           }
         }
 
+        val caseSummary = CaseSummaryFactory()
+          .fromOffenderDetails(offenderDetails)
+          .produce()
+
+        ApDeliusContext_addResponseToUserAccessCall(
+          CaseAccessFactory()
+            .withCrn(offenderDetails.otherIds.crn)
+            .produce(),
+          userEntity.deliusUsername,
+        )
+
         val expectedDataFrame = BookingsReportGenerator()
           .createReport(
             bookings.toBookingsReportData { crn ->
-              PersonInfoResult.Success.Full(crn, offenderDetails, inmateDetails)
+              PersonSummaryInfoResult.Success.Full(crn, caseSummary)
             },
             BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
           )
@@ -206,8 +220,24 @@ class ReportsTest : IntegrationTestBase() {
           }
         }
 
+        val caseSummary = CaseSummaryFactory()
+          .fromOffenderDetails(offenderDetails)
+          .produce()
+
+        ApDeliusContext_addResponseToUserAccessCall(
+          CaseAccessFactory()
+            .withCrn(offenderDetails.otherIds.crn)
+            .produce(),
+          userEntity.deliusUsername,
+        )
+
         val expectedDataFrame = BookingsReportGenerator()
-          .createReport(bookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+          .createReport(
+            bookings.toBookingsReportData { crn ->
+              PersonSummaryInfoResult.Success.Full(crn, caseSummary)
+            },
+            BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+          )
 
         webTestClient.get()
           .uri("/reports/bookings?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -268,8 +298,24 @@ class ReportsTest : IntegrationTestBase() {
           }
         }
 
+        val caseSummary = CaseSummaryFactory()
+          .fromOffenderDetails(offenderDetails)
+          .produce()
+
+        ApDeliusContext_addResponseToUserAccessCall(
+          CaseAccessFactory()
+            .withCrn(offenderDetails.otherIds.crn)
+            .produce(),
+          userEntity.deliusUsername,
+        )
+
         val expectedDataFrame = BookingsReportGenerator()
-          .createReport(bookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+          .createReport(
+            bookings.toBookingsReportData { crn ->
+              PersonSummaryInfoResult.Success.Full(crn, caseSummary)
+            },
+            BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+          )
 
         webTestClient.get()
           .uri("/reports/bookings?year=2023&month=4")
@@ -369,10 +415,21 @@ class ReportsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.of(2023, 5, 3))
         }
 
+        val caseSummary = CaseSummaryFactory()
+          .fromOffenderDetails(offenderDetails)
+          .produce()
+
+        ApDeliusContext_addResponseToUserAccessCall(
+          CaseAccessFactory()
+            .withCrn(offenderDetails.otherIds.crn)
+            .produce(),
+          userEntity.deliusUsername,
+        )
+
         val expectedDataFrame = BookingsReportGenerator()
           .createReport(
             shouldBeIncludedBookings.toBookingsReportData { crn ->
-              PersonInfoResult.Success.Full(crn, offenderDetails, inmateDetails)
+              PersonSummaryInfoResult.Success.Full(crn, caseSummary)
             },
             BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toBookingsReportData
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -66,7 +67,7 @@ class BookingsReportGeneratorTest {
       .take(4)
       .toList()
 
-    val allBookings = approvedPremisesBookings + temporaryAccommodationBookings
+    val allBookings = (approvedPremisesBookings + temporaryAccommodationBookings).toBookingsReportData()
 
     val actual1 = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
     assertThat(actual1.count()).isEqualTo(5)
@@ -112,7 +113,7 @@ class BookingsReportGeneratorTest {
       .take(4)
       .toList()
 
-    val allBookings = expectedBookings + unexpectedBookings
+    val allBookings = (expectedBookings + unexpectedBookings).toBookingsReportData()
 
     val actual = reportGenerator.createReport(allBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, probationRegionId, 2023, 4))
     assertThat(actual.count()).isEqualTo(5)
@@ -136,7 +137,7 @@ class BookingsReportGeneratorTest {
       .take(5)
       .toList()
 
-    val actual = reportGenerator.createReport(expectedBookings, BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(expectedBookings.toBookingsReportData(), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
     assertThat(actual.count()).isEqualTo(5)
   }
 
@@ -157,7 +158,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::probationRegion]).isEqualTo("East of England")
   }
@@ -179,7 +183,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::crn]).isEqualTo("X123456")
   }
@@ -204,7 +211,10 @@ class BookingsReportGeneratorTest {
       .withBooking(booking)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::offerAccepted]).isTrue
   }
@@ -225,7 +235,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::offerAccepted]).isFalse
   }
@@ -257,7 +270,10 @@ class BookingsReportGeneratorTest {
         .produce(),
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::isCancelled]).isTrue
     assertThat(actual.count()).isEqualTo(1)
@@ -280,7 +296,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::isCancelled]).isFalse
     assertThat(actual.count()).isEqualTo(1)
@@ -310,7 +329,10 @@ class BookingsReportGeneratorTest {
       .withBooking(booking)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::startDate]).isEqualTo(today)
     assertThat(actual.count()).isEqualTo(1)
@@ -333,7 +355,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::startDate]).isNull()
     assertThat(actual.count()).isEqualTo(1)
@@ -378,7 +403,10 @@ class BookingsReportGeneratorTest {
         .produce(),
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualEndDate]).isEqualTo(today)
   }
@@ -399,7 +427,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualEndDate]).isNull()
   }
@@ -429,7 +460,10 @@ class BookingsReportGeneratorTest {
       .withBooking(booking)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isEqualTo(37)
   }
@@ -450,7 +484,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isNull()
   }
@@ -501,7 +538,10 @@ class BookingsReportGeneratorTest {
         .produce(),
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::currentNightsStayed]).isNull()
   }
@@ -552,7 +592,10 @@ class BookingsReportGeneratorTest {
         .produce(),
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isEqualTo(87L)
   }
@@ -573,7 +616,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.approvedPremises, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isNull()
   }
@@ -613,7 +659,10 @@ class BookingsReportGeneratorTest {
         .produce(),
     )
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::accommodationOutcome]).isEqualTo("Joined the Space Force")
   }
@@ -634,7 +683,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::accommodationOutcome]).isNull()
   }
@@ -655,7 +707,10 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::referralId]).isNull()
     assertThat(actual[0][BookingsReportRow::referralDate]).isNull()
@@ -717,7 +772,10 @@ class BookingsReportGeneratorTest {
       .withApplication(application)
       .produce()
 
-    val actual = reportGenerator.createReport(listOf(booking), BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::referralId]).isEqualTo(application.id.toString())
     assertThat(actual[0][BookingsReportRow::referralDate]).isEqualTo(application.submittedAt!!.toLocalDate())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -16,10 +16,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
@@ -787,5 +789,72 @@ class BookingsReportGeneratorTest {
     assertThat(actual[0][BookingsReportRow::dateDutyToReferMade]).isEqualTo(LocalDate.now())
     assertThat(actual[0][BookingsReportRow::isReferralEligibleForCas3]).isTrue
     assertThat(actual[0][BookingsReportRow::referralEligibilityReason]).isEqualTo("Some reason")
+  }
+
+  @Test
+  fun `The personal details columns are empty if there is no person information available for the booking`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData(),
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::personName]).isNull()
+    assertThat(actual[0][BookingsReportRow::pncNumber]).isNull()
+    assertThat(actual[0][BookingsReportRow::gender]).isNull()
+    assertThat(actual[0][BookingsReportRow::ethnicity]).isNull()
+    assertThat(actual[0][BookingsReportRow::dateOfBirth]).isNull()
+  }
+
+  @Test
+  fun `The personal details columns are returned when there is person information available for the booking`() {
+    val booking = BookingEntityFactory()
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+          .produce()
+      }
+      .produce()
+
+    val offenderDetailSummary = OffenderDetailsSummaryFactory()
+      .withFirstName("Johannes")
+      .withLastName("Kepler")
+      .withPncNumber("SOME-PNC-NUMBER")
+      .withGender("Male")
+      .withEthnicity("Other White")
+      .withDateOfBirth(LocalDate.parse("1571-12-27"))
+      .produce()
+
+    val actual = reportGenerator.createReport(
+      listOf(booking).toBookingsReportData { crn ->
+        PersonInfoResult.Success.Full(crn, offenderDetailSummary, null)
+      },
+      BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
+    )
+    assertThat(actual.count()).isEqualTo(1)
+    assertThat(actual[0][BookingsReportRow::personName]).isEqualTo("Johannes Kepler")
+    assertThat(actual[0][BookingsReportRow::pncNumber]).isEqualTo("SOME-PNC-NUMBER")
+    assertThat(actual[0][BookingsReportRow::gender]).isEqualTo("Male")
+    assertThat(actual[0][BookingsReportRow::ethnicity]).isEqualTo("Other White")
+    assertThat(actual[0][BookingsReportRow::dateOfBirth]).isEqualTo("1571-12-27")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -10,18 +10,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProfileFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
@@ -835,24 +837,32 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    val offenderDetailSummary = OffenderDetailsSummaryFactory()
-      .withFirstName("Johannes")
-      .withLastName("Kepler")
-      .withPncNumber("SOME-PNC-NUMBER")
+    val caseSummary = CaseSummaryFactory()
+      .withName(
+        NameFactory()
+          .withForename("Johannes")
+          .withMiddleNames(listOf())
+          .withSurname("Kepler")
+          .produce(),
+      )
       .withGender("Male")
-      .withEthnicity("Other White")
+      .withProfile(
+        ProfileFactory()
+          .withEthnicity("Other White")
+          .produce(),
+      )
       .withDateOfBirth(LocalDate.parse("1571-12-27"))
       .produce()
 
     val actual = reportGenerator.createReport(
       listOf(booking).toBookingsReportData { crn ->
-        PersonInfoResult.Success.Full(crn, offenderDetailSummary, null)
+        PersonSummaryInfoResult.Success.Full(crn, caseSummary)
       },
       BookingsReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4),
     )
     assertThat(actual.count()).isEqualTo(1)
     assertThat(actual[0][BookingsReportRow::personName]).isEqualTo("Johannes Kepler")
-    assertThat(actual[0][BookingsReportRow::pncNumber]).isEqualTo("SOME-PNC-NUMBER")
+    assertThat(actual[0][BookingsReportRow::pncNumber]).isNull()
     assertThat(actual[0][BookingsReportRow::gender]).isEqualTo("Male")
     assertThat(actual[0][BookingsReportRow::ethnicity]).isEqualTo("Other White")
     assertThat(actual[0][BookingsReportRow::dateOfBirth]).isEqualTo("1571-12-27")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -34,6 +34,7 @@ fun randomDouble(min: Double, max: Double) = Random.nextDouble(min, max)
 
 fun LocalDate.randomDateAfter(maxDays: Int = 14): LocalDate = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateBefore(maxDays: Int = 14): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
+fun LocalDate.randomDateAround(maxDays: Int = 14): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 
 fun LocalDateTime.randomDateTimeAfter(maxDays: Int = 14): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportData
+
+fun List<BookingEntity>.toBookingsReportData(): List<BookingsReportData> =
+  this.toBookingsReportData { PersonInfoResult.Unknown(it) }
+
+fun List<BookingEntity>.toBookingsReportData(configuration: (crn: String) -> PersonInfoResult): List<BookingsReportData> =
+  this.map { BookingsReportData(it, configuration(it.crn)) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportData
 
 fun List<BookingEntity>.toBookingsReportData(): List<BookingsReportData> =
-  this.toBookingsReportData { PersonInfoResult.Unknown(it) }
+  this.toBookingsReportData { PersonSummaryInfoResult.Unknown(it) }
 
-fun List<BookingEntity>.toBookingsReportData(configuration: (crn: String) -> PersonInfoResult): List<BookingsReportData> =
+fun List<BookingEntity>.toBookingsReportData(
+  configuration: (crn: String) -> PersonSummaryInfoResult,
+): List<BookingsReportData> =
   this.map { BookingsReportData(it, configuration(it.crn)) }


### PR DESCRIPTION
> See [ticket #1535 on the CAS3 Trello board](https://trello.com/c/b8NYSvNw/1535-report-mi-spreadsheet-includes-personal-data).

This PR introduces columns containing personal data to the bookings report. These columns are:
- `personName`
- `pncNumber`
- `gender`
- `ethnicity`
- `dateOfBirth`

Of these columns, four are populated as expected - `pncNumber` is currently not available and is always presented as a blank cell. This is because we do not store personal information within our service and have to obtain it elsewhere. Although we cache results from the Community API, the number of results expected in a typical spreadsheet is between 200 and 400 rows, and performing a request to the cache for each CRN incurs an unacceptable performance degradation (see below). The alternative solution is to use the AP-Delius Integration API, which provides an endpoint for accessing personal data in bulk, but this endpoint only provides a subset of the personal data and does not currently include the PNC number.

### Performance testing
We are beginning to run into performance limits in various aspects of the service. Including another external integration has the potential to introduce significant performance impacts, so a Gatling test has been introduced to quantify the impact of this integration on creating booking reports.

The performance test is structured in the following way:
- 1200 bookings are created for the same CRN, distributed randomly over a period spanning from 60 days before to 60 days after the current date, using the following steps:
  - creating a premises
  - creating a room in that premises
  - creating an application
  - updating that application
  - submitting that application
  - creating a booking for that room
- 100 reports are generated for random months over this period.

Each run was performed on an M1 Macbook Pro under similar background load conditions. Prior to each test, the database was cleared and all caches purged to ensure each run was fully independent.

The control test was measured using the current `main` branch:
<img width="1034" alt="Control test results measured using the current `main` branch" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/3bb0e62c-0a1c-431f-a7ec-58a045463fbe">

The single CRN endpoint test:
<img width="1034" alt="Test results measured using the single CRN endpoint" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/19b8faa5-f9fa-467b-859f-a319f25cd66f">


The bulk data endpoint test:
<img width="1034" alt="Test results measured using the bulk data endpoint" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/235c01a8-46b8-49c1-ba5f-dd20fd16e9f2">

The findings, summarised in a table:

| Test | Success rate | Minimum time (s)[1] | Maximum time (s)[1] | Mean time (s)[1] | Median time (s)[1] | Std. Dev. (s)[1] |
|:---|---:|---:|---:|---:|---:|---:|
| Control | 100.0% | 8.658 | 49.901 | 29.526 | 31.704 | 11.488 |
| Single CRN[2] |  9.8% | 47.878 | 57.193 | 53.311 | 54.885 | 3.429 |
| Bulk CRNs | 100.0% | 8.609 | 48.642 | 26.669 | 26.485 | 12.527 |

[1]: As measured for the successful subset of requests.
[2]: Calculated from a reduced sample of 61 requests due to how Gatling schedules users in its simulations.

