### PR TITLE
Flush changes in migration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
@@ -35,6 +35,7 @@ class ApplicationStatusMigrationJob(
         slice.get().forEach {
           setStatus(it)
         }
+        applicationRepository.flush()
       }
     } catch (e: Exception) {
       Sentry.captureException(e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
@@ -38,7 +38,6 @@ class ApplicationStatusMigrationJob(
       }
     } catch (e: Exception) {
       Sentry.captureException(e)
-      throw e
     }
   }
 


### PR DESCRIPTION
Even though we're paginating, it's all happening in one transaction, so the garbage collector isn't clearing up any memory until the transaction is complete. I *think* running `applicationRepository.flush()` at the end of each page should sort it.