### PR TITLE
Expose representations of CAS2 status updates within SubmittedApplication

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -145,7 +145,7 @@ class SubmissionsController(
   ): Cas2SubmittedApplication {
     val personInfo = offenderService.getFullInfoForPersonOrThrow(application.crn)
 
-    return applicationTransformer.transformJpaToSubmittedApplication(
+    return applicationTransformer.transformJpaToApiRepresentation(
       application,
       personInfo,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getFullInfoForPersonOrThrow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getInfoForPersonOrThrowInternalServerError
 import java.util.UUID
@@ -32,7 +32,7 @@ import java.util.UUID
 class SubmissionsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
-  private val applicationsTransformer: ApplicationsTransformer,
+  private val applicationTransformer: SubmittedApplicationTransformer,
   private val offenderService: OffenderService,
   private val externalUserService: ExternalUserService,
   private val statusUpdateService: StatusUpdateService,
@@ -134,7 +134,7 @@ class SubmissionsController(
     Cas2SubmittedApplicationSummary {
     val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
 
-    return applicationsTransformer.transformJpaSummaryToCas2SubmittedSummary(
+    return applicationTransformer.transformJpaSummaryToCas2SubmittedSummary(
       application,
       personInfo,
     )
@@ -145,7 +145,7 @@ class SubmissionsController(
   ): Cas2SubmittedApplication {
     val personInfo = offenderService.getFullInfoForPersonOrThrow(application.crn)
 
-    return applicationsTransformer.transformJpaToSubmittedApplication(
+    return applicationTransformer.transformJpaToSubmittedApplication(
       application,
       personInfo,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -134,7 +134,7 @@ class SubmissionsController(
     Cas2SubmittedApplicationSummary {
     val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
 
-    return applicationTransformer.transformJpaSummaryToCas2SubmittedSummary(
+    return applicationTransformer.transformJpaSummaryToApiRepresentation(
       application,
       personInfo,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.hibernate.annotations.OrderBy
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
@@ -89,6 +90,7 @@ data class Cas2ApplicationEntity(
   var submittedAt: OffsetDateTime?,
 
   @OneToMany(mappedBy = "application")
+  @OrderBy(clause = "createdAt DESC")
   var statusUpdates: MutableList<Cas2StatusUpdateEntity>? = null,
 
   @Transient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -38,7 +38,7 @@ data class Cas2StatusUpdateEntity(
   val application: Cas2ApplicationEntity,
 
   @CreationTimestamp
-  val createdAt: OffsetDateTime? = null,
+  var createdAt: OffsetDateTime? = null,
 ) {
   override fun toString() = "Cas2StatusEntity: $id"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
@@ -39,4 +41,8 @@ data class Cas2StatusUpdateEntity(
   val createdAt: OffsetDateTime? = null,
 ) {
   override fun toString() = "Cas2StatusEntity: $id"
+
+  fun status(): Cas2ApplicationStatus {
+    return Cas2ApplicationStatusSeeding.getById(statusId)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -36,7 +36,7 @@ data class Cas2StatusUpdateEntity(
   val application: Cas2ApplicationEntity,
 
   @CreationTimestamp
-  private val createdAt: OffsetDateTime? = null,
+  val createdAt: OffsetDateTime? = null,
 ) {
   override fun toString() = "Cas2StatusEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -5,6 +5,11 @@ import java.util.UUID
 
 object Cas2ApplicationStatusSeeding {
 
+  fun getById(id: UUID): Cas2ApplicationStatus {
+    return statusList().find { status -> status.id == id }
+      ?: error("Status with id $id not found")
+  }
+
   fun statusList(): List<Cas2ApplicationStatus> {
     return listOf(
       Cas2ApplicationStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExternalUserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExternalUserTransformer.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ExternalUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
+
+@Component
+class ExternalUserTransformer {
+
+  fun transformJpaToApi(externalUserEntity: ExternalUserEntity): ExternalUser {
+    return ExternalUser(
+      id = externalUserEntity.id,
+      username = externalUserEntity.username,
+      origin = externalUserEntity.origin,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
+
+@Component("Cas2StatusUpdateTransformer")
+class StatusUpdateTransformer(
+  private val externalUserTransformer: ExternalUserTransformer,
+) {
+
+  fun transformJpaToApi(
+    jpa: Cas2StatusUpdateEntity,
+  ):
+    Cas2StatusUpdate {
+    return Cas2StatusUpdate(
+      id = jpa.id,
+      name = jpa.status().name,
+      label = jpa.label,
+      description = jpa.description,
+      updatedBy = externalUserTransformer.transformJpaToApi(jpa.assessor),
+      updatedAt = jpa.createdAt?.toInstant(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -38,7 +38,7 @@ class SubmittedApplicationTransformer(
     )
   }
 
-  fun transformJpaSummaryToCas2SubmittedSummary(
+  fun transformJpaSummaryToApiRepresentation(
     jpaSummary: Cas2ApplicationSummary,
     personInfo:
       PersonInfoResult.Success,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -18,7 +18,7 @@ class SubmittedApplicationTransformer(
   private val nomisUserTransformer: NomisUserTransformer,
 ) {
 
-  fun transformJpaToSubmittedApplication(
+  fun transformJpaToApiRepresentation(
     jpa: Cas2ApplicationEntity,
     personInfo:
       PersonInfoResult

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -3,50 +3,54 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 
-@Component("Cas2ApplicationsTransformer")
-class ApplicationsTransformer(
+@Component("Cas2SubmittedApplicationTransformer")
+class SubmittedApplicationTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
+  private val nomisUserTransformer: NomisUserTransformer,
 ) {
 
-  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult.Success):
-    Cas2Application {
-    return Cas2Application(
+  fun transformJpaToSubmittedApplication(
+    jpa: Cas2ApplicationEntity,
+    personInfo:
+      PersonInfoResult
+      .Success,
+  ):
+    Cas2SubmittedApplication {
+    return Cas2SubmittedApplication(
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
-      createdByUserId = jpa.createdByUser.id,
+      submittedBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
       createdAt = jpa.createdAt.toInstant(),
       submittedAt = jpa.submittedAt?.toInstant(),
-      data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       status = getStatus(jpa),
-      type = "CAS2",
     )
   }
 
-  fun transformJpaSummaryToSummary(
+  fun transformJpaSummaryToCas2SubmittedSummary(
     jpaSummary: Cas2ApplicationSummary,
     personInfo:
       PersonInfoResult.Success,
-  ): uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary {
-    return uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
-      .Cas2ApplicationSummary(
-        id = jpaSummary.getId(),
-        person = personTransformer.transformModelToPersonApi(personInfo),
-        createdByUserId = jpaSummary.getCreatedByUserId(),
-        createdAt = jpaSummary.getCreatedAt().toInstant(),
-        submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
-        status = getStatusFromSummary(jpaSummary),
-        type = "CAS2",
-      )
+  ): Cas2SubmittedApplicationSummary {
+    return Cas2SubmittedApplicationSummary(
+      id = jpaSummary.getId(),
+      person = personTransformer.transformModelToPersonApi(personInfo),
+      createdByUserId = jpaSummary.getCreatedByUserId(),
+      createdAt = jpaSummary.getCreatedAt().toInstant(),
+      submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
+      status = getStatusFromSummary(jpaSummary),
+    )
   }
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -3,10 +3,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -16,6 +18,7 @@ class SubmittedApplicationTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
   private val nomisUserTransformer: NomisUserTransformer,
+  private val statusUpdateTransformer: StatusUpdateTransformer,
 ) {
 
   fun transformJpaToApiRepresentation(
@@ -31,6 +34,7 @@ class SubmittedApplicationTransformer(
       submittedBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
+      statusUpdates = jpa.statusUpdates?.map { update -> transformUpdate(update) },
       createdAt = jpa.createdAt.toInstant(),
       submittedAt = jpa.submittedAt?.toInstant(),
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
@@ -51,6 +55,10 @@ class SubmittedApplicationTransformer(
       submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
       status = getStatusFromSummary(jpaSummary),
     )
+  }
+
+  private fun transformUpdate(jpa: Cas2StatusUpdateEntity): Cas2StatusUpdate {
+    return statusUpdateTransformer.transformJpaToApi(jpa)
   }
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1616,6 +1616,10 @@ components:
         submittedAt:
           type: string
           format: date-time
+        statusUpdates:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
       required:
         - id
         - person
@@ -1800,6 +1804,31 @@ components:
         - id
         - person
         - createdAt
+    Cas2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        updatedBy:
+          $ref: '#/components/schemas/ExternalUser'
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - label
+        - description
     ApplicationStatus:
       type: string
       enum:
@@ -2427,6 +2456,21 @@ components:
       required:
         - user
         - taskType
+    ExternalUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: 'CAS2_ASSESSOR_USER'
+        origin:
+          type: string
+          example: 'NACRO'
+      required:
+        - id
+        - username
     NomisUser:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5694,6 +5694,10 @@ components:
         submittedAt:
           type: string
           format: date-time
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdate'
       required:
         - id
         - person
@@ -5878,6 +5882,31 @@ components:
         - id
         - person
         - createdAt
+    Cas2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        updatedBy:
+          $ref: '#/components/schemas/ExternalUser'
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - label
+        - description
     ApplicationStatus:
       type: string
       enum:
@@ -6505,6 +6534,21 @@ components:
       required:
         - user
         - taskType
+    ExternalUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: 'CAS2_ASSESSOR_USER'
+        origin:
+          type: string
+          example: 'NACRO'
+      required:
+        - id
+        - username
     NomisUser:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2011,6 +2011,10 @@ components:
         submittedAt:
           type: string
           format: date-time
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdate'
       required:
         - id
         - person
@@ -2195,6 +2199,31 @@ components:
         - id
         - person
         - createdAt
+    Cas2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        updatedBy:
+          $ref: '#/components/schemas/ExternalUser'
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - label
+        - description
     ApplicationStatus:
       type: string
       enum:
@@ -2822,6 +2851,21 @@ components:
       required:
         - user
         - taskType
+    ExternalUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: 'CAS2_ASSESSOR_USER'
+        origin:
+          type: string
+          example: 'NACRO'
+      required:
+        - id
+        - username
     NomisUser:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -23,6 +24,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
+  private var statusUpdates: Yielded<MutableList<Cas2StatusUpdateEntity>> = { mutableListOf() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
 
@@ -66,6 +68,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.submittedAt = { submittedAt }
   }
 
+  fun withStatusUpdates(statusUpdates: MutableList<Cas2StatusUpdateEntity>) = apply {
+    this.statusUpdates = { statusUpdates }
+  }
+
   fun withEventNumber(eventNumber: String) = apply {
     this.eventNumber = { eventNumber }
   }
@@ -79,6 +85,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     schemaVersion = this.applicationSchema(),
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
+    statusUpdates = this.statusUpdates(),
     schemaUpToDate = false,
     nomsNumber = this.nomsNumber(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var assessor: Yielded<ExternalUserEntity> = { ExternalUserEntityFactory().produce() }
+  private var application: Yielded<Cas2ApplicationEntity>? = null
+  private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList().random().id }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var label: Yielded<String> = { "More information requested" }
+  private var description: Yielded<String> = { "More information about the application has been requested" }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAssessor(assessor: ExternalUserEntity) = apply {
+    this.assessor = { assessor }
+  }
+
+  fun withApplication(application: Cas2ApplicationEntity) = apply {
+    this.application = { application }
+  }
+
+  fun withStatusId(statusId: UUID) = apply {
+    this.statusId = { statusId }
+  }
+
+  fun withLabel(label: String) = apply {
+    this.label = { label }
+  }
+
+  fun withDescription(description: String) = apply {
+    this.description = { description }
+  }
+
+  override fun produce(): Cas2StatusUpdateEntity = Cas2StatusUpdateEntity(
+    id = this.id(),
+    assessor = this.assessor(),
+    application = this.application?.invoke() ?: error("Must provide a submitted application"),
+    statusId = this.statusId(),
+    createdAt = this.createdAt(),
+    label = this.label(),
+    description = this.description(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
@@ -35,6 +35,10 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
     this.statusId = { statusId }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   fun withLabel(label: String) = apply {
     this.label = { label }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DateChangeEntityFactory
@@ -104,6 +105,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
@@ -172,6 +174,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2StatusUpdateTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
@@ -362,6 +365,9 @@ abstract class IntegrationTestBase {
   lateinit var cas2ApplicationRepository: Cas2ApplicationTestRepository
 
   @Autowired
+  lateinit var cas2StatusUpdateRepository: Cas2StatusUpdateTestRepository
+
+  @Autowired
   lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationApplicationTestRepository
 
   @Autowired
@@ -483,6 +489,7 @@ abstract class IntegrationTestBase {
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
   lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
   lateinit var cas2ApplicationEntityFactory: PersistedFactory<Cas2ApplicationEntity, UUID, Cas2ApplicationEntityFactory>
+  lateinit var cas2StatusUpdateEntityFactory: PersistedFactory<Cas2StatusUpdateEntity, UUID, Cas2StatusUpdateEntityFactory>
   lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
   lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
@@ -567,6 +574,7 @@ abstract class IntegrationTestBase {
     nonArrivalReasonEntityFactory = PersistedFactory({ NonArrivalReasonEntityFactory() }, nonArrivalReasonRepository)
     approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)
     cas2ApplicationEntityFactory = PersistedFactory({ Cas2ApplicationEntityFactory() }, cas2ApplicationRepository)
+    cas2StatusUpdateEntityFactory = PersistedFactory({ Cas2StatusUpdateEntityFactory() }, cas2StatusUpdateRepository)
     temporaryAccommodationApplicationEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationEntityFactory() }, temporaryAccommodationApplicationRepository)
     offlineApplicationEntityFactory = PersistedFactory({ OfflineApplicationEntityFactory() }, offlineApplicationRepository)
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesApplicationJsonSchemaEntityFactory() }, approvedPremisesApplicationJsonSchemaRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -30,6 +31,9 @@ import java.util.UUID
 class Cas2SubmissionTest : IntegrationTestBase() {
   @SpykBean
   lateinit var realApplicationRepository: ApplicationRepository
+
+  @SpykBean
+  lateinit var realStatusUpdateRepository: Cas2StatusUpdateRepository
 
   @Autowired
   lateinit var nomisUserTransformer: NomisUserTransformer
@@ -40,6 +44,7 @@ class Cas2SubmissionTest : IntegrationTestBase() {
     // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
     // Manually clearing after each test seems to fix this.
     clearMocks(realApplicationRepository)
+    clearMocks(realStatusUpdateRepository)
   }
 
   @Nested
@@ -186,7 +191,7 @@ class Cas2SubmissionTest : IntegrationTestBase() {
   inner class GetToShow {
     @Test
     fun `Assessor can view single submitted application`() {
-      `Given a CAS2 Assessor` { _, jwt ->
+      `Given a CAS2 Assessor` { assessor, jwt ->
         `Given a CAS2 User` { user, _ ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
@@ -228,6 +233,33 @@ class Cas2SubmissionTest : IntegrationTestBase() {
               )
             }
 
+            val update1 = cas2StatusUpdateEntityFactory.produceAndPersist {
+              withApplication(applicationEntity)
+              withAssessor(assessor)
+              withLabel("1st update")
+            }
+
+            val update2 = cas2StatusUpdateEntityFactory.produceAndPersist {
+              withApplication(applicationEntity)
+              withAssessor(assessor)
+              withLabel("2nd update")
+            }
+
+            val update3 = cas2StatusUpdateEntityFactory.produceAndPersist {
+              withApplication(applicationEntity)
+              withAssessor(assessor)
+              withLabel("3rd update")
+            }
+
+            update1.apply { this.createdAt = OffsetDateTime.now().minusDays(20) }
+            realStatusUpdateRepository.save(update1)
+
+            update2.apply { this.createdAt = OffsetDateTime.now().minusDays(15) }
+            realStatusUpdateRepository.save(update2)
+
+            update3.apply { this.createdAt = OffsetDateTime.now().minusDays(1) }
+            realStatusUpdateRepository.save(update3)
+
             val rawResponseBody = webTestClient.get()
               .uri("/cas2/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
@@ -258,6 +290,9 @@ class Cas2SubmissionTest : IntegrationTestBase() {
                   serializableToJsonNode(it.document) &&
                 newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
             }
+
+            Assertions.assertThat(responseBody.statusUpdates!!.map { update -> update.label })
+              .isEqualTo(listOf("3rd update", "2nd update", "1st update"))
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas2StatusUpdateTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas2StatusUpdateTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
+import java.util.UUID
+
+@Repository
+interface Cas2StatusUpdateTestRepository : JpaRepository<Cas2StatusUpdateEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ExternalUserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ExternalUserTransformerTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ExternalUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
+
+class ExternalUserTransformerTest {
+  private val externalUserTransformer = ExternalUserTransformer()
+
+  @Test
+  fun `transforms JPA ExternalUser db entity to ExternalUser api representation`() {
+    val jpaEntity = ExternalUserEntityFactory().produce()
+
+    val expectedRepresentation = ExternalUser(
+      id = jpaEntity.id,
+      username = jpaEntity.username,
+      origin = jpaEntity.origin,
+    )
+
+    val transformation = externalUserTransformer.transformJpaToApi(jpaEntity)
+
+    Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -11,12 +11,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
@@ -26,7 +24,6 @@ import java.util.UUID
 
 class ApplicationsTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
-  private val mockNomisUserTransformer = mockk<NomisUserTransformer>()
 
   private val objectMapper = ObjectMapper().apply {
     registerModule(Jdk8Module())
@@ -38,7 +35,6 @@ class ApplicationsTransformerTest {
     .approvedpremisesapi.transformer.cas2.ApplicationsTransformer(
       objectMapper,
       mockPersonTransformer,
-      mockNomisUserTransformer,
     )
 
   private val user = NomisUserEntityFactory().produce()
@@ -48,12 +44,9 @@ class ApplicationsTransformerTest {
   private val submittedCas2ApplicationFactory = cas2ApplicationFactory
     .withSubmittedAt(OffsetDateTime.now())
 
-  private val mockNomisUser = mockk<NomisUser>()
-
   @BeforeEach
   fun setup() {
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
-    every { mockNomisUserTransformer.transformJpaToApi(any()) } returns mockNomisUser
   }
 
   @Nested
@@ -125,29 +118,6 @@ class ApplicationsTransformerTest {
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
-    }
-  }
-
-  @Nested
-  inner class TransformJpaToSubmittedApplication {
-    @Test
-    fun `transforms submitted application to API representation with NomisUser and no data`() {
-      val jpaEntity = submittedCas2ApplicationFactory.produce()
-
-      val transformation = applicationsTransformer.transformJpaToSubmittedApplication(jpaEntity, mockk())
-
-      assertThat(transformation.submittedBy).isEqualTo(mockNomisUser)
-      assertThat(transformation).hasOnlyFields(
-        "createdAt",
-        "document",
-        "id",
-        "outdatedSchema",
-        "person",
-        "schemaVersion",
-        "status",
-        "submittedAt",
-        "submittedBy",
-      )
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/StatusUpdateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/StatusUpdateTransformerTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas2
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ExternalUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
+import java.time.OffsetDateTime
+
+class StatusUpdateTransformerTest {
+  private val user = NomisUserEntityFactory().produce()
+  private val submittedApplication = Cas2ApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .withSubmittedAt(OffsetDateTime.now())
+    .produce()
+
+  private val mockExternalUserApi = mockk<ExternalUser>()
+  private val mockExternalUserTransformer = mockk<ExternalUserTransformer>()
+  private val statusUpdateTransformer = StatusUpdateTransformer(mockExternalUserTransformer)
+
+  @BeforeEach
+  fun setup() {
+    every { mockExternalUserTransformer.transformJpaToApi(any()) } returns mockExternalUserApi
+  }
+
+  @Test
+  fun `transforms JPA Cas2StatusUpdate db entity to API representation`() {
+    val status = Cas2ApplicationStatusSeeding.statusList().random()
+
+    val jpaEntity = Cas2StatusUpdateEntityFactory()
+      .withStatusId(status.id)
+      .withApplication(submittedApplication)
+      .produce()
+
+    val expectedRepresentation = Cas2StatusUpdate(
+      id = jpaEntity.id,
+      name = status.name,
+      label = jpaEntity.label,
+      description = jpaEntity.description,
+      updatedBy = mockExternalUserApi,
+      updatedAt = jpaEntity.createdAt?.toInstant(),
+    )
+
+    val transformation = statusUpdateTransformer.transformJpaToApi(jpaEntity)
+
+    Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas2
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
+import java.time.OffsetDateTime
+
+class SubmittedApplicationTransformerTest {
+  private val mockPersonTransformer = mockk<PersonTransformer>()
+  private val mockNomisUserTransformer = mockk<NomisUserTransformer>()
+
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
+  private val applicationTransformer = SubmittedApplicationTransformer(
+    objectMapper,
+    mockPersonTransformer,
+    mockNomisUserTransformer,
+  )
+
+  private val user = NomisUserEntityFactory().produce()
+
+  private val cas2ApplicationFactory = Cas2ApplicationEntityFactory().withCreatedByUser(user)
+
+  private val submittedCas2ApplicationFactory = cas2ApplicationFactory
+    .withSubmittedAt(OffsetDateTime.now())
+
+  private val mockNomisUser = mockk<NomisUser>()
+
+  @BeforeEach
+  fun setup() {
+    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockNomisUserTransformer.transformJpaToApi(any()) } returns mockNomisUser
+  }
+
+  @Nested
+  inner class TransformJpaToSubmittedApplication {
+    @Test
+    fun `transforms submitted application to API representation with NomisUser and no data`() {
+      val jpaEntity = submittedCas2ApplicationFactory.produce()
+
+      val transformation = applicationTransformer.transformJpaToSubmittedApplication(jpaEntity, mockk())
+
+      assertThat(transformation.submittedBy).isEqualTo(mockNomisUser)
+      assertThat(transformation).hasOnlyFields(
+        "createdAt",
+        "document",
+        "id",
+        "outdatedSchema",
+        "person",
+        "schemaVersion",
+        "status",
+        "statusUpdates",
+        "submittedAt",
+        "submittedBy",
+      )
+    }
+  }
+  // transformJpaSummaryToCas2SubmittedSummary
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -10,14 +10,20 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.sql.Timestamp
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.UUID
 
 class SubmittedApplicationTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
@@ -73,5 +79,23 @@ class SubmittedApplicationTransformerTest {
       )
     }
   }
-  // transformJpaSummaryToCas2SubmittedSummary
+
+  @Nested
+  inner class TransformJpaSummaryToCas2SubmittedSummary {
+    @Test
+    fun `transforms submitted summary application to API summary representation `() {
+      val applicationSummary = object : Cas2ApplicationSummary {
+        override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
+        override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+        override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
+        override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+      }
+
+      val transformation = applicationTransformer.transformJpaSummaryToCas2SubmittedSummary(applicationSummary, mockk())
+
+      assertThat(transformation.id).isEqualTo(applicationSummary.getId())
+      assertThat(transformation.status).isEqualTo(ApplicationStatus.submitted)
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -92,7 +92,7 @@ class SubmittedApplicationTransformerTest {
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
       }
 
-      val transformation = applicationTransformer.transformJpaSummaryToCas2SubmittedSummary(applicationSummary, mockk())
+      val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(applicationSummary, mockk())
 
       assertThat(transformation.id).isEqualTo(applicationSummary.getId())
       assertThat(transformation.status).isEqualTo(ApplicationStatus.submitted)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -56,7 +56,7 @@ class SubmittedApplicationTransformerTest {
     fun `transforms submitted application to API representation with NomisUser and no data`() {
       val jpaEntity = submittedCas2ApplicationFactory.produce()
 
-      val transformation = applicationTransformer.transformJpaToSubmittedApplication(jpaEntity, mockk())
+      val transformation = applicationTransformer.transformJpaToApiRepresentation(jpaEntity, mockk())
 
       assertThat(transformation.submittedBy).isEqualTo(mockNomisUser)
       assertThat(transformation).hasOnlyFields(


### PR DESCRIPTION
## Expose status updates within submitted application

Our representation of a `SubmittedApplication` now includes a list of `StatusUpdate`s

![status_updates_in_submitted_application](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/9c8fbfb0-fbfb-4eb2-b18c-2fb71afc092a)

Note that:

- `updatedAt` is the creation timestamp of the status update
- `updatedBy` is a new representation of an `ExternalUser`
- status updates are ordered by date descending i.e. most recent first