### PR TITLE
[1710] - Return restricted person response when LAO call fails with runtime exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import io.sentry.Sentry
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -493,7 +494,8 @@ class OffenderService(
                   accessResponse.deserializeTo<UserOffenderAccess>()
                   return PersonInfoResult.Success.Restricted(crn, offender.otherIds.nomsNumber)
                 } catch (exception: Exception) {
-                  accessResponse.throwException()
+                  Sentry.captureException(RuntimeException("LAO calls returns but failed to marshal the response", exception))
+                  return PersonInfoResult.Success.Restricted(crn, offender.otherIds.nomsNumber)
                 }
               }
 


### PR DESCRIPTION
# Changes in this PR
Please refer [1710](https://trello.com/c/jvMr1obF/1710-listing-assessments-should-not-500-due-to-limited-access-to-any-one-of-the-referrals) for more information.

This PR to handle bug in offender service where runtime exception thrown when LAO API call failed with 403 without response body. 

Expected Result:
We should return Restricted Person response instead of throwing runtime exception. Additionally we will send the error to Sentry to report  the issue for further investigation.

Background:
We get forbidden exception when HPT shouldn’t have access to the personal details within the referral (AKA a limited access offender or an LAO), But for some reason LAO calls return 403 status with empty body which caused offenderService to throw runtime exception due response marshalling failure. 

Decision:
For CAS3, anyone within a regional HPT team will be loading all referrals assigned to that region - regardless which they intend to work on. So the referral can be a restricted access to HPT and this is an expected LAO scenario. So we expect it technically handle it safely. Hence we are fixing by returning Restricted person response instead of throwing runtimeException

Note: This fix is applied only in this instance of LAO calls, There may be similar calls in different places, which we should monitor and fix as needed in the future.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.