### PR TITLE
(APS-72) Add `sentenceType` to Domain Event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -950,6 +950,7 @@ class ApplicationService(
       mappa = mappaLevel,
       offenceId = application.offenceId,
       releaseType = submitApplication.releaseType.toString(),
+      sentenceType = submitApplication.sentenceType.toString(),
       age = Period.between(offenderDetails.dateOfBirth, LocalDate.now()).years,
       gender = when (offenderDetails.gender.lowercase()) {
         "male" -> ApplicationSubmitted.Gender.male

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -472,6 +472,9 @@ components:
         releaseType:
           type: string
           example: 'rotl'
+        sentenceType:
+          type: string
+          example: 'standardDeterminate'
         age:
           type: integer
           example: 43

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1237,6 +1237,7 @@ class ApplicationServiceTest {
             ) &&
               data.deliusEventNumber == application.eventNumber &&
               data.releaseType == submitApprovedPremisesApplication.releaseType.toString() &&
+              data.sentenceType == submitApprovedPremisesApplication.sentenceType.toString() &&
               data.age == Period.between(offenderDetails.dateOfBirth, LocalDate.now()).years &&
               data.gender == ApplicationSubmitted.Gender.male &&
               data.submittedBy == ApplicationSubmittedSubmittedBy(


### PR DESCRIPTION
This adds an application’s Sentence Type to the ApplicationSubmitted domain event, which will allow the calculation of the nDelius referral type.