### PR TITLE
633 Add name and email address to `ExternalUser`

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,7 @@ generic-service:
     SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
     SERVICES_PRISONS-API_BASE-URL: https://prison-api-dev.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
+    SERVICES_MANAGE-USERS-API_BASE-URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://dev.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,6 +18,7 @@ generic-service:
     SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier-preprod.hmpps.service.justice.gov.uk
     SERVICES_PRISONS-API_BASE-URL: https://api-preprod.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user-pp.aks-live-1.studio-hosting.service.justice.gov.uk
+    SERVICES_MANAGE-USERS-API_BASE-URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://preprod.offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys-preprod.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,6 +26,7 @@ generic-service:
     SERVICES_HMPPS-TIER_BASE-URL: https://hmpps-tier.hmpps.service.justice.gov.uk
     SERVICES_PRISONS-API_BASE-URL: https://api.prison.service.justice.gov.uk
     SERVICES_NOMIS-USER-ROLES-API_BASE-URL: https://nomis-user.aks-live-1.studio-hosting.service.justice.gov.uk
+    SERVICES_MANAGE-USERS-API_BASE-URL: https://manage-users-api.hmpps.service.justice.gov.uk
     SERVICES_CASE-NOTES_BASE-URL: https://offender-case-notes.service.justice.gov.uk
     SERVICES_AP-OASYS-CONTEXT-API_BASE-URL: https://approved-premises-and-oasys.hmpps.service.justice.gov.uk
     SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL: https://manage-adjudications-api.hmpps.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ManageUsersApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ManageUsersApiClient.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.manageusers.ExternalUserDetails
+
+@Component
+class ManageUsersApiClient(
+  @Qualifier("manageUsersApiWebClient") webClient: WebClient,
+  objectMapper: ObjectMapper,
+  webClientCache: WebClientCache,
+) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+
+  fun getExternalUserDetails(username: String, jwt: String) = getRequest<ExternalUserDetails> {
+    withHeader("Authorization", "Bearer $jwt")
+    path = "/externalusers/$username"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -263,4 +263,21 @@ class WebClientConfiguration(
       .filter(oauth2Client)
       .build()
   }
+
+  @Bean(name = ["manageUsersApiWebClient"])
+  fun manageUsersApiClient(
+    @Value("\${services.manage-users-api.base-url}") manageUsersBaseUrl: String,
+  ): WebClient {
+    return WebClient.builder()
+      .baseUrl(manageUsersBaseUrl)
+      .clientConnector(
+        ReactorClientHttpConnector(
+          HttpClient
+            .create()
+            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+        ),
+      )
+      .build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExternalUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExternalUserEntity.kt
@@ -22,6 +22,8 @@ data class ExternalUserEntity(
   val username: String,
   var isEnabled: Boolean,
   var origin: String,
+  var name: String,
+  var email: String,
 
   @CreationTimestamp
   private val createdAt: OffsetDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/manageusers/ExternalUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/manageusers/ExternalUserDetails.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.manageusers
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class ExternalUserDetails(
+  val username: String,
+  val userId: UUID,
+  val firstName: String,
+  val lastName: String,
+  val email: String,
+  val authSource: String,
+  val enabled: Boolean,
+  val locked: Boolean,
+  val verified: Boolean,
+  val lastLoggedIn: LocalDateTime?,
+  val inactiveReason: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ExternalUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ExternalUserService.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ManageUsersApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserRepository
 import java.util.UUID
@@ -10,6 +12,7 @@ import java.util.UUID
 class ExternalUserService(
   private val httpAuthService: HttpAuthService,
   private val userRepository: ExternalUserRepository,
+  private val manageUsersApiClient: ManageUsersApiClient,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -26,14 +29,21 @@ class ExternalUserService(
     val existingUser = userRepository.findByUsername(normalisedUsername)
     if (existingUser != null) return existingUser
 
-    // We will obtain some further user details from the Manage-Users API
-    // e.g. name, email, phone number
+    val jwt = httpAuthService.getCas2AuthenticatedPrincipalOrThrow().token.tokenValue
+    val externalUserDetailsResponse = manageUsersApiClient.getExternalUserDetails(normalisedUsername, jwt)
+
+    val externalUserDetails = when (externalUserDetailsResponse) {
+      is ClientResult.Success -> externalUserDetailsResponse.body
+      is ClientResult.Failure -> externalUserDetailsResponse.throwException()
+    }
 
     return userRepository.save(
       ExternalUserEntity(
         id = UUID.randomUUID(),
-        username = username,
-        isEnabled = true,
+        username = externalUserDetails.username,
+        isEnabled = externalUserDetails.enabled,
+        name = "${externalUserDetails.firstName} ${externalUserDetails.lastName}",
+        email = externalUserDetails.email,
         origin = "NACRO",
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExternalUserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExternalUserTransformer.kt
@@ -12,6 +12,8 @@ class ExternalUserTransformer {
       id = externalUserEntity.id,
       username = externalUserEntity.username,
       origin = externalUserEntity.origin,
+      name = externalUserEntity.name,
+      email = externalUserEntity.email,
     )
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,6 +138,8 @@ services:
     base-url: http://localhost:9570
   nomis-user-roles-api:
     base-url: http://localhost:9575
+  manage-users-api:
+    base-url: http://localhost:9560
   case-notes:
     base-url: http://localhost:9004
   ap-delius-context-api:

--- a/src/main/resources/db/migration/all/20231120153953__add_name_and_email_to_external_users.sql
+++ b/src/main/resources/db/migration/all/20231120153953__add_name_and_email_to_external_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE external_users ADD COLUMN email TEXT;
+ALTER TABLE external_users ADD COLUMN name TEXT;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2477,12 +2477,20 @@ components:
         username:
           type: string
           example: 'CAS2_ASSESSOR_USER'
+        name:
+          type: string
+          example: 'Roger Smith'
+        email:
+          type: string
+          example: 'roger@external.example.com'
         origin:
           type: string
           example: 'NACRO'
       required:
         - id
         - username
+        - name
+        - email
     NomisUser:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6625,12 +6625,20 @@ components:
         username:
           type: string
           example: 'CAS2_ASSESSOR_USER'
+        name:
+          type: string
+          example: 'Roger Smith'
+        email:
+          type: string
+          example: 'roger@external.example.com'
         origin:
           type: string
           example: 'NACRO'
       required:
         - id
         - username
+        - name
+        - email
     NomisUser:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2872,12 +2872,20 @@ components:
         username:
           type: string
           example: 'CAS2_ASSESSOR_USER'
+        name:
+          type: string
+          example: 'Roger Smith'
+        email:
+          type: string
+          example: 'roger@external.example.com'
         origin:
           type: string
           example: 'NACRO'
       required:
         - id
         - username
+        - name
+        - email
     NomisUser:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserDetailsFactory.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.manageusers.ExternalUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ExternalUserDetailsFactory : Factory<ExternalUserDetails> {
+  private var username: Yielded<String> = { randomStringUpperCase(8) }
+  private var userId: Yielded<UUID> = { UUID.randomUUID() }
+  private var firstName: Yielded<String> = { randomStringUpperCase(8) }
+  private var lastName: Yielded<String> = { randomStringUpperCase(8) }
+  private var email: Yielded<String> = { randomEmailAddress() }
+  private var authSource: Yielded<String> = { "auth" }
+  private var enabled: Yielded<Boolean> = { true }
+  private var locked: Yielded<Boolean> = { false }
+  private var verified: Yielded<Boolean> = { true }
+  private var lastLoggedIn: Yielded<LocalDateTime?> = { null }
+  private var inactiveReason: Yielded<String?> = { null }
+
+  fun withUsername(username: String) = apply {
+    this.username = { username }
+  }
+
+  fun withFirstName(firstName: String) = apply {
+    this.firstName = { firstName }
+  }
+
+  fun withLastName(lastName: String) = apply {
+    this.lastName = { lastName }
+  }
+
+  fun withEmail(email: String) = apply {
+    this.email = { email }
+  }
+
+  override fun produce(): ExternalUserDetails = ExternalUserDetails(
+    username = this.username(),
+    userId = this.userId(),
+    firstName = this.firstName(),
+    lastName = this.lastName(),
+    email = this.email(),
+    authSource = this.authSource(),
+    enabled = this.enabled(),
+    locked = this.locked(),
+    verified = this.verified(),
+    lastLoggedIn = this.lastLoggedIn(),
+    inactiveReason = this.inactiveReason(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserEntityFactory.kt
@@ -11,6 +11,8 @@ class ExternalUserEntityFactory : Factory<ExternalUserEntity> {
   private var username: Yielded<String> = { randomStringUpperCase(12) }
   private var isEnabled: Yielded<Boolean> = { true }
   private var origin: Yielded<String> = { "NACRO" }
+  private var name: Yielded<String> = { "John Smith" }
+  private var email: Yielded<String> = { "john@external.example.com" }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -25,5 +27,7 @@ class ExternalUserEntityFactory : Factory<ExternalUserEntity> {
     username = this.username(),
     isEnabled = this.isEnabled(),
     origin = this.origin(),
+    name = this.name(),
+    email = this.email(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/ManageUsersAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/ManageUsersAPI.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.manageusers.ExternalUserDetails
+
+fun IntegrationTestBase.ManageUsers_mockSuccessfulExternalUsersCall(
+  username: String,
+  externalUserDetails: ExternalUserDetails,
+) =
+  wiremockServer.stubFor(
+    WireMock.get(urlEqualTo("/externalusers/$username"))
+      .willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200)
+          .withBody(
+            objectMapper.writeValueAsString(externalUserDetails),
+          ),
+      ),
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ExternalUserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ExternalUserServiceTest.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.jwt.Jwt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ManageUsersApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
+
+class ExternalUserServiceTest {
+  private val mockHttpAuthService = mockk<HttpAuthService>()
+  private val mockUserRepository = mockk<ExternalUserRepository>()
+  private val mockManageUsersApiClient = mockk<ManageUsersApiClient>()
+
+  private val userService = ExternalUserService(
+    mockHttpAuthService,
+    mockUserRepository,
+    mockManageUsersApiClient,
+  )
+
+  @Nested
+  inner class GetUserForRequest {
+    @Test
+    fun `returns existing User when exists, does not call Manage-Users API or save`
+    () {
+      val username = "JIM_JIMMERSON"
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+      val mockToken = mockk<Jwt>()
+
+      every { mockPrincipal.token } returns mockToken
+      every { mockToken.tokenValue } returns "JWT"
+
+      every { mockHttpAuthService.getCas2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+      every { mockPrincipal.name } returns username
+
+      val user = ExternalUserEntityFactory().produce()
+
+      every { mockUserRepository.findByUsername(username) } returns user
+
+      assertThat(userService.getUserForRequest()).isEqualTo(user)
+
+      verify(exactly = 0) { mockManageUsersApiClient.getExternalUserDetails(username, "JWT") }
+      verify(exactly = 0) { mockUserRepository.save(any()) }
+    }
+
+    @Test
+    fun `returns new User when one does not already exist, does call Manage-Users API and save`() {
+      val username = "JIM_JIMMERSON"
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+      val mockToken = mockk<Jwt>()
+
+      every { mockPrincipal.token } returns mockToken
+      every { mockToken.tokenValue } returns "JWT"
+
+      every { mockHttpAuthService.getCas2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+      every { mockPrincipal.name } returns username
+
+      every { mockUserRepository.findByUsername(username) } returns null
+      every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as ExternalUserEntity }
+
+      every { mockManageUsersApiClient.getExternalUserDetails(username, "JWT") } returns ClientResult.Success(
+        HttpStatus.OK,
+        ExternalUserDetailsFactory()
+          .withUsername(username)
+          .withFirstName("Jim")
+          .withLastName("Jimmerson")
+          .withEmail("jim@external.example.com")
+          .produce(),
+      )
+
+      assertThat(userService.getUserForRequest()).matches {
+        it.name == "Jim Jimmerson"
+        it.email == "jim@external.example.com"
+        it.username == "JIM_JIMMERSON"
+        it.origin == "NACRO"
+      }
+
+      verify(exactly = 1) { mockManageUsersApiClient.getExternalUserDetails(username, "JWT") }
+      verify(exactly = 1) { mockUserRepository.save(any()) }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ExternalUserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ExternalUserTransformerTest.kt
@@ -17,6 +17,8 @@ class ExternalUserTransformerTest {
       id = jpaEntity.id,
       username = jpaEntity.username,
       origin = jpaEntity.origin,
+      name = jpaEntity.name,
+      email = jpaEntity.email,
     )
 
     val transformation = externalUserTransformer.transformJpaToApi(jpaEntity)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -72,6 +72,8 @@ services:
     base-url: http://localhost:#WIREMOCK_PORT
   nomis-user-roles-api:
     base-url: http://localhost:#WIREMOCK_PORT
+  manage-users-api:
+    base-url: http://localhost:#WIREMOCK_PORT
   case-notes:
     base-url: http://localhost:#WIREMOCK_PORT
   ap-delius-context-api:


### PR DESCRIPTION
See [Trello 633](https://trello.com/c/ojaf1IBa/633-add-name-and-email-address-to-external-users)

Note that to run locally [AP-Tools now provides HMPPS Manage-Users API on port 9560](https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/52)

### Add name and email address to `ExternalUser`

The representation of an `ExternalUser` which is used in `Cas2StatusUpdate.updatedBy` needs to have more information than we were initially extracting from the logged in user's JWT.

Our `ExternalUserService` now connects to the HMPPS-Manage-Users' `/externalusers/{username}` endpoint and we add `name` and `email` properties to:

- the record which we persist in the `external_users table` and also to 
- the JSON representation which we provide to the UI.

![extended_external_user](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/60634b18-8db4-4d54-b541-6fa5aea9fa2f)
