### PR TITLE
Save a Person on a CAS2 Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -6,7 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
@@ -25,6 +28,14 @@ interface Cas2ApplicationRepository : JpaRepository<Cas2ApplicationEntity, UUID>
 SELECT
     CAST(a.id AS TEXT) as id,
     a.crn,
+    a.noms_number as nomsNumber,
+    a.pnc_number as pncNumber,
+    a.name,
+    a.date_of_birth as dateOfBirth,
+    a.nationality,
+    a.sex,
+    a.prison_name as prisonName,
+    a.person_status as personStatus,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
     a.submitted_at as submittedAt
@@ -41,6 +52,14 @@ WHERE a.created_by_user_id = :userId
 SELECT
     CAST(a.id AS TEXT) as id,
     a.crn,
+    a.noms_number as nomsNumber,
+    a.pnc_number as pncNumber,
+    a.name,
+    a.date_of_birth as dateOfBirth,
+    a.nationality,
+    a.sex,
+    a.prison_name as prisonName,
+    a.person_status as personStatus,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
     a.submitted_at as submittedAt
@@ -73,6 +92,22 @@ data class Cas2ApplicationEntity(
 
   val crn: String,
 
+  var nomsNumber: String,
+
+  var pncNumber: String?,
+
+  var name: String,
+
+  var dateOfBirth: LocalDate,
+
+  var nationality: String?,
+
+  var sex: String?,
+
+  var prisonName: String?,
+
+  var personStatus: String,
+
   @ManyToOne
   @JoinColumn(name = "created_by_user_id")
   val createdByUser: NomisUserEntity,
@@ -96,17 +131,41 @@ data class Cas2ApplicationEntity(
   @Transient
   var schemaUpToDate: Boolean,
 
-  var nomsNumber: String?,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
 }
 
+@Suppress("TooManyFunctions")
 interface AppSummary {
   fun getId(): UUID
   fun getCrn(): String
   fun getCreatedByUserId(): UUID
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?
+  fun getNomsNumber(): String
+  fun getPncNumber(): String?
+  fun getName(): String
+  fun getDateOfBirth(): LocalDate
+  fun getNationality(): String?
+  fun getSex(): String
+  fun getPrisonName(): String?
+  fun getPersonStatus(): String
+  fun getPerson(): FullPerson
 }
 
-interface Cas2ApplicationSummary : AppSummary
+interface Cas2ApplicationSummary : AppSummary {
+  override fun getPerson(): FullPerson {
+    return FullPerson(
+      type = PersonType.fullPerson,
+      crn = this.getCrn(),
+      nomsNumber = this.getNomsNumber(),
+      pncNumber = this.getPncNumber(),
+      name = this.getName(),
+      dateOfBirth = this.getDateOfBirth(),
+      nationality = this.getNationality(),
+      sex = this.getSex(),
+      prisonName = this.getPrisonName(),
+      status = FullPerson.Status.valueOf(this.getPersonStatus()),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.io.DefaultResourceLoader
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
@@ -17,9 +18,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import java.io.IOException
 import java.io.InputStreamReader
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@Suppress("MagicNumber")
 class Cas2ApplicationsSeedJob(
   fileName: String,
   private val repository: Cas2ApplicationRepository,
@@ -74,6 +77,13 @@ class Cas2ApplicationsSeedJob(
         submittedAt = row.submittedAt,
         schemaVersion = jsonSchemaService.getNewestSchema(Cas2ApplicationJsonSchemaEntity::class.java),
         schemaUpToDate = true,
+        name = "Aadland Bertrand",
+        dateOfBirth = LocalDate.of(1978, 1, 6),
+        sex = "Male",
+        personStatus = Cas2NewApplication.PersonStatus.inCustody.name,
+        nationality = null,
+        pncNumber = null,
+        prisonName = null,
       ),
     )
     if (row.statusUpdates != "0") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -4,6 +4,7 @@ import org.springframework.core.io.DefaultResourceLoader
 import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import java.io.IOException
 import java.io.InputStreamReader
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -31,6 +33,7 @@ const val MOST_UPDATES = 6
 const val MINUTES_PER_DAY = 60 * 24
 
 @Component
+@Suppress("MagicNumber")
 class Cas2AutoScript(
   private val seedLogger: SeedLogger,
   private val nomisUserRepository: NomisUserRepository,
@@ -69,6 +72,13 @@ class Cas2AutoScript(
         submittedAt = submittedAt,
         schemaVersion = jsonSchemaService.getNewestSchema(Cas2ApplicationJsonSchemaEntity::class.java),
         schemaUpToDate = true,
+        name = "Aadland Bertrand",
+        dateOfBirth = LocalDate.of(1978, 1, 6),
+        sex = "Male",
+        personStatus = Cas2NewApplication.PersonStatus.inCustody.name,
+        nationality = null,
+        pncNumber = null,
+        prisonName = null,
       ),
     )
     if (state == "IN_REVIEW") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -5,6 +5,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ProbationOffenderSearchResult
@@ -84,8 +86,36 @@ class PersonTransformer {
         probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyName
           ?: probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyId
       },
-      isRestricted = (probationOffenderResult.probationOffenderDetail.currentExclusion ?: false || probationOffenderResult.probationOffenderDetail.currentRestriction ?: false),
     )
+
+  fun transformCas2ApplicationEntityToPersonApi(application: Cas2ApplicationEntity) =
+    FullPerson(
+      type = PersonType.fullPerson,
+      crn = application.crn,
+      name = application.name,
+      dateOfBirth = application.dateOfBirth,
+      sex = application.sex ?: "Not found",
+      status = FullPerson.Status.valueOf(application.personStatus),
+      nomsNumber = application.nomsNumber,
+      pncNumber = application.pncNumber ?: "Not found",
+      nationality = application.nationality ?: "Not found",
+      prisonName = application.prisonName,
+    )
+
+  fun transformCas2ApplicationSummaryToPersonApi(applicationSummary: Cas2ApplicationSummary) =
+    FullPerson(
+      type = PersonType.fullPerson,
+      crn = applicationSummary.getCrn(),
+      name = applicationSummary.getName(),
+      dateOfBirth = applicationSummary.getDateOfBirth(),
+      sex = applicationSummary.getSex() ?: "Not found",
+      status = FullPerson.Status.valueOf(applicationSummary.getPersonStatus()),
+      nomsNumber = applicationSummary.getNomsNumber(),
+      pncNumber = applicationSummary.getPncNumber() ?: "Not found",
+      nationality = applicationSummary.getNationality() ?: "Not found",
+      prisonName = applicationSummary.getPrisonName(),
+    )
+
   private fun inOutStatusToPersonInfoApiStatus(inOutStatus: InOutStatus?) = when (inOutStatus) {
     InOutStatus.IN -> FullPerson.Status.inCustody
     InOutStatus.OUT -> FullPerson.Status.inCommunity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 
 @Component("Cas2ApplicationsTransformer")
@@ -15,11 +14,11 @@ class ApplicationsTransformer(
   private val personTransformer: PersonTransformer,
 ) {
 
-  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult):
+  fun transformJpaToApi(jpa: Cas2ApplicationEntity):
     Cas2Application {
     return Cas2Application(
       id = jpa.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.transformCas2ApplicationEntityToPersonApi(jpa),
       createdByUserId = jpa.createdByUser.id,
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
@@ -34,13 +33,11 @@ class ApplicationsTransformer(
 
   fun transformJpaSummaryToSummary(
     jpaSummary: Cas2ApplicationSummary,
-    personInfo:
-      PersonInfoResult.Success,
   ): uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary {
     return uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
       .Cas2ApplicationSummary(
         id = jpaSummary.getId(),
-        person = personTransformer.transformModelToPersonApi(personInfo),
+        person = personTransformer.transformCas2ApplicationSummaryToPersonApi(jpaSummary),
         createdByUserId = jpaSummary.getCreatedByUserId(),
         createdAt = jpaSummary.getCreatedAt().toInstant(),
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 
@@ -22,14 +21,11 @@ class SubmittedApplicationTransformer(
 
   fun transformJpaToApiRepresentation(
     jpa: Cas2ApplicationEntity,
-    personInfo:
-      PersonInfoResult
-      .Success,
   ):
     Cas2SubmittedApplication {
     return Cas2SubmittedApplication(
       id = jpa.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.transformCas2ApplicationEntityToPersonApi(jpa),
       submittedBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
@@ -42,12 +38,10 @@ class SubmittedApplicationTransformer(
 
   fun transformJpaSummaryToApiRepresentation(
     jpaSummary: Cas2ApplicationSummary,
-    personInfo:
-      PersonInfoResult.Success,
   ): Cas2SubmittedApplicationSummary {
     return Cas2SubmittedApplicationSummary(
       id = jpaSummary.getId(),
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.transformCas2ApplicationSummaryToPersonApi(jpaSummary),
       createdByUserId = jpaSummary.getCreatedByUserId(),
       createdAt = jpaSummary.getCreatedAt().toInstant(),
       submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),

--- a/src/main/resources/db/migration/all/20231213095259__add_person_to_cas_2_application.sql
+++ b/src/main/resources/db/migration/all/20231213095259__add_person_to_cas_2_application.sql
@@ -1,0 +1,7 @@
+ALTER TABLE cas_2_applications ADD COLUMN pnc_number TEXT;
+ALTER TABLE cas_2_applications ADD COLUMN name TEXT NOT NULL;
+ALTER TABLE cas_2_applications ADD COLUMN date_of_birth DATE NOT NULL;
+ALTER TABLE cas_2_applications ADD COLUMN nationality TEXT;
+ALTER TABLE cas_2_applications ADD COLUMN sex TEXT;
+ALTER TABLE cas_2_applications ADD COLUMN prison_name TEXT;
+ALTER TABLE cas_2_applications ADD COLUMN person_status TEXT NOT NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1894,6 +1894,38 @@ components:
           example: "M1502750438"
       required:
         - crn
+    Cas2NewApplication:
+      type: object
+      properties:
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+        name:
+          type: string
+        dateOfBirth:
+          type: string
+          format: date
+        nationality:
+          type: string
+        sex:
+          type: string
+        personStatus:
+          type: string
+          enum:
+            - InCustody
+            - InCommunity
+            - Unknown
+        prisonName:
+          type: string
+        pncNumber:
+          type: string
+      required:
+        - crn
+        - nomsNumber
+        - name
+        - dateOfBirth
+        - personStatus
     UpdateApplicationType:
       type: string
       enum:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -15,7 +15,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '_shared.yml#/components/schemas/NewApplication'
+              $ref: '_shared.yml#/components/schemas/Cas2NewApplication'
         required: true
       responses:
         201:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6066,6 +6066,38 @@ components:
           example: "M1502750438"
       required:
         - crn
+    Cas2NewApplication:
+      type: object
+      properties:
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+        name:
+          type: string
+        dateOfBirth:
+          type: string
+          format: date
+        nationality:
+          type: string
+        sex:
+          type: string
+        personStatus:
+          type: string
+          enum:
+            - InCustody
+            - InCommunity
+            - Unknown
+        prisonName:
+          type: string
+        pncNumber:
+          type: string
+      required:
+        - crn
+        - nomsNumber
+        - name
+        - dateOfBirth
+        - personStatus
     UpdateApplicationType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -17,7 +17,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/NewApplication'
+              $ref: '#/components/schemas/Cas2NewApplication'
         required: true
       responses:
         201:
@@ -2289,6 +2289,38 @@ components:
           example: "M1502750438"
       required:
         - crn
+    Cas2NewApplication:
+      type: object
+      properties:
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+        name:
+          type: string
+        dateOfBirth:
+          type: string
+          format: date
+        nationality:
+          type: string
+        sex:
+          type: string
+        personStatus:
+          type: string
+          enum:
+            - InCustody
+            - InCommunity
+            - Unknown
+        prisonName:
+          type: string
+        pncNumber:
+          type: string
+      required:
+        - crn
+        - nomsNumber
+        - name
+        - dateOfBirth
+        - personStatus
     UpdateApplicationType:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
@@ -10,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -27,6 +29,14 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var statusUpdates: Yielded<MutableList<Cas2StatusUpdateEntity>> = { mutableListOf() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+
+  private var name: Yielded<String> = { "First Surname" }
+  private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(60) }
+  private var nationality: Yielded<String?> = { null }
+  private var sex: Yielded<String?> = { null }
+  private var prisonName: Yielded<String?> = { null }
+  private var pncNumber: Yielded<String?> = { null }
+  private var personStatus: Yielded<String> = { Cas2NewApplication.PersonStatus.inCustody.name }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -80,6 +90,22 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.eventNumber = { eventNumber }
   }
 
+  fun withNationality(nationality: String) = apply {
+    this.nationality = { nationality }
+  }
+
+  fun withSex(sex: String) = apply {
+    this.sex = { sex }
+  }
+
+  fun withPrisonName(prisonName: String) = apply {
+    this.prisonName = { prisonName }
+  }
+
+  fun withPncNumber(pncNumber: String) = apply {
+    this.pncNumber = { pncNumber }
+  }
+
   override fun produce(): Cas2ApplicationEntity = Cas2ApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -92,5 +118,12 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     statusUpdates = this.statusUpdates(),
     schemaUpToDate = false,
     nomsNumber = this.nomsNumber(),
+    name = this.name(),
+    sex = this.sex(),
+    nationality = this.nationality(),
+    dateOfBirth = this.dateOfBirth(),
+    prisonName = this.prisonName(),
+    pncNumber = this.pncNumber(),
+    personStatus = this.personStatus(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -13,8 +13,8 @@ import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Application
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockNotFoundInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
@@ -159,6 +158,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withApplicationSchema(applicationSchema)
               withCreatedByUser(userEntity)
               withCrn(offenderDetails.otherIds.crn)
+              withNomsNumber("NOMS123")
               withData("{}")
             }
 
@@ -166,6 +166,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withApplicationSchema(applicationSchema)
               withCreatedByUser(otherUser)
               withCrn(offenderDetails.otherIds.crn)
+              withNomsNumber("NOMS456")
               withData("{}")
             }
 
@@ -200,31 +201,13 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get list of applications returns 500 when a person cannot be found`() {
-      `Given a CAS2 User`() { userEntity, jwt ->
-        val crn = "X1234"
-
-        produceAndPersistBasicApplication(crn, userEntity)
-        CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-        loadPreemptiveCacheForOffenderDetails(crn)
-
-        webTestClient.get()
-          .uri("/cas2/applications")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .is5xxServerError
-          .expectBody()
-          .jsonPath("$.detail").isEqualTo("Unable to get Person via crn: $crn")
-      }
-    }
-
-    @Test
     fun `Get list of applications returns successfully when the person cannot be fetched from the prisons API`() {
       `Given a CAS2 User`() { userEntity, jwt ->
         val crn = "X1234"
 
-        val application = produceAndPersistBasicApplication(crn, userEntity)
+        val nomsNumber = "NOMS123"
+
+        val application = produceAndPersistBasicApplication(crn, nomsNumber, userEntity)
 
         val offenderDetails = OffenderDetailsSummaryFactory()
           .withCrn(crn)
@@ -258,8 +241,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
           application.id == it[0].id &&
             application.crn == person.crn &&
-            person.nomsNumber == null &&
-            person.status == FullPerson.Status.unknown &&
+            person.nomsNumber == application.nomsNumber &&
+            person.status == FullPerson.Status.inCustody &&
             person.prisonName == null
         }
       }
@@ -337,52 +320,6 @@ class Cas2ApplicationTest : IntegrationTestBase() {
         }
       }
     }
-
-    @Test
-    fun `Get single application returns successfully when the person cannot be fetched from the prisons API`() {
-      `Given a CAS2 User`() { userEntity, jwt ->
-        val crn = "X1234"
-
-        val application = produceAndPersistBasicApplication(crn, userEntity)
-
-        val offenderDetails = OffenderDetailsSummaryFactory()
-          .withCrn(crn)
-          .withNomsNumber("ABC123")
-          .produce()
-
-        CommunityAPI_mockSuccessfulOffenderDetailsCall(offenderDetails)
-        loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
-        PrisonAPI_mockNotFoundInmateDetailsCall(offenderDetails.otherIds.nomsNumber!!)
-        loadPreemptiveCacheForInmateDetails(offenderDetails.otherIds.nomsNumber!!)
-
-        val rawResponseBody = webTestClient.get()
-          .uri("/cas2/applications/${application.id}")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .returnResult<String>()
-          .responseBody
-          .blockFirst()
-
-        val responseBody = objectMapper.readValue(
-          rawResponseBody,
-          Cas2Application::class.java,
-        )
-
-        Assertions.assertThat(responseBody.person is FullPerson).isTrue
-
-        Assertions.assertThat(responseBody).matches {
-          val person = it.person as FullPerson
-
-          application.id == it.id &&
-            application.crn == person.crn &&
-            person.nomsNumber == null &&
-            person.status == FullPerson.Status.unknown &&
-            person.prisonName == null
-        }
-      }
-    }
   }
 
   @Nested
@@ -402,8 +339,12 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .bodyValue(
-              NewApplication(
+              Cas2NewApplication(
                 crn = offenderDetails.otherIds.crn,
+                nomsNumber = "NOMS456",
+                dateOfBirth = offenderDetails.dateOfBirth,
+                name = "${offenderDetails.firstName} ${offenderDetails.surname}",
+                personStatus = Cas2NewApplication.PersonStatus.inCustody,
               ),
             )
             .exchange()
@@ -420,35 +361,6 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               it.schemaVersion == applicationSchema.id
           }
         }
-      }
-    }
-
-    @Test
-    fun `Create new application returns 404 when a person cannot be found`() {
-      `Given a CAS2 User` { userEntity, jwt ->
-        val crn = "X1234"
-
-        CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-        loadPreemptiveCacheForOffenderDetails(crn)
-
-        cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withAddedAt(OffsetDateTime.now())
-          withId(UUID.randomUUID())
-        }
-
-        webTestClient.post()
-          .uri("/cas2/applications")
-          .header("Authorization", "Bearer $jwt")
-          .bodyValue(
-            NewApplication(
-              crn = crn,
-            ),
-          )
-          .exchange()
-          .expectStatus()
-          .isNotFound
-          .expectBody()
-          .jsonPath("$.detail").isEqualTo("No Offender with an ID of $crn could be found")
       }
     }
   }
@@ -525,6 +437,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
   private fun produceAndPersistBasicApplication(
     crn: String,
+    nomsNumber: String,
     userEntity: NomisUserEntity,
   ): Cas2ApplicationEntity {
     val jsonSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -552,6 +465,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     val application = cas2ApplicationEntityFactory.produceAndPersist {
       withApplicationSchema(jsonSchema)
       withCrn(crn)
+      withNomsNumber(nomsNumber)
       withCreatedByUser(userEntity)
       withData(
         """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -135,7 +135,6 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
                 nomsNumber = "NOMS321",
                 pncNumber = "PNC123",
                 nationality = "English",
-                isRestricted = false,
                 prisonName = "HMP Bristol",
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
@@ -28,8 +28,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.UserAccessService
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -37,7 +37,6 @@ class ApplicationServiceTest {
   private val mockUserRepository = mockk<NomisUserRepository>()
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
   private val mockJsonSchemaService = mockk<JsonSchemaService>()
-  private val mockOffenderService = mockk<OffenderService>()
   private val mockUserService = mockk<NomisUserService>()
   private val mockUserAccessService = mockk<UserAccessService>()
   private val mockDomainEventService = mockk<DomainEventService>()
@@ -47,7 +46,6 @@ class ApplicationServiceTest {
     mockUserRepository,
     mockApplicationRepository,
     mockJsonSchemaService,
-    mockOffenderService,
     mockUserService,
     mockUserAccessService,
     mockDomainEventService,
@@ -128,50 +126,22 @@ class ApplicationServiceTest {
 
   @Nested
   inner class CreateApplication {
-    @Test
-    fun `returns FieldValidationError when Offender is not found`() {
-      val crn = "CRN345"
-      val username = "SOMEPERSON"
-
-      every { mockOffenderService.getOffenderByCrn(crn) } returns AuthorisableActionResult.NotFound()
-
-      val user = userWithUsername(username)
-
-      val result = applicationService.createApplication(crn, user, "jwt")
-
-      assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
-      result as ValidatableActionResult.FieldValidationError
-      assertThat(result.validationMessages).containsEntry("$.crn", "doesNotExist")
-    }
-
-    @Test
-    fun `returns FieldValidationError when user is not authorised to view CRN`() {
-      val crn = "CRN345"
-      val username = "SOMEPERSON"
-
-      every { mockOffenderService.getOffenderByCrn(crn) } returns AuthorisableActionResult.Unauthorised()
-
-      val user = userWithUsername(username)
-
-      val result = applicationService.createApplication(crn, user, "jwt")
-
-      assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
-      result as ValidatableActionResult.FieldValidationError
-      assertThat(result.validationMessages).containsEntry("$.crn", "userPermission")
-    }
 
     @Test
     fun `returns Success with created Application`() {
       val crn = "CRN345"
       val username = "SOMEPERSON"
+      val newApplication = Cas2NewApplication(
+        crn = crn,
+        nomsNumber = "NOMS123",
+        dateOfBirth = LocalDate.now().minusYears(40),
+        name = "Bob Smith",
+        personStatus = Cas2NewApplication.PersonStatus.inCustody,
+      )
 
       val schema = Cas2ApplicationJsonSchemaEntityFactory().produce()
 
       val user = userWithUsername(username)
-
-      every { mockOffenderService.getOffenderByCrn(crn) } returns AuthorisableActionResult.Success(
-        OffenderDetailsSummaryFactory().produce(),
-      )
 
       every { mockJsonSchemaService.getNewestSchema(Cas2ApplicationJsonSchemaEntity::class.java) } returns schema
       every { mockApplicationRepository.save(any()) } answers {
@@ -179,7 +149,7 @@ class ApplicationServiceTest {
           Cas2ApplicationEntity
       }
 
-      val result = applicationService.createApplication(crn, user, "jwt")
+      val result = applicationService.createApplication(newApplication, user, "jwt")
 
       assertThat(result is ValidatableActionResult.Success).isTrue
       result as ValidatableActionResult.Success
@@ -512,15 +482,6 @@ class ApplicationServiceTest {
         it.invocation.args[0]
           as Cas2ApplicationEntity
       }
-
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withGender("male")
-        .withCrn(application.crn)
-        .produce()
-
-      every { mockOffenderService.getOffenderByCrn(application.crn) } returns AuthorisableActionResult.Success(
-        offenderDetails,
-      )
 
       val _schema = application.schemaVersion as Cas2ApplicationJsonSchemaEntity
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOffenderDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -440,7 +442,6 @@ class PersonTransformerTest {
           pncNumber = pncNumber,
           nationality = probationOffenderDetail.offenderProfile?.nationality!!,
           prisonName = inmateDetail.assignedLivingUnit?.agencyName,
-          isRestricted = false,
         ),
       )
     }
@@ -454,8 +455,8 @@ class PersonTransformerTest {
         .produce()
       val probationOffenderDetail = ProbationOffenderDetailFactory()
         .withGender(null)
-        .withOtherIds(otherIds = IDs(nomsNumber = nomsNumber, crn = crn))
-        .withOffenderProfile(offenderProfile = ProbationOffenderProfile(religion = "Atheist"))
+        .withOtherIds(otherIds = IDs(nomsNumber = nomsNumber, crn = crn, pncNumber = null))
+        .withOffenderProfile(offenderProfile = ProbationOffenderProfile(religion = "Atheist", nationality = null))
         .produce()
 
       val probationOffenderSearchResult = ProbationOffenderSearchResult.Success.Full(nomsNumber, probationOffenderDetail, inmateDetail)
@@ -476,9 +477,55 @@ class PersonTransformerTest {
           pncNumber = "Not found",
           nationality = "Not found",
           prisonName = inmateDetail.assignedLivingUnit?.agencyName,
-          isRestricted = false,
         ),
       )
+    }
+
+    @Nested
+    inner class transformCas2ApplicationEntityToPersonApi {
+      @Test
+      fun `returns the correct response when optional data nationality, sex, prison name, pnc number are missing`() {
+        val crn = "CRN123"
+        val nomsNumber = "NOMS456"
+        val createdByUser = NomisUserEntityFactory().produce()
+        val applicationEntity = Cas2ApplicationEntityFactory()
+          .withCreatedByUser(createdByUser)
+          .withCrn(crn)
+          .withNomsNumber(nomsNumber)
+          .produce()
+        val result = personTransformer.transformCas2ApplicationEntityToPersonApi(applicationEntity)
+
+        assertThat(result.crn).isEqualTo(crn)
+        assertThat(result.nomsNumber).isEqualTo(nomsNumber)
+      }
+
+      @Test
+      fun `returns the correct response when optional data nationality, sex, prison name, pnc number exist`() {
+        val crn = "CRN123"
+        val nomsNumber = "NOMS456"
+        val createdByUser = NomisUserEntityFactory().produce()
+        val nationality = "British"
+        val sex = "Male"
+        val prisonName = "HMP Bristol"
+        val pncNumber = "PNC123"
+        val applicationEntity = Cas2ApplicationEntityFactory()
+          .withCreatedByUser(createdByUser)
+          .withCrn(crn)
+          .withNomsNumber(nomsNumber)
+          .withNationality(nationality)
+          .withSex(sex)
+          .withPrisonName(prisonName)
+          .withPncNumber(pncNumber)
+          .produce()
+        val result = personTransformer.transformCas2ApplicationEntityToPersonApi(applicationEntity)
+
+        assertThat(result.crn).isEqualTo(crn)
+        assertThat(result.nomsNumber).isEqualTo(nomsNumber)
+        assertThat(result.nationality).isEqualTo(nationality)
+        assertThat(result.sex).isEqualTo(sex)
+        assertThat(result.prisonName).isEqualTo(prisonName)
+        assertThat(result.pncNumber).isEqualTo(pncNumber)
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -11,14 +11,17 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -47,6 +50,8 @@ class ApplicationsTransformerTest {
   @BeforeEach
   fun setup() {
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.transformCas2ApplicationEntityToPersonApi(any()) } returns mockk<FullPerson>()
+    every { mockPersonTransformer.transformCas2ApplicationSummaryToPersonApi(any()) } returns mockk<FullPerson>()
   }
 
   @Nested
@@ -58,7 +63,7 @@ class ApplicationsTransformerTest {
         .withSubmittedAt(null)
         .produce()
 
-      val result = applicationsTransformer.transformJpaToApi(application, mockk())
+      val result = applicationsTransformer.transformJpaToApi(application)
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.createdByUserId).isEqualTo(user.id)
@@ -70,7 +75,7 @@ class ApplicationsTransformerTest {
     fun `transformJpaToApi transforms a submitted CAS2 application correctly`() {
       val application = submittedCas2ApplicationFactory.produce()
 
-      val result = applicationsTransformer.transformJpaToApi(application, mockk())
+      val result = applicationsTransformer.transformJpaToApi(application)
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
@@ -85,35 +90,64 @@ class ApplicationsTransformerTest {
     () {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
-        override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getCrn() = "CRN456"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
+        override fun getNomsNumber() = "NOMS123"
+        override fun getPncNumber() = "PNC321"
+        override fun getName() = "Robert Smith"
+        override fun getDateOfBirth() = LocalDate.now().minusYears(60)
+        override fun getNationality() = "British"
+        override fun getSex() = "Male"
+        override fun getPrisonName() = "HMP Bristol"
+        override fun getPersonStatus() = Cas2NewApplication.PersonStatus.inCustody.name
       }
+
+      val person = FullPerson(
+        crn = "CRN456",
+        nomsNumber = "NOMS123",
+        name = "Robert Smith",
+        dateOfBirth = LocalDate.now().minusYears(60),
+        sex = "Male",
+        status = FullPerson.Status.inCustody,
+        type = PersonType.fullPerson,
+      )
+
+      every { mockPersonTransformer.transformCas2ApplicationSummaryToPersonApi(application) } returns person
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockk(),
       )
+
+      val personReturned = result.person as FullPerson
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
+      assertThat(personReturned).isEqualTo(person)
     }
 
     @Test
     fun `transforms a submitted CAS2 application correctly`() {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
-        override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getCrn() = "CRN456"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getNomsNumber() = "NOMS123"
+        override fun getPncNumber() = "PNC321"
+        override fun getName() = "Robert Smith"
+        override fun getDateOfBirth() = LocalDate.now().minusYears(60)
+        override fun getNationality() = "British"
+        override fun getSex() = "Male"
+        override fun getPrisonName() = "HMP Bristol"
+        override fun getPersonStatus() = Cas2NewApplication.PersonStatus.inCustody.name
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockk(),
       )
 
       assertThat(result.id).isEqualTo(application.getId())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -10,9 +10,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Submitt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -59,7 +61,8 @@ class SubmittedApplicationTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.transformCas2ApplicationEntityToPersonApi(any()) } returns mockk<FullPerson>()
+    every { mockPersonTransformer.transformCas2ApplicationSummaryToPersonApi(any()) } returns mockk<FullPerson>()
     every { mockNomisUserTransformer.transformJpaToApi(any()) } returns mockNomisUser
     every { mockStatusUpdateTransformer.transformJpaToApi(any()) } returns mockStatusUpdateApi
   }
@@ -70,7 +73,7 @@ class SubmittedApplicationTransformerTest {
     fun `transforms to API representation with NomisUser, no data and status updates`() {
       val jpaEntity = submittedCas2ApplicationFactory.produce()
 
-      val transformation = applicationTransformer.transformJpaToApiRepresentation(jpaEntity, mockk())
+      val transformation = applicationTransformer.transformJpaToApiRepresentation(jpaEntity)
 
       assertThat(transformation.submittedBy).isEqualTo(mockNomisUser)
 
@@ -102,9 +105,17 @@ class SubmittedApplicationTransformerTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
+        override fun getPncNumber() = randomStringMultiCaseWithNumbers(6)
+        override fun getName() = "Robert Smith"
+        override fun getDateOfBirth() = LocalDate.now().minusYears(60)
+        override fun getNationality() = "British"
+        override fun getSex() = "Male"
+        override fun getPrisonName() = "HMP Bristol"
+        override fun getPersonStatus() = Cas2NewApplication.PersonStatus.inCustody.name
       }
 
-      val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(applicationSummary, mockk())
+      val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(applicationSummary)
 
       assertThat(transformation.id).isEqualTo(applicationSummary.getId())
     }


### PR DESCRIPTION
Currently, we store the CRN of a person on an application, and then use that CRN to make an API call to retrieve the rest of the person's data whenever we return an application or application summary.

Instead, we would like to store a "snapshot" of the information about the Person on an CAS2 application, at the moment when the application is created.

We would like to save these fields on an Application Entity, which will be used to build the `person` field on an `Application` that is returned to the frontend. 

```      
nomsNumber
pncNumber 
name 
dateOfBirth 
nationality 
sex 
prisonName 
personStatus 
isRestricted 
```

To do this we need to:

1. Change the `Cas2ApplicationEntity` 
We plan to change the underlying entity to hold these new fields. 
1. Run a migration to add these new columns to CAS2 applications
Is what I'm doing right? What if there are existing applications without these columns but some of them are not nullable?
1. Save the required new data when an application is created
In `createApplication` on the Application service we take the fields needed and save them against the application. This requires a new model to match what a new CAS2 Application requires.
1. Change how we transform entities to api responses
Instead of using a result from the API, we get the FullPerson from the jpa entity

Should not be merged until we're happy with the frontend as well:
https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/360

## outstanding questions
* is migration done properly?
* it's a lot of new fields which is quite fiddly. would there be neater way of passing these fields from frontend?
