### PR TITLE
(APS 45) Update migration to only update status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
@@ -34,6 +35,10 @@ import javax.persistence.Table
 
 @Repository
 interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
+
+  @Modifying
+  @Query("UPDATE ApprovedPremisesApplicationEntity ap set ap.status = :status where ap.id = :applicationId")
+  fun updateStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus)
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
@@ -38,6 +38,7 @@ class ApplicationStatusMigrationJob(
   }
 
   private fun setStatus(application: ApprovedPremisesApplicationEntity) {
+    entityManager.detach(application)
     val assessment = application.getLatestAssessment()
 
     application.status = when {
@@ -52,6 +53,6 @@ class ApplicationStatusMigrationJob(
     }
 
     log.info("Updating application ${application.id} to ${application.status}")
-    applicationRepository.saveAndFlush(application)
+    applicationRepository.updateStatus(application.id, application.status!!)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -47,6 +47,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
   private var name: Yielded<String> = { "${randomStringUpperCase(4)} ${randomStringUpperCase(6)}" }
   private var targetLocation: Yielded<String?> = { null }
+  private var status: Yielded<ApprovedPremisesApplicationStatus?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -164,6 +165,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.targetLocation = { targetLocation }
   }
 
+  fun withStatus(status: ApprovedPremisesApplicationStatus?) {
+    this.status = { status }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -194,6 +199,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     nomsNumber = this.nomsNumber(),
     name = this.name(),
     targetLocation = this.targetLocation(),
-    status = ApprovedPremisesApplicationStatus.STARTED,
+    status = this.status(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SetApplicationStatusMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SetApplicationStatusMigrationTest.kt
@@ -192,6 +192,10 @@ class SetApplicationStatusMigrationTest : MigrationJobTestBase() {
       )
     }
 
+    application.status = null
+
+    approvedPremisesApplicationRepository.save(application)
+
     return Pair(application, assessment)
   }
 


### PR DESCRIPTION
Currently, when running `save` against the application, we save the entire object, which may cause issues in production when real users are using the system. This detaches the entity to remove it from the [JPA entity lifecycle](https://dzone.com/articles/jpa-entity-lifecycle) and then runs a custom update to only update the status field.