### PR TITLE
Remove join from count query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -71,7 +71,6 @@ AND (
     SELECT COUNT(*)
       FROM approved_premises_applications apa
       LEFT JOIN applications a ON a.id = apa.id
-      LEFT JOIN assessments ass ON ass.application_id = apa.id AND ass.reallocated_at IS NULL 
       WHERE apa.is_inapplicable IS NOT TRUE
       AND (
         :crnOrName IS NULL OR 


### PR DESCRIPTION
For some reason, this is skewing the count returned in the search results. We don't need this join anyway, so we should remove it.