### PR TITLE
Search for person by NOMIS ID for CAS2

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://prison-api-dev.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
     SERVICES_MANAGE-USERS-API_BASE-URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
+    SERVICES_PROBATION-OFFENDER-SEARCH-API_BASE-URL: https://probation-offender-search-dev.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://dev.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,6 +19,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://api-preprod.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-pp.aks-live-1.studio-hosting.service.justice.gov.uk
     SERVICES_MANAGE-USERS-API_BASE-URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
+    SERVICES_PROBATION-OFFENDER-SEARCH-API_BASE-URL: https://probation-offender-search-preprod.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://preprod.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-preprod.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -27,6 +27,7 @@ generic-service:
     SERVICES_PRISONS-API_BASE-URL: https://api.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user.aks-live-1.studio-hosting.service.justice.gov.uk
     SERVICES_MANAGE-USERS-API_BASE-URL: https://manage-users-api.hmpps.service.justice.gov.uk
+    SERVICES_PROBATION-OFFENDER-SEARCH-API_BASE-URL: https://probation-offender-search.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -17,6 +17,7 @@ generic-service:
     SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
     SERVICES_PRISONS-API_BASE-URL: https://prison-api-dev.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
+    SERVICES_PROBATION-OFFENDER-SEARCH-API_BASE-URL: https://probation-offender-search-dev.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://dev.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ProbationOffenderSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ProbationOffenderSearchApiClient.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderSearchNomsRequest
+
+@Component
+class ProbationOffenderSearchApiClient(
+  @Qualifier("probationOffenderSearchApiWebClient") webClient: WebClient,
+  objectMapper: ObjectMapper,
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+
+  fun searchOffenderByNomsNumber(nomsNumber: String) = postRequest<List<ProbationOffenderDetail>> {
+    path = "/search"
+    body = ProbationOffenderSearchNomsRequest(nomsNumber = nomsNumber)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -280,4 +280,28 @@ class WebClientConfiguration(
       )
       .build()
   }
+
+  @Bean(name = ["probationOffenderSearchApiWebClient"])
+  fun probationOffenderSearchApiClient(
+    clientRegistrations: ClientRegistrationRepository,
+    authorizedClients: OAuth2AuthorizedClientRepository,
+    @Value("\${services.probation-offender-search-api.base-url}") probationOffenderSearchBaseUrl: String,
+  ): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
+
+    oauth2Client.setDefaultClientRegistrationId("delius-backed-apis")
+
+    return WebClient.builder()
+      .baseUrl(probationOffenderSearchBaseUrl)
+      .clientConnector(
+        ReactorClientHttpConnector(
+          HttpClient
+            .create()
+            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+        ),
+      )
+      .filter(oauth2Client)
+      .build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ProbationOffenderSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ProbationOffenderSearchResult.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderDetail
+
+sealed interface ProbationOffenderSearchResult {
+  val nomsNumber: String
+
+  sealed interface Success : ProbationOffenderSearchResult {
+    data class Full(override val nomsNumber: String, val probationOffenderDetail: ProbationOffenderDetail, val inmateDetail: InmateDetail?) : Success
+  }
+
+  data class NotFound(override val nomsNumber: String) : ProbationOffenderSearchResult
+  data class Unknown(override val nomsNumber: String, val throwable: Throwable? = null) : ProbationOffenderSearchResult
+  data class Forbidden(override val nomsNumber: String, val throwable: Throwable? = null) : ProbationOffenderSearchResult
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderDetail.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi
+
+import java.time.LocalDate
+
+data class ProbationOffenderDetail(
+  val previousSurname: String? = null,
+  val offenderId: Long,
+  val title: String? = null,
+  val firstName: String? = null,
+  val middleNames: List<String>? = null,
+  val surname: String? = null,
+  val dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
+  val otherIds: IDs,
+  val contactDetails: ContactDetails? = null,
+  val offenderProfile: OffenderProfile? = null,
+  val softDeleted: Boolean? = null,
+  val currentDisposal: String? = null,
+  val partitionArea: String? = null,
+  val currentRestriction: Boolean? = null,
+  val restrictionMessage: String? = null,
+  val currentExclusion: Boolean? = null,
+  val exclusionMessage: String? = null,
+  val highlight: Map<String, List<String>>? = null,
+  val accessDenied: Boolean? = null,
+  val currentTier: String? = null,
+  val activeProbationManagedSentence: Boolean? = null,
+)
+
+data class IDs(
+  val crn: String,
+  val pncNumber: String? = null,
+  val croNumber: String? = null,
+  val niNumber: String? = null,
+  val nomsNumber: String? = null,
+  val immigrationNumber: String? = null,
+  val mostRecentPrisonerNumber: String? = null,
+  val previousCrn: String? = null,
+)
+
+data class ContactDetails(
+  val phoneNumbers: List<String>? = null,
+  val emailAddresses: List<String>? = null,
+  val allowSMS: Boolean? = null,
+)
+
+data class OffenderProfile(
+  val ethnicity: String? = null,
+  val nationality: String? = null,
+  val secondaryNationality: String? = null,
+  val notes: String? = null,
+  val immigrationStatus: String? = null,
+  val religion: String? = null,
+  val sexualOrientation: String? = null,
+  val offenderDetails: String? = null,
+  val remandStatus: String? = null,
+  val riskColour: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderSearchNomsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderSearchNomsRequest.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude
+data class ProbationOffenderSearchNomsRequest(val nomsNumber: String)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,11 @@ spring:
             client-id: approved-premises-api
             client-secret: clientsecret
             authorization-grant-type: client_credentials
+          probation-offender-search-api:
+            provider: hmpps-auth
+            client-id: approved-premises-api
+            client-secret: clientsecret
+            authorization-grant-type: client_credentials
           case-notes:
             provider: hmpps-auth
             client-id: approved-premises-api
@@ -140,6 +145,8 @@ services:
     base-url: http://localhost:9575
   manage-users-api:
     base-url: http://localhost:9560
+  probation-offender-search-api:
+    base-url: http://localhost:9004
   case-notes:
     base-url: http://localhost:9004
   ap-delius-context-api:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -239,11 +239,11 @@ paths:
     get:
       tags:
         - People operations
-      summary: Searches for a Person by their CRN
+      summary: Searches for a Person by their Prison Number (NOMIS ID)
       parameters:
-        - name: crn
+        - name: nomsNumber
           in: query
-          description: CRN to search for
+          description: Prison Number to search for
           required: true
           schema:
             type: string

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -241,11 +241,11 @@ paths:
     get:
       tags:
         - People operations
-      summary: Searches for a Person by their CRN
+      summary: Searches for a Person by their Prison Number (NOMIS ID)
       parameters:
-        - name: crn
+        - name: nomsNumber
           in: query
-          description: CRN to search for
+          description: Prison Number to search for
           required: true
           schema:
             type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.IDs
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.OffenderProfile
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
+
+class ProbationOffenderDetailFactory : Factory<ProbationOffenderDetail> {
+  private var offenderId: Yielded<Long> = { randomInt(100000, 900000).toLong() }
+  private var firstName: Yielded<String> = { randomStringUpperCase(8) }
+  private var surname: Yielded<String> = { randomStringUpperCase(8) }
+  private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore() }
+  private var gender: Yielded<String> = { randomOf(listOf("Male", "Female", "Other")) }
+  private var otherIds: Yielded<IDs> = { IDs(crn = "CRN") }
+  private var offenderProfile: Yielded<OffenderProfile> = { OffenderProfile() }
+  private var softDeleted: Yielded<Boolean?> = { false }
+  private var currentRestriction: Yielded<Boolean?> = { false }
+  private var currentExclusion: Yielded<Boolean?> = { false }
+
+  fun withFirstName(firstName: String) = apply {
+    this.firstName = { firstName }
+  }
+
+  fun withSurname(surname: String) = apply {
+    this.surname = { surname }
+  }
+
+  fun withOffenderId(offenderId: Long) = apply {
+    this.offenderId = { offenderId }
+  }
+
+  fun withDateOfBirth(dateOfBirth: LocalDate) = apply {
+    this.dateOfBirth = { dateOfBirth }
+  }
+
+  fun withGender(gender: String) = apply {
+    this.gender = { gender }
+  }
+
+  fun withOtherIds(otherIds: IDs) = apply {
+    this.otherIds = { otherIds }
+  }
+
+  fun withOffenderProfile(offenderProfile: OffenderProfile) = apply {
+    this.offenderProfile = { offenderProfile }
+  }
+
+  fun withCurrentRestriction(currentRestriction: Boolean) = apply {
+    this.currentRestriction = { currentRestriction }
+  }
+
+  fun withCurrentExclusion(currentExclusion: Boolean) = apply {
+    this.currentExclusion = { currentExclusion }
+  }
+
+  override fun produce(): ProbationOffenderDetail = ProbationOffenderDetail(
+          previousSurname = null,
+          offenderId = this.offenderId(),
+          title = null,
+          firstName = this.firstName(),
+          middleNames = null,
+          surname = this.surname(),
+          dateOfBirth = this.dateOfBirth(),
+          gender = this.gender(),
+          otherIds = this.otherIds(),
+          contactDetails = null,
+          offenderProfile = this.offenderProfile(),
+          softDeleted = this.softDeleted(),
+          currentDisposal = null,
+          partitionArea = null,
+          currentRestriction = this.currentRestriction(),
+          restrictionMessage = null,
+          currentExclusion = this.currentExclusion(),
+          exclusionMessage = null,
+          highlight = null,
+          accessDenied = null,
+          currentTier = null,
+          activeProbationManagedSentence = null
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -769,6 +769,22 @@ abstract class IntegrationTestBase {
       )
     }
 
+  fun mockSuccessfulPostCallWithJsonResponse(url: String, requestBody: StringValuePattern, responseBody: Any, responseStatus: Int = 200) =
+    mockOAuth2ClientCredentialsCallIfRequired {
+      wiremockServer.stubFor(
+        post(urlEqualTo(url))
+          .withRequestBody(requestBody)
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(responseStatus)
+              .withBody(
+                objectMapper.writeValueAsString(responseBody),
+              ),
+          ),
+      )
+    }
+
   fun mockSuccessfulGetCallWithBodyAndJsonResponse(url: String, requestBody: StringValuePattern, responseBody: Any, responseStatus: Int = 200) =
     mockOAuth2ClientCredentialsCallIfRequired {
       wiremockServer.stubFor(
@@ -802,6 +818,17 @@ abstract class IntegrationTestBase {
     mockOAuth2ClientCredentialsCallIfRequired {
       wiremockServer.stubFor(
         WireMock.get(urlEqualTo(url))
+          .willReturn(
+            aResponse()
+              .withStatus(responseStatus),
+          ),
+      )
+    }
+
+  fun mockUnsuccessfulPostCall(url: String, responseStatus: Int) =
+    mockOAuth2ClientCredentialsCallIfRequired {
+      wiremockServer.stubFor(
+        WireMock.post(urlEqualTo(url))
           .willReturn(
             aResponse()
               .withStatus(responseStatus),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -3,185 +3,184 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOffenderDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockNotFoundSearchCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockServerErrorSearchCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.IDs
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.OffenderProfile
 import java.time.LocalDate
 
 class Cas2PersonSearchTest : IntegrationTestBase() {
-  @Test
-  fun `Searching by CRN without a JWT returns 401`() {
-    webTestClient.get()
-      .uri("/cas2/people/search?crn=CRN")
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
+    @Nested
+    inner class PeopleSearchGet {
+        @Test
+        fun `Searching by NOMIS ID without a JWT returns 401`() {
+            webTestClient.get()
+              .uri("/cas2/people/search?nomsNumber=nomsNumber").exchange()
+              .expectStatus()
+              .isUnauthorized
+        }
 
-  @Test
-  fun `Searching for a CRN with a non-Delius or NOMIS JWT returns 403`() {
-    val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username",
-      authSource = "other source",
-    )
+        @Test
+        fun `Searching for a NOMIS ID with a non-Delius or NOMIS JWT returns 403`() {
+            val jwt = jwtAuthHelper.createClientCredentialsJwt(
+              username = "username",
+              authSource = "other source",
+            )
 
-    webTestClient.get()
-      .uri("/cas2/people/search?crn=CRN")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isForbidden
-  }
+            webTestClient.get()
+              .uri("/cas2/people/search?nomsNumber=nomsNumber")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isForbidden
+        }
 
-  @Test
-  fun `Searching for a CRN without ROLE_PRISON returns 403`() {
-    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-      subject = "username",
-      authSource = "nomis",
-      roles = listOf("ROLE_OTHER"),
-    )
+        @Test
+        fun `Searching for a NOMIS ID without ROLE_PRISON returns 403`() {
+            val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+              subject = "username",
+              authSource = "nomis",
+              roles = listOf("ROLE_OTHER"),
+            )
 
-    webTestClient.get()
-      .uri("/cas2/people/search?crn=CRN")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isForbidden
-  }
+            webTestClient.get()
+              .uri("/cas2/people/search?nomsNumber=nomsNumber")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isForbidden
+        }
 
-  @Test
-  fun `Searching for a CRN that does not exist returns 404`() {
-    mockClientCredentialsJwtRequest()
+        @Test
+        fun `Searching for a NOMIS ID that does not exist returns 404`() {
+            mockClientCredentialsJwtRequest()
 
-    `Given a CAS2 User` { userEntity, jwt ->
-      wiremockServer.stubFor(
-        get(WireMock.urlEqualTo("/secure/offenders/crn/CRN"))
-          .willReturn(
-            aResponse()
-              .withHeader("Content-Type", "application/json")
-              .withStatus(404),
-          ),
-      )
+          `Given a CAS2 User` { userEntity, jwt ->
+            wiremockServer.stubFor(
+              get(WireMock.urlEqualTo("/search?nomsNumber=nomsNumber"))
+                .willReturn(
+                  aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(404),
+                ),
+            )
 
-      webTestClient.get()
-        .uri("/cas2/people/search?crn=CRN")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isNotFound
+            webTestClient.get()
+              .uri("/cas2/people/search?nomsNumber=nomsNumber")
+              .header("Authorization", "Bearer $jwt")
+              .exchange().expectStatus()
+              .isNotFound
+          }
+        }
+
+        @Test
+        fun `Searching for a NOMIS ID returns OK with correct body`() {
+          `Given a CAS2 User` { userEntity, jwt ->
+            val offender = ProbationOffenderDetailFactory().withOtherIds(IDs(crn = "CRN", nomsNumber = "NOMS321"))
+              .withFirstName("James")
+              .withSurname("Someone")
+              .withDateOfBirth(
+                LocalDate
+                  .parse("1985-05-05")
+              )
+              .withGender("Male")
+              .withOffenderProfile(OffenderProfile(nationality = "English"))
+              .produce()
+
+            val inmateDetail = InmateDetailFactory().withOffenderNo("NOMS321")
+              .withInOutStatus(InOutStatus.IN)
+              .withAssignedLivingUnit(
+                AssignedLivingUnit(
+                  agencyId = "BRI",
+                  locationId = 5,
+                  description = "B-2F-004",
+                  agencyName = "HMP Bristol",
+                ),
+              )
+              .produce()
+
+            ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall("NOMS321", listOf(offender))
+            PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
+
+            webTestClient.get()
+              .uri("/cas2/people/search?nomsNumber=NOMS321")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  FullPerson(
+                    type = PersonType.fullPerson,
+                    crn = "CRN",
+                    name = "James Someone",
+                    dateOfBirth = LocalDate.parse("1985-05-05"),
+                    sex = "Male",
+                    status = FullPerson.Status.inCustody,
+                    nomsNumber = "NOMS321",
+                    nationality = "English",
+                    isRestricted = false,
+                    prisonName = "HMP Bristol"
+                  ),
+                ),
+              )
+            }
+        }
+
+        @Test
+        fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized`() {
+            `Given a CAS2 User` { userEntity, jwt ->
+              ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall()
+
+                webTestClient.get()
+                        .uri("/cas2/people/search?nomsNumber=NOMS321")
+                        .header("Authorization", "Bearer $jwt")
+                        .exchange()
+                        .expectStatus()
+                        .isForbidden
+            }
+        }
+
+        @Test
+        fun `Searching for a NOMIS ID returns Unauthorised error when it is not found`() {
+            `Given a CAS2 User` { userEntity, jwt ->
+              ProbationOffenderSearchAPI_mockNotFoundSearchCall()
+
+                webTestClient.get()
+                        .uri("/cas2/people/search?nomsNumber=NOMS321")
+                        .header("Authorization", "Bearer $jwt")
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+            }
+        }
+
+        @Test
+        fun `Searching for a NOMIS ID returns server error when there is a server error`() {
+            `Given a CAS2 User` { userEntity, jwt ->
+              ProbationOffenderSearchAPI_mockServerErrorSearchCall()
+
+                webTestClient.get()
+                        .uri("/cas2/people/search?nomsNumber=NOMS321")
+                        .header("Authorization", "Bearer $jwt")
+                        .exchange()
+                        .expectStatus()
+                        .is5xxServerError
+            }
+        }
     }
-  }
-
-  @Test
-  fun `Searching for a CRN returns OK with correct body`() {
-    `Given a CAS2 User` { userEntity, jwt ->
-      `Given an Offender`(
-        offenderDetailsConfigBlock = {
-          withCrn("CRN")
-          withDateOfBirth(LocalDate.parse("1985-05-05"))
-          withNomsNumber("NOMS321")
-          withFirstName("James")
-          withLastName("Someone")
-          withGender("Male")
-          withEthnicity("White British")
-          withNationality("English")
-          withReligionOrBelief("Judaism")
-          withGenderIdentity("Prefer to self-describe")
-          withSelfDescribedGenderIdentity("This is a self described identity")
-        },
-        inmateDetailsConfigBlock = {
-          withOffenderNo("NOMS321")
-          withInOutStatus(InOutStatus.IN)
-          withAssignedLivingUnit(
-            AssignedLivingUnit(
-              agencyId = "BRI",
-              locationId = 5,
-              description = "B-2F-004",
-              agencyName = "HMP Bristol",
-            ),
-          )
-        },
-      ) { offenderDetails, inmateDetails ->
-        webTestClient.get()
-          .uri("/cas2/people/search?crn=CRN")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .json(
-            objectMapper.writeValueAsString(
-              FullPerson(
-                type = PersonType.fullPerson,
-                crn = "CRN",
-                name = "James Someone",
-                dateOfBirth = LocalDate.parse("1985-05-05"),
-                sex = "Male",
-                status = FullPerson.Status.inCustody,
-                nomsNumber = "NOMS321",
-                ethnicity = "White British",
-                nationality = "English",
-                religionOrBelief = "Judaism",
-                genderIdentity = "This is a self described identity",
-                prisonName = "HMP Bristol",
-                isRestricted = false,
-              ),
-            ),
-          )
-      }
-    }
-  }
-
-  @Test
-  fun `Searching for a CRN without a NomsNumber returns OK with correct body`() {
-    `Given a CAS2 User` { userEntity, jwt ->
-      `Given an Offender`(
-        offenderDetailsConfigBlock = {
-          withCrn("CRN")
-          withDateOfBirth(LocalDate.parse("1985-05-05"))
-          withNomsNumber(null)
-          withFirstName("James")
-          withLastName("Someone")
-          withGender("Male")
-          withEthnicity("White British")
-          withNationality("English")
-          withReligionOrBelief("Judaism")
-          withGenderIdentity("Prefer to self-describe")
-          withSelfDescribedGenderIdentity("This is a self described identity")
-        },
-      ) { offenderDetails, _ ->
-        webTestClient.get()
-          .uri("/cas2/people/search?crn=CRN")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .json(
-            objectMapper.writeValueAsString(
-              FullPerson(
-                type = PersonType.fullPerson,
-                crn = "CRN",
-                name = "James Someone",
-                dateOfBirth = LocalDate.parse("1985-05-05"),
-                sex = "Male",
-                status = FullPerson.Status.unknown,
-                nomsNumber = null,
-                ethnicity = "White British",
-                nationality = "English",
-                religionOrBelief = "Judaism",
-                genderIdentity = "This is a self described identity",
-                prisonName = null,
-                isRestricted = false,
-              ),
-            ),
-          )
-      }
-    }
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/ProbationOffenderSearchAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/ProbationOffenderSearchAPI.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderSearchNomsRequest
+
+fun IntegrationTestBase.ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall(nomsNumber: String, response: List<ProbationOffenderDetail?>) =
+        mockSuccessfulPostCallWithJsonResponse(
+                url = "/search",
+                requestBody = WireMock.equalToJson(
+                        objectMapper.writeValueAsString(
+                                ProbationOffenderSearchNomsRequest(nomsNumber = nomsNumber),
+                        ),
+                        true,
+                        true,
+                ),
+                responseBody = response,
+        )
+
+fun IntegrationTestBase.ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall() =
+        mockUnsuccessfulPostCall(
+                url = "/search",
+                responseStatus = 403,
+        )
+
+fun IntegrationTestBase.ProbationOffenderSearchAPI_mockServerErrorSearchCall() =
+        mockUnsuccessfulPostCall(
+                url = "/search",
+                responseStatus = 500,
+        )
+
+fun IntegrationTestBase.ProbationOffenderSearchAPI_mockNotFoundSearchCall() =
+        mockUnsuccessfulPostCall(
+                url = "/search",
+                responseStatus = 404,
+        )

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -74,6 +74,8 @@ services:
     base-url: http://localhost:#WIREMOCK_PORT
   manage-users-api:
     base-url: http://localhost:#WIREMOCK_PORT
+  probation-offender-search-api:
+    base-url: http://localhost:#WIREMOCK_PORT
   case-notes:
     base-url: http://localhost:#WIREMOCK_PORT
   ap-delius-context-api:


### PR DESCRIPTION
This depends on the AP Tools PR being merged: https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/51 
If you'd like to call the added controller function from the UI there is this WIP PR: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/310

We need to allow a CAS2 user to search for an offender by prison number (nomsNumber), from an API that returns a CRN in order to make subsequent requests for OASyS data. This PR makes a request to [the `probation-offender-search` API](https://github.com/ministryofjustice/probation-offender-search). The shape of the [data returned should match what's returned from the probation API](http://localhost:8084/swagger-ui/index.html#/offender-search/search_1), which is a list of OffenderDetails.

See their controller tests:
https://github.com/ministryofjustice/probation-offender-search/blob/7093fdf716f969de3b80827675f8389cef01f95c/src/test/kotlin/uk/gov/justice/hmpps/probationsearch/controllers/OffenderSearchControllerTest.kt
And Swagger: http://localhost:8084/swagger-ui/index.html#/offender-search/search_1 

I have some outstanding questions on the implementation:

~~1. If an offender is an LAO, we don't want to allow the user to continue. If I understand correctly if `currentExclusion` or `currentRestriction` are `true` then the offender is an LAO? In which case we can just return a Forbidden response? I'm not entirely sure what those fields mean on this probation offender search API.~~ the implementation for LAO should mean a forbidden response is returned if they are LAO
2. The current `FullPerson` requires a date of birth, which according to the Probation API model might potentially be `null`. How should we handle that? Do we want to continue on CAS2 if there is no DoB, as it could potentially be the wrong person? Or, should there be the concept of a CAS2 Person that might not have a DoB? Orrrr, do we make another call to another Delius API to get that DoB.
~~3. We don't get an `inOutStatus` from the Probation API. Can we assume the person is in custody, because the POM is making an application for CAS2? Would this have implications if it was wrong?~~ we are making call to Prison API to get extra prison info
4. Are we making the right call to the `probation-offender-search` API, and have I understood the shape of the data we should expect back? 


