### PR TITLE
[Feature/1722] - Change CAS3 assessment search by using status directly in DB query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -117,7 +117,11 @@ class AssessmentTransformer(
     AssessmentStatus.cas1InProgress -> DomainAssessmentSummaryStatus.IN_PROGRESS
     AssessmentStatus.cas1NotStarted -> DomainAssessmentSummaryStatus.NOT_STARTED
     AssessmentStatus.cas1Reallocated -> DomainAssessmentSummaryStatus.REALLOCATED
-    else -> DomainAssessmentSummaryStatus.IN_PROGRESS
+    AssessmentStatus.cas3InReview -> DomainAssessmentSummaryStatus.IN_REVIEW
+    AssessmentStatus.cas3Unallocated -> DomainAssessmentSummaryStatus.UNALLOCATED
+    AssessmentStatus.cas3Rejected -> DomainAssessmentSummaryStatus.REJECTED
+    AssessmentStatus.cas3Closed -> DomainAssessmentSummaryStatus.CLOSED
+    AssessmentStatus.cas3ReadyToPlace -> DomainAssessmentSummaryStatus.READY_TO_PLACE
   }
 
   private fun transformDomainSummaryDecisionToApi(decision: String?) = when (decision) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -1,13 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessmentStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentSummary
 
 fun List<AssessmentSummary>.sort(sortDirection: SortDirection, sortField: AssessmentSortField): List<AssessmentSummary> {
@@ -30,39 +26,4 @@ fun List<AssessmentSummary>.sort(sortDirection: SortDirection, sortField: Assess
   }
 
   return this.sortedWith(comparator)
-}
-
-fun List<AssessmentSummary>.filterByStatuses(statuses: List<AssessmentStatus>?): List<AssessmentSummary> {
-  if (statuses == null) {
-    return this
-  }
-
-  val approvedPremisesStatuses = statuses.mapNotNull { it.toApprovedPremisesAssessmentStatus() }.toSet()
-  val temporaryAccommodationStatuses = statuses.mapNotNull { it.toTemporaryAccommodationAssessmentStatus() }.toSet()
-
-  return this.filter {
-    when (it) {
-      is ApprovedPremisesAssessmentSummary -> approvedPremisesStatuses.contains(it.status)
-      is TemporaryAccommodationAssessmentSummary -> temporaryAccommodationStatuses.contains(it.status)
-      else -> throw RuntimeException("Unknown assessment summary type '${it::class.qualifiedName}'; could not narrow AssessmentStatus enum to its corresponding service-specific enum.")
-    }
-  }
-}
-
-private fun AssessmentStatus.toApprovedPremisesAssessmentStatus() = when (this) {
-  AssessmentStatus.cas1AwaitingResponse -> ApprovedPremisesAssessmentStatus.awaitingResponse
-  AssessmentStatus.cas1Completed -> ApprovedPremisesAssessmentStatus.completed
-  AssessmentStatus.cas1Reallocated -> ApprovedPremisesAssessmentStatus.reallocated
-  AssessmentStatus.cas1InProgress -> ApprovedPremisesAssessmentStatus.inProgress
-  AssessmentStatus.cas1NotStarted -> ApprovedPremisesAssessmentStatus.notStarted
-  else -> null
-}
-
-private fun AssessmentStatus.toTemporaryAccommodationAssessmentStatus() = when (this) {
-  AssessmentStatus.cas3Unallocated -> TemporaryAccommodationAssessmentStatus.unallocated
-  AssessmentStatus.cas3InReview -> TemporaryAccommodationAssessmentStatus.inReview
-  AssessmentStatus.cas3ReadyToPlace -> TemporaryAccommodationAssessmentStatus.readyToPlace
-  AssessmentStatus.cas3Closed -> TemporaryAccommodationAssessmentStatus.closed
-  AssessmentStatus.cas3Rejected -> TemporaryAccommodationAssessmentStatus.rejected
-  else -> null
 }

--- a/src/main/resources/db/migration/all/20231211082335__add_indices_for_cas3_assessment_search.sql
+++ b/src/main/resources/db/migration/all/20231211082335__add_indices_for_cas3_assessment_search.sql
@@ -1,0 +1,2 @@
+CREATE INDEX ON temporary_accommodation_applications(probation_region_id);
+CREATE INDEX ON applications(crn);


### PR DESCRIPTION
# Changes in this PR
Refere [1722](https://trello.com/c/TTDY9BDm/1722-improve-performance-of-loading-referrals-during-the-receive-journey) for more information.

This PR to overcome performance problem in searching CAS3 assessment. 

**Current**:  the search is happening by selecting all assessment and then filter by assessment status.

**Change**:  This PR is to add the additional WHERE clause to an in existing query using 'status'(assement-status). Additionally merging existing 2 CAS3 assessment search query into single query.

Added indexes to applications(crn), temporary_accommodation_applications(probation_region_id) to improve assessment search query performance.

The status where clause is derived by following the existing logic as below

```
**Status**                                    **DB Query**
rejected                                          assessment.decision = 'REJECTED'
closed                                            assessment.decision = 'ACCEPTED' AND applications.completed_at !=null
ready_to_place                             assessment.decision = 'ACCEPTED' AND applications.completed_at =null
in_review                                       assessment.decision = null AND assessments.allocated_to_user_id !=null
unallocated                                   assessment.decision = null AND assessments.allocated_to_user_id =null
```

We may need to make changes in front end to search assessment with status whenever the user change the status view page.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.