### PR TITLE
Increase memory limit for responses from Delius Integration API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -87,6 +87,11 @@ class WebClientConfiguration(
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
         ),
       )
+      .exchangeStrategies(
+        ExchangeStrategies.builder().codecs {
+          it.defaultCodecs().maxInMemorySize(maxResponseInMemorySizeBytes)
+        }.build(),
+      )
       .build()
   }
 


### PR DESCRIPTION
In certain situations, downloading a booking report can result in a `WebClientResponseException`:

```
200 OK from GET https://approved-premises-and-delius.hmpps.service.justice.gov.uk/probation-cases/summaries; nested exception is org.springframework.core.io.buffer.DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144
```

The memory limit for a `WebClient` is configurable and has already been increased to 750000 bytes for the Prison API. This uses the same configurable limit value on a provisional basis to alleviate the problem, although in future being able to configure this limit on a per-API basis may be preferable.