### PR TITLE
Restore OAuth config for Nomis-User-Roles API client

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,11 @@ spring:
             client-id: approved-premises-api
             client-secret: clientsecret
             authorization-grant-type: client_credentials
+          nomis-user-roles-api:
+            provider: hmpps-auth
+            client-id: approved-premises-api
+            client-secret: clientsecret
+            authorization-grant-type: client_credentials
           probation-offender-search-api:
             provider: hmpps-auth
             client-id: approved-premises-api


### PR DESCRIPTION
It's not clear why Spring is throwing this error:

```
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException:
Error creating bean with name 'caseNotesWebClient' defined in class path resource
[uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.class]:
Unsatisfied dependency expressed through method 'caseNotesWebClient' parameter 0;
nested exception is org.springframework.beans.factory.BeanCreationException:
Error creating bean with name 'clientRegistrationRepository' defined in class path resource
[org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2ClientRegistrationRepositoryConfiguration.class]:
Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException:
Failed to instantiate [org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository]:
Factory method 'clientRegistrationRepository' threw exception;
nested exception is java.lang.IllegalStateException:
Provider ID must be specified for client registration 'nomis-user-roles-api'
```

From the [earlier ARN client code](https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/2b33cee325e646319015502183caca6a47773f27) it seemed like this is not needed.