### PR TITLE
[bugFix-1720]-Return error when mandatory mappa registration details missing in Risk details from Delius

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
@@ -55,7 +55,7 @@ class RegistrationClientResponseFactory : Factory<Registration> {
       description = randomStringUpperCase(20),
     )
   }
-  private var registerCategory: Yielded<RegistrationKeyValue> = {
+  private var registerCategory: Yielded<RegistrationKeyValue?> = {
     RegistrationKeyValue(
       code = "M2",
       description = "MAPPA Cat 2",
@@ -129,7 +129,7 @@ class RegistrationClientResponseFactory : Factory<Registration> {
     this.registerLevel = { registerLevel }
   }
 
-  fun withRegisterCategory(registerCategory: RegistrationKeyValue) = apply {
+  fun withRegisterCategory(registerCategory: RegistrationKeyValue?) = apply {
     this.registerCategory = { registerCategory }
   }
 


### PR DESCRIPTION
# Changes in this PR
Refer [1726](https://trello.com/c/mSSzt3eH/1726-guard-against-risk-registrations-that-dont-have-risk-categories) for more information.

This PR is to return `RiskStatus.Error` when missing mandatory element `registration.registerCategory`, `registration.registerLevel` from MAPP Risk details from Delius endpoint `/secure/offenders/crn/$crn/registrations?activeOnly=true`


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.