### PR TITLE
Detach application after fetching assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApplicationStatusMigrationJob.kt
@@ -38,7 +38,6 @@ class ApplicationStatusMigrationJob(
   }
 
   private fun setStatus(application: ApprovedPremisesApplicationEntity) {
-    entityManager.detach(application)
     val assessment = application.getLatestAssessment()
 
     application.status = when {
@@ -53,6 +52,7 @@ class ApplicationStatusMigrationJob(
     }
 
     log.info("Updating application ${application.id} to ${application.status}")
+    entityManager.detach(application)
     applicationRepository.updateStatus(application.id, application.status!!)
   }
 }


### PR DESCRIPTION
I don’t know why this worked in test, but I think we need to detach the application after we’ve done everything we need to do with the application.

https://ministryofjustice.sentry.io/issues/4633236006/?referrer=slack&notification_uuid=1f80056b-a46b-4f9a-902b-7be138a494d9&alert_rule_id=13862421&alert_type=issue