### PR TITLE
Rename applicationSortField to sortBy

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -84,14 +84,14 @@ class ApplicationsController(
     page: Int?,
     crn: String?,
     sortDirection: SortDirection?,
-    applicationSortField: ApplicationSortField?,
+    sortBy: ApplicationSortField?,
   ): ResponseEntity<List<ApplicationSummary>> {
     if (xServiceName != ServiceName.approvedPremises) {
       throw ForbiddenProblem()
     }
     val user = userService.getUserForRequest()
     val (applications, metadata) =
-      applicationService.getAllApprovedPremisesApplications(page, crn, sortDirection, applicationSortField)
+      applicationService.getAllApprovedPremisesApplications(page, crn, sortDirection, sortBy)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -123,9 +123,9 @@ class ApplicationService(
     page: Int?,
     crn: String?,
     sortDirection: SortDirection?,
-    applicationSortField: ApplicationSortField?,
+    sortBy: ApplicationSortField?,
   ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
-    val sortField = when (applicationSortField) {
+    val sortField = when (sortBy) {
       ApplicationSortField.arrivalDate -> "arrivalDate"
       ApplicationSortField.createdAt -> "a.created_at"
       ApplicationSortField.tier -> "tier"

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1715,7 +1715,7 @@ paths:
           description: The direction to sort the results by. If blank, will sort in descending order
           schema:
             $ref: '_shared.yml#/components/schemas/SortDirection'
-        - name: applicationSortField
+        - name: sortBy
           in: query
           description: The field to sort the results by.
           schema:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1717,7 +1717,7 @@ paths:
           description: The direction to sort the results by. If blank, will sort in descending order
           schema:
             $ref: '#/components/schemas/SortDirection'
-        - name: applicationSortField
+        - name: sortBy
           in: query
           description: The field to sort the results by.
           schema:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2857,7 +2857,7 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/applications/all?page=1&sortDirection=desc&applicationSortField=createdAt")
+            .uri("/applications/all?page=1&sortDirection=desc&sortBy=createdAt")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
@@ -2918,7 +2918,7 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/applications/all?page=1&sortDirection=asc&applicationSortField=createdAt")
+            .uri("/applications/all?page=1&sortDirection=asc&sortBy=createdAt")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
@@ -2979,7 +2979,7 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/applications/all?page=1&sortDirection=desc&applicationSortField=arrivalDate")
+            .uri("/applications/all?page=1&sortDirection=desc&sortBy=arrivalDate")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
@@ -3040,7 +3040,7 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/applications/all?page=1&sortDirection=asc&applicationSortField=arrivalDate")
+            .uri("/applications/all?page=1&sortDirection=asc&sortBy=arrivalDate")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
@@ -3138,7 +3138,7 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/applications/all?page=1&sortDirection=asc&applicationSortField=tier")
+            .uri("/applications/all?page=1&sortDirection=asc&sortBy=tier")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
@@ -3236,7 +3236,7 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/applications/all?page=1&sortDirection=desc&applicationSortField=tier")
+            .uri("/applications/all?page=1&sortDirection=desc&sortBy=tier")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()


### PR DESCRIPTION
When I did the frontend, I assumed we'd named the sortBy field to be the same as the other endpoints (I missed this in the review!). Rather than changing the implementation in the frontend, I've changed it here for consistency's sake.