### PR TITLE
Fix N+1 queries when fetching premises availability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/BookingSummaryForAvailability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/BookingSummaryForAvailability.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import java.time.LocalDate
+
+interface BookingSummaryForAvailability {
+  fun getArrivalDate(): LocalDate
+  fun getDepartureDate(): LocalDate
+  fun getArrived(): Boolean
+  fun getIsNotArrived(): Boolean
+  fun getCancelled(): Boolean
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -96,15 +96,15 @@ class PremisesService(
     val lostBeds = lostBedsRepository.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate)
 
     return startDate.getDaysUntilExclusiveEnd(endDate).map { date ->
-      val bookingsOnDay = bookings.filter { booking -> booking.arrivalDate <= date && booking.departureDate > date }
+      val bookingsOnDay = bookings.filter { booking -> booking.getArrivalDate() <= date && booking.getDepartureDate() > date }
       val lostBedsOnDay = lostBeds.filter { lostBed -> lostBed.startDate <= date && lostBed.endDate > date && lostBed.cancellation == null }
 
       Availability(
         date = date,
-        pendingBookings = bookingsOnDay.count { it.arrival == null && it.nonArrival == null && it.cancellation == null },
-        arrivedBookings = bookingsOnDay.count { it.arrival != null },
-        nonArrivedBookings = bookingsOnDay.count { it.nonArrival != null },
-        cancelledBookings = bookingsOnDay.count { it.cancellation != null },
+        pendingBookings = bookingsOnDay.count { !it.getArrived() && !it.getIsNotArrived() && !it.getCancelled() },
+        arrivedBookings = bookingsOnDay.count { it.getArrived() },
+        nonArrivedBookings = bookingsOnDay.count { it.getIsNotArrived() },
+        cancelledBookings = bookingsOnDay.count { it.getCancelled() },
         lostBeds = lostBedsOnDay.size,
       )
     }.associateBy { it.date }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSummaryForAvailabilityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingSummaryForAvailabilityFactory.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.BookingSummaryForAvailability
+import java.time.LocalDate
+
+class BookingSummaryForAvailabilityFactory : Factory<BookingSummaryForAvailabilityImpl> {
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var departureDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var arrived: Yielded<Boolean> = { false }
+  private var isNotArrived: Yielded<Boolean> = { false }
+  private var cancelled: Yielded<Boolean> = { false }
+
+  fun withArrivalDate(arrivalDate: LocalDate) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+  fun withDepartureDate(departureDate: LocalDate) = apply {
+    this.departureDate = { departureDate }
+  }
+  fun withArrived(arrived: Boolean) = apply {
+    this.arrived = { arrived }
+  }
+  fun withIsNotArrived(isNotArrived: Boolean) = apply {
+    this.isNotArrived = { isNotArrived }
+  }
+  fun withCancelled(cancelled: Boolean) = apply {
+    this.cancelled = { cancelled }
+  }
+
+  override fun produce(): BookingSummaryForAvailabilityImpl = BookingSummaryForAvailabilityImpl(
+    arrivalDateVar = this.arrivalDate(),
+    departureDateVar = this.departureDate(),
+    arrivedVar = this.arrived(),
+    isNotArrivedVar = this.isNotArrived(),
+    cancelledVar = this.cancelled(),
+  )
+}
+
+class BookingSummaryForAvailabilityImpl(
+  private var arrivalDateVar: LocalDate,
+  private var departureDateVar: LocalDate,
+  private var arrivedVar: Boolean,
+  private var isNotArrivedVar: Boolean,
+  private var cancelledVar: Boolean,
+) : BookingSummaryForAvailability {
+  override fun getArrivalDate(): LocalDate = this.arrivalDateVar
+  override fun getDepartureDate(): LocalDate = this.departureDateVar
+  override fun getArrived(): Boolean = this.arrivedVar
+  override fun getIsNotArrived(): Boolean = this.isNotArrivedVar
+  override fun getCancelled(): Boolean = this.cancelledVar
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -10,17 +10,12 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingSummaryForAvailabilityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
@@ -139,53 +134,37 @@ class PremisesServiceTest {
       )
       .produce()
 
-    val pendingBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val pendingBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate.plusDays(1))
       .withDepartureDate(startDate.plusDays(3))
-      .withStaffKeyWorkerCode(null)
+      .withArrived(false)
+      .withCancelled(false)
+      .withIsNotArrived(false)
       .produce()
 
-    val arrivedBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val arrivedBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate)
       .withDepartureDate(startDate.plusDays(2))
-      .withStaffKeyWorkerCode("123")
+      .withArrived(true)
+      .withCancelled(false)
+      .withIsNotArrived(false)
       .produce()
 
-    val arrivalEntity = ArrivalEntityFactory()
-      .withBooking(arrivedBookingEntity)
-      .produce()
-
-    arrivedBookingEntity.arrivals += arrivalEntity
-
-    val nonArrivedBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val nonArrivedBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate.plusDays(3))
       .withDepartureDate(startDate.plusDays(5))
-      .withStaffKeyWorkerCode(null)
+      .withArrived(false)
+      .withCancelled(false)
+      .withIsNotArrived(true)
       .produce()
 
-    val nonArrivalEntity = NonArrivalEntityFactory()
-      .withBooking(nonArrivedBookingEntity)
-      .withYieldedReason { NonArrivalReasonEntityFactory().produce() }
-      .produce()
-
-    nonArrivedBookingEntity.nonArrival = nonArrivalEntity
-
-    val cancelledBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val cancelledBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate.plusDays(4))
       .withDepartureDate(startDate.plusDays(6))
-      .withStaffKeyWorkerCode(null)
+      .withArrived(false)
+      .withCancelled(true)
+      .withIsNotArrived(false)
       .produce()
-
-    val cancelledArrivalEntity = CancellationEntityFactory()
-      .withYieldedReason { CancellationReasonEntityFactory().produce() }
-      .withBooking(cancelledBookingEntity)
-      .produce()
-
-    cancelledBookingEntity.cancellations = mutableListOf(cancelledArrivalEntity)
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf(
       pendingBookingEntity,
@@ -288,53 +267,37 @@ class PremisesServiceTest {
       .withYieldedBed { bed }
       .produce()
 
-    val pendingBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val pendingBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate.plusDays(1))
       .withDepartureDate(startDate.plusDays(3))
-      .withStaffKeyWorkerCode(null)
+      .withCancelled(false)
+      .withArrived(false)
+      .withIsNotArrived(false)
       .produce()
 
-    val arrivedBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val arrivedBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate)
       .withDepartureDate(startDate.plusDays(2))
-      .withStaffKeyWorkerCode("123")
+      .withCancelled(false)
+      .withArrived(true)
+      .withIsNotArrived(false)
       .produce()
 
-    val arrivalEntity = ArrivalEntityFactory()
-      .withBooking(arrivedBookingEntity)
-      .produce()
-
-    arrivedBookingEntity.arrivals += arrivalEntity
-
-    val nonArrivedBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val nonArrivedBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate.plusDays(3))
       .withDepartureDate(startDate.plusDays(5))
-      .withStaffKeyWorkerCode(null)
+      .withCancelled(false)
+      .withArrived(false)
+      .withIsNotArrived(true)
       .produce()
 
-    val nonArrivalEntity = NonArrivalEntityFactory()
-      .withBooking(nonArrivedBookingEntity)
-      .withYieldedReason { NonArrivalReasonEntityFactory().produce() }
-      .produce()
-
-    nonArrivedBookingEntity.nonArrival = nonArrivalEntity
-
-    val cancelledBookingEntity = BookingEntityFactory()
-      .withPremises(premises)
+    val cancelledBookingEntity = BookingSummaryForAvailabilityFactory()
       .withArrivalDate(startDate.plusDays(4))
       .withDepartureDate(startDate.plusDays(6))
-      .withStaffKeyWorkerCode(null)
+      .withCancelled(true)
+      .withArrived(false)
+      .withIsNotArrived(false)
       .produce()
-
-    val cancelledArrivalEntity = CancellationEntityFactory()
-      .withYieldedReason { CancellationReasonEntityFactory().produce() }
-      .withBooking(cancelledBookingEntity)
-      .produce()
-
-    cancelledBookingEntity.cancellations = mutableListOf(cancelledArrivalEntity)
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf(
       pendingBookingEntity,


### PR DESCRIPTION
When checking out [some of the endpoints that had N+1 queries via Application Insights](https://portal.azure.com/#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA1WOSw7CMAxE95zCYlOKVAEH6Io9Cy5QhWYEkZraJE6hiMOTgvjtrHnzRrYQ9BZ96xBnd7qcEEBtx8k2e%252B6wMx5U11QYkcADbCUB3kXEyogr6KPoKM%252FiXDjqMSCeu3mGuGqeJ2U1XWNTMOq4r9%252FH0in8llOvuRqT9ya4G8gMx293kfPFv1%252BupuzjliUdRmLBizbTz3lPWWizntDvHlnE9gGhmpMD9QAAAA%253D%253D/timespan/P1D) I noticed that the `premisesPremisesIdSummaryGet` endpoint was making a lot of queries (sometimes upwards of 700!). Digging into it it seems that when we fetch bookings when calculating the availability for a premises, we're querying for each booking's cancellations, arrivals and departures, thus ending up in an N+1 query situation.

This updates one of our queries to use JPA projection to only fetch counts of cancellations, arrivals and departures, which should cut down on the number of queries made and speed up the response from this endpoint.