### PR TITLE
[APS-67] Introduce facade for offender details

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -65,6 +65,8 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
+    DATA-SOURCES_OFFENDER-DETAILS: community_api
+
   namespace_secrets:
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -58,6 +58,8 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
+    DATA-SOURCES_OFFENDER-DETAILS: community_api
+
   namespace_secrets:
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -69,6 +69,8 @@ generic-service:
     ARRIVED-DEPARTED-DOMAIN-EVENTS-DISABLED: true
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
+    DATA-SOURCES_OFFENDER-DETAILS: community_api
+
   namespace_secrets:
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -58,6 +58,8 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
+    DATA-SOURCES_OFFENDER-DETAILS: community_api
+
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"
     unilink-aovpn2: "83.98.63.176/29"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+
+interface OffenderDetailsDataSource {
+  val name: OffenderDetailsDataSourceName
+
+  fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary>
+}
+
+enum class OffenderDetailsDataSourceName {
+  COMMUNITY_API,
+  AP_DELIUS_CONTEXT_API,
+}
+
+@Component
+@Primary
+class ConfiguredOffenderDetailsDataSource(
+  dataSources: List<OffenderDetailsDataSource>,
+  @Value("\${data-sources.offender-details}")
+  private val dataSourceName: OffenderDetailsDataSourceName,
+) : OffenderDetailsDataSource {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  private lateinit var dataSource: OffenderDetailsDataSource
+
+  init {
+    log.info("Getting '$dataSourceName' offender details data source...")
+    dataSource = dataSources.first { it.name == dataSourceName }
+    log.info("Retrieved instance of type ${dataSource::class}")
+  }
+
+  override val name: OffenderDetailsDataSourceName
+    get() = dataSource.name
+
+  override fun getOffenderDetailSummary(crn: String) = dataSource.getOffenderDetailSummary(crn)
+}
+
+@Component
+class CommunityApiOffenderDetailsDataSource : OffenderDetailsDataSource {
+  override val name: OffenderDetailsDataSourceName
+    get() = OffenderDetailsDataSourceName.COMMUNITY_API
+
+  override fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary> {
+    throw NotImplementedError("Getting details for individual offenders from the Community API is not currently supported")
+  }
+}
+
+@Component
+class ApDeliusContextApiOffenderDetailsDataSource : OffenderDetailsDataSource {
+  override val name: OffenderDetailsDataSourceName
+    get() = OffenderDetailsDataSourceName.AP_DELIUS_CONTEXT_API
+
+  override fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary> {
+    throw NotImplementedError("Getting details for individual offenders from the AP Delius Context API is not currently supported")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
 
 interface OffenderDetailsDataSource {
   val name: OffenderDetailsDataSourceName
 
   fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary>
+  fun getUserAccessForOffenderCrn(deliusUsername: String, crn: String): ClientResult<UserOffenderAccess>
 }
 
 enum class OffenderDetailsDataSourceName {
@@ -40,6 +42,7 @@ class ConfiguredOffenderDetailsDataSource(
     get() = dataSource.name
 
   override fun getOffenderDetailSummary(crn: String) = dataSource.getOffenderDetailSummary(crn)
+  override fun getUserAccessForOffenderCrn(deliusUsername: String, crn: String) = dataSource.getUserAccessForOffenderCrn(deliusUsername, crn)
 }
 
 @Component
@@ -58,6 +61,8 @@ class CommunityApiOffenderDetailsDataSource(
 
     return offenderResponse
   }
+
+  override fun getUserAccessForOffenderCrn(deliusUsername: String, crn: String): ClientResult<UserOffenderAccess> = communityApiClient.getUserAccessForOffenderCrn(deliusUsername, crn)
 }
 
 @Component
@@ -67,5 +72,12 @@ class ApDeliusContextApiOffenderDetailsDataSource : OffenderDetailsDataSource {
 
   override fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary> {
     throw NotImplementedError("Getting details for individual offenders from the AP Delius Context API is not currently supported")
+  }
+
+  override fun getUserAccessForOffenderCrn(
+    deliusUsername: String,
+    crn: String,
+  ): ClientResult<UserOffenderAccess> {
+    throw NotImplementedError("Getting user access for individual offenders from the AP Delius Context API is not currently supported")
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -37,3 +37,6 @@ seed:
 
 assign-default-region-to-users-with-unknown-region: true
 preemptive-cache-logging-enabled: true
+
+data-sources:
+  offender-details: community_api

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/CommunityApiOffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/CommunityApiOffenderDetailsDataSourceTest.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.CommunityApiOffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import java.util.stream.Stream
+
+class CommunityApiOffenderDetailsDataSourceTest {
+  private val mockCommunityApiClient = mockk<CommunityApiClient>()
+
+  private val communityApiOffenderDetailsDataSource = CommunityApiOffenderDetailsDataSource(mockCommunityApiClient)
+
+  @ParameterizedTest
+  @MethodSource("cacheableOffenderDetailSummaryClientResults")
+  fun `getOffenderDetailSummary returns cached response from Community API when it exists`(
+    expectedResult: ClientResult<OffenderDetailSummary>,
+  ) {
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("SOME-CRN") } returns expectedResult
+
+    val result = communityApiOffenderDetailsDataSource.getOffenderDetailSummary("SOME-CRN")
+
+    assertThat(result).isEqualTo(expectedResult)
+  }
+
+  @ParameterizedTest
+  @MethodSource("cacheableOffenderDetailSummaryClientResults")
+  fun `getOffenderDetailSummary returns response from Community API call when cached response does not exist`(
+    expectedResult: ClientResult<OffenderDetailSummary>,
+  ) {
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithWait("SOME-CRN") } returns cacheTimeoutClientResult()
+
+    every { mockCommunityApiClient.getOffenderDetailSummaryWithCall("SOME-CRN") } returns expectedResult
+
+    val result = communityApiOffenderDetailsDataSource.getOffenderDetailSummary("SOME-CRN")
+
+    assertThat(result).isEqualTo(expectedResult)
+  }
+
+  private companion object {
+    @JvmStatic
+    fun cacheableOffenderDetailSummaryClientResults(): Stream<Arguments> {
+      val successBody = OffenderDetailsSummaryFactory()
+        .withCrn("SOME-CRN")
+        .produce()
+
+      return Stream.of(
+        Arguments.of(
+          ClientResult.Failure.CachedValueUnavailable<OffenderDetailSummary>("some-cache-key"),
+        ),
+        Arguments.of(
+          ClientResult.Failure.StatusCode<OffenderDetailSummary>(
+            HttpMethod.GET,
+            "/",
+            HttpStatus.NOT_FOUND,
+            null,
+            false,
+          ),
+        ),
+        Arguments.of(
+          ClientResult.Failure.Other<OffenderDetailSummary>(
+            HttpMethod.POST,
+            "/",
+            RuntimeException("Some error"),
+          ),
+        ),
+        Arguments.of(
+          ClientResult.Success(HttpStatus.OK, successBody, true),
+        ),
+      )
+    }
+
+    @JvmStatic
+    fun <T> cacheTimeoutClientResult() =
+      ClientResult.Failure.PreemptiveCacheTimeout<T>("some-cache", "some-cache-key", 1000)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderDetailsDataSourceTest.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.ConfiguredOffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSourceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+
+class ConfiguredOffenderDetailsDataSourceTest {
+  private val mockCommunityApiDataSource = mockk<OffenderDetailsDataSource>()
+  private val mockApDeliusDataSource = mockk<OffenderDetailsDataSource>()
+
+  @BeforeEach
+  fun setup() {
+    every { mockCommunityApiDataSource.name } returns OffenderDetailsDataSourceName.COMMUNITY_API
+    every { mockApDeliusDataSource.name } returns OffenderDetailsDataSourceName.AP_DELIUS_CONTEXT_API
+  }
+
+  @Test
+  fun `getOffenderDetailSummary delegates to the Community API data source when configured`() {
+    every { mockCommunityApiDataSource.getOffenderDetailSummary(any()) } returns mockk<ClientResult<OffenderDetailSummary>>()
+
+    val source = getConfiguredDataSource(OffenderDetailsDataSourceName.COMMUNITY_API)
+
+    source.getOffenderDetailSummary("FOO")
+
+    verify(exactly = 1) {
+      mockCommunityApiDataSource.getOffenderDetailSummary("FOO")
+    }
+    verify(exactly = 0) {
+      mockApDeliusDataSource.getOffenderDetailSummary(any())
+    }
+  }
+
+  @Test
+  fun `getOffenderDetailSummary delegates to the AP-Delius data source when configured`() {
+    every { mockApDeliusDataSource.getOffenderDetailSummary(any()) } returns mockk<ClientResult<OffenderDetailSummary>>()
+
+    val source = getConfiguredDataSource(OffenderDetailsDataSourceName.AP_DELIUS_CONTEXT_API)
+
+    source.getOffenderDetailSummary("FOO")
+
+    verify(exactly = 0) {
+      mockCommunityApiDataSource.getOffenderDetailSummary(any())
+    }
+    verify(exactly = 1) {
+      mockApDeliusDataSource.getOffenderDetailSummary("FOO")
+    }
+  }
+
+  private fun getConfiguredDataSource(sourceName: OffenderDetailsDataSourceName): ConfiguredOffenderDetailsDataSource {
+    return ConfiguredOffenderDetailsDataSource(
+      dataSources = listOf(mockCommunityApiDataSource, mockApDeliusDataSource),
+      dataSourceName = sourceName,
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -156,3 +156,6 @@ arrived-departed-domain-events-disabled: false
 manual-bookings-domain-events-disabled: false
 
 upstream-timeout-ms: 2000
+
+data-sources:
+  offender-details: community_api


### PR DESCRIPTION
> See [APS-67 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-67).

This PR introduces a facade for retrieving offender details, allowing us to abstract to some degree over the source of this information, simplifying the planned transition away from the Community API in favour of the AP Delius Context API.

This facade is implemented such that it can be configured through the Spring property `data-sources.offender-details` or the environment variable `DATA-SOURCES_OFFENDER-DETAILS`, which accepts values of either `community_api` or `ap_delius_context_api`. This allows for control over when and in what environments the transition to the AP Delius Context API occurs, and allows us to rollback the transition without reverting significant code changes should problems occur.

Currently, this facade only supports the Community API for individual offenders, and it replicates the existing behaviour. Future work will expand the facade to support listings, as well as providing an implementation backed by the AP Delius Context API.