### PR TITLE
Use streaming correctly when using large dataset

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
@@ -19,11 +19,14 @@ class ApplicationStatusMigrationJob(
   @Suppress("UNCHECKED_CAST")
   override fun process() {
     try {
-      val applications = applicationRepository.findAllForService(
-        ApprovedPremisesApplicationEntity::class.java,
-      ) as Stream<ApprovedPremisesApplicationEntity>
-      applications.peek(entityManager::detach).forEach {
-        setStatus(it)
+      (
+        applicationRepository.findAllForService(
+          ApprovedPremisesApplicationEntity::class.java,
+        ) as Stream<ApprovedPremisesApplicationEntity>
+        ).use { applications ->
+        applications.peek(entityManager::detach).forEach {
+          setStatus(it)
+        }
       }
     } catch (e: Exception) {
       Sentry.captureException(e)


### PR DESCRIPTION
When looking at https://www.baeldung.com/spring-data-jpa-iterate-large-result-sets#streaming-from-the-database, I missed that the `try` block used the output of `findAllForService` within an argument for the data to stream correctly. This way to do this in Kotlin is with a `.use` block, so I’ve updated the code to do this.