### PR TITLE
[1635]- CAS3 booking arrival date change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -455,7 +455,7 @@ class PremisesController(
         throwIfBookingDatesConflict(body.arrivalDate, body.expectedDepartureDate, bookingId, bedId)
         throwIfLostBedDatesConflict(body.arrivalDate, body.expectedDepartureDate, null, bedId)
 
-        bookingService.createArrival(
+        bookingService.createCas3Arrival(
           booking = booking,
           arrivalDate = body.arrivalDate,
           expectedDepartureDate = body.expectedDepartureDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
-import javax.persistence.OneToOne
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
@@ -26,7 +26,7 @@ data class ArrivalEntity(
   val expectedDepartureDate: LocalDate,
   val notes: String?,
   val createdAt: OffsetDateTime,
-  @OneToOne
+  @ManyToOne
   @JoinColumn(name = "booking_id")
   var booking: BookingEntity,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -130,8 +130,8 @@ data class BookingEntity(
   var arrivalDate: LocalDate,
   var departureDate: LocalDate,
   var keyWorkerStaffCode: String?,
-  @OneToOne(mappedBy = "booking")
-  var arrival: ArrivalEntity?,
+  @OneToMany(mappedBy = "booking")
+  var arrivals: MutableList<ArrivalEntity>,
   @OneToMany(mappedBy = "booking")
   var departures: MutableList<DepartureEntity>,
   @OneToOne(mappedBy = "booking")
@@ -178,6 +178,9 @@ data class BookingEntity(
   val isCancelled: Boolean
     get() = cancellation != null
 
+  val arrival: ArrivalEntity?
+    get() = arrivals.maxByOrNull { it.createdAt }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is BookingEntity) return false
@@ -187,7 +190,6 @@ data class BookingEntity(
     if (arrivalDate != other.arrivalDate) return false
     if (departureDate != other.departureDate) return false
     if (keyWorkerStaffCode != other.keyWorkerStaffCode) return false
-    if (arrival != other.arrival) return false
     if (nonArrival != other.nonArrival) return false
     if (confirmation != other.confirmation) return false
     if (originalArrivalDate != other.originalArrivalDate) return false
@@ -197,7 +199,7 @@ data class BookingEntity(
     return true
   }
 
-  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, arrival, nonArrival, confirmation, originalArrivalDate, originalDepartureDate, createdAt)
+  override fun hashCode() = Objects.hash(crn, arrivalDate, departureDate, keyWorkerStaffCode, nonArrival, confirmation, originalArrivalDate, originalDepartureDate, createdAt)
 
   override fun toString() = "BookingEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -896,6 +896,10 @@ class BookingService(
     notes: String?,
     keyWorkerStaffCode: String?,
   ) = validated<ArrivalEntity> {
+    if (booking.premises is TemporaryAccommodationPremisesEntity) {
+      return generalError("CAS3 booking arrival not supported here, preferred method is createCas3Arrival")
+    }
+
     if (booking.arrival != null) {
       return generalError("This Booking already has an Arrival set")
     }
@@ -939,7 +943,7 @@ class BookingService(
     keyWorkerStaffCode: String?,
   ) = validated<ArrivalEntity> {
     if (booking.premises !is TemporaryAccommodationPremisesEntity) {
-      return generalError("CAS3 Arrivals cannot be set on non-temporary accommodation premises")
+      return generalError("CAS3 Arrivals cannot be set on non-CAS3 premise")
     }
 
     if (expectedDepartureDate.isBefore(arrivalDate)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -208,7 +208,7 @@ class BookingService(
           arrivalDate = arrivalDate,
           departureDate = departureDate,
           keyWorkerStaffCode = null,
-          arrival = null,
+          arrivals = mutableListOf(),
           departures = mutableListOf(),
           nonArrival = null,
           cancellations = mutableListOf(),
@@ -361,7 +361,7 @@ class BookingService(
           arrivalDate = arrivalDate,
           departureDate = departureDate,
           keyWorkerStaffCode = null,
-          arrival = null,
+          arrivals = mutableListOf(),
           departures = mutableListOf(),
           nonArrival = null,
           cancellations = mutableListOf(),
@@ -694,7 +694,7 @@ class BookingService(
           arrivalDate = arrivalDate,
           departureDate = departureDate,
           keyWorkerStaffCode = null,
-          arrival = null,
+          arrivals = mutableListOf(),
           departures = mutableListOf(),
           nonArrival = null,
           cancellations = mutableListOf(),
@@ -920,7 +920,7 @@ class BookingService(
     booking.departureDate = expectedDepartureDate
     updateBooking(booking)
 
-    booking.arrival = arrivalEntity
+    booking.arrivals += arrivalEntity
 
     if (booking.premises is TemporaryAccommodationPremisesEntity) {
       cas3DomainEventService.savePersonArrivedEvent(booking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -34,7 +34,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var originalArrivalDate: Yielded<LocalDate>? = null
   private var originalDepartureDate: Yielded<LocalDate>? = null
   private var keyWorkerStaffCode: Yielded<String?> = { null }
-  private var arrival: Yielded<ArrivalEntity>? = null
+  private var arrivals: Yielded<MutableList<ArrivalEntity>>? = null
   private var departures: Yielded<MutableList<DepartureEntity>>? = null
   private var nonArrival: Yielded<NonArrivalEntity>? = null
   private var cancellations: Yielded<MutableList<CancellationEntity>>? = null
@@ -79,12 +79,12 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.keyWorkerStaffCode = { staffKeyWorkerCode }
   }
 
-  fun withYieldedArrival(arrival: Yielded<ArrivalEntity>) = apply {
-    this.arrival = arrival
+  fun withYieldedArrivals(arrivals: Yielded<MutableList<ArrivalEntity>>) = apply {
+    this.arrivals = arrivals
   }
 
-  fun withArrival(arrival: ArrivalEntity) = apply {
-    this.arrival = { arrival }
+  fun withArrivals(arrivals: MutableList<ArrivalEntity>) = apply {
+    this.arrivals = { arrivals }
   }
 
   fun withYieldedDepartures(departures: Yielded<MutableList<DepartureEntity>>) = apply {
@@ -185,7 +185,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
     arrivalDate = this.arrivalDate(),
     departureDate = this.departureDate(),
     keyWorkerStaffCode = this.keyWorkerStaffCode(),
-    arrival = this.arrival?.invoke(),
+    arrivals = this.arrivals?.invoke() ?: mutableListOf(),
     departures = this.departures?.invoke() ?: mutableListOf(),
     nonArrival = this.nonArrival?.invoke(),
     cancellations = this.cancellations?.invoke() ?: mutableListOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -164,7 +164,7 @@ class BookingSearchTest : IntegrationTestBase() {
                 withBooking(booking)
               }
 
-              booking.arrival = arrival
+              booking.arrivals.add(arrival)
             }
             // Closed
             3 -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -335,9 +335,9 @@ class BookingTest : IntegrationTestBase() {
           withCrn(offenderDetails.otherIds.crn)
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)
@@ -489,9 +489,9 @@ class BookingTest : IntegrationTestBase() {
           withCrn(offenderDetails.otherIds.crn)
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -119,9 +119,9 @@ class ReportsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.of(2023, 4, 7))
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)
@@ -199,9 +199,9 @@ class ReportsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.of(2023, 4, 7))
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)
@@ -279,9 +279,9 @@ class ReportsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.of(2023, 4, 7))
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)
@@ -478,9 +478,9 @@ class ReportsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.of(2023, 4, 7))
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)
@@ -572,9 +572,9 @@ class ReportsTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.of(2023, 4, 7))
         }
 
-        bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
+        bookings[1].let { it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList() }
         bookings[2].let {
-          it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+          it.arrivals = arrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
           it.departures = departureEntityFactory.produceAndPersistMultiple(1) {
             withBooking(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -289,7 +289,7 @@ class BedUtilisationReportGeneratorTest {
       .withDepartureDate(LocalDate.parse("2023-04-04"))
       .produce()
       .apply {
-        arrival = ArrivalEntityFactory()
+        arrivals += ArrivalEntityFactory()
           .withBooking(this)
           .produce()
       }
@@ -301,7 +301,7 @@ class BedUtilisationReportGeneratorTest {
       .withDepartureDate(LocalDate.parse("2023-05-04"))
       .produce()
       .apply {
-        arrival = ArrivalEntityFactory()
+        arrivals += ArrivalEntityFactory()
           .withBooking(this)
           .produce()
       }
@@ -636,7 +636,7 @@ class BedUtilisationReportGeneratorTest {
           .withBooking(this)
           .withWorkingDayCount(5)
           .produce()
-        arrival = ArrivalEntityFactory()
+        arrivals += ArrivalEntityFactory()
           .withBooking(this)
           .withArrivalDate(LocalDate.parse("2023-03-28"))
           .produce()
@@ -668,7 +668,7 @@ class BedUtilisationReportGeneratorTest {
           .withBooking(this)
           .withWorkingDayCount(4)
           .produce()
-        arrival = ArrivalEntityFactory()
+        arrivals += ArrivalEntityFactory()
           .withBooking(this)
           .withArrivalDate(LocalDate.parse("2023-04-25"))
           .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -223,7 +223,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    booking.arrival = ArrivalEntityFactory()
+    booking.arrivals += ArrivalEntityFactory()
       .withArrivalDate(today)
       .withExpectedDepartureDate(today.plusDays(84L))
       .withBooking(booking)
@@ -354,7 +354,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    booking.arrival = ArrivalEntityFactory()
+    booking.arrivals += ArrivalEntityFactory()
       .withArrivalDate(arrivalDate)
       .withExpectedDepartureDate(arrivalDate.plusDays(84L))
       .withBooking(booking)
@@ -413,7 +413,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    booking.arrival = ArrivalEntityFactory()
+    booking.arrivals += ArrivalEntityFactory()
       .withArrivalDate(arrivalDate)
       .withExpectedDepartureDate(expectedDepartureDate)
       .withBooking(booking)
@@ -467,7 +467,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    booking.arrival = ArrivalEntityFactory()
+    booking.arrivals += ArrivalEntityFactory()
       .withArrivalDate(arrivalDate)
       .withExpectedDepartureDate(expectedDepartureDate)
       .withBooking(booking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1013,7 +1013,7 @@ class BookingServiceTest {
         .withBooking(bookingEntity)
         .produce()
 
-      bookingEntity.arrival = arrivalEntity
+      bookingEntity.arrivals += arrivalEntity
 
       val result = bookingService.createArrival(
         booking = bookingEntity,
@@ -1171,7 +1171,7 @@ class BookingServiceTest {
         .withBooking(bookingEntity)
         .produce()
 
-      bookingEntity.arrival = arrivalEntity
+      bookingEntity.arrivals += arrivalEntity
 
       val result = bookingService.createCas1Arrival(
         booking = bookingEntity,
@@ -4980,7 +4980,7 @@ class BookingServiceTest {
         .withDepartureDate(LocalDate.parse("2023-07-16"))
         .produce()
         .apply {
-          arrival = ArrivalEntityFactory()
+          arrivals += ArrivalEntityFactory()
             .withBooking(this)
             .produce()
         }
@@ -5009,7 +5009,7 @@ class BookingServiceTest {
         .withDepartureDate(LocalDate.parse("2023-07-16"))
         .produce()
         .apply {
-          arrival = ArrivalEntityFactory()
+          arrivals += ArrivalEntityFactory()
             .withBooking(this)
             .produce()
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1470,6 +1470,161 @@ class BookingServiceTest {
   }
 
   @Nested
+  inner class CreateCas3Arrival {
+    private val bookingEntity = createTemporaryAccommdationBooking()
+
+    @BeforeEach
+    fun setup() {
+      every { mockArrivalRepository.save(any()) } answers { it.invocation.args[0] as ArrivalEntity }
+      every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
+      every { mockCas3DomainEventService.savePersonArrivedEvent(any()) } just Runs
+    }
+
+    @Test
+    fun `createCas3Arrival should throw GeneralValidationError when premises is not temporary accommodation`() {
+      val keyWorker = ContextStaffMemberFactory().produce()
+      val approvedPremisesBooking = createApprovedPremisesBooking(createApprovedPremises(), keyWorker)
+
+      val result = bookingService.createCas3Arrival(
+        booking = approvedPremisesBooking,
+        arrivalDate = LocalDate.parse("2022-08-25"),
+        expectedDepartureDate = LocalDate.parse("2022-08-26"),
+        notes = "notes",
+        keyWorkerStaffCode = "158",
+        user = UserEntityFactory()
+          .withUnitTestControlProbationRegion()
+          .produce(),
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
+      assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("CAS3 Arrivals cannot be set on non-temporary accommodation premises")
+      verify(exactly = 0) { mockArrivalRepository.save(any()) }
+      verify(exactly = 0) { mockBookingRepository.save(any()) }
+      verify(exactly = 0) { mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity) }
+    }
+
+    @Test
+    fun `createArrival returns FieldValidationError with correct param to message map when invalid parameters supplied`() {
+      val result = bookingService.createCas3Arrival(
+        booking = bookingEntity,
+        arrivalDate = LocalDate.parse("2022-08-27"),
+        expectedDepartureDate = LocalDate.parse("2022-08-26"),
+        notes = "notes",
+        keyWorkerStaffCode = null,
+        user = UserEntityFactory()
+          .withUnitTestControlProbationRegion()
+          .produce(),
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+        entry("$.expectedDepartureDate", "beforeBookingArrivalDate"),
+      )
+      verify(exactly = 0) { mockArrivalRepository.save(any()) }
+      verify(exactly = 0) { mockBookingRepository.save(any()) }
+      verify(exactly = 0) { mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity) }
+    }
+
+    @Test
+    fun `createArrival should not returns GeneralValidationError when Booking already has an Arrival and doesnt save domain event`() {
+      val arrivalEntity = ArrivalEntityFactory()
+        .withBooking(bookingEntity)
+        .produce()
+      bookingEntity.arrivals += arrivalEntity
+
+      val result = bookingService.createCas3Arrival(
+        booking = bookingEntity,
+        arrivalDate = LocalDate.parse("2022-08-25"),
+        expectedDepartureDate = LocalDate.parse("2022-08-26"),
+        notes = "notes",
+        keyWorkerStaffCode = null,
+        user = UserEntityFactory()
+          .withUnitTestControlProbationRegion()
+          .produce(),
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+      result as ValidatableActionResult.Success
+      assertThat(result.entity.arrivalDate).isEqualTo(LocalDate.parse("2022-08-25"))
+      assertThat(result.entity.arrivalDateTime).isEqualTo(Instant.parse("2022-08-25T00:00:00Z"))
+      assertThat(result.entity.expectedDepartureDate).isEqualTo(LocalDate.parse("2022-08-26"))
+      assertThat(result.entity.notes).isEqualTo("notes")
+
+      verify(exactly = 1) { mockArrivalRepository.save(any()) }
+      verify(exactly = 1) { mockBookingRepository.save(any()) }
+      verify(exactly = 0) {
+        mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity)
+      }
+    }
+
+    @Test
+    fun `createArrival returns Success with correct result for CAS3 when validation passed and saves domain event`() {
+      val result = bookingService.createCas3Arrival(
+        booking = bookingEntity,
+        arrivalDate = LocalDate.parse("2022-08-27"),
+        expectedDepartureDate = LocalDate.parse("2022-08-29"),
+        notes = "notes",
+        keyWorkerStaffCode = null,
+        user = UserEntityFactory()
+          .withUnitTestControlProbationRegion()
+          .produce(),
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+      result as ValidatableActionResult.Success
+      assertThat(result.entity.arrivalDate).isEqualTo(LocalDate.parse("2022-08-27"))
+      assertThat(result.entity.arrivalDateTime).isEqualTo(Instant.parse("2022-08-27T00:00:00Z"))
+      assertThat(result.entity.expectedDepartureDate).isEqualTo(LocalDate.parse("2022-08-29"))
+      assertThat(result.entity.notes).isEqualTo("notes")
+
+      verify(exactly = 1) { mockArrivalRepository.save(any()) }
+      verify(exactly = 1) { mockBookingRepository.save(any()) }
+      verify(exactly = 1) { mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity) }
+    }
+
+    private fun createTemporaryAccommdationBooking() = BookingEntityFactory()
+      .withYieldedPremises {
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+          .produce()
+      }
+      .withStaffKeyWorkerCode(null)
+      .produce()
+
+    private fun createApprovedPremisesBooking(
+      premises: ApprovedPremisesEntity,
+      keyWorker: uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember,
+    ) = BookingEntityFactory()
+      .withPremises(premises)
+      .withStaffKeyWorkerCode(keyWorker.code)
+      .withApplication(
+        ApprovedPremisesApplicationEntityFactory()
+          .withSubmittedAt(OffsetDateTime.parse("2023-02-15T15:00:00Z"))
+          .withCreatedByUser(
+            UserEntityFactory()
+              .withUnitTestControlProbationRegion()
+              .produce(),
+          )
+          .produce(),
+      )
+      .produce()
+
+    private fun createApprovedPremises() = ApprovedPremisesEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+  }
+
+  @Nested
   inner class CreateNonArrival {
     val premises = ApprovedPremisesEntityFactory()
       .withYieldedProbationRegion {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1065,7 +1065,7 @@ class BookingServiceTest {
     }
 
     @Test
-    fun `createArrival returns Success with correct result for CAS3 when validation passed and saves domain event`() {
+    fun `createArrival returns GeneralValidationError with correct message when Booking is CAS3 `() {
       val bookingEntity = BookingEntityFactory()
         .withYieldedPremises {
           TemporaryAccommodationPremisesEntityFactory()
@@ -1095,16 +1095,10 @@ class BookingServiceTest {
           .produce(),
       )
 
-      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
-      result as ValidatableActionResult.Success
-      assertThat(result.entity.arrivalDate).isEqualTo(LocalDate.parse("2022-08-27"))
-      assertThat(result.entity.arrivalDateTime).isEqualTo(Instant.parse("2022-08-27T00:00:00Z"))
-      assertThat(result.entity.expectedDepartureDate).isEqualTo(LocalDate.parse("2022-08-29"))
-      assertThat(result.entity.notes).isEqualTo("notes")
-
+      assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
+      assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("CAS3 booking arrival not supported here, preferred method is createCas3Arrival")
       verify(exactly = 0) { mockStaffMemberService.getStaffMemberByCode(any(), any()) }
-
-      verify(exactly = 1) {
+      verify(exactly = 0) {
         mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity)
       }
     }
@@ -1497,7 +1491,7 @@ class BookingServiceTest {
       )
 
       assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
-      assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("CAS3 Arrivals cannot be set on non-temporary accommodation premises")
+      assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("CAS3 Arrivals cannot be set on non-CAS3 premise")
       verify(exactly = 0) { mockArrivalRepository.save(any()) }
       verify(exactly = 0) { mockBookingRepository.save(any()) }
       verify(exactly = 0) { mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -157,7 +157,7 @@ class PremisesServiceTest {
       .withBooking(arrivedBookingEntity)
       .produce()
 
-    arrivedBookingEntity.arrival = arrivalEntity
+    arrivedBookingEntity.arrivals += arrivalEntity
 
     val nonArrivedBookingEntity = BookingEntityFactory()
       .withPremises(premises)
@@ -306,7 +306,7 @@ class PremisesServiceTest {
       .withBooking(arrivedBookingEntity)
       .produce()
 
-    arrivedBookingEntity.arrival = arrivalEntity
+    arrivedBookingEntity.arrivals += arrivalEntity
 
     val nonArrivedBookingEntity = BookingEntityFactory()
       .withPremises(premises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
@@ -230,7 +230,7 @@ class DomainEventBuilderTest {
       .withApplication(application)
       .produce()
 
-    booking.arrival = ArrivalEntityFactory()
+    booking.arrivals += ArrivalEntityFactory()
       .withBooking(booking)
       .withArrivalDateTime(arrivalDateTime)
       .withExpectedDepartureDate(expectedDepartureDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSummaryTransformerTest.kt
@@ -27,7 +27,7 @@ class BookingSummaryTransformerTest {
       departureDate = LocalDate.parse("2022-08-30"),
       keyWorkerStaffCode = "789",
       crn = "CRN123",
-      arrival = null,
+      arrivals = mutableListOf(),
       departures = mutableListOf(),
       nonArrival = null,
       cancellations = mutableListOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -142,7 +142,7 @@ class BookingTransformerTest {
     departureDate = LocalDate.parse("2022-08-30"),
     keyWorkerStaffCode = "789",
     crn = "CRN123",
-    arrival = null,
+    arrivals = mutableListOf(),
     departures = mutableListOf(),
     nonArrival = null,
     cancellations = mutableListOf(),
@@ -455,7 +455,7 @@ class BookingTransformerTest {
   @Test
   fun `Approved Premises Arrived entity is correctly transformed`() {
     val arrivalBooking = baseBookingEntity.copy(id = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3")).apply {
-      arrival = ArrivalEntity(
+      arrivals += ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -722,7 +722,7 @@ class BookingTransformerTest {
   fun `Approved Premises Departed entity is correctly transformed`() {
     val bookingId = UUID.fromString("e0a3f9d7-0677-40bf-85a9-6673a7af33ee")
     val departedBooking = baseBookingEntity.copy(id = bookingId).apply {
-      arrival = ArrivalEntity(
+      arrivals += ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -899,7 +899,7 @@ class BookingTransformerTest {
   fun `Temporary Accommodation entity with zero day turnaround period and departure is correctly transformed to closed status`() {
     val bookingId = UUID.fromString("e0a3f9d7-0677-40bf-85a9-6673a7af33ee")
     val departedBooking = baseBookingEntity.copy(id = bookingId, service = ServiceName.temporaryAccommodation.value).apply {
-      arrival = ArrivalEntity(
+      arrivals += ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -1113,7 +1113,7 @@ class BookingTransformerTest {
     val departedBooking = baseBookingEntity.copy(id = bookingId, service = ServiceName.temporaryAccommodation.value).apply {
       departureDate = departedAt.toLocalDate()
 
-      arrival = ArrivalEntity(
+      arrivals += ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -1331,7 +1331,7 @@ class BookingTransformerTest {
     val departedBooking = baseBookingEntity.copy(id = bookingId, service = ServiceName.temporaryAccommodation.value).apply {
       departureDate = departedAt.toLocalDate()
 
-      arrival = ArrivalEntity(
+      arrivals += ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -1540,7 +1540,7 @@ class BookingTransformerTest {
     val bookingId = UUID.fromString("e0a3f9d7-0677-40bf-85a9-6673a7af33ee")
     val departedBooking = baseBookingEntity.copy(id = bookingId).apply {
       service = ServiceName.temporaryAccommodation.value
-      arrival = ArrivalEntity(
+      arrivals += ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),


### PR DESCRIPTION
# Changes in this PR
Refer [1635](https://trello.com/c/D6yRwBAV/1635-users-can-change-a-bookings-arrival-date) for more information.

This PR contains changes to allow arrival date changes for CAS3 premises booking only. We leverage on existing API `/premises/{premisesId}/bookings/{bookingId}/arrivals` to achieve updating the arrival date for CAS3 booking.

So we changed the booking entity to refer list of arrivals instead of single arrival entity and the latest arrival record can be retrieved as well. The CAS1,CAS2 booking will have only 1 arrival entity, but CAS3 will have multiple arrival entity

Note: Existing CAS1,CAS2 booking continue to follow existing process of creating single arrival only.


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.