### PR TITLE
[APS-67] Introduce facade for offender risks

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -67,6 +67,7 @@ generic-service:
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
     DATA-SOURCES_OFFENDER-DETAILS: community_api
+    DATA-SOURCES_OFFENDER-RISKS: community_api
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -60,6 +60,7 @@ generic-service:
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
     DATA-SOURCES_OFFENDER-DETAILS: community_api
+    DATA-SOURCES_OFFENDER-RISKS: community_api
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -70,6 +70,7 @@ generic-service:
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
     DATA-SOURCES_OFFENDER-DETAILS: community_api
+    DATA-SOURCES_OFFENDER-RISKS: community_api
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -60,6 +60,7 @@ generic-service:
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
     DATA-SOURCES_OFFENDER-DETAILS: community_api
+    DATA-SOURCES_OFFENDER-RISKS: community_api
 
   allowlist:
     unilink-aovpn1: "194.75.210.216/29"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+
+interface OffenderRisksDataSource {
+  val name: OffenderRisksDataSourceName
+
+  fun getPersonRisks(crn: String): PersonRisks
+}
+
+enum class OffenderRisksDataSourceName {
+  COMMUNITY_API,
+  AP_DELIUS_CONTEXT_API,
+}
+
+@Component
+@Primary
+class ConfiguredOffenderRisksDataSource(
+  dataSources: List<OffenderRisksDataSource>,
+  @Value("\${data-sources.offender-risks}")
+  private val dataSourceName: OffenderRisksDataSourceName,
+) : OffenderRisksDataSource {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  private lateinit var dataSource: OffenderRisksDataSource
+
+  init {
+    log.info("Getting '$dataSourceName' offender risks data source...")
+    dataSource = dataSources.first { it.name == dataSourceName }
+    log.info("Retrieved instance of type ${dataSource::class}")
+  }
+
+  override val name: OffenderRisksDataSourceName
+    get() = dataSource.name
+
+  override fun getPersonRisks(crn: String): PersonRisks =
+    dataSource.getPersonRisks(crn)
+}
+
+@Component
+class CommunityApiOffenderRisksDataSource : OffenderRisksDataSource {
+  override val name: OffenderRisksDataSourceName
+    get() = OffenderRisksDataSourceName.COMMUNITY_API
+
+  override fun getPersonRisks(crn: String): PersonRisks {
+    throw NotImplementedError("Getting risks for individual offenders from the Community API is not currently supported")
+  }
+}
+
+@Component
+class ApDeliusContextApiOffenderRisksDataSource : OffenderRisksDataSource {
+  override val name: OffenderRisksDataSourceName
+    get() = OffenderRisksDataSourceName.AP_DELIUS_CONTEXT_API
+
+  override fun getPersonRisks(crn: String): PersonRisks {
+    throw NotImplementedError("Getting risks for individual offenders from the AP Delius Context API is not currently supported")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
@@ -3,8 +3,20 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Primary
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registration
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 
 interface OffenderRisksDataSource {
   val name: OffenderRisksDataSourceName
@@ -42,13 +54,144 @@ class ConfiguredOffenderRisksDataSource(
 }
 
 @Component
-class CommunityApiOffenderRisksDataSource : OffenderRisksDataSource {
+class CommunityApiOffenderRisksDataSource(
+  private val communityApiClient: CommunityApiClient,
+  private val apOASysContextApiClient: ApOASysContextApiClient,
+  private val hmppsTierApiClient: HMPPSTierApiClient,
+) : OffenderRisksDataSource {
+
+  private val ignoredRegisterTypesForFlags = listOf("RVHR", "RHRH", "RMRH", "RLRH", "MAPP")
+
   override val name: OffenderRisksDataSourceName
     get() = OffenderRisksDataSourceName.COMMUNITY_API
 
   override fun getPersonRisks(crn: String): PersonRisks {
-    throw NotImplementedError("Getting risks for individual offenders from the Community API is not currently supported")
+    val registrationsResponse = communityApiClient.getRegistrationsForOffenderCrn(crn)
+
+    return PersonRisks(
+      roshRisks = getRoshRisksEnvelope(crn),
+      mappa = getMappaEnvelope(registrationsResponse),
+      tier = getRiskTierEnvelope(crn),
+      flags = getFlagsEnvelope(registrationsResponse),
+    )
   }
+
+  private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> {
+    when (val roshRisksResponse = apOASysContextApiClient.getRoshRatings(crn)) {
+      is ClientResult.Success -> {
+        val summary = roshRisksResponse.body.rosh
+
+        if (summary.anyRisksAreNull()) {
+          return RiskWithStatus(
+            status = RiskStatus.NotFound,
+            value = null,
+          )
+        }
+
+        return RiskWithStatus(
+          status = RiskStatus.Retrieved,
+          value = RoshRisks(
+            overallRisk = summary.determineOverallRiskLevel().text,
+            riskToChildren = summary.riskChildrenCommunity!!.text,
+            riskToPublic = summary.riskPublicCommunity!!.text,
+            riskToKnownAdult = summary.riskKnownAdultCommunity!!.text,
+            riskToStaff = summary.riskStaffCommunity!!.text,
+            lastUpdated = roshRisksResponse.body.dateCompleted?.toLocalDate()
+              ?: roshRisksResponse.body.initiationDate.toLocalDate(),
+          ),
+        )
+      }
+      is ClientResult.Failure.StatusCode -> return if (roshRisksResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(
+          status = RiskStatus.NotFound,
+          value = null,
+        )
+      } else {
+        RiskWithStatus(
+          status = RiskStatus.Error,
+          value = null,
+        )
+      }
+      is ClientResult.Failure -> return RiskWithStatus(
+        status = RiskStatus.Error,
+        value = null,
+      )
+    }
+  }
+
+  private fun getMappaEnvelope(registrationsResponse: ClientResult<Registrations>): RiskWithStatus<Mappa> {
+    when (registrationsResponse) {
+      is ClientResult.Success -> {
+        val firstMappaRegistration = registrationsResponse.body.registrations.firstOrNull { it.type.code == "MAPP" }
+
+        return if (firstMappaRegistration.isMandatoryPropertyMissing()) {
+          RiskWithStatus(status = RiskStatus.Error)
+        } else {
+          RiskWithStatus(
+            value = firstMappaRegistration?.let { registration ->
+              Mappa(
+                level = "CAT ${registration.registerCategory!!.code}/LEVEL ${registration.registerLevel!!.code}",
+                lastUpdated = registration.registrationReviews?.filter { it.completed }?.maxOfOrNull { it.reviewDate } ?: registration.startDate,
+              )
+            },
+          )
+        }
+      }
+      is ClientResult.Failure.StatusCode -> return if (registrationsResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> {
+        return RiskWithStatus(status = RiskStatus.Error)
+      }
+    }
+  }
+
+  private fun getRiskTierEnvelope(crn: String): RiskWithStatus<RiskTier> {
+    return when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
+      is ClientResult.Success -> {
+        RiskWithStatus(
+          status = RiskStatus.Retrieved,
+          value = RiskTier(
+            level = tierResponse.body.tierScore,
+            lastUpdated = tierResponse.body.calculationDate.toLocalDate(),
+          ),
+        )
+      }
+      is ClientResult.Failure.StatusCode -> if (tierResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+    }
+  }
+
+  private fun getFlagsEnvelope(registrationsResponse: ClientResult<Registrations>): RiskWithStatus<List<String>> {
+    return when (registrationsResponse) {
+      is ClientResult.Success -> {
+        RiskWithStatus(
+          value = registrationsResponse.body.registrations.filter { !ignoredRegisterTypesForFlags.contains(it.type.code) }.map { it.type.description },
+        )
+      }
+
+      is ClientResult.Failure.StatusCode -> if (registrationsResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+
+      is ClientResult.Failure -> {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+    }
+  }
+
+  private fun Registration?.isMandatoryPropertyMissing() =
+    this != null && (this.registerCategory == null || this.registerLevel == null)
 }
 
 @Component

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -40,3 +40,4 @@ preemptive-cache-logging-enabled: true
 
 data-sources:
   offender-details: community_api
+  offender-risks: community_api

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/CommunityApiOffenderRisksDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/CommunityApiOffenderRisksDataSourceTest.kt
@@ -1,0 +1,413 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.CommunityApiOffenderRisksDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshRatings
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class CommunityApiOffenderRisksDataSourceTest {
+  private val mockCommunityApiClient = mockk<CommunityApiClient>()
+  private val mockApOASysContextApiClient = mockk<ApOASysContextApiClient>()
+  private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
+
+  private val communityApiOffenderRisksDataSource = CommunityApiOffenderRisksDataSource(
+    mockCommunityApiClient,
+    mockApOASysContextApiClient,
+    mockHMPPSTierApiClient,
+  )
+
+  @Test
+  fun `getPersonRisks returns NotFound envelopes for RoSH, Tier, Mappa & flags when respective Clients return 404`() {
+    val crn = "a-crn"
+
+    mock404RoSH(crn)
+    mock404Tier(crn)
+    mock404Registrations(crn)
+
+    val result = communityApiOffenderRisksDataSource.getPersonRisks(crn)
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.tier.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.flags.status).isEqualTo(RiskStatus.NotFound)
+  }
+
+  @Test
+  fun `getPersonRisks returns Error envelopes for RoSH, Tier, Mappa & flags when respective Clients return 500`() {
+    val crn = "a-crn"
+
+    mock500RoSH(crn)
+    mock500Tier(crn)
+    mock500Registrations(crn)
+
+    val result = communityApiOffenderRisksDataSource.getPersonRisks(crn)
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Error)
+  }
+
+  @Test
+  fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier, Mappa & flags when respective Clients return 200`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200Registrations(
+      crn,
+      Registrations(
+        registrations = listOf(
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "MAPP", description = "MAPPA"))
+            .withRegisterCategory(RegistrationKeyValue(code = "C1", description = "C1"))
+            .withRegisterLevel(RegistrationKeyValue(code = "L1", description = "L1"))
+            .withStartDate(LocalDate.parse("2022-09-06"))
+            .produce(),
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
+            .produce(),
+        ),
+      ),
+    )
+
+    val result = communityApiOffenderRisksDataSource.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Very High")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Retrieved)
+    result.mappa.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("CAT C1/LEVEL L1")
+    }
+
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.value).contains("RISK FLAG")
+  }
+
+  @Test
+  fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier,flags and Mappa with Error status when missing 'registration-registerCategory' element`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200Registrations(
+      crn,
+      Registrations(
+        registrations = listOf(
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "MAPP", description = "MAPPA"))
+            .withRegisterCategory(null)
+            .withRegisterLevel(RegistrationKeyValue(code = "L1", description = "L1"))
+            .withStartDate(LocalDate.parse("2022-09-06"))
+            .produce(),
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
+            .produce(),
+        ),
+      ),
+    )
+
+    val result = communityApiOffenderRisksDataSource.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Very High")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.mappa.value).isNull()
+
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.value).contains("RISK FLAG")
+  }
+
+  @Test
+  fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier,flags and Mappa with Rrror status when missing 'registration-registerLevel' element`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200Registrations(
+      crn,
+      Registrations(
+        registrations = listOf(
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "MAPP", description = "MAPPA"))
+            .withRegisterCategory(RegistrationKeyValue(code = "C1", description = "C1"))
+            .withRegisterLevel(null)
+            .withStartDate(LocalDate.parse("2022-09-06"))
+            .produce(),
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
+            .produce(),
+        ),
+      ),
+    )
+
+    val result = communityApiOffenderRisksDataSource.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Very High")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.mappa.value).isNull()
+
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.value).contains("RISK FLAG")
+  }
+
+  @Test
+  fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier,flags and Mappa with Retrieved status when missing 'registration' element`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200Registrations(
+      crn,
+      Registrations(
+        registrations = listOf(
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "TEST", description = "TEST"))
+            .withRegisterCategory(RegistrationKeyValue(code = "C1", description = "C1"))
+            .withRegisterLevel(RegistrationKeyValue(code = "L1", description = "L1"))
+            .withStartDate(LocalDate.parse("2022-09-06"))
+            .produce(),
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
+            .produce(),
+        ),
+      ),
+    )
+
+    val result = communityApiOffenderRisksDataSource.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Very High")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.mappa.value).isNull()
+
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.value).contains("RISK FLAG")
+  }
+
+  private fun mock404RoSH(crn: String) {
+    every { mockApOASysContextApiClient.getRoshRatings(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/rosh/a-crn",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+  }
+
+  private fun mock404Tier(crn: String) {
+    every { mockHMPPSTierApiClient.getTier(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/crn/a-crn/tier",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+  }
+
+  private fun mock404Registrations(crn: String) {
+    every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/secure/offenders/crn/a-crn/registrations?activeOnly=true",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+  }
+
+  private fun mock500RoSH(crn: String) {
+    every { mockApOASysContextApiClient.getRoshRatings(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/rosh/a-crn",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        body = null,
+      )
+  }
+
+  private fun mock500Tier(crn: String) {
+    every { mockHMPPSTierApiClient.getTier(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/crn/a-crn/tier",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        body = null,
+      )
+  }
+
+  private fun mock500Registrations(crn: String) {
+    every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/secure/offenders/crn/a-crn/registrations?activeOnly=true",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        body = null,
+      )
+  }
+
+  private fun mock200RoSH(crn: String, body: RoshRatings) {
+    every { mockApOASysContextApiClient.getRoshRatings(crn) } returns
+      ClientResult.Success(HttpStatus.OK, body = body)
+  }
+
+  private fun mock200Tier(crn: String, body: Tier) {
+    every { mockHMPPSTierApiClient.getTier(crn) } returns
+      ClientResult.Success(HttpStatus.OK, body = body)
+  }
+
+  private fun mock200Registrations(crn: String, body: Registrations) {
+    every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns
+      ClientResult.Success(HttpStatus.OK, body = body)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderRisksDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderRisksDataSourceTest.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.ConfiguredOffenderRisksDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSourceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+
+class ConfiguredOffenderRisksDataSourceTest {
+  private val mockCommunityApiDataSource = mockk<OffenderRisksDataSource>()
+  private val mockApDeliusDataSource = mockk<OffenderRisksDataSource>()
+
+  @BeforeEach
+  fun setup() {
+    every { mockCommunityApiDataSource.name } returns OffenderRisksDataSourceName.COMMUNITY_API
+    every { mockApDeliusDataSource.name } returns OffenderRisksDataSourceName.AP_DELIUS_CONTEXT_API
+  }
+
+  @Test
+  fun `getOffenderDetailSummary delegates to the Community API data source when configured`() {
+    every { mockCommunityApiDataSource.getPersonRisks(any()) } returns mockk<PersonRisks>()
+
+    val source = getConfiguredDataSource(OffenderRisksDataSourceName.COMMUNITY_API)
+
+    source.getPersonRisks("FOO")
+
+    verify(exactly = 1) {
+      mockCommunityApiDataSource.getPersonRisks("FOO")
+    }
+    verify(exactly = 0) {
+      mockApDeliusDataSource.getPersonRisks(any())
+    }
+  }
+
+  @Test
+  fun `getOffenderDetailSummary delegates to the AP-Delius data source when configured`() {
+    every { mockApDeliusDataSource.getPersonRisks(any()) } returns mockk<PersonRisks>()
+
+    val source = getConfiguredDataSource(OffenderRisksDataSourceName.AP_DELIUS_CONTEXT_API)
+
+    source.getPersonRisks("FOO")
+
+    verify(exactly = 0) {
+      mockCommunityApiDataSource.getPersonRisks(any())
+    }
+    verify(exactly = 1) {
+      mockApDeliusDataSource.getPersonRisks("FOO")
+    }
+  }
+
+  private fun getConfiguredDataSource(sourceName: OffenderRisksDataSourceName): ConfiguredOffenderRisksDataSource {
+    return ConfiguredOffenderRisksDataSource(
+      dataSources = listOf(mockCommunityApiDataSource, mockApDeliusDataSource),
+      dataSourceName = sourceName,
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -160,3 +160,4 @@ upstream-timeout-ms: 2000
 
 data-sources:
   offender-details: community_api
+  offender-risks: community_api


### PR DESCRIPTION
> See [APS-67 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-67).

This PR introduces a facade for retrieving offender risks, allowing us to abstract to some degree over the source of this information, simplifying the planned transition away from the Community API in favour of the AP Delius Context API.

This facade is implemented such that it can be configured through the Spring property `data-sources.offender-risks` or the environment variable `DATA-SOURCES_OFFENDER-RISKS`, which accepts values of either `community_api` or `ap_delius_context_api`. This allows for control over when and in what environments the transition to the AP Delius Context API occurs, and allows us to rollback the transition without reverting significant code changes should problems occur.

Currently, this facade only supports the Community API and it replicates the existing behaviour. Future work will provide an implementation backed by the AP Delius Context API.