### PR TITLE
(APS-41) Placement with a cancelled booking can be rebooked

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -175,6 +175,9 @@ data class BookingEntity(
   val turnaround: TurnaroundEntity?
     get() = turnarounds.maxByOrNull { it.createdAt }
 
+  val isCancelled: Boolean
+    get() = cancellation != null
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is BookingEntity) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -154,7 +154,9 @@ class BookingService(
         return@validated generalError("placementRequestIsWithdrawn")
       }
 
-      if (placementRequest.booking != null) {
+      val existingBooking = placementRequest.booking
+
+      if (existingBooking != null && !existingBooking.isCancelled) {
         return@validated placementRequest.booking!!.id hasConflictError "A Booking has already been made for this Placement Request"
       }
 


### PR DESCRIPTION
This adds a `isCancelled` helper to a booking to check if a booking is cancelled, we can then use it to add to the
`createApprovedPremisesBookingFromPlacementRequest` validations to allow placement requests with cancelled bookings to have a new booking applied to them.

I’ve also DRYed up the expectations in the unit tests a little bit. There’s still a bit too much repetition in the setup stage than I’d like, but it’s a bit better than it was.