### PR TITLE
Detekt monitors for wildcard java util imports

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -18,6 +18,8 @@ style:
     maxLineLength: 200
   ReturnCount:
     max: 4
+  WildcardImport:
+    excludeImports: [] # We remove the default exception of ['java.util.*'] inline with our existing style guide
 
 complexity:
   LongMethod:


### PR DESCRIPTION
[This came up during a recent PR review](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1105#discussion_r1387866695).

This keeps the rules inline with how we’ve been importing on the project so far. With this change we don’t review whether this is the right/wrong choice, we just aim to consistently apply the previous rule.

Detekt defaults this to be excluded[1] so we remove the exclusion.

[1] https://detekt.dev/docs/rules/style/#wildcardimport

With the exception removed we can see detekt correctly starts to fail:

![Screenshot 2023-11-14 at 12 17 09](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/4a0b6b6c-fa97-4faf-9fe3-51853456c77e)
