### PR TITLE
Feature/APS-68 add new columns to raw data reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -48,6 +48,8 @@ class ApplicationReportGenerator : ReportGenerator<ApplicationEntityReportRow, A
         departureReason = this.getDepartureReason(),
         hasNotArrived = this.getHasNotArrived(),
         notArrivedReason = this.getNotArrivedReason(),
+        paroleDecisionDate = this.getParoleDecisionDate()?.toLocalDate(),
+        type = this.getType(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -3,11 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntityReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 
-class ApplicationReportGenerator(
-  private val offenderService: OffenderService,
-) : ReportGenerator<ApplicationEntityReportRow, ApplicationReportRow, ApplicationReportProperties>(ApplicationReportRow::class) {
+class ApplicationReportGenerator : ReportGenerator<ApplicationEntityReportRow, ApplicationReportRow, ApplicationReportProperties>(ApplicationReportRow::class) {
   override fun filter(properties: ApplicationReportProperties): (ApplicationEntityReportRow) -> Boolean = {
     true
   }
@@ -17,6 +14,7 @@ class ApplicationReportGenerator(
       ApplicationReportRow(
         id = this.getId(),
         crn = this.getCrn(),
+        lastAllocatedToAssessorDate = this.getLastAllocatedToAssessorDate()?.toLocalDateTime()?.toLocalDate(),
         applicationAssessedDate = this.getApplicationAssessedDate()?.toLocalDate(),
         assessorCru = this.getAssessorCru(),
         assessmentDecision = this.getAssessmentDecision(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -39,4 +39,6 @@ data class ApplicationReportRow(
   val departureMoveOnCategory: String?,
   val hasNotArrived: Boolean?,
   val notArrivedReason: String?,
+  val paroleDecisionDate: LocalDate?,
+  val type: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 data class ApplicationReportRow(
   val id: String,
   val crn: String,
+  val lastAllocatedToAssessorDate: LocalDate?,
   val applicationAssessedDate: LocalDate?,
   val assessorCru: String?,
   val assessmentDecision: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -526,6 +526,7 @@ class BookingService(
         applicationId = applicationId,
         crn = booking.crn,
         occurredAt = bookingCreatedAt.toInstant(),
+        bookingId = booking.id,
         data = BookingMadeEnvelope(
           id = domainEventId,
           timestamp = bookingCreatedAt.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -79,7 +79,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.time.OffsetTime
 import java.time.ZoneOffset
 import java.util.UUID
 import javax.transaction.Transactional
@@ -1192,7 +1191,7 @@ class BookingService(
                 surname = staffDetails.staff.surname,
                 username = staffDetails.username,
               ),
-              cancelledAt = cancelledAt.atTime(OffsetTime.MIN).toInstant(),
+              cancelledAt = cancelledAt.atTime(0, 0).toInstant(ZoneOffset.UTC),
               cancellationReason = reason.name,
             ),
           ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -104,6 +104,7 @@ class DomainEventService(
       detailUrl = bookingMadeDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
+      bookingId = domainEvent.bookingId,
     )
 
   @Transactional
@@ -192,12 +193,13 @@ class DomainEventService(
     detailUrl: String,
     crn: String,
     nomsNumber: String,
+    bookingId: UUID? = null,
   ) {
     domainEventRepository.save(
       DomainEventEntity(
         id = domainEvent.id,
         applicationId = domainEvent.applicationId,
-        bookingId = null,
+        bookingId = bookingId,
         crn = domainEvent.crn,
         type = enumTypeFromDataType(domainEvent.data!!::class.java),
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -108,7 +108,7 @@ class ReportService(
   }
 
   fun createCas1ApplicationPerformanceReport(properties: ApplicationReportProperties, outputStream: OutputStream) {
-    ApplicationReportGenerator(offenderService)
+    ApplicationReportGenerator()
       .createReport(applicationEntityReportRowRepository.generateApprovedPremisesReportRowsForCalendarMonth(properties.month, properties.year), properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)

--- a/src/main/resources/db/migration/all/20231211094704__index_domain_event_booking_id_and_backfill_cas1_ids.sql
+++ b/src/main/resources/db/migration/all/20231211094704__index_domain_event_booking_id_and_backfill_cas1_ids.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ON domain_events(booking_id);
+
+UPDATE domain_events SET booking_id = cast(data -> 'eventDetails' ->> 'bookingId' as UUID) WHERE type = 'APPROVED_PREMISES_BOOKING_MADE';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -198,9 +198,9 @@ class ApplicationReportsTest : IntegrationTestBase() {
           val applicationRowWithNonArrivedBooking = actual.find { reportRow -> reportRow.id == applicationWithNonArrivedBooking.id.toString() }!!
 
           assertApplicationRowHasCorrectData(applicationWithBooking.id, applicationRowWithBooking, userEntity, hasBooking = true)
-          assertApplicationRowHasCorrectData(applicationWithDepartedBooking.id, applicationRowWithDepartedBooking, userEntity, hasBooking = true)
-          assertApplicationRowHasCorrectData(applicationWithCancelledBooking.id, applicationRowWithCancelledBooking, userEntity, hasBooking = true)
-          assertApplicationRowHasCorrectData(applicationWithNonArrivedBooking.id, applicationRowWithNonArrivedBooking, userEntity, hasBooking = true)
+          assertApplicationRowHasCorrectData(applicationWithDepartedBooking.id, applicationRowWithDepartedBooking, userEntity, hasDeparture = true)
+          assertApplicationRowHasCorrectData(applicationWithCancelledBooking.id, applicationRowWithCancelledBooking, userEntity, hasCancellation = true)
+          assertApplicationRowHasCorrectData(applicationWithNonArrivedBooking.id, applicationRowWithNonArrivedBooking, userEntity, hasNonArrival = true)
         }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -123,7 +123,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnit
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.time.OffsetTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventService as Cas3DomainEventService
 
@@ -2159,7 +2158,7 @@ class BookingServiceTest {
               legacyApCode = premises.qCode,
               localAuthorityAreaName = premises.localAuthorityArea!!.name,
             ) &&
-              data.cancelledAt == cancelledAt.atTime(OffsetTime.MIN).toInstant() &&
+              data.cancelledAt == Instant.parse("2022-08-25T00:00:00.00Z") &&
               data.cancellationReason == reasonEntity.name
           },
         )
@@ -2237,7 +2236,7 @@ class BookingServiceTest {
               legacyApCode = premises.qCode,
               localAuthorityAreaName = premises.localAuthorityArea!!.name,
             ) &&
-              data.cancelledAt == cancelledAt.atTime(OffsetTime.MIN).toInstant() &&
+              data.cancelledAt == Instant.parse("2022-08-25T00:00:00.00Z") &&
               data.cancellationReason == reasonEntity.name
           },
         )


### PR DESCRIPTION
APS-68 Adding new columns to Application Reports, as detailed on the ticket.

Whilst the ticket details 5 columns, 2 were already being provided in the report. An example report generated locally via teh UI - [applications-2023-12 (3).xlsx](https://github.com/ministryofjustice/hmpps-approved-premises-api/files/13613686/applications-2023-12.3.xlsx)
is attached.

The following has now been resolved by populated the domain_event.booking_id column, indexing the column and backfilling the existing entries via a migration script

> The updated SQL includes a JOIN on a value taken from a 'json' column to help us find if a placement_application exists for the given Booking ID:
> 
> `left join placement_requests on cast(placement_requests.booking_id as text) = booking_made_event.data -> 'eventDetails' ->> 'bookingId'
> left join placement_applications on placement_applications.id = placement_requests.placement_application_id`
> 
> According to [postgres json type documentation](https://www.postgresql.org/docs/current/datatype-json.html), values in the json type cannot be indexed, and as such the join will most likely have performance issues with large sets of data. At a minimum this should be sanity checked against a realistic data set in pre-prod once deployed to the environment.
> 
> We could look at converting the column type to jsonb, which then allows indexing of specific values, but there are some concerns:
> 
> - switching to JSONB will lose insignificant formatting and order is not preserved. It's not clear if this will be an issue
> - switching to JSONB will drop duplicate keys - this _shouldnt_ be an issue if JSON is well defined
> - we'd have to add the index onto the domain_event.data, making the definition of the column specific to a given domain event type
> 
> Alternatively, we could look at sourcing the relationship straight from a postgres column. There is a column 'booking_id' in domain_events (added for CAS3) which isn't populated for CAS1. If this was populated for the APPROVED_PREMISES_BOOKING_MADE event, we could use this instead. This data is readily available in the BookingService that creates the event. For existing data we could use a  migration query to populate this for existing domain event entries
> 