### PR TITLE
Add CAS2 application status reference data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -60,6 +60,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/events/cas2/application-submitted/*", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasRole("CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReferenceDataController.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.ReferenceDataCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
+
+@Service("Cas2ReferenceDataController")
+class ReferenceDataController : ReferenceDataCas2Delegate {
+  override fun referenceDataApplicationStatusGet(): ResponseEntity<List<Cas2ApplicationStatus>> {
+    return ResponseEntity.ok(Cas2ApplicationStatusSeeding.statusList())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import java.util.UUID
+
+object Cas2ApplicationStatusSeeding {
+
+  fun statusList(): List<Cas2ApplicationStatus> {
+    return listOf(
+      Cas2ApplicationStatus(
+        id = UUID.fromString("c989f05f-c574-49a2-8381-11d332d98d40"),
+        name = "received",
+        label = "Received",
+        description = "The application has been received and is yet to be processed",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("f5cd423b-08eb-4efb-96ff-5cc6bb073905"),
+        name = "moreInfoRequested",
+        label = "More information requested",
+        description = "More information about the application has been requested from the POM (Prison Offender Manager).",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("ba4d8432-250b-4ab9-81ec-7eb4b16e5dd1"),
+        name = "awaitingDecision",
+        label = "Awaiting decision",
+        description = "All information has been received and the application is awaiting assessment.",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("176bbda0-0766-4d77-8d56-18ed8f9a4ef2"),
+        name = "placeOffered",
+        label = "Place offered",
+        description = "A place has been offered which has been sent by email.",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("a919097d-b324-471c-9834-756f255e87ea"),
+        name = "onWaitingList",
+        label = "On waiting list",
+        description = "No suitable place is currently available.",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("758eee61-2a6d-46b9-8bdd-869536d77f1b"),
+        name = "noPlaceOffered",
+        label = "No place offered",
+        description = "No place was offered and this has been confirmed by email.",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("4ad9bbfa-e5b0-456f-b746-146f7fd511dd"),
+        name = "incomplete",
+        label = "Incomplete",
+        description = "More information was requested, but not provided. The application remains incomplete.",
+      ),
+      Cas2ApplicationStatus(
+        id = UUID.fromString("004e2419-9614-4c1e-a207-a8418009f23d"),
+        name = "withdrawn",
+        label = "Withdrawn",
+        description = "The application was withdrawn by the referrer, or MoJ staff.",
+      ),
+    )
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1746,6 +1746,26 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2ApplicationStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+      required:
+        - id
+        - name
+        - label
+        - description
     Cas2SubmittedApplicationSummary:
       type: object
       properties:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -336,3 +336,23 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /reference-data/application-status:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all application status update choices
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Cas2ApplicationStatus'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5773,6 +5773,26 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2ApplicationStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+      required:
+        - id
+        - name
+        - label
+        - description
     Cas2SubmittedApplicationSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -338,6 +338,26 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/application-status:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all application status update choices
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas2ApplicationStatus'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
 components:
   responses:
     401Response:
@@ -2086,6 +2106,26 @@ components:
           required:
             - createdByUserId
             - status
+    Cas2ApplicationStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+      required:
+        - id
+        - name
+        - label
+        - description
     Cas2SubmittedApplicationSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReferenceDataTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
+
+class Cas2ReferenceDataTest : IntegrationTestBase() {
+
+  @Test
+  fun `All available application status options are returned`() {
+    val expectedStatusOptions = objectMapper.writeValueAsString(
+      Cas2ApplicationStatusSeeding.statusList(),
+    )
+
+    val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt()
+
+    webTestClient.get()
+      .uri("/cas2/reference-data/application-status")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedStatusOptions)
+  }
+}


### PR DESCRIPTION
## Add /cas2/reference-data/application-status endpoint

This endpoint will allow the UI to build a form for an assessor to provide a status update.

The status options are currently defined inline in `model/reference/Cas2ApplicationStatusSeeding.kt`
but we'll introduce database seeding to manage them.

![cas2_reference_data](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/dce4fb69-06fc-433d-9c1f-7f2cbf4347e2)
