### PR TITLE
(Fix) Use allocations engine to fetch users for a Task

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -43,6 +43,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.AllocationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getIndices
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
@@ -203,10 +204,10 @@ class TasksController(
 
         transformedTask = getAssessmentTask(assessment, user)
 
-        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRolesPassingLAO(
+        transformedAllocatableUsers = userService.getAllocatableUsersForAllocationType(
           assessment.application.crn,
           assessment.application.getRequiredQualifications(),
-          listOf(UserRole.CAS1_ASSESSOR),
+          AllocationType.Assessment,
         )
           .map {
             val workload = userService.getUserWorkload(it.id)
@@ -221,10 +222,10 @@ class TasksController(
         transformedTask = getPlacementRequestTask(placementRequest, user)
 
         transformedAllocatableUsers =
-          userService.getUsersWithQualificationsAndRolesPassingLAO(
+          userService.getAllocatableUsersForAllocationType(
             placementRequest.application.crn,
             emptyList(),
-            listOf(UserRole.CAS1_MATCHER),
+            AllocationType.PlacementRequest,
           )
             .map {
               val workload = userService.getUserWorkload(it.id)
@@ -238,10 +239,10 @@ class TasksController(
 
         transformedTask = getPlacementApplicationTask(placementApplication, user)
 
-        transformedAllocatableUsers = userService.getUsersWithQualificationsAndRolesPassingLAO(
+        transformedAllocatableUsers = userService.getAllocatableUsersForAllocationType(
           placementApplication.application.crn,
           placementApplication.application.getRequiredQualifications(),
-          listOf(UserRole.CAS1_ASSESSOR),
+          AllocationType.PlacementApplication,
         )
           .map {
             val workload = userService.getUserWorkload(it.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -116,12 +116,11 @@ class UserService(
     return Pair(users, metadata)
   }
 
-  fun getUsersWithQualificationsAndRolesPassingLAO(crn: String, qualifications: List<UserQualification>?, roles: List<UserRole>?): List<UserEntity> {
+  fun getAllocatableUsersForAllocationType(crn: String, qualifications: List<UserQualification>, allocationType: AllocationType): List<UserEntity> {
     val isLao = offenderService.isLao(crn)
+    val allocationsEngine = UserAllocationsEngine(userRepository, allocationType, qualifications, isLao, false)
 
-    return userRepository.findAll(hasQualificationsAndRoles(qualifications, roles, true), Sort.by(Sort.Direction.ASC, "name")).filter {
-      !isLao || it.hasQualification(UserQualification.LAO) || offenderService.getOffenderByCrn(crn, it.deliusUsername) is AuthorisableActionResult.Success
-    }
+    return allocationsEngine.getUserPool()
   }
 
   fun getUserForAssessmentAllocation(application: ApplicationEntity): UserEntity? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserAllocationsEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserAllocationsEngine.kt
@@ -18,7 +18,13 @@ enum class AllocationType {
   Assessment, PlacementRequest, PlacementApplication
 }
 
-class UserAllocationsEngine(private val userRepository: UserRepository, private val allocationType: AllocationType, private val requiredQualifications: List<UserQualification>, private val isLao: Boolean) {
+class UserAllocationsEngine(
+  private val userRepository: UserRepository,
+  private val allocationType: AllocationType,
+  private val requiredQualifications: List<UserQualification>,
+  private val isLao: Boolean,
+  private val excludeAutoAllocations: Boolean = true,
+) {
   fun getAllocatedUser(): UserEntity? {
     val userIds = this.getUserPool().map { it.id }
 
@@ -73,9 +79,11 @@ class UserAllocationsEngine(private val userRepository: UserRepository, private 
       }
 
       // Finally, we want to make sure the user does not have the exclusion role for our allocation type
-      predicates.add(
-        allUsersWithoutExclusionRole(root, criteriaBuilder),
-      )
+      if (excludeAutoAllocations) {
+        predicates.add(
+          allUsersWithoutExclusionRole(root, criteriaBuilder),
+        )
+      }
 
       query.groupBy(root.get<UUID>("id"))
       criteriaBuilder.and(*predicates.toTypedArray())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1252,7 +1252,7 @@ class TasksTest : IntegrationTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
         `Given a User` { user, _ ->
           `Given a User`(
-            roles = listOf(UserRole.CAS1_ASSESSOR),
+            roles = listOf(UserRole.CAS1_MATCHER),
           ) { allocatableUser, _ ->
             `Given an Offender` { offenderDetails, inmateDetails ->
               `Given a Placement Application`(
@@ -1299,7 +1299,7 @@ class TasksTest : IntegrationTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
         `Given a User` { user, _ ->
           `Given a User`(
-            roles = listOf(UserRole.CAS1_ASSESSOR),
+            roles = listOf(UserRole.CAS1_MATCHER),
           ) { allocatableUser, _ ->
             `Given an Offender` { offenderDetails, inmateDetails ->
               `Given a Placement Application`(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -275,6 +275,7 @@ class UserServiceTest {
         EqMatcher(AllocationType.Assessment),
         EqMatcher<List<UserQualification>>(emptyList()),
         EqMatcher(true),
+        EqMatcher(true),
       ).getAllocatedUser()
     } returns userForAllocation
 
@@ -307,6 +308,7 @@ class UserServiceTest {
         EqMatcher(AllocationType.Assessment),
         EqMatcher(listOf(UserQualification.PIPE, UserQualification.EMERGENCY)),
         EqMatcher(false),
+        EqMatcher(true),
       ).getAllocatedUser()
     } returns userForAllocation
 
@@ -330,6 +332,7 @@ class UserServiceTest {
         EqMatcher(mockUserRepository),
         EqMatcher(AllocationType.PlacementRequest),
         EqMatcher<List<UserQualification>>(emptyList()),
+        EqMatcher(true),
         EqMatcher(true),
       ).getAllocatedUser()
     } returns userForAllocation
@@ -355,6 +358,7 @@ class UserServiceTest {
         EqMatcher(AllocationType.PlacementRequest),
         EqMatcher<List<UserQualification>>(emptyList()),
         EqMatcher(false),
+        EqMatcher(true),
       ).getAllocatedUser()
     } returns userForAllocation
 
@@ -378,6 +382,7 @@ class UserServiceTest {
         EqMatcher(mockUserRepository),
         EqMatcher(AllocationType.PlacementApplication),
         EqMatcher<List<UserQualification>>(emptyList()),
+        EqMatcher(true),
         EqMatcher(true),
       ).getAllocatedUser()
     } returns userForAllocation
@@ -403,6 +408,7 @@ class UserServiceTest {
         EqMatcher(AllocationType.PlacementApplication),
         EqMatcher<List<UserQualification>>(emptyList()),
         EqMatcher(false),
+        EqMatcher(true),
       ).getAllocatedUser()
     } returns userForAllocation
 


### PR DESCRIPTION
When returning the eligible users for a Task, we’ve had issues where ineligible users are being returned. Tracking this down, it seems to be a problem where the `hasQualificationsAndRoles` specification is returning users that have any qualification in the provided list of required  qualifications, not all of the roles.

This is a situation we’ve already covered when automatically allocating users to a task, so I’ve updated the UserAllocationsEngine (which handles automatic allocations) to accept an `excludeAutoAllocations` flag. This allows us to return all qualfied users in our pool of potential users (currentlt the AllocationsEngine excludes users who have roles that prevent them from being automatically allocated a task)

I’ve also made some tweaks to the Tasks tests to make sure the expected users have the correct roles.