### PR TITLE
Increase memory limit responses for probation offender search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -295,6 +295,11 @@ class WebClientConfiguration(
         ),
       )
       .filter(oauth2Client)
+      .exchangeStrategies(
+        ExchangeStrategies.builder().codecs {
+          it.defaultCodecs().maxInMemorySize(maxResponseInMemorySizeBytes)
+        }.build(),
+      )
       .build()
   }
 }


### PR DESCRIPTION
We are seeing a `DataBufferLimitException` thrown when searching for the NOMIS ID that we use in our e2es on the dev environment, we think because the domain events in cas1/3 have a created a long list of addresses for this person on the nDelius API. [1]

This commit configures the memory limit for the relevant client, as we've done elsewhere [2] to see if that unblocks us while we wait for a more long term solution.

[1]https://mojdt.slack.com/archives/C03K0HB0LBE/p1702296717838819?thread_ts=1702291579.139989&cid=C03K0HB0LBE 
[2] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1120