### PR TITLE
Call saveAndFlush and use entityManager

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
+import javax.persistence.EntityManager
 
 @Service
 class MigrationJobService(
@@ -32,6 +33,7 @@ class MigrationJobService(
         )
         MigrationJobType.applicationStatuses -> ApplicationStatusMigrationJob(
           applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(EntityManager::class.java),
           pageSize,
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SetApplicationStatusMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SetApplicationStatusMigrationTest.kt
@@ -117,7 +117,7 @@ class SetApplicationStatusMigrationTest : MigrationJobTestBase() {
 
     createBookingForApplicationAndAssessment(applicationWithBooking, applicationWithBookingAssessment!!)
 
-    migrationJobService.runMigrationJob(MigrationJobType.applicationStatuses)
+    migrationJobService.runMigrationJob(MigrationJobType.applicationStatuses, 1)
 
     assertThat(reloadApplication(applicationWithNoAssessment).status).isEqualTo(ApprovedPremisesApplicationStatus.STARTED)
     assertThat(reloadApplication(applicationWithAssessmentWithNoData).status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT)


### PR DESCRIPTION
This calls `saveAndFlush` when updating the DB entries to save the applications immediately, as well as passing the entityManager to the Job so we can clear the transaction cache after each page.