### PR TITLE
(APS-14) Tighten up placement application withdrawl logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -105,8 +105,7 @@ class PlacementApplicationsController(
   }
 
   override fun placementApplicationsIdWithdrawPost(id: UUID): ResponseEntity<PlacementApplication> {
-    val user = userService.getUserForRequest()
-    val result = placementApplicationService.withdrawPlacementApplication(id, user)
+    val result = placementApplicationService.withdrawPlacementApplication(id)
 
     val validationResult = extractEntityFromAuthorisableActionResult(result)
     val placementApplication = extractEntityFromValidatableActionResult(validationResult)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -68,7 +68,12 @@ data class PlacementApplicationEntity(
 
   @OneToMany(mappedBy = "placementApplication")
   var placementDates: MutableList<PlacementDateEntity>,
-)
+
+  @OneToMany(mappedBy = "placementApplication")
+  var placementRequests: MutableList<PlacementRequestEntity>,
+) {
+  fun canBeWithdrawn() = placementRequests.all { it.booking == null }
+}
 
 enum class PlacementType {
   ROTL,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -23,7 +23,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
 
   fun findAllByApplication(application: ApplicationEntity): List<PlacementRequestEntity>
 
-  fun findAllByPlacementApplication(placementApplication: PlacementApplicationEntity?): List<PlacementRequestEntity>
+  fun findAllByPlacementApplication(placementApplication: PlacementApplicationEntity): List<PlacementRequestEntity>
 
   fun findAllByAllocatedToUser_IdAndReallocatedAtNullAndIsWithdrawnFalse(userId: UUID): List<PlacementRequestEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -25,6 +25,7 @@ class PlacementApplicationTransformer(
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       outdatedSchema = !jpa.schemaUpToDate,
       submittedAt = jpa.submittedAt?.toInstant(),
+      canBeWithdrawn = jpa.canBeWithdrawn(),
     )
   }
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3120,6 +3120,8 @@ components:
               $ref: '#/components/schemas/AnyValue'
             document:
               $ref: '#/components/schemas/AnyValue'
+            canBeWithdrawn:
+              type: boolean
           required:
             - id
             - createdByUserId

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7147,6 +7147,8 @@ components:
               $ref: '#/components/schemas/AnyValue'
             document:
               $ref: '#/components/schemas/AnyValue'
+            canBeWithdrawn:
+              type: boolean
           required:
             - id
             - createdByUserId

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3480,6 +3480,8 @@ components:
               $ref: '#/components/schemas/AnyValue'
             document:
               $ref: '#/components/schemas/AnyValue'
+            canBeWithdrawn:
+              type: boolean
           required:
             - id
             - createdByUserId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -84,19 +84,20 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
 
   override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
     id = this.id(),
-    createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
+    createdByUser = this.createdByUser?.invoke() ?: throw RuntimeException("Must provide a createdByUser"),
     schemaVersion = this.schemaVersion(),
+    schemaUpToDate = false,
     data = this.data(),
     document = this.document(),
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
-    schemaUpToDate = false,
     allocatedToUser = this.allocatedToUser(),
     allocatedAt = null,
     reallocatedAt = this.reallocatedAt(),
     decision = this.decision(),
     placementType = this.placementType(),
     placementDates = this.placementDates() ?: mutableListOf(),
+    placementRequests = mutableListOf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -265,16 +265,14 @@ class PlacementApplicationServiceTest {
         .withEmail(null)
         .produce()
 
-      val placementRequest1 = createPlacementRequestForApplication(placementApplication, placementRequestAllocatedUser1)
-      val placementRequest2 = createPlacementRequestForApplication(placementApplication, placementRequestAllocatedUser2)
+      placementApplication.placementRequests = mutableListOf(
+        createPlacementRequestForApplication(placementApplication, placementRequestAllocatedUser1),
+        createPlacementRequestForApplication(placementApplication, placementRequestAllocatedUser2),
+      )
 
       val templateId = UUID.randomUUID().toString()
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
-      every { placementRequestRepository.findAllByPlacementApplication(placementApplication) } returns listOf(
-        placementRequest1,
-        placementRequest2,
-      )
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
       every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
@@ -368,10 +366,11 @@ class PlacementApplicationServiceTest {
         .withYieldedPremises { premisesEntity }
         .produce()
 
-      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
-      every { placementRequestRepository.findAllByPlacementApplication(placementApplication) } returns listOf(
+      placementApplication.placementRequests = mutableListOf(
         placementRequest,
       )
+
+      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
 
       val result = placementApplicationService.withdrawPlacementApplication(placementApplication.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -4,24 +4,35 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
@@ -37,6 +48,9 @@ class PlacementApplicationServiceTest {
   private val userService = mockk<UserService>()
   private val placementDateRepository = mockk<PlacementDateRepository>()
   private val placementRequestService = mockk<PlacementRequestService>()
+  private val placementRequestRepository = mockk<PlacementRequestRepository>()
+  private val emailNotificationService = mockk<EmailNotificationService>()
+  private val notifyConfig = mockk<NotifyConfig>()
 
   private val placementApplicationService = PlacementApplicationService(
     placementApplicationRepository,
@@ -45,6 +59,9 @@ class PlacementApplicationServiceTest {
     userService,
     placementDateRepository,
     placementRequestService,
+    placementRequestRepository,
+    emailNotificationService,
+    notifyConfig,
   )
 
   @Nested
@@ -187,6 +204,148 @@ class PlacementApplicationServiceTest {
       assertThat(validationResult is ValidatableActionResult.FieldValidationError).isTrue
       validationResult as ValidatableActionResult.FieldValidationError
       assertThat(validationResult.validationMessages).containsEntry("$.userId", "lackingMatcherRole")
+    }
+  }
+
+  @Nested
+  inner class WithdrawPlacementApplication {
+    lateinit var user: UserEntity
+    lateinit var application: ApprovedPremisesApplicationEntity
+    lateinit var assessment: ApprovedPremisesAssessmentEntity
+
+    @BeforeEach
+    fun setup() {
+      user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(user)
+        .produce()
+
+      application.assessments = mutableListOf(
+        assessment,
+      )
+    }
+
+    @Test
+    fun `it withdraws an application and associated placement requests, emailing allocated users`() {
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce(),
+        )
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementRequestAllocatedUser1 = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail("user@example.com")
+        .produce()
+
+      val placementRequestAllocatedUser2 = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val placementRequest1 = createPlacementRequestForApplication(placementApplication, placementRequestAllocatedUser1)
+      val placementRequest2 = createPlacementRequestForApplication(placementApplication, placementRequestAllocatedUser2)
+
+      val templateId = UUID.randomUUID().toString()
+
+      every { userService.getUserForRequest() } returns user
+      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
+      every { placementRequestRepository.findAllByPlacementApplication(placementApplication) } returns listOf(
+        placementRequest1,
+        placementRequest2,
+      )
+      every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
+      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
+      every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
+      every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
+
+      val result = placementApplicationService.withdrawPlacementApplication(placementApplication.id)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(validationResult is ValidatableActionResult.Success).isTrue
+      validationResult as ValidatableActionResult.Success
+
+      val entity = validationResult.entity
+
+      assertThat(entity.decision).isEqualTo(PlacementApplicationDecision.WITHDRAWN_BY_PP)
+
+      verify(exactly = 1) {
+        emailNotificationService.sendEmail(
+          placementRequestAllocatedUser1.email!!,
+          templateId,
+          mapOf(
+            "name" to placementRequestAllocatedUser1.name,
+            "crn" to placementApplication.application.crn,
+          ),
+        )
+      }
+    }
+
+    @Test
+    fun `it returns unauthorised if a user did not create the placement application`() {
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce(),
+        )
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
+        .withCreatedByUser(
+          UserEntityFactory()
+            .withYieldedProbationRegion {
+              ProbationRegionEntityFactory()
+                .withYieldedApArea { ApAreaEntityFactory().produce() }
+                .produce()
+            }
+            .produce(),
+        )
+        .produce()
+
+      every { userService.getUserForRequest() } returns user
+      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
+
+      val result = placementApplicationService.withdrawPlacementApplication(placementApplication.id)
+
+      assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+    }
+
+    private fun createPlacementRequestForApplication(placementApplication: PlacementApplicationEntity, allocatedUser: UserEntity): PlacementRequestEntity {
+      return PlacementRequestEntityFactory()
+        .withPlacementRequirements(
+          PlacementRequirementsEntityFactory()
+            .withApplication(placementApplication.application)
+            .withAssessment(placementApplication.application.assessments[0])
+            .produce(),
+        )
+        .withApplication(placementApplication.application)
+        .withPlacementApplication(placementApplication)
+        .withAssessment(placementApplication.application.assessments[0])
+        .withAllocatedToUser(allocatedUser)
+        .produce()
     }
   }
 }


### PR DESCRIPTION
When working on the frontend, we identified a couple of issues with the placement application withdrawl logic, and we also needed to ensure that applications that already had associated bookings could not be withdrawn.