### PR TITLE
Buffer `WebClient` responses to avoid `DataBufferLimitException`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -3,11 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
 import java.util.concurrent.atomic.AtomicInteger
 
 abstract class BaseHMPPSClient(
@@ -54,23 +59,13 @@ abstract class BaseHMPPSClient(
         }
       }
 
-      val request = webClient.method(method)
-        .uri(requestBuilder.path ?: "")
-        .headers { it.addAll(requestBuilder.headers) }
-
-      if (requestBuilder.body != null) {
-        request.bodyValue(requestBuilder.body!!)
-      }
-
-      val result = request.retrieve().toEntity(String::class.java).block()!!
-
-      val deserialized = objectMapper.readValue(result.body, typeReference)
+      val (statusCode, body) = performRequest(typeReference, method, requestBuilder)
 
       if (cacheConfig != null && requestBuilder.isPreemptiveCall) {
-        webClientCache.cacheSuccessfulWebClientResponse(requestBuilder, cacheConfig, result)
+        webClientCache.cacheSuccessfulWebClientResponse(requestBuilder, cacheConfig, statusCode, body)
       }
 
-      return ClientResult.Success(result.statusCode, deserialized, false)
+      return ClientResult.Success(statusCode, body, false)
     } catch (exception: WebClientResponseException) {
       if (cacheConfig != null && requestBuilder.isPreemptiveCall) {
         webClientCache.cacheFailedWebClientResponse(requestBuilder, cacheConfig, exception, attempt.get(), method)
@@ -84,6 +79,37 @@ abstract class BaseHMPPSClient(
     } catch (exception: Exception) {
       return ClientResult.Failure.Other(method, requestBuilder.path ?: "", exception)
     }
+  }
+
+  private fun <ResponseType : Any> performRequest(typeReference: TypeReference<ResponseType>, method: HttpMethod, requestBuilder: HMPPSRequestConfiguration): Pair<HttpStatus, ResponseType> {
+    val request = webClient.method(method)
+      .uri(requestBuilder.path ?: "")
+      .headers { it.addAll(requestBuilder.headers) }
+
+    if (requestBuilder.body != null) {
+      request.bodyValue(requestBuilder.body!!)
+    }
+
+    val result = request
+      .retrieve()
+      .toEntityFlux(DataBuffer::class.java)
+      .block()!!
+
+    val pipedOutputStream = PipedOutputStream()
+    val pipedInputStream = PipedInputStream(pipedOutputStream)
+
+    val body = result
+      .body
+      ?.doOnError { pipedInputStream.close() }
+      ?.doFinally { pipedOutputStream.close() }
+
+    DataBufferUtils
+      .write(body, pipedOutputStream)
+      .subscribe(DataBufferUtils.releaseConsumer())
+
+    val deserialized = objectMapper.readValue(pipedInputStream, typeReference)
+
+    return result.statusCode to deserialized
   }
 
   class HMPPSRequestConfiguration {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import java.time.Duration
@@ -93,20 +92,26 @@ class WebClientCache(
   fun cacheSuccessfulWebClientResponse(
     requestBuilder: BaseHMPPSClient.HMPPSRequestConfiguration,
     cacheConfig: PreemptiveCacheConfig,
-    result: ResponseEntity<String>,
+    statusCode: HttpStatus,
+    body: Any?,
   ) {
     val cacheKeySet = getCacheKeySet(requestBuilder, cacheConfig)
 
     val cacheEntry = PreemptiveCacheMetadata(
-      httpStatus = result.statusCode,
+      httpStatus = statusCode,
       refreshableAfter = Instant.now().plusSeconds(cacheConfig.successSoftTtlSeconds.toLong()),
       method = null,
       path = null,
-      hasResponseBody = result.body != null,
+      hasResponseBody = body != null,
       attempt = null,
     )
 
-    writeToRedis(cacheKeySet, cacheEntry, result.body, cacheConfig.hardTtlSeconds.toLong())
+    writeToRedis(
+      cacheKeySet,
+      cacheEntry,
+      body?.let { objectMapper.writeValueAsString(it) },
+      cacheConfig.hardTtlSeconds.toLong(),
+    )
   }
 
   private fun <ResponseType : Any> pollCacheWithBlockingWait(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WebClientBufferingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WebClientBufferingTest.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.BaseHMPPSClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.WebClientCache
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+
+class WebClientBufferingTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var needsBufferingWebClient: NeedsBufferingWebClient
+
+  @Value("\${max-response-in-memory-size-bytes}")
+  var maxResponseInMemorySizeBytes: Int = 0
+
+  @Test
+  fun `Very large responses from a downstream request are streamed instead of throwing a DataBufferLimitException`() {
+    val expected = OffenderDetailsSummaryFactory().produceMany().take(1000).toList()
+
+    assertThat(objectMapper.writeValueAsString(expected).length).isGreaterThan(maxResponseInMemorySizeBytes)
+
+    mockSuccessfulGetCallWithJsonResponse(
+      "/example",
+      expected,
+    )
+
+    val result = needsBufferingWebClient.getBigPileOfData()
+
+    assertThat(result is ClientResult.Success).isTrue
+    result as ClientResult.Success
+    assertThat(result.body).isEqualTo(expected)
+  }
+}
+
+@Component
+class NeedsBufferingWebClient(
+  @Qualifier("communityApiWebClient") private val webClient: WebClient,
+  objectMapper: ObjectMapper,
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+  private val cacheConfig = WebClientCache.PreemptiveCacheConfig(
+    cacheName = "offenderDetailSummary",
+    successSoftTtlSeconds = 5,
+    failureSoftTtlBackoffSeconds = listOf(5, 10, 20),
+    hardTtlSeconds = 30,
+  )
+
+  fun getBigPileOfData() = getRequest<List<OffenderDetailSummary>> {
+    path = "/example"
+    isPreemptiveCall = true
+    preemptiveCacheKey = "bigPileOfData"
+    preemptiveCacheConfig = cacheConfig
+  }
+}


### PR DESCRIPTION
The memory limit for responses from the Delius Integration API has recently been increased to 750,000 bytes (see #1120). However, this was still not sufficient when generating booking reports, as personal information is requested for several hundred CRNs concurrently. Continuing to increase this memory limit can only achieve so much as the API is limited by how much memory it has access to. This introduces a buffering approach for the responses which circumvents the limit and also avoids constructing potentially large strings as an intermediate step.