### PR TITLE
Only update applications without statuses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -115,9 +115,12 @@ AND apa.is_inapplicable IS NOT TRUE
   fun <T : ApplicationEntity> findAllForServiceAndNameNull(type: Class<T>, pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
 
   @Query(
-    "SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type",
+    "SELECT * FROM approved_premises_applications apa " +
+      "LEFT JOIN applications a ON a.id = apa.id " +
+      "WHERE apa.status IS NULL",
+    nativeQuery = true,
   )
-  fun <T : ApplicationEntity> findAllForService(type: Class<T>, pageable: Pageable?): Slice<ApplicationEntity>
+  fun findAllWithNullStatus(pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
 
   @Query(
     "SELECT application.created_at as createdAt, CAST(application.created_by_user_id as TEXT) as createdByUserId FROM approved_premises_applications apa " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import io.sentry.Sentry
 import org.springframework.context.ApplicationContext
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
@@ -46,6 +47,7 @@ class MigrationJobService(
 
       migrationLogger.info("Finished migration job: $migrationJobType")
     } catch (exception: Exception) {
+      Sentry.captureException(exception)
       migrationLogger.error("Unable to complete Migration Job", exception)
     }
   }


### PR DESCRIPTION
We’re still having problems in preprod when updating statuses and pages getting  skipped. To get around this, I’ve changed the query to only fetch  applications without a status. This borrows from an approach we used in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/906 when we were updating offender names, which seemed to work. 

Only fetching applications without a status also means we can run the task multiple times and only fetch/update a subset of applications too.