### PR TITLE
Enable CAS3 domain events in `test` and `preprod` environments

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -28,7 +28,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
-    DOMAIN-EVENTS_CAS3_EMIT-ENABLED:
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted
     HMPPS_SQS_USE_WEB_TOKEN: true
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -28,7 +28,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: false
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
-    DOMAIN-EVENTS_CAS3_EMIT-ENABLED:
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
 


### PR DESCRIPTION
> See [ticket #1700 on the CAS3 Trello board](https://trello.com/c/lBb6hRsw/1700-enable-all-domain-events-in-preprod-to-enable-further-testing-by-the-delius-team).

This PR enables the six current CAS3 domain events in the `test` and `preprod` environments. This is needed to enable the Delius integrations team to carry out testing.