### PR TITLE
Fix for CAS2's search by NOMIS ID feature 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ContactDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ContactDetails.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi
+
+import java.time.LocalDate
+
+data class ContactDetails(
+  val phoneNumbers: List<PhoneNumber>? = null,
+  val emailAddresses: List<String>? = null,
+  val allowSMS: Boolean? = null,
+  val addresses: List<Address>? = null,
+)
+
+data class PhoneNumber(
+  val number: String? = null,
+  val type: PhoneTypes? = null,
+) {
+
+  enum class PhoneTypes {
+    TELEPHONE, MOBILE
+  }
+}
+
+data class Address(
+  val id: Long,
+  val from: LocalDate,
+  val to: LocalDate? = null,
+  val noFixedAbode: Boolean? = null,
+  val notes: String? = null,
+  val addressNumber: String? = null,
+  val buildingName: String? = null,
+  val streetName: String? = null,
+  val district: String? = null,
+  val town: String? = null,
+  val county: String? = null,
+  val postcode: String? = null,
+  val telephoneNumber: String? = null,
+  val status: KeyValue? = null,
+  val type: KeyValue? = null,
+)
+
+data class KeyValue(
+  val code: String? = null,
+  val description: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/IDs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/IDs.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi
+
+data class IDs(
+  val crn: String,
+  val pncNumber: String? = null,
+  val croNumber: String? = null,
+  val niNumber: String? = null,
+  val nomsNumber: String? = null,
+  val immigrationNumber: String? = null,
+  val mostRecentPrisonerNumber: String? = null,
+  val previousCrn: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/OffenderAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/OffenderAlias.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi
+
+import java.time.LocalDate
+
+data class OffenderAlias(
+  val id: String? = null,
+  val dateOfBirth: LocalDate? = null,
+  val firstName: String? = null,
+  val middleNames: List<String>? = null,
+  val surname: String? = null,
+  val gender: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderDetail.kt
@@ -39,10 +39,20 @@ data class IDs(
 )
 
 data class ContactDetails(
-  val phoneNumbers: List<String>? = null,
+  val phoneNumbers: List<PhoneNumber>? = null,
   val emailAddresses: List<String>? = null,
   val allowSMS: Boolean? = null,
 )
+
+data class PhoneNumber(
+  val number: String? = null,
+  val type: PhoneTypes? = null,
+) {
+
+  enum class PhoneTypes {
+    TELEPHONE, MOBILE
+  }
+}
 
 data class OffenderProfile(
   val ethnicity: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/probationoffendersearchapi/ProbationOffenderDetail.kt
@@ -21,38 +21,7 @@ data class ProbationOffenderDetail(
   val restrictionMessage: String? = null,
   val currentExclusion: Boolean? = null,
   val exclusionMessage: String? = null,
-  val highlight: Map<String, List<String>>? = null,
-  val accessDenied: Boolean? = null,
-  val currentTier: String? = null,
-  val activeProbationManagedSentence: Boolean? = null,
 )
-
-data class IDs(
-  val crn: String,
-  val pncNumber: String? = null,
-  val croNumber: String? = null,
-  val niNumber: String? = null,
-  val nomsNumber: String? = null,
-  val immigrationNumber: String? = null,
-  val mostRecentPrisonerNumber: String? = null,
-  val previousCrn: String? = null,
-)
-
-data class ContactDetails(
-  val phoneNumbers: List<PhoneNumber>? = null,
-  val emailAddresses: List<String>? = null,
-  val allowSMS: Boolean? = null,
-)
-
-data class PhoneNumber(
-  val number: String? = null,
-  val type: PhoneTypes? = null,
-) {
-
-  enum class PhoneTypes {
-    TELEPHONE, MOBILE
-  }
-}
 
 data class OffenderProfile(
   val ethnicity: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
@@ -78,9 +78,5 @@ class ProbationOffenderDetailFactory : Factory<ProbationOffenderDetail> {
     restrictionMessage = null,
     currentExclusion = this.currentExclusion(),
     exclusionMessage = null,
-    highlight = null,
-    accessDenied = null,
-    currentTier = null,
-    activeProbationManagedSentence = null,
   )
 }


### PR DESCRIPTION
Searches by NOMIS ID are failing in preprod, because the ContactDetails type on the ProbationOffenderSearch's OffenderDetail is expecting a list of strings when it should be a PhoneNumber type.

This change should fix this error in Sentry:
https://ministryofjustice.sentry.io/issues/4684242081/events/oldest/?project=4503931792392192&referrer=oldest-event

https://mojdt.slack.com/archives/CR5ESQ8T1/p1701357376640669?thread_ts=1701357217.778399&cid=CR5ESQ8T1  


