### PR TITLE
[1702]- Premises summary include local authority name for CAS3 temporary accommodation premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -31,16 +31,17 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
   @Query(
     """
         SELECT
-          new uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesSummary(p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, pdu.name, p.status, CAST(COUNT(b) as int))
+          new uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesSummary(p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, pdu.name, p.status, CAST(COUNT(b) as int), la.name)
         FROM
           TemporaryAccommodationPremisesEntity p
           LEFT JOIN p.rooms r 
           LEFT JOIN r.beds b
           LEFT JOIN p.probationRegion pr
           LEFT JOIN p.probationDeliveryUnit pdu
+          LEFT JOIN p.localAuthorityArea la
         WHERE 
           pr.id = :regionId
-        GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, pdu.name, p.status
+        GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, pdu.name, p.status, la.name
       """,
   )
   fun findAllTemporaryAccommodationSummary(regionId: UUID): List<TemporaryAccommodationPremisesSummary>
@@ -258,6 +259,7 @@ data class TemporaryAccommodationPremisesSummary(
   val pdu: String,
   val status: PropertyStatus,
   val bedCount: Int,
+  val localAuthorityAreaName: String?,
 )
 
 interface BookingSummary {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesSummaryTransformer.kt
@@ -19,6 +19,7 @@ class PremisesSummaryTransformer() {
     bedCount = domain.bedCount,
     pdu = domain.pdu,
     service = "CAS3",
+    localAuthorityAreaName = domain.localAuthorityAreaName,
   )
 
   fun transformDomainToApi(domain: DomainApprovedPremisesSummary): ApiPremisesSummary = ApprovedPremisesSummary(

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -176,6 +176,8 @@ components:
           properties:
             pdu:
               type: string
+            localAuthorityAreaName:
+              type: string
       required:
         - pdu
     NewPremises:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4324,6 +4324,8 @@ components:
           properties:
             pdu:
               type: string
+            localAuthorityAreaName:
+              type: string
       required:
         - pdu
     NewPremises:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -571,6 +571,8 @@ components:
           properties:
             pdu:
               type: string
+            localAuthorityAreaName:
+              type: string
       required:
         - pdu
     NewPremises:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -64,6 +64,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
         .jsonPath("$[0].postcode").isEqualTo("NW1 6XE")
         .jsonPath("$[0].status").isEqualTo("active")
         .jsonPath("$[0].pdu").isEqualTo(expectedCas3Premises.probationDeliveryUnit!!.name)
+        .jsonPath("$[0].localAuthorityAreaName").isEqualTo(expectedCas3Premises.localAuthorityArea!!.name)
         .jsonPath("$[0].bedCount").isEqualTo(5)
         .jsonPath("$.length()").isEqualTo(1)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
@@ -25,6 +25,7 @@ class PremisesSummaryTransformerTest {
       pdu = "North east",
       status = PropertyStatus.active,
       bedCount = 1,
+      localAuthorityAreaName = "Rochford",
     )
 
     val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
@@ -40,6 +41,7 @@ class PremisesSummaryTransformerTest {
         status = PropertyStatus.active,
         bedCount = 1,
         service = "CAS3",
+        localAuthorityAreaName = "Rochford",
       ),
     )
   }
@@ -71,6 +73,39 @@ class PremisesSummaryTransformerTest {
         bedCount = 1,
         apCode = "APCODE",
         service = "CAS1",
+      ),
+    )
+  }
+
+  @Test
+  fun `transformDomainToApi transforms the DomainTemporaryAccommodationPremisesSummary into a TemporaryAccommodationPremisesSummary without optional elements`() {
+    val uuid = UUID.randomUUID()
+    val domainPremisesSummary = DomainTemporaryAccommodationPremisesSummary(
+      id = uuid,
+      name = "bob",
+      addressLine1 = "address",
+      addressLine2 = null,
+      postcode = "123ABC",
+      pdu = "North east",
+      status = PropertyStatus.active,
+      bedCount = 1,
+      localAuthorityAreaName = null,
+    )
+
+    val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
+
+    assertThat(result).isEqualTo(
+      TemporaryAccommodationPremisesSummary(
+        id = uuid,
+        name = "bob",
+        addressLine1 = "address",
+        addressLine2 = null,
+        postcode = "123ABC",
+        pdu = "North east",
+        status = PropertyStatus.active,
+        bedCount = 1,
+        service = "CAS3",
+        localAuthorityAreaName = null,
       ),
     )
   }


### PR DESCRIPTION
# Changes in this PR
Refer [1702](https://trello.com/c/CxWyysoq/1702-premises-list-includes-local-authority-for-gm) for more information.

This change is to return optional 'localAuthorityAreaName' in API 'premises/summary' endpoint for temporary accommodation premises only.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.