### PR TITLE
[1673]-Add cancelledAt and modify cancellationContex to notes for CAS…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
@@ -59,7 +59,8 @@ class DomainEventBuilder(
             noms = booking.nomsNumber,
           ),
           cancellationReason = cancellation.reason.name,
-          cancellationContext = cancellation.notes,
+          notes = cancellation.notes,
+          cancelledAt = cancellation.date,
         ),
       ),
     )

--- a/src/main/resources/static/cas3-domain-events-api.yml
+++ b/src/main/resources/static/cas3-domain-events-api.yml
@@ -227,7 +227,10 @@ components:
           format: uri
         cancellationReason:
           type: string
-        cancellationContext:
+        cancelledAt:
+          type: string
+          format: date
+        notes:
           type: string
       required:
         - personReference

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3BookingCancelledEventDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3BookingCancelledEventDetailsFactory.kt
@@ -4,8 +4,10 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3BookingCancelledEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.net.URI
+import java.time.LocalDate
 import java.util.UUID
 
 class CAS3BookingCancelledEventDetailsFactory : Factory<CAS3BookingCancelledEventDetails> {
@@ -13,8 +15,9 @@ class CAS3BookingCancelledEventDetailsFactory : Factory<CAS3BookingCancelledEven
   private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
   private var premisesId: Yielded<UUID> = { UUID.randomUUID() }
   private var cancellationReason: Yielded<String> = { randomStringMultiCaseWithNumbers(12) }
-  private var cancellationContext: Yielded<String?> = { randomStringMultiCaseWithNumbers(12) }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(12) }
   private var applicationId: Yielded<UUID?> = { null }
+  private var cancelledAt: Yielded<LocalDate?> = { LocalDate.now().randomDateBefore() }
 
   fun withPersonReference(configuration: PersonReferenceFactory.() -> Unit) = apply {
     this.personReference = { PersonReferenceFactory().apply(configuration).produce() }
@@ -32,12 +35,16 @@ class CAS3BookingCancelledEventDetailsFactory : Factory<CAS3BookingCancelledEven
     this.cancellationReason = { cancellationReason }
   }
 
-  fun withCancellationContext(cancellationContext: String?) = apply {
-    this.cancellationContext = { cancellationContext }
+  fun withNotes(cancellationContext: String?) = apply {
+    this.notes = { cancellationContext }
   }
 
   fun withApplicationId(applicationId: UUID?) = apply {
     this.applicationId = { applicationId }
+  }
+
+  fun withCancelledAt(date: LocalDate) = apply {
+    this.cancelledAt = { date }
   }
 
   override fun produce(): CAS3BookingCancelledEventDetails {
@@ -49,9 +56,10 @@ class CAS3BookingCancelledEventDetailsFactory : Factory<CAS3BookingCancelledEven
       bookingId = bookingId,
       bookingUrl = URI("http://api/premises/${this.premisesId()}/bookings/$bookingId"),
       cancellationReason = this.cancellationReason(),
-      cancellationContext = this.cancellationContext(),
+      notes = this.notes(),
       applicationId = applicationId,
       applicationUrl = applicationId?.let { URI("http://api/applications/$it") },
+      cancelledAt = this.cancelledAt(),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
@@ -82,9 +82,10 @@ class DomainEventBuilderTest {
         data.bookingId == booking.id &&
         data.bookingUrl.toString() == "http://api/premises/${premises.id}/bookings/${booking.id}" &&
         data.cancellationReason == cancellationReasonName &&
-        data.cancellationContext == cancellationNotes &&
+        data.notes == cancellationNotes &&
         data.applicationId == application.id &&
         data.applicationUrl.toString() == "http://api/applications/${application.id}"
+      data.cancelledAt == booking.cancellation?.date
     }
   }
 


### PR DESCRIPTION
# Changes in this PR
Refer this ticket#[1673](https://trello.com/c/4BNwFwIL/1673-bookingcancelled-event-includes-cancelledat-and-notes) for more information.

This PR is to add additional field `cancelledAt` and modify existing field `cancellationContext` to `notes` to CAS3 premises cancellation domain event.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.