### PR TITLE
Aps23 users must be able to add manual notes into the timeline view

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -1,21 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ApplicationsApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Assessment
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Document
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationTask
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
@@ -26,20 +23,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApproved
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -53,18 +43,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Applications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromNestedAuthorisableValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getFullInfoForPersonOrThrow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getInfoForPersonOrThrow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getInfoForPersonOrThrowInternalServerError
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromOffenderDetailSummaryResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPersonDetailsForCrn
 import java.net.URI
 import java.util.UUID
 import javax.transaction.Transactional
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary as JPAApplicationSummary
 
 @Service
+@Suppress("LongParameterList", "TooManyFunctions")
 class ApplicationsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
@@ -77,9 +66,7 @@ class ApplicationsController(
   private val documentTransformer: DocumentTransformer,
   private val assessmentService: AssessmentService,
   private val userService: UserService,
-  private val taskTransformer: TaskTransformer,
 ) : ApplicationsApiDelegate {
-  private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun applicationsGet(xServiceName: ServiceName?): ResponseEntity<List<ApplicationSummary>> {
     val serviceName = xServiceName ?: ServiceName.approvedPremises
@@ -94,7 +81,10 @@ class ApplicationsController(
   override fun applicationsApplicationIdGet(applicationId: UUID): ResponseEntity<Application> {
     val user = userService.getUserForRequest()
 
-    val application = when (val applicationResult = applicationService.getApplicationForUsername(applicationId, user.deliusUsername)) {
+    val application = when (
+      val applicationResult =
+        applicationService.getApplicationForUsername(applicationId, user.deliusUsername)
+    ) {
       is AuthorisableActionResult.NotFound -> null
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> applicationResult.entity
@@ -104,7 +94,10 @@ class ApplicationsController(
       return ResponseEntity.ok(getPersonDetailAndTransform(application, user))
     }
 
-    val offlineApplication = when (val offlineApplicationResult = applicationService.getOfflineApplicationForUsername(applicationId, user.deliusUsername)) {
+    val offlineApplication = when (
+      val offlineApplicationResult =
+        applicationService.getOfflineApplicationForUsername(applicationId, user.deliusUsername)
+    ) {
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
       is AuthorisableActionResult.Success -> offlineApplicationResult.entity
@@ -114,16 +107,37 @@ class ApplicationsController(
   }
 
   @Transactional
-  override fun applicationsPost(body: NewApplication, xServiceName: ServiceName?, createWithRisks: Boolean?): ResponseEntity<Application> {
+  override fun applicationsPost(body: NewApplication, xServiceName: ServiceName?, createWithRisks: Boolean?):
+    ResponseEntity<Application> {
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val user = userService.getUserForRequest()
 
     val personInfo = offenderService.getFullInfoForPersonOrThrow(body.crn, user)
 
     val applicationResult = when (xServiceName ?: ServiceName.approvedPremises) {
-      ServiceName.approvedPremises -> applicationService.createApprovedPremisesApplication(personInfo.offenderDetailSummary, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)
+      ServiceName.approvedPremises ->
+        applicationService.createApprovedPremisesApplication(
+          personInfo.offenderDetailSummary,
+          user,
+          deliusPrincipal.token.tokenValue,
+          body.convictionId,
+          body.deliusEventNumber,
+          body.offenceId,
+          createWithRisks,
+        )
       ServiceName.temporaryAccommodation -> {
-        when (val actionResult = applicationService.createTemporaryAccommodationApplication(body.crn, user, deliusPrincipal.token.tokenValue, body.convictionId, body.deliusEventNumber, body.offenceId, createWithRisks)) {
+        when (
+          val actionResult =
+            applicationService.createTemporaryAccommodationApplication(
+              body.crn,
+              user,
+              deliusPrincipal.token.tokenValue,
+              body.convictionId,
+              body.deliusEventNumber,
+              body.offenceId,
+              createWithRisks,
+            )
+        ) {
           is AuthorisableActionResult.NotFound -> throw NotFoundProblem(actionResult.id!!, actionResult.entityType!!)
           is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
           is AuthorisableActionResult.Success -> actionResult.entity
@@ -137,9 +151,12 @@ class ApplicationsController(
     }
 
     val application = when (applicationResult) {
-      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = applicationResult.message)
-      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = applicationResult.validationMessages)
-      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = applicationResult.conflictingEntityId, conflictReason = applicationResult.message)
+      is ValidatableActionResult.GeneralValidationError ->
+        throw BadRequestProblem(errorDetail = applicationResult.message)
+      is ValidatableActionResult.FieldValidationError ->
+        throw BadRequestProblem(invalidParams = applicationResult.validationMessages)
+      is ValidatableActionResult.ConflictError ->
+        throw ConflictProblem(id = applicationResult.conflictingEntityId, conflictReason = applicationResult.message)
       is ValidatableActionResult.Success -> applicationResult.entity
     }
 
@@ -170,7 +187,6 @@ class ApplicationsController(
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = serializedData,
-        username = user.deliusUsername,
       )
       else -> throw RuntimeException("Unsupported UpdateApplication type: ${body::class.qualifiedName}")
     }
@@ -182,13 +198,24 @@ class ApplicationsController(
     }
 
     val updatedApplication = when (validationResult) {
-      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
-      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
-      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.GeneralValidationError ->
+        throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError ->
+        throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError ->
+        throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
       is ValidatableActionResult.Success -> validationResult.entity
     }
 
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication, user))
+  }
+
+  override fun applicationsApplicationIdNotesPost(
+    applicationId: UUID,
+    body: ApplicationTimelineNote,
+  ): ResponseEntity<ApplicationTimelineNote> {
+    val savedNote = applicationService.addNoteToApplication(applicationId, body)
+    return ResponseEntity.ok(savedNote)
   }
 
   override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID, body: NewWithdrawal): ResponseEntity<Unit> {
@@ -206,9 +233,12 @@ class ApplicationsController(
     return ResponseEntity.ok(Unit)
   }
 
-  override fun applicationsApplicationIdTimelineGet(applicationId: UUID, xServiceName: ServiceName): ResponseEntity<List<TimelineEvent>> {
+  override fun applicationsApplicationIdTimelineGet(applicationId: UUID, xServiceName: ServiceName):
+    ResponseEntity<List<TimelineEvent>> {
     val user = userService.getUserForRequest()
-    if (xServiceName != ServiceName.approvedPremises || !user.hasAnyRole(UserRole.CAS1_ADMIN, UserRole.CAS1_WORKFLOW_MANAGER)) {
+    if (xServiceName != ServiceName.approvedPremises ||
+      !user.hasAnyRole(UserRole.CAS1_ADMIN, UserRole.CAS1_WORKFLOW_MANAGER)
+    ) {
       throw ForbiddenProblem()
     }
     val events = applicationService.getApplicationTimeline(applicationId)
@@ -223,8 +253,15 @@ class ApplicationsController(
     val username = deliusPrincipal.name
 
     val submitResult = when (submitApplication) {
-      is SubmitApprovedPremisesApplication -> applicationService.submitApprovedPremisesApplication(applicationId, submitApplication, username, deliusPrincipal.token.tokenValue)
-      is SubmitTemporaryAccommodationApplication -> applicationService.submitTemporaryAccommodationApplication(applicationId, submitApplication)
+      is SubmitApprovedPremisesApplication ->
+        applicationService.submitApprovedPremisesApplication(
+          applicationId,
+          submitApplication,
+          username,
+          deliusPrincipal.token.tokenValue,
+        )
+      is SubmitTemporaryAccommodationApplication ->
+        applicationService.submitTemporaryAccommodationApplication(applicationId, submitApplication)
       else -> throw RuntimeException("Unsupported SubmitApplication type: ${submitApplication::class.qualifiedName}")
     }
 
@@ -235,9 +272,12 @@ class ApplicationsController(
     }
 
     when (validationResult) {
-      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
-      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
-      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.GeneralValidationError ->
+        throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError ->
+        throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError ->
+        throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
       is ValidatableActionResult.Success -> Unit
     }
 
@@ -248,7 +288,10 @@ class ApplicationsController(
     val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val username = deliusPrincipal.name
 
-    val application = when (val applicationResult = applicationService.getApplicationForUsername(applicationId, username)) {
+    val application = when (
+      val applicationResult =
+        applicationService.getApplicationForUsername(applicationId, username)
+    ) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> applicationResult.entity
@@ -272,7 +315,13 @@ class ApplicationsController(
   override fun applicationsApplicationIdAssessmentGet(applicationId: UUID): ResponseEntity<Assessment> {
     val user = userService.getUserForRequest()
 
-    val assessment = when (val applicationResult = assessmentService.getAssessmentForUserAndApplication(user, applicationId)) {
+    val assessment = when (
+      val applicationResult =
+        assessmentService.getAssessmentForUserAndApplication(
+          user,
+          applicationId,
+        )
+    ) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Assessment")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> applicationResult.entity
@@ -290,52 +339,13 @@ class ApplicationsController(
     if (xServiceName != ServiceName.approvedPremises) {
       throw ForbiddenProblem()
     }
-    val placementApplicationEntities = placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(applicationId)
+    val placementApplicationEntities =
+      placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(applicationId)
     val placementApplications = placementApplicationEntities.map {
       placementApplicationTransformer.transformJpaToApi(it)
     }
 
     return ResponseEntity.ok(placementApplications)
-  }
-
-  private fun getPersonDetail(crn: String, forceFullLaoCheck: Boolean = false): Pair<OffenderDetailSummary, InmateDetail?> {
-    val user = userService.getUserForRequest()
-
-    val ignoreLao = if (forceFullLaoCheck) {
-      false
-    } else {
-      user.hasQualification(UserQualification.LAO)
-    }
-
-    return getPersonDetailsForCrn(log, crn, user.deliusUsername, offenderService, ignoreLao)
-      ?: throw InternalServerErrorProblem("Unable to get Person via crn: $crn")
-  }
-
-  private fun getAssessmentTask(assessment: AssessmentEntity, user: UserEntity): AssessmentTask {
-    val offenderDetailsResult = offenderService.getOffenderByCrn(assessment.application.crn, user.deliusUsername)
-
-    return taskTransformer.transformAssessmentToTask(
-      assessment = assessment,
-      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
-    )
-  }
-
-  private fun getPlacementRequestTask(placementRequest: PlacementRequestEntity, user: UserEntity): PlacementRequestTask {
-    val offenderDetailsResult = offenderService.getOffenderByCrn(placementRequest.application.crn, user.deliusUsername)
-
-    return taskTransformer.transformPlacementRequestToTask(
-      placementRequest = placementRequest,
-      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
-    )
-  }
-
-  private fun getPlacementApplicationTask(placementApplication: PlacementApplicationEntity, user: UserEntity): PlacementApplicationTask {
-    val offenderDetailsResult = offenderService.getOffenderByCrn(placementApplication.application.crn, user.deliusUsername)
-
-    return taskTransformer.transformPlacementApplicationToTask(
-      placementApplication = placementApplication,
-      personName = getNameFromOffenderDetailSummaryResult(offenderDetailsResult),
-    )
   }
 
   private fun getPersonDetailAndTransform(application: ApplicationEntity, user: UserEntity): Application {
@@ -344,8 +354,16 @@ class ApplicationsController(
     return applicationsTransformer.transformJpaToApi(application, personInfo)
   }
 
-  private fun getPersonDetailAndTransformToSummary(application: uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary, user: UserEntity): ApplicationSummary {
-    val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn(), user)
+  private fun getPersonDetailAndTransformToSummary(
+    application: JPAApplicationSummary,
+    user: UserEntity,
+  ):
+    ApplicationSummary {
+    val personInfo =
+      offenderService.getInfoForPersonOrThrowInternalServerError(
+        application.getCrn(),
+        user,
+      )
 
     return applicationsTransformer.transformDomainToApiSummary(application, personInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+interface ApplicationTimelineNoteRepository : JpaRepository<ApplicationTimelineNoteEntity, UUID> {
+
+  fun findApplicationTimelineNoteEntitiesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity>
+}
+
+@Entity
+@Table(name = "application_timeline_notes")
+data class ApplicationTimelineNoteEntity(
+  @Id
+  val id: UUID,
+  val applicationId: UUID,
+  val createdBy: UUID,
+  val createdAtDate: OffsetDateTime,
+  val body: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class ApplicationTimelineNoteService(
+  private val applicationTimelineNoteRepository: ApplicationTimelineNoteRepository,
+) {
+
+  fun getApplicationTimelineNotesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity> =
+    applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
+
+  fun saveApplicationTimelineNotes(applicationId: UUID, applicationTimelineNote: ApplicationTimelineNote):
+    ApplicationTimelineNoteEntity {
+    return applicationTimelineNoteRepository.save(
+      ApplicationTimelineNoteEntity(
+        id = UUID.randomUUID(),
+        applicationId = applicationId,
+        createdBy = applicationTimelineNote.createdByUserId,
+        createdAtDate = OffsetDateTime.now(),
+        body = applicationTimelineNote.note,
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
+
+@Component
+class ApplicationTimelineNoteTransformer {
+
+  fun transformJpaToApi(jpa: ApplicationTimelineNoteEntity) = ApplicationTimelineNote(
+    id = jpa.id,
+    createdAt = jpa.createdAtDate.toInstant(),
+    createdByUserId = jpa.createdBy,
+    note = jpa.body,
+  )
+
+  fun transformToTimelineEvents(jpa: ApplicationTimelineNoteEntity) = TimelineEvent(
+    type = TimelineEventType.applicationTimelineNote,
+    id = jpa.id.toString(),
+    occurredAt = jpa.createdAtDate.toInstant(),
+    content = jpa.body,
+    createdBy = jpa.createdBy.toString(),
+  )
+}

--- a/src/main/resources/db/migration/all/20231102094837__create_application_timeline_notes.sql
+++ b/src/main/resources/db/migration/all/20231102094837__create_application_timeline_notes.sql
@@ -1,0 +1,9 @@
+CREATE TABLE application_timeline_notes (
+    id UUID NOT NULL,
+    application_id UUID NOT NULL,
+    created_by UUID NOT NULL,
+    created_at_date DATE NOT NULL,
+    body TEXT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (application_id) REFERENCES approved_premises_applications(id)
+);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1786,6 +1786,24 @@ components:
         - withdrawn
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
+    ApplicationTimelineNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        note:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - note
+      description: Notes added to an application
     NewApplication:
       type: object
       properties:
@@ -2930,6 +2948,10 @@ components:
         occurredAt:
           type: string
           format: date-time
+        content:
+          type: string
+        createdBy:
+          type: string
     TimelineEventType:
       type: string
       enum:
@@ -2946,6 +2968,7 @@ components:
         - approved_premises_information_request
         - cas3_person_arrived
         - cas3_person_departed
+        - application_timeline_note
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1866,6 +1866,46 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /applications/{applicationId}/notes:
+    post:
+      tags:
+        - Add a note on applications
+      summary: Add a note on applications
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the note to add
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/ApplicationTimelineNote'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ApplicationTimelineNote'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /applications/{applicationId}/timeline:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1868,6 +1868,46 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /applications/{applicationId}/notes:
+    post:
+      tags:
+        - Add a note on applications
+      summary: Add a note on applications
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the note to add
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ApplicationTimelineNote'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ApplicationTimelineNote'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /applications/{applicationId}/timeline:
     get:
       tags:
@@ -5773,6 +5813,24 @@ components:
         - withdrawn
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
+    ApplicationTimelineNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        note:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - note
+      description: Notes added to an application
     NewApplication:
       type: object
       properties:
@@ -6917,6 +6975,10 @@ components:
         occurredAt:
           type: string
           format: date-time
+        content:
+          type: string
+        createdBy:
+          type: string
     TimelineEventType:
       type: string
       enum:
@@ -6933,6 +6995,7 @@ components:
         - approved_premises_information_request
         - cas3_person_arrived
         - cas3_person_departed
+        - application_timeline_note
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2126,6 +2126,24 @@ components:
         - withdrawn
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
+    ApplicationTimelineNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        note:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - note
+      description: Notes added to an application
     NewApplication:
       type: object
       properties:
@@ -3270,6 +3288,10 @@ components:
         occurredAt:
           type: string
           format: date-time
+        content:
+          type: string
+        createdBy:
+          type: string
     TimelineEventType:
       type: string
       enum:
@@ -3286,6 +3308,7 @@ components:
         - approved_premises_information_request
         - cas3_person_arrived
         - cas3_person_departed
+        - application_timeline_note
     SeedRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdBy: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdAtDate: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var body: Yielded<String> = { randomStringUpperCase(12) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy.id }
+  }
+
+  fun withCreatedAtDate(createdAtDate: OffsetDateTime) = apply {
+    this.createdAtDate = { createdAtDate }
+  }
+
+  fun withBody(body: String) = apply {
+    this.body = { body }
+  }
+
+  override fun produce(): ApplicationTimelineNoteEntity = ApplicationTimelineNoteEntity(
+    id = this.id(),
+    applicationId = this.applicationId(),
+    createdBy = this.createdBy(),
+    createdAtDate = this.createdAtDate(),
+    body = this.body(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClien
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTeamCodeEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTimelineNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
@@ -82,6 +83,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
@@ -401,6 +404,9 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesAssessmentRepository: ApprovedPremisesAssessmentTestRepository
 
   @Autowired
+  lateinit var applicationTimelineNoteRepository: ApplicationTimelineNoteRepository
+
+  @Autowired
   lateinit var temporaryAccommodationAssessmentRepository: TemporaryAccommodationAssessmentTestRepository
 
   @Autowired
@@ -509,6 +515,7 @@ abstract class IntegrationTestBase {
   lateinit var placementApplicationFactory: PersistedFactory<PlacementApplicationEntity, UUID, PlacementApplicationEntityFactory>
   lateinit var placementDateFactory: PersistedFactory<PlacementDateEntity, UUID, PlacementDateEntityFactory>
   lateinit var probationAreaProbationRegionMappingFactory: PersistedFactory<ProbationAreaProbationRegionMappingEntity, UUID, ProbationAreaProbationRegionMappingEntityFactory>
+  lateinit var applicationTimelineNoteEntityFactory: PersistedFactory<ApplicationTimelineNoteEntity, UUID, ApplicationTimelineNoteEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -592,6 +599,7 @@ abstract class IntegrationTestBase {
     placementApplicationFactory = PersistedFactory({ PlacementApplicationEntityFactory() }, placementApplicationRepository)
     placementDateFactory = PersistedFactory({ PlacementDateEntityFactory() }, placementDateRepository)
     probationAreaProbationRegionMappingFactory = PersistedFactory({ ProbationAreaProbationRegionMappingEntityFactory() }, probationAreaProbationRegionMappingRepository)
+    applicationTimelineNoteEntityFactory = PersistedFactory({ ApplicationTimelineNoteEntityFactory() }, applicationTimelineNoteRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -72,6 +72,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Mana
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApprovedPremisesApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
@@ -80,6 +81,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import java.sql.Timestamp
@@ -101,6 +103,8 @@ class ApplicationServiceTest {
   private val mockUserService = mockk<UserService>()
   private val mockAssessmentService = mockk<AssessmentService>()
   private val mockOfflineApplicationRepository = mockk<OfflineApplicationRepository>()
+  private val mockApplicationTimelineNoteService = mockk<ApplicationTimelineNoteService>()
+  private val mockApplicationTimelineNoteTransformer = mockk<ApplicationTimelineNoteTransformer>()
   private val mockDomainEventService = mockk<DomainEventService>()
   private val mockCas3DomainEventService = mockk<Cas3DomainEventService>()
   private val mockCommunityApiClient = mockk<CommunityApiClient>()
@@ -120,6 +124,8 @@ class ApplicationServiceTest {
     mockUserService,
     mockAssessmentService,
     mockOfflineApplicationRepository,
+    mockApplicationTimelineNoteService,
+    mockApplicationTimelineNoteTransformer,
     mockDomainEventService,
     mockCas3DomainEventService,
     mockCommunityApiClient,
@@ -794,7 +800,6 @@ class ApplicationServiceTest {
       applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = "{}",
-        username = username,
       ) is AuthorisableActionResult.NotFound,
     ).isTrue
   }
@@ -832,7 +837,6 @@ class ApplicationServiceTest {
       applicationService.updateTemporaryAccommodationApplication(
         applicationId = applicationId,
         data = "{}",
-        username = username,
       ) is AuthorisableActionResult.Unauthorised,
     ).isTrue
   }
@@ -868,7 +872,6 @@ class ApplicationServiceTest {
     val result = applicationService.updateTemporaryAccommodationApplication(
       applicationId = applicationId,
       data = "{}",
-      username = username,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -914,7 +917,6 @@ class ApplicationServiceTest {
     val result = applicationService.updateTemporaryAccommodationApplication(
       applicationId = applicationId,
       data = "{}",
-      username = username,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -967,7 +969,6 @@ class ApplicationServiceTest {
     val result = applicationService.updateTemporaryAccommodationApplication(
       applicationId = applicationId,
       data = updatedData,
-      username = username,
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
1. New endpoint /applications/{applicationId}/notes. 
2. Database migration.
3. New ApplicationTimelineNoteEntity and ApplicationTimelineNoteRepository and ApplicationTimelineNoteService.
4. Tests for creating notes.
5. Tweaked Timeline endpoint return to include these notes as a new TimlineEventType.
6. Tests that show the timeline endpoint can return these notes in payload.

