### PR TITLE
(649) Fix: ensure new assessor is persisted on GET to individual SubmittedApplication

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -47,6 +47,7 @@ class SubmissionsController(
 
   override fun submissionsApplicationIdGet(applicationId: UUID): ResponseEntity<Cas2SubmittedApplication> {
     httpAuthService.getCas2AuthenticatedPrincipalOrThrow()
+    ensureExternalUserPersisted()
 
     val application = when (
       val applicationResult = applicationService.getSubmittedApplicationForAssessor(applicationId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -189,6 +189,24 @@ class Cas2SubmissionTest : IntegrationTestBase() {
 
   @Nested
   inner class GetToShow {
+
+    @Test
+    fun `Previously unknown Assessor has an ExternalUser record created from their JWT`() {
+      externalUserRepository.deleteAll()
+      val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt("PREVIOUSLY_UNKNOWN_ASSESSOR")
+
+      webTestClient.get()
+        .uri("/cas2/submissions/fea7986d-cae6-4a7a-8420-5b31376ce787")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+
+      Assertions.assertThat(
+        externalUserRepository.findByUsername("PREVIOUSLY_UNKNOWN_ASSESSOR"),
+      ).isNotNull
+    }
+
     @Test
     fun `Assessor can view single submitted application`() {
       `Given a CAS2 Assessor` { assessor, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -121,6 +121,23 @@ class Cas2SubmissionTest : IntegrationTestBase() {
 
   @Nested
   inner class GetToIndex {
+    @Test
+    fun `Previously unknown Assessor has an ExternalUser record created from their JWT`() {
+      val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt("PREVIOUSLY_UNKNOWN_ASSESSOR")
+
+      externalUserRepository.deleteAll()
+
+      webTestClient.get()
+        .uri("/cas2/submissions")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      Assertions.assertThat(
+        externalUserRepository.findByUsername("PREVIOUSLY_UNKNOWN_ASSESSOR"),
+      ).isNotNull
+    }
 
     @Test
     fun `Assessor can view ALL submitted applications`() {


### PR DESCRIPTION
At present we rely on an explicit `ensureExternalUserPersisted()` function within controller actions to ensure that the logged in assessor is recorded in our `external_users` table.

It would be good to develop this, perhaps:

- making it the responsibility of `HttpAuthService.getCas2AuthenticatedPrincipalOrThrow()`, or
- do something more elaborate using Spring's `UserContext` see [NomisUserRoles](https://github.com/ministryofjustice/nomis-user-roles-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/utils/UserContext.kt#L6) and [Baeldung: Get User in Spring Security](https://www.baeldung.com/get-user-in-spring-security)