### PR TITLE
Add PNC number to FullPerson

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -75,12 +75,11 @@ class PersonTransformer {
       crn = probationOffenderResult.probationOffenderDetail.otherIds.crn,
       name = "${probationOffenderResult.probationOffenderDetail.firstName} ${probationOffenderResult.probationOffenderDetail.surname}",
       dateOfBirth = probationOffenderResult.probationOffenderDetail.dateOfBirth!!,
-      sex = probationOffenderResult.probationOffenderDetail.gender ?: "Not Found",
+      sex = probationOffenderResult.probationOffenderDetail.gender ?: "Not found",
       status = inOutStatusToPersonInfoApiStatus(probationOffenderResult.inmateDetail?.inOutStatus),
       nomsNumber = probationOffenderResult.probationOffenderDetail.otherIds.nomsNumber,
-      nationality = probationOffenderResult.probationOffenderDetail.offenderProfile?.nationality
-        ?: "Not Found",
       pncNumber = probationOffenderResult.probationOffenderDetail.otherIds.pncNumber ?: "Not found",
+      nationality = probationOffenderResult.probationOffenderDetail.offenderProfile?.nationality ?: "Not found",
       prisonName = inOutStatusToPersonInfoApiStatus(probationOffenderResult.inmateDetail?.inOutStatus).takeIf { it == FullPerson.Status.inCustody }?.let {
         probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyName
           ?: probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -80,6 +80,7 @@ class PersonTransformer {
       nomsNumber = probationOffenderResult.probationOffenderDetail.otherIds.nomsNumber,
       nationality = probationOffenderResult.probationOffenderDetail.offenderProfile?.nationality
         ?: "Not Found",
+      pncNumber = probationOffenderResult.probationOffenderDetail.otherIds.pncNumber ?: "Not found",
       prisonName = inOutStatusToPersonInfoApiStatus(probationOffenderResult.inmateDetail?.inOutStatus).takeIf { it == FullPerson.Status.inCustody }?.let {
         probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyName
           ?: probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyId

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -669,6 +669,8 @@ components:
               format: date
             nomsNumber:
               type: string
+            pncNumber:
+              type: string
             ethnicity:
               type: string
             nationality:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4841,6 +4841,8 @@ components:
               format: date
             nomsNumber:
               type: string
+            pncNumber:
+              type: string
             ethnicity:
               type: string
             nationality:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1064,6 +1064,8 @@ components:
               format: date
             nomsNumber:
               type: string
+            pncNumber:
+              type: string
             ethnicity:
               type: string
             nationality:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
@@ -16,7 +16,7 @@ class ProbationOffenderDetailFactory : Factory<ProbationOffenderDetail> {
   private var firstName: Yielded<String> = { randomStringUpperCase(8) }
   private var surname: Yielded<String> = { randomStringUpperCase(8) }
   private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore() }
-  private var gender: Yielded<String> = { randomOf(listOf("Male", "Female", "Other")) }
+  private var gender: Yielded<String?> = { randomOf(listOf("Male", "Female", "Other")) }
   private var otherIds: Yielded<IDs> = { IDs(crn = "CRN") }
   private var offenderProfile: Yielded<OffenderProfile> = { OffenderProfile() }
   private var softDeleted: Yielded<Boolean?> = { false }
@@ -39,7 +39,7 @@ class ProbationOffenderDetailFactory : Factory<ProbationOffenderDetail> {
     this.dateOfBirth = { dateOfBirth }
   }
 
-  fun withGender(gender: String) = apply {
+  fun withGender(gender: String?) = apply {
     this.gender = { gender }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -89,7 +89,8 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
     @Test
     fun `Searching for a NOMIS ID returns OK with correct body`() {
       `Given a CAS2 User` { userEntity, jwt ->
-        val offender = ProbationOffenderDetailFactory().withOtherIds(IDs(crn = "CRN", nomsNumber = "NOMS321"))
+        val offender = ProbationOffenderDetailFactory()
+          .withOtherIds(IDs(crn = "CRN", nomsNumber = "NOMS321", pncNumber = "PNC123"))
           .withFirstName("James")
           .withSurname("Someone")
           .withDateOfBirth(
@@ -132,6 +133,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
                 sex = "Male",
                 status = FullPerson.Status.inCustody,
                 nomsNumber = "NOMS321",
+                pncNumber = "PNC123",
                 nationality = "English",
                 isRestricted = false,
                 prisonName = "HMP Bristol",


### PR DESCRIPTION
We need to display a person's PNC number to our CAS2 users.
We can get this when we search for an offender when we call `searchOffenderByNomsNumber` on the ProbationOffenderSearch. https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/61284aa89c71b09a6d095ebc6fe8b491c26dc3b3/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt#L39 

This PR adds the number as an optional field to the `FullPerson` model and the `PersonTransformer`.