### PR TITLE
Hide withdrawn placement applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -20,7 +20,7 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   fun findAllByAllocatedToUser_IdAndReallocatedAtNull(userId: UUID): List<PlacementApplicationEntity>
 
-  fun findAllByApplication(application: ApprovedPremisesApplicationEntity): List<PlacementApplicationEntity>
+  fun findAllByApplicationAndDecisionIsNullOrDecisionIsNot(application: ApprovedPremisesApplicationEntity, decision: PlacementApplicationDecision): List<PlacementApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -50,7 +50,7 @@ class PlacementApplicationService(
 
   fun getAllPlacementApplicationEntitiesForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
     val application = applicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity
-    return placementApplicationRepository.findAllByApplication(application)
+    return placementApplicationRepository.findAllByApplicationAndDecisionIsNullOrDecisionIsNot(application, PlacementApplicationDecision.WITHDRAWN_BY_PP)
   }
 
   fun createApplication(


### PR DESCRIPTION
When returning placement applications for an application, we don’t want to show withdrawn ones. I've added a test to confirm this, as well as extending the tests to test all non-withdrawn placement applications get returned.