### PR TITLE
Increase maximum database connections to 20 per replica

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
       test:
         - "stdout"
 
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+
   flyway:
     repeatable-sql-migration-prefix: "R"
     sql-migration-prefix: ""
@@ -228,4 +232,3 @@ upstream-timeout-ms: 10000
 case-notes-service-upstream-timeout-ms: 30000
 
 max-response-in-memory-size-bytes: 750000
-


### PR DESCRIPTION
We noticed a bunch of errors during a 3 minute window where database connections couldn't be created. [Slack alerts](https://mojdt.slack.com/archives/C044ZUGJRC7/p1699463989529889). [Slack conversation](https://mojdt.slack.com/archives/C03K0HB0LBE/p1699464447663939).

On investigating App Insights we see the following:

Blue = max available connections
Purple = sum of active connections
Ping = connections pending
Green = connections timed out

![Screenshot 2023-11-08 at 18 38 02](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/235f76e0-97ea-4948-a419-9c19ef021cf0)

This tells me that something hogged all 40 connections and explains why we see failures to acquire new connections shortly after. We should investigate separately what logic required such a dramatic increase. I suspect it's the booking/search being unpaginated. For now though, we can increase our max database connections to be more resilient.

There are many examples of other teams increasing their max database pool size:

- hmpps tier to 25 https://github.com/ministryofjustice/hmpps-tier/blob/8faa4bfd31580767bed8bba453cdddd70098f3ad/src/main/resources/application.yml#L17
- csr-api to 35 https://github.com/ministryofjustice/csr-api/blob/536fc26119c38d0bc4c83f2ad52482bb39414e00/src/main/resources/application.yml#L13
- community-api to 30 https://github.com/ministryofjustice/community-api/blob/54fdf94c9ce2e6e534ac18c11c82c73ff1f2995d/src/main/resources/application.yml#L9

Tier in particular increases to 25 whilst they have a db.t4g.small instance in prod[3]. They do only have 2 replicas in prod[4] whilst we have 4, any value we set will result in double the connections to our database.

Our RDS instance in prod is a db.t3.small[2]

When we query on preprod we see the number of connections for this instance is 192:

```
show max_connections;
-- success --
max_connections
---------------
192
```

If we set this to 20 and * 4 replicas our new maximum should be 80, up from 40. Well within the database’s max of 192.

[2] https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf#L13C35-L13C46
[3] https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf#L16
[4] https://github.com/ministryofjustice/hmpps-tier/blob/8faa4bfd31580767bed8bba453cdddd70098f3ad/helm_deploy/hmpps-tier/values.yaml#L4C3-L4C15