### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.5.0
+  hmpps: ministryofjustice/hmpps@7
   mem: circleci/rememborb@0.0.2
   node: circleci/node@5.1.0
   slack: circleci/slack@4.12.5
@@ -346,9 +346,9 @@ workflows:
       - request-preprod-approval:
           type: approval
           requires:
-#            TODO: Uncomment this when we have confirmed the e2es work correctly
-#            - cas1_e2e_tests
-#            - cas3_e2e_tests
+            #            TODO: Uncomment this when we have confirmed the e2es work correctly
+            #            - cas1_e2e_tests
+            #            - cas3_e2e_tests
             - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod

--- a/.circleci/config.yml-z
+++ b/.circleci/config.yml-z
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@5.1
+  hmpps: ministryofjustice/hmpps@7
 
 parameters:
   alerts-slack-channel:
@@ -61,32 +61,32 @@ workflows:
             - validate
             - build_docker
             - helm_lint
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          context:
-#            - hmpps-common-vars
-#            - approved-premises-api-preprod
-#          requires:
-#            - request-preprod-approval
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - approved-premises-api-prod
-#          requires:
-#            - request-prod-approval
+  #      - request-preprod-approval:
+  #          type: approval
+  #          requires:
+  #            - deploy_dev
+  #      - hmpps/deploy_env:
+  #          name: deploy_preprod
+  #          env: "preprod"
+  #          context:
+  #            - hmpps-common-vars
+  #            - approved-premises-api-preprod
+  #          requires:
+  #            - request-preprod-approval
+  #      - request-prod-approval:
+  #          type: approval
+  #          requires:
+  #            - deploy_preprod
+  #      - hmpps/deploy_env:
+  #          name: deploy_prod
+  #          env: "prod"
+  #          slack_notification: true
+  #          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+  #          context:
+  #            - hmpps-common-vars
+  #            - approved-premises-api-prod
+  #          requires:
+  #            - request-prod-approval
 
   security:
     triggers:
@@ -124,5 +124,3 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-
-

--- a/helm_deploy/hmpps-approved-premises-api/Chart.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-approved-premises-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-approved-premises-api/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-approved-premises-api
 
@@ -9,12 +8,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-approved-premises-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-approved-premises-api-cert
     contextColour: green
     v1_2_enabled: true
@@ -69,14 +68,8 @@ generic-service:
       SPRING_REDIS_PASSWORD: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: hmpps-approved-premises-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in approved-premises-api/values.yaml
 
 generic-service:
@@ -68,28 +67,27 @@ generic-service:
       NOTIFY_GUESTLISTAPIKEY: "NOTIFY_GUESTLISTAPIKEY"
 
   allowlist:
-    unilink-aovpn1: "194.75.210.216/29"
-    unilink-aovpn2: "83.98.63.176/29"
-    unilink-aovpn3: "78.33.10.50/31"
-    unilink-aovpn4: "78.33.10.52/30"
-    unilink-aovpn5: "78.33.10.56/30"
-    unilink-aovpn6: "78.33.10.60/32"
-    unilink-aovpn7: "78.33.32.99/32"
-    unilink-aovpn8: "78.33.32.100/30"
-    unilink-aovpn9: "78.33.32.104/30"
-    unilink-aovpn10: "78.33.32.108/32"
-    unilink-aovpn11: "217.138.45.109/32"
-    unilink-aovpn12: "217.138.45.110/32"
-    ncc-tsc-team-1: "5.148.32.192/26"
-    ncc-tsc-team-2: "5.148.69.16/28"
-    ncc-tsc-team-3: "31.221.110.80/29"
-    ncc-tsc-team-4: "154.51.64.64/27"
-    ncc-tsc-team-5: "154.51.128.224/27"
-    ncc-tsc-team-6: "167.98.1.160/28"
-    ncc-tsc-team-7: "167.98.25.176/28"
-    ncc-tsc-team-8: "167.98.200.192/27"
-    ncc-tsc-team-9: "195.95.131.0/24"
-    ncc-mvss-team-1: "5.148.8.192/26"
+    unilink-aovpn1: 194.75.210.216/29
+    unilink-aovpn3: 78.33.10.50/31
+    unilink-aovpn4: 78.33.10.52/30
+    unilink-aovpn5: 78.33.10.56/30
+    unilink-aovpn6: 78.33.10.60/32
+    unilink-aovpn7: 78.33.32.99/32
+    unilink-aovpn8: 78.33.32.100/30
+    unilink-aovpn9: 78.33.32.104/30
+    unilink-aovpn10: 78.33.32.108/32
+    ncc-tsc-team-1: 5.148.32.192/26
+    ncc-tsc-team-2: 5.148.69.16/28
+    ncc-tsc-team-3: 31.221.110.80/29
+    ncc-tsc-team-4: 154.51.64.64/27
+    ncc-tsc-team-5: 154.51.128.224/27
+    ncc-tsc-team-6: 167.98.1.160/28
+    ncc-tsc-team-7: 167.98.25.176/28
+    ncc-tsc-team-8: 167.98.200.192/27
+    ncc-tsc-team-9: 195.95.131.0/24
+    ncc-mvss-team-1: 5.148.8.192/26
+    groups:
+      - unilink_staff
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in approved-premises-api/values.yaml
 
 generic-service:
@@ -56,29 +55,28 @@ generic-service:
     URL-TEMPLATES_API_CAS3_REFERRAL-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/referral-submitted/#eventId
 
   allowlist:
-    unilink-aovpn1: "194.75.210.216/29"
-    unilink-aovpn2: "83.98.63.176/29"
-    unilink-aovpn3: "78.33.10.50/31"
-    unilink-aovpn4: "78.33.10.52/30"
-    unilink-aovpn5: "78.33.10.56/30"
-    unilink-aovpn6: "78.33.10.60/32"
-    unilink-aovpn7: "78.33.32.99/32"
-    unilink-aovpn8: "78.33.32.100/30"
-    unilink-aovpn9: "78.33.32.104/30"
-    unilink-aovpn10: "78.33.32.108/32"
-    unilink-aovpn11: "217.138.45.109/32"
-    unilink-aovpn12: "217.138.45.110/32"
-    ncc-tsc-team-1: "5.148.32.192/26"
-    ncc-tsc-team-2: "5.148.69.16/28"
-    ncc-tsc-team-3: "31.221.110.80/29"
-    ncc-tsc-team-4: "154.51.64.64/27"
-    ncc-tsc-team-5: "154.51.128.224/27"
-    ncc-tsc-team-6: "167.98.1.160/28"
-    ncc-tsc-team-7: "167.98.25.176/28"
-    ncc-tsc-team-8: "167.98.200.192/27"
-    ncc-tsc-team-9: "195.95.131.0/24"
-    ncc-mvss-team-1: "5.148.8.192/26"
-    dxw-vpn: "54.76.254.148/32"
+    unilink-aovpn1: 194.75.210.216/29
+    unilink-aovpn3: 78.33.10.50/31
+    unilink-aovpn4: 78.33.10.52/30
+    unilink-aovpn5: 78.33.10.56/30
+    unilink-aovpn6: 78.33.10.60/32
+    unilink-aovpn7: 78.33.32.99/32
+    unilink-aovpn8: 78.33.32.100/30
+    unilink-aovpn9: 78.33.32.104/30
+    unilink-aovpn10: 78.33.32.108/32
+    ncc-tsc-team-1: 5.148.32.192/26
+    ncc-tsc-team-2: 5.148.69.16/28
+    ncc-tsc-team-3: 31.221.110.80/29
+    ncc-tsc-team-4: 154.51.64.64/27
+    ncc-tsc-team-5: 154.51.128.224/27
+    ncc-tsc-team-6: 167.98.1.160/28
+    ncc-tsc-team-7: 167.98.25.176/28
+    ncc-tsc-team-8: 167.98.200.192/27
+    ncc-tsc-team-9: 195.95.131.0/24
+    ncc-mvss-team-1: 5.148.8.192/26
+    dxw-vpn: 54.76.254.148/32
+    groups:
+      - unilink_staff
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

3 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-approved-premises-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `unilink_staff`
- The size of the allowlist defined in this file will change: `22 => 19 (3 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- unilink-cf-1
  

- unilink-cf-2
  

- unilink-newcastle-2
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-test.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `unilink_staff`
- The size of the allowlist defined in this file will change: `23 => 20 (3 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- unilink-cf-1
  

- unilink-cf-2
  

- unilink-newcastle-2
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
