### PR TITLE
Filter out null timeliness entries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/PlacementMetricsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/PlacementMetricsReportGenerator.kt
@@ -39,8 +39,12 @@ class PlacementMetricsReportGenerator(
     }
 
     val successfulRequests = applications.filter { row -> row.bookingMadeAt !== null }
-    val averageTimeliness = successfulRequests.map { row -> row.overallTimeliness!! }.average()
-    val averagePlacementMatchingTimeliness = successfulRequests.map { row -> row.placementMatchingTimeliness!! }.average()
+    val averageTimeliness = successfulRequests
+      .mapNotNull { row -> row.overallTimeliness }
+      .average()
+    val averagePlacementMatchingTimeliness = successfulRequests
+      .mapNotNull { row -> row.placementMatchingTimeliness }
+      .average()
 
     successfulRequests.map { row ->
       val start = row.applicationSubmittedAt

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/PlacementMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/PlacementMetricsReportGeneratorTest.kt
@@ -56,6 +56,7 @@ class PlacementMetricsReportGeneratorTest {
       createTimelinessEntity("A1", LocalDateTime.now(), LocalDateTime.now(), 7, 3),
       createTimelinessEntity("A1", LocalDateTime.now(), LocalDateTime.now(), 3, 4),
       createTimelinessEntity("A1", LocalDateTime.now(), LocalDateTime.now(), 1, 1),
+      createTimelinessEntity("A1", LocalDateTime.now(), LocalDateTime.now(), null, null),
     )
 
     every { mockWorkingDayCountService.getWorkingDaysCount(any(), any()) } returns 1


### PR DESCRIPTION
The Placement Metrics report is failing because some of the timeliness values are null. Instead of using a bang to make them not null, let’s filter out the null entries.