### PR TITLE
Remove `status` on CAS2 SubmittedApplications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
@@ -38,7 +37,6 @@ class SubmittedApplicationTransformer(
       createdAt = jpa.createdAt.toInstant(),
       submittedAt = jpa.submittedAt?.toInstant(),
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
-      status = getStatus(jpa),
     )
   }
 
@@ -53,26 +51,10 @@ class SubmittedApplicationTransformer(
       createdByUserId = jpaSummary.getCreatedByUserId(),
       createdAt = jpaSummary.getCreatedAt().toInstant(),
       submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
-      status = getStatusFromSummary(jpaSummary),
     )
   }
 
   private fun transformUpdate(jpa: Cas2StatusUpdateEntity): Cas2StatusUpdate {
     return statusUpdateTransformer.transformJpaToApi(jpa)
-  }
-
-  private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {
-    if (entity.submittedAt !== null) {
-      return ApplicationStatus.submitted
-    }
-
-    return ApplicationStatus.inProgress
-  }
-
-  private fun getStatusFromSummary(summary: Cas2ApplicationSummary): ApplicationStatus {
-    return when {
-      summary.getSubmittedAt() != null -> ApplicationStatus.submitted
-      else -> ApplicationStatus.inProgress
-    }
   }
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1611,8 +1611,6 @@ components:
           type: boolean
         document:
           $ref: '#/components/schemas/AnyValue'
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
         submittedAt:
           type: string
           format: date-time
@@ -1790,8 +1788,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
         person:
           $ref: '#/components/schemas/Person'
         createdAt:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5713,8 +5713,6 @@ components:
           type: boolean
         document:
           $ref: '#/components/schemas/AnyValue'
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
         submittedAt:
           type: string
           format: date-time
@@ -5892,8 +5890,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
         person:
           $ref: '#/components/schemas/Person'
         createdAt:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2006,8 +2006,6 @@ components:
           type: boolean
         document:
           $ref: '#/components/schemas/AnyValue'
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
         submittedAt:
           type: string
           format: date-time
@@ -2185,8 +2183,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
         person:
           $ref: '#/components/schemas/Person'
         createdAt:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -10,7 +10,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
@@ -86,7 +85,6 @@ class SubmittedApplicationTransformerTest {
         "outdatedSchema",
         "person",
         "schemaVersion",
-        "status",
         "statusUpdates",
         "submittedAt",
         "submittedBy",
@@ -109,7 +107,6 @@ class SubmittedApplicationTransformerTest {
       val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(applicationSummary, mockk())
 
       assertThat(transformation.id).isEqualTo(applicationSummary.getId())
-      assertThat(transformation.status).isEqualTo(ApplicationStatus.submitted)
     }
   }
 }


### PR DESCRIPTION
We do not need this field, as it relates to the `ApplicationStatus` types which are not revelant to our submissions, and do not want them confused with our `StatusUpdates` which are added by assessors to a submitted application.