### PR TITLE
Abandon preemptive caching for records that we fail 25 times on

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
@@ -42,6 +42,14 @@ class InmateDetailsCacheRefreshWorker(
         return@forEach
       }
 
+      if (cacheEntryStatus == PreemptiveCacheEntryStatus.ABANDONED) {
+        if (loggingEnabled) {
+          log.info("No upstream call made when refreshing Inmate Details for $it, the request has now failed too many times")
+        }
+
+        return@forEach
+      }
+
       val prisonsApiResult = prisonsApiClient.getInmateDetailsWithCall(it)
 
       logConspicuously("Upstream API response: $prisonsApiResult")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -138,5 +138,5 @@ class CacheKeySet(
 }
 
 enum class PreemptiveCacheEntryStatus {
-  MISS, REQUIRES_REFRESH, EXISTS
+  MISS, REQUIRES_REFRESH, EXISTS, ABANDONED
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
@@ -197,6 +197,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
         path = null,
         hasResponseBody = true,
         attempt = null,
+        abandoned = false
       )
 
       redisTemplate.boundValueOps(qualifiedMetadataKey).set(


### PR DESCRIPTION
There are two cases where NOMS numbers cannot be found upstream. eg: a6833DY[1] and A0943AE[2].

We confirmed that these NOMS numbers have been ‘merged’[3] which means they will never return data again. Since we have referrals or bookings that reference these noms numbers, the service and it’s preemptive caching logic will still attempt to cache offender data for these people at regular intervals.

This is leaving us with Sentry errors, 2.7k over the last 30 days where we are flagging the situation: `Unable to make upstream request after 1597 attempts` and wasted/distracting resource usage.

As a way to handle this situation we introduce an upper limit for failure. Currently set to 25 which includes back offs. If the cache warmer cannot find information in 25 requests we give up. We mark the metadata as abandoned and skip any further requests to fetch this information.

Question: is 25 reasonable?

Meta data is stored in redis and could theoretically be unset. If that happened new attempts would attempt to recache 25 times before getting back into the same abandoned state.

[1] https://ministryofjustice.sentry.io/issues/4538149828/?project=4503931792392192&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=0
[2] https://ministryofjustice.sentry.io/issues/4521955843/?project=4503931792392192&project=4504129156218880&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=1
[3] https://mojdt.slack.com/archives/CR5ESQ8T1/p1694695349149839