### PR TITLE
(APS 72) Add a job to update the sentence type/situation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateSentenceTypeAndSituationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateSentenceTypeAndSituationJob.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import java.util.UUID
+
+class UpdateSentenceTypeAndSituationJob(
+  private val applicationRepository: UpdateSentenceTypeAndSituationRepository,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = true
+
+  override fun process() {
+    val items = applicationRepository.getIdSentenceTypeAndSituationFromAllApplicationData()
+
+    items.forEach { item ->
+      log.info("Updating application ${item.getId()}")
+      applicationRepository.updateSentenceTypeAndSituation(
+        item.getId(),
+        item.getSentenceType(),
+        item.getSituation(),
+      )
+    }
+  }
+}
+
+@Repository
+interface UpdateSentenceTypeAndSituationRepository : JpaRepository<ApplicationEntity, UUID> {
+  @Query(
+    """
+      SELECT
+        CAST(a.id AS TEXT) as id,
+        a.data -> 'basic-information' -> 'sentence-type' ->> 'sentenceType' as sentenceType,
+        a.data -> 'basic-information' -> 'situation' ->> 'situation' as situation
+      FROM approved_premises_applications apa
+      LEFT JOIN applications a ON a.id = apa.id
+      WHERE a.service = 'approved-premises'
+    """,
+    nativeQuery = true,
+  )
+  fun getIdSentenceTypeAndSituationFromAllApplicationData(): List<ApplicationIdSentenceTypeAndSituation>
+
+  @Modifying
+  @Query("UPDATE ApprovedPremisesApplicationEntity ap set ap.sentenceType = :sentenceType, ap.situation = :situation WHERE ap.id = :applicationId")
+  fun updateSentenceTypeAndSituation(applicationId: UUID, sentenceType: String?, situation: String?)
+}
+
+interface ApplicationIdSentenceTypeAndSituation {
+  fun getId(): UUID
+
+  fun getSentenceType(): String?
+
+  fun getSituation(): String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import io.sentry.Sentry
+import org.springframework.beans.factory.getBean
 import org.springframework.context.ApplicationContext
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
@@ -10,6 +11,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepositor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationRepository
 
 @Service
 class MigrationJobService(
@@ -25,9 +28,12 @@ class MigrationJobService(
 
     try {
       val job: MigrationJob = when (migrationJobType) {
-        MigrationJobType.updateAllUsersFromCommunityApi -> UpdateAllUsersFromCommunityApiJob(
+        MigrationJobType.allUsersFromCommunityApi -> UpdateAllUsersFromCommunityApiJob(
           applicationContext.getBean(UserRepository::class.java),
           applicationContext.getBean(UserService::class.java),
+        )
+        MigrationJobType.sentenceTypeAndSituation -> UpdateSentenceTypeAndSituationJob(
+          applicationContext.getBean(UpdateSentenceTypeAndSituationRepository::class.java),
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3164,6 +3164,7 @@ components:
       type: string
       enum:
         - update_all_users_from_community_api
+        - update_sentence_type_and_situation
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7336,6 +7336,7 @@ components:
       type: string
       enum:
         - update_all_users_from_community_api
+        - update_sentence_type_and_situation
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3559,6 +3559,7 @@ components:
       type: string
       enum:
         - update_all_users_from_community_api
+        - update_sentence_type_and_situation
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
@@ -13,7 +13,7 @@ class MigrationJobScaffoldingTest : SeedTestBase() {
       .uri("/migration-job")
       .bodyValue(
         MigrationJobRequest(
-          jobType = MigrationJobType.updateAllUsersFromCommunityApi,
+          jobType = MigrationJobType.allUsersFromCommunityApi,
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateAllUsersFromCommunityApiMigrationTest.kt
@@ -42,7 +42,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
     )
 
     val startTime = System.currentTimeMillis()
-    migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.allUsersFromCommunityApi, 1)
     val endTime = System.currentTimeMillis()
 
     assertThat(endTime - startTime).isGreaterThan(500 * 2)
@@ -81,7 +81,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
         .produce(),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi)
+    migrationJobService.runMigrationJob(MigrationJobType.allUsersFromCommunityApi)
 
     val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
     val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateSentenceTypeAndSituationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateSentenceTypeAndSituationJobTest.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.fasterxml.jackson.core.type.TypeReference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+
+class UpdateSentenceTypeAndSituationJobTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @Autowired
+  lateinit var applicationRepository: ApplicationRepository
+
+  @Test
+  fun `all applications have the sentence type and situation updated`() {
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apAreaEntityFactory.produceAndPersist())
+    }
+
+    val user = userEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+    }
+
+    val applications = generateSequence {
+      approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withApplicationSchema(applicationSchema)
+        withCreatedByUser(user)
+        withData(
+          objectMapper.writeValueAsString(
+            mapOf(
+              "basic-information" to mapOf(
+                "sentence-type" to mapOf(
+                  "sentenceType" to randomStringLowerCase(10),
+                ),
+                "situation" to mapOf(
+                  "situation" to randomStringLowerCase(10),
+                ),
+              ),
+            ),
+          ),
+        )
+      }
+    }.take(50).toList()
+
+    migrationJobService.runMigrationJob(MigrationJobType.sentenceTypeAndSituation, 1)
+
+    applications.forEach {
+      val application = applicationRepository.findByIdOrNull(it.id)!! as ApprovedPremisesApplicationEntity
+      val data = objectMapper.readValue(application.data, object : TypeReference<Map<String, Map<String, Map<String, String>>>>() {})
+      assertThat(application.situation).isEqualTo(data["basic-information"]?.get("situation")?.get("situation")!!)
+      assertThat(application.sentenceType).isEqualTo(data["basic-information"]?.get("sentence-type")?.get("sentenceType")!!)
+    }
+  }
+}


### PR DESCRIPTION
This adds a new data migration job to backfill the sentence type and situation. To keep things contained I’ve created a new repository and put the helper classes in the job itself.

As we’re only fetching a small subset of data, we _should_ be able to get away without having to paginate through the results, but the proof of the pudding will be in the eating when we run it in preprod!