### PR TITLE
Use native query to retrieve data for bookings report

### DIFF
--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
@@ -1,20 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
 
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
-import io.gatling.javaapi.core.CoreDsl.exec
-import io.gatling.javaapi.core.CoreDsl.jsonPath
 import io.gatling.javaapi.core.CoreDsl.repeat
 import io.gatling.javaapi.core.CoreDsl.scenario
 import io.gatling.javaapi.core.CoreDsl.stressPeakUsers
+import io.gatling.javaapi.core.Session
 import io.gatling.javaapi.core.Simulation
-import io.gatling.javaapi.http.HttpDsl.http
-import io.gatling.javaapi.http.HttpDsl.status
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.submitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.updateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import kotlin.time.Duration.Companion.minutes
@@ -22,55 +18,26 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 class ApplyJourneyStressSimulation : Simulation() {
-  private val createTemporaryAccommodationApplication = exec(
-    http("Create Application")
-      .post("/applications")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .body(
-        toJson(
-          NewApplication(
-            crn = "X320741",
-            convictionId = 0L,
-            deliusEventNumber = "",
-            offenceId = "",
-          ),
-        ),
-      )
-      .check(status().`is`(201))
-      .check(jsonPath("$.id").saveAs("application_id")),
+  private val applicationIdKey = "application_id"
+  private val getApplicationId = { session: Session -> session.getUUID(applicationIdKey) }
+
+  private val createTemporaryAccommodationApplication = createTemporaryAccommodationApplication(
+    saveApplicationIdAs = applicationIdKey,
   )
     .exitHereIfFailed()
     .pause(1.seconds.toJavaDuration())
 
   private val updateTemporaryAccommodationApplication = repeat({ randomInt(1, 20) }, "n").on(
-    exec(
-      http("Update Application")
-        .put("/applications/#{application_id}")
-        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-        .body(
-          toJson(
-            UpdateTemporaryAccommodationApplication(
-              type = "CAS3",
-              data = mapOf(),
-            ),
-          ),
-        ),
-    ).pause(5.seconds.toJavaDuration()),
+    updateTemporaryAccommodationApplication(
+      applicationId = getApplicationId,
+    )
+      .pause(5.seconds.toJavaDuration()),
   )
 
-  private val submitTemporaryAccommodationApplication = exec(
-    http("Submit Application")
-      .post("/applications/#{application_id}/submission")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .body(
-        toJson(
-          SubmitTemporaryAccommodationApplication(
-            type = "CAS3",
-            translatedDocument = "{}",
-          ),
-        ),
-      ),
-  ).pause(10.seconds.toJavaDuration())
+  private val submitTemporaryAccommodationApplication = submitTemporaryAccommodationApplication(
+    applicationId = getApplicationId,
+  )
+    .pause(10.seconds.toJavaDuration())
 
   private val temporaryAccommodationApplyJourney = scenario("Apply journey for Temporary Accommodation")
     .exec(

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/BookingsReportGenerationTimeSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/BookingsReportGenerationTimeSimulation.kt
@@ -1,0 +1,150 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
+
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.exec
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.getProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.getUserProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.submitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.updateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAround
+import java.time.LocalDate
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class BookingsReportGenerationTimeSimulation : Simulation() {
+  private val arrivalDateKey = "arrival_date"
+  private val getArrivalDate = { session: Session -> session.get<LocalDate>(arrivalDateKey)!! }
+
+  private val reportDateKey = "report_date"
+
+  private val probationRegionIdKey = "probation_region_id"
+  private val getProbationRegionId = { session: Session -> session.getUUID(probationRegionIdKey) }
+
+  private val probationDeliveryUnitIdKey = "probation_delivery_unit_id"
+  private val getProbationDeliveryUnitId = { session: Session -> session.getUUID(probationDeliveryUnitIdKey) }
+
+  private val premisesIdKey = "premises_id"
+  private val getPremisesId = { session: Session -> session.getUUID(premisesIdKey) }
+
+  private val bedIdKey = "bed_id"
+  private val getBedId = { session: Session -> session.getUUID(bedIdKey) }
+
+  private val applicationIdKey = "application_id"
+  private val getApplicationId = { session: Session -> session.getUUID(applicationIdKey) }
+
+  private val createArrivalDate = exec { session ->
+    session.set(arrivalDateKey, LocalDate.now().randomDateAround(60))
+  }
+
+  private val createReportDate = exec { session ->
+    session.set(reportDateKey, LocalDate.now().randomDateAround(60))
+  }
+
+  private val getUserProbationRegion = getUserProbationRegion(probationRegionIdKey)
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val getProbationDeliveryUnit = getProbationDeliveryUnit(
+    probationRegionId = getProbationRegionId,
+    saveProbationDeliveryUnitIdAs = probationDeliveryUnitIdKey,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationPremises = createTemporaryAccommodationPremises(
+    probationRegionId = getProbationRegionId,
+    probationDeliveryUnitId = getProbationDeliveryUnitId,
+    savePremisesIdAs = premisesIdKey,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationRoom = createTemporaryAccommodationRoom(
+    premisesId = getPremisesId,
+    saveBedIdAs = bedIdKey,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationApplication = createTemporaryAccommodationApplication(
+    saveApplicationIdAs = applicationIdKey,
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val updateTemporaryAccommodationApplication = updateTemporaryAccommodationApplication(
+    applicationId = getApplicationId,
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val submitTemporaryAccommodationApplication = submitTemporaryAccommodationApplication(
+    applicationId = getApplicationId,
+    arrivalDate = getArrivalDate,
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val createTemporaryAccommodationBooking = createTemporaryAccommodationBooking(
+    bedId = getBedId,
+    arrivalDate = getArrivalDate,
+  )
+    .exitHereIfFailed()
+    .pause(1.seconds.toJavaDuration())
+
+  private val setupBooking = scenario("Setup booking")
+    .exec(
+      authorizeUser(),
+      createArrivalDate,
+      getUserProbationRegion,
+      getProbationDeliveryUnit,
+      createTemporaryAccommodationPremises,
+      createTemporaryAccommodationRoom,
+      createTemporaryAccommodationApplication,
+      updateTemporaryAccommodationApplication,
+      submitTemporaryAccommodationApplication,
+      createTemporaryAccommodationBooking,
+    )
+
+  private val downloadBookingsReport = exec(
+    http("Download Booking Report")
+      .get("/reports/bookings/")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+      .queryParam("year") { session -> session.get<LocalDate>(reportDateKey)!!.year }
+      .queryParam("month") { session -> session.get<LocalDate>(reportDateKey)!!.monthValue }
+      .queryParam("probationRegionId", getProbationRegionId)
+      .check(status().`is`(200)),
+  )
+    .pause(1.seconds.toJavaDuration())
+
+  private val bookingsReportDownloadJourney = scenario("Bookings report journey")
+    .exec(
+      authorizeUser(),
+      createReportDate,
+      getUserProbationRegion,
+      downloadBookingsReport,
+    )
+
+  init {
+    setUp(
+      setupBooking.injectOpen(
+        constantUsersPerSec(20.0).during(60.seconds.toJavaDuration()),
+      )
+        .andThen(
+          bookingsReportDownloadJourney.injectOpen(
+            constantUsersPerSec(0.25).during(400.seconds.toJavaDuration()),
+          ),
+        ),
+    ).withAuthorizedUserHttpProtocol()
+  }
+}

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Applications.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Applications.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import java.time.LocalDate
+import java.util.UUID
+
+fun createTemporaryAccommodationApplication(
+  crn: (Session) -> String = { _ -> "X320741" },
+  saveApplicationIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Application")
+    .post("/applications")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        NewApplication(
+          crn = crn(session),
+          convictionId = 0L,
+          deliusEventNumber = "",
+          offenceId = "",
+        )
+      },
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (saveApplicationIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveApplicationIdAs))
+      }
+    },
+)
+
+fun updateTemporaryAccommodationApplication(
+  applicationId: (Session) -> UUID,
+) = CoreDsl.exec(
+  HttpDsl.http("Update Application")
+    .put { session -> "/applications/${applicationId(session)}" }
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson(
+        UpdateTemporaryAccommodationApplication(
+          type = UpdateApplicationType.CAS3,
+          data = mapOf(),
+        ),
+      ),
+    ),
+)
+
+fun submitTemporaryAccommodationApplication(
+  applicationId: (Session) -> UUID,
+  arrivalDate: (Session) -> LocalDate = { _ -> LocalDate.now() },
+) = CoreDsl.exec(
+  HttpDsl.http("Submit Application")
+    .post { session -> "/applications/${applicationId(session)}/submission" }
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        SubmitTemporaryAccommodationApplication(
+          arrivalDate = arrivalDate(session),
+          type = "CAS3",
+          translatedDocument = "{}",
+          summaryData = "{}",
+        )
+      },
+    ),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Bookings.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Bookings.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import java.time.LocalDate
+import java.util.UUID
+
+fun createTemporaryAccommodationBooking(
+  bedId: (Session) -> UUID,
+  crn: (Session) -> String = { _ -> "X320741" },
+  arrivalDate: (Session) -> LocalDate = { _ -> LocalDate.now() },
+  departureDate: (Session) -> LocalDate = { session -> arrivalDate(session).plusDays(84) },
+  saveBookingIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Booking")
+    .post("/premises/#{premises_id}/bookings")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        NewBooking(
+          crn = crn(session),
+          arrivalDate = arrivalDate(session),
+          departureDate = departureDate(session),
+          bedId = bedId(session),
+          serviceName = ServiceName.temporaryAccommodation,
+          enableTurnarounds = true,
+          assessmentId = null,
+        )
+      },
+    )
+    .let {
+      when (saveBookingIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveBookingIdAs))
+      }
+    },
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Premises.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Premises.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+fun createTemporaryAccommodationPremises(
+  probationRegionId: (Session) -> UUID,
+  probationDeliveryUnitId: (Session) -> UUID,
+  savePremisesIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Premises")
+    .post("/premises")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson { session ->
+        NewPremises(
+          name = randomStringMultiCaseWithNumbers(16),
+          addressLine1 = randomStringMultiCaseWithNumbers(16),
+          postcode = randomPostCode(),
+          probationRegionId = probationRegionId(session),
+          characteristicIds = listOf(),
+          status = PropertyStatus.active,
+          probationDeliveryUnitId = probationDeliveryUnitId(session),
+        )
+      },
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (savePremisesIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(savePremisesIdAs))
+      }
+    },
+)
+
+fun createTemporaryAccommodationRoom(
+  premisesId: (Session) -> UUID,
+  saveRoomIdAs: String? = null,
+  saveBedIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create Room")
+    .post { session -> "/premises/${premisesId(session)}/rooms" }
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .body(
+      toJson(
+        NewRoom(
+          name = randomStringUpperCase(8),
+          characteristicIds = listOf(),
+          notes = randomStringMultiCaseWithNumbers(20),
+        ),
+      ),
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (saveRoomIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveRoomIdAs))
+      }
+    }
+    .let {
+      when (saveBedIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.beds[0].id").saveAs(saveBedIdAs))
+      }
+    },
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/ReferenceData.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/ReferenceData.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import java.util.UUID
+
+fun getProbationDeliveryUnit(
+  probationRegionId: (Session) -> UUID,
+  saveProbationDeliveryUnitIdAs: String,
+) = CoreDsl.exec(
+
+  HttpDsl.http("Get Probation Delivery Unit")
+    .get("/reference-data/probation-delivery-units")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .queryParam("probationRegionId") { session -> probationRegionId(session) }
+    .check(HttpDsl.status().`is`(200))
+    .check(CoreDsl.jsonPath("$[0].id").saveAs(saveProbationDeliveryUnitIdAs)),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Users.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Users.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+
+fun getUserProbationRegion(
+  saveProbationRegionIdAs: String,
+) = CoreDsl.exec(
+  HttpDsl.http("Get User's Probation Region")
+    .get("/profile")
+    .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+    .check(HttpDsl.status().`is`(200))
+    .check(CoreDsl.jsonPath("$.region.id").saveAs(saveProbationRegionIdAs)),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
@@ -23,7 +23,7 @@ fun authorizeUser(): ChainBuilder {
 fun Simulation.SetUp.withAuthorizedUserHttpProtocol() = apply {
   val protocol = http
     .baseUrl(BASE_URL)
-    .acceptHeader("application/json")
+    .acceptHeader("*/*")
     .contentTypeHeader("application/json")
     .authorizationHeader("Bearer #{access_token}")
 

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Json.kt
@@ -2,5 +2,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.gatling.javaapi.core.CoreDsl.StringBody
+import io.gatling.javaapi.core.Session
 
-fun toJson(value: Any) = StringBody(ObjectMapper().writeValueAsString(value))
+private val objectMapper = lazy { ObjectMapper().findAndRegisterModules() }
+
+fun toJson(value: Any) = StringBody(objectMapper.value.writeValueAsString(value))
+
+fun toJson(f: (Session) -> Any) = StringBody { session -> objectMapper.value.writeValueAsString(f(session)) }

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Session.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Session.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
+
+import io.gatling.javaapi.core.Session
+import java.util.UUID
+
+fun Session.getUUID(key: String) = UUID.fromString(this.getString(key))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -25,9 +25,6 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   @Query("SELECT b FROM BookingEntity b WHERE b.premises.id IN :premisesIds AND b.arrivalDate <= :endDate AND b.departureDate >= :startDate AND SIZE(b.cancellations) = 0")
   fun findAllNotCancelledByPremisesIdsAndOverlappingDate(premisesIds: List<UUID>, startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
 
-  @Query("SELECT b FROM BookingEntity b WHERE b.arrivalDate <= :endDate AND b.departureDate >= :startDate")
-  fun findAllByOverlappingDate(startDate: LocalDate, endDate: LocalDate): List<BookingEntity>
-
   @Query("SELECT b FROM BookingEntity b WHERE b.arrivalDate <= :endDate AND b.departureDate >= :startDate AND b.bed = :bed")
   fun findAllByOverlappingDateForBed(startDate: LocalDate, endDate: LocalDate, bed: BedEntity): List<BookingEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BookingsReportRow.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
 import java.time.LocalDate
 
 data class BookingsReportRow(
+  val bookingId: String?,
   val referralId: String?,
   val referralDate: LocalDate?,
   val riskOfSeriousHarm: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.util.UUID
+
+interface BookingsReportRepository : JpaRepository<BookingEntity, UUID> {
+  @Query(
+    """
+    SELECT
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      CAST(app.id AS VARCHAR) AS referralId,
+      app.submitted_at AS referralDate,
+      cas3_app.risk_ratings->'roshRisks'->'value'->>'overallRisk' AS riskOfSeriousHarm,
+      cas3_app.is_registered_sex_offender AS sexOffender,
+      cas3_app.needs_accessible_property AS needForAccessibleProperty,
+      cas3_app.has_history_of_arson AS historyOfArsonOffence,
+      cas3_app.is_duty_to_refer_submitted AS dutyToReferMade,
+      cas3_app.duty_to_refer_submission_date AS dateDutyToReferMade,
+      cas3_app.is_eligible AS isReferralEligibleForCas3,
+      cas3_app.eligibility_reason AS referralEligibilityReason,
+      probation_region.name AS probationRegion,
+      booking.crn AS crn,
+      CAST(confirmation.id AS VARCHAR) AS confirmationId,
+      CAST(cancellation.id AS VARCHAR) AS cancellationId,
+      cancellation_reason.name AS cancellationReason,
+      arr.arrival_date AS startDate,
+      arr.expected_departure_date AS endDate,
+      departure.date_time AS actualEndDate,
+      move_on_category.name AS accommodationOutcome
+    FROM
+      bookings booking
+    LEFT JOIN
+      premises premises ON premises.id = booking.premises_id
+    LEFT JOIN
+      probation_regions probation_region ON probation_region.id = premises.probation_region_id
+    LEFT JOIN
+      applications app ON booking.application_id = app.id
+    LEFT JOIN
+      temporary_accommodation_applications cas3_app ON booking.application_id = cas3_app.id
+    LEFT JOIN
+      confirmations confirmation ON confirmation.booking_id = booking.id
+    LEFT JOIN
+      departures departure ON departure.booking_id = booking.id
+    LEFT JOIN
+      arrivals arr ON arr.booking_id = booking.id
+    LEFT JOIN
+      cancellations cancellation ON cancellation.booking_id = booking.id
+    LEFT JOIN
+      cancellation_reasons cancellation_reason ON cancellation_reason.id = cancellation.cancellation_reason_id
+    LEFT JOIN
+      move_on_categories move_on_category ON move_on_category.id = departure.move_on_category_id
+    WHERE
+      booking.arrival_date <= :endDate
+      AND booking.departure_date >= :startDate
+      AND premises.service = :serviceName
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.probation_region_id = :probationRegionId)
+    ORDER BY booking.id
+    """,
+    nativeQuery = true,
+  )
+  fun findAllByOverlappingDate(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    serviceName: String,
+    probationRegionId: UUID?,
+  ): List<BookingsReportData>
+}
+
+interface BookingsReportData {
+  val bookingId: String
+  val referralId: String?
+  val referralDate: LocalDate?
+  val riskOfSeriousHarm: String?
+  val sexOffender: Boolean?
+  val needForAccessibleProperty: Boolean?
+  val historyOfArsonOffence: Boolean?
+  val dutyToReferMade: Boolean?
+  val dateDutyToReferMade: LocalDate?
+  val referralEligibleForCas3: Boolean?
+  val referralEligibilityReason: String?
+  val probationRegion: String
+  val crn: String
+  val confirmationId: String?
+  val cancellationId: String?
+  val cancellationReason: String?
+  val startDate: LocalDate?
+  val endDate: LocalDate?
+  val actualEndDate: Timestamp?
+  val accommodationOutcome: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.Dai
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.PlacementMetricsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ReferralsMetricsProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import java.io.OutputStream
 import java.time.LocalDate
@@ -49,13 +50,19 @@ class ReportService(
   private val domainEventRepository: DomainEventRepository,
   private val assessmentRepository: AssessmentRepository,
   private val timelinessEntityRepository: ApplicationTimelinessEntityRepository,
+  private val bookingsReportRepository: BookingsReportRepository,
   private val objectMapper: ObjectMapper,
 ) {
   fun createBookingsReport(properties: BookingsReportProperties, outputStream: OutputStream) {
     val startOfMonth = LocalDate.of(properties.year, properties.month, 1)
     val endOfMonth = LocalDate.of(properties.year, properties.month, startOfMonth.month.length(startOfMonth.isLeapYear))
 
-    val bookingsInScope = bookingRepository.findAllByOverlappingDate(startOfMonth, endOfMonth)
+    val bookingsInScope = bookingsReportRepository.findAllByOverlappingDate(
+      startOfMonth,
+      endOfMonth,
+      properties.serviceName.value,
+      properties.probationRegionId,
+    )
 
     BookingsReportGenerator()
       .createReport(bookingsInScope, properties)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -34,6 +34,7 @@ fun randomDouble(min: Double, max: Double) = Random.nextDouble(min, max)
 
 fun LocalDate.randomDateAfter(maxDays: Int = 14): LocalDate = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateBefore(maxDays: Int = 14): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
+fun LocalDate.randomDateAround(maxDays: Int = 14): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 
 fun LocalDateTime.randomDateTimeAfter(maxDays: Int = 14): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportData
+import java.sql.Timestamp
+import java.time.LocalDate
+
+fun List<BookingEntity>.toBookingsReportData(): List<BookingsReportData> = this
+  .map {
+    val application = it.application as? TemporaryAccommodationApplicationEntity
+    object : BookingsReportData {
+      override val bookingId: String
+        get() = it.id.toString()
+      override val referralId: String?
+        get() = application?.id?.toString()
+      override val referralDate: LocalDate?
+        get() = application?.submittedAt?.toLocalDate()
+      override val riskOfSeriousHarm: String?
+        get() = application?.riskRatings?.roshRisks?.value?.overallRisk
+      override val sexOffender: Boolean?
+        get() = application?.isRegisteredSexOffender
+      override val needForAccessibleProperty: Boolean?
+        get() = application?.needsAccessibleProperty
+      override val historyOfArsonOffence: Boolean?
+        get() = application?.hasHistoryOfArson
+      override val dutyToReferMade: Boolean?
+        get() = application?.isDutyToReferSubmitted
+      override val dateDutyToReferMade: LocalDate?
+        get() = application?.dutyToReferSubmissionDate
+      override val referralEligibleForCas3: Boolean?
+        get() = application?.isEligible
+      override val referralEligibilityReason: String?
+        get() = application?.eligibilityReason
+      override val probationRegion: String
+        get() = it.premises.probationRegion.name
+      override val crn: String
+        get() = it.crn
+      override val confirmationId: String?
+        get() = it.confirmation?.id?.toString()
+      override val cancellationId: String?
+        get() = it.cancellation?.id?.toString()
+      override val cancellationReason: String?
+        get() = it.cancellation?.reason?.name
+      override val startDate: LocalDate?
+        get() = it.arrival?.arrivalDate
+      override val endDate: LocalDate?
+        get() = it.arrival?.expectedDepartureDate
+      override val actualEndDate: Timestamp?
+        get() = it.departure?.dateTime?.let { time -> Timestamp.from(time.toInstant()) }
+      override val accommodationOutcome: String?
+        get() = it.departure?.moveOnCategory?.name
+    }
+  }
+  .sortedBy { it.bookingId }


### PR DESCRIPTION
This PR replaces the Hibernate-managed JPQL query for `BookingRepository.findAllByOverlappingDate` with a handwritten native SQL query called from `BookingsReportRepository.findAllByOverlappingDate`.

This native SQL query returns just the set of data that is needed to populate the booking report and avoids the N+1 query problem caused by lazily loading dependent entities on the booking.

### Performance testing
The performance test used to assess the performance of this change was performed using the same code and methodology as for #1100.

The original control test from `main` as of #1100, using JPQL and allowing Hibernate to generate multiple queries:
<img width="1034" alt="Control test results measured using the `main` branch" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/3bb0e62c-0a1c-431f-a7ec-58a045463fbe">

The results of the test as a result of using a handwritten native query:
<img width="1034" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/115487933/a62fcacd-a3a7-4d87-80c2-ecaacce016fc">


The findings, summarised in a table:

| Test | Success rate | Minimum time (s)[1] | Maximum time (s)[1] | Mean time (s)[1] | Median time (s)[1] | Std. Dev. (s)[1] |
|:---|---:|---:|---:|---:|---:|---:|
| Control (JPQL query) | 100.0% | 8.658 | 49.901 | 29.526 | 31.704 | 11.488 |
| Native query |  100.0% | 0.057 | 0.576 | 0.210 | 0.218 | 0.061 |

[1]: As measured for the successful subset of requests.