### PR TITLE
Change cas3 e2e test booking to use non-lao crn

### DIFF
--- a/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
+++ b/src/main/resources/db/migration/dev+test/R__5_create_bookings_for_cas3_kss.sql
@@ -439,7 +439,7 @@ VALUES
     'b8d2b571-b5ce-4df4-8e99-f65a86470ef0',
     CURRENT_DATE - (5 * 2),
     CURRENT_DATE - (5 * 2) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 2),
     CURRENT_DATE - (5 * 2) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -511,7 +511,7 @@ VALUES
     'dd833ba5-2924-4bda-8e5f-6036c2eef8c8',
     CURRENT_DATE - (5 * 3),
     CURRENT_DATE - (5 * 3) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 3),
     CURRENT_DATE - (5 * 3) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -583,7 +583,7 @@ VALUES
     '10df1538-39d3-4f69-af32-53907f020f61',
     CURRENT_DATE - (5 * 4),
     CURRENT_DATE - (5 * 4) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 4),
     CURRENT_DATE - (5 * 4) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -655,7 +655,7 @@ VALUES
     '013d0da0-9dc9-4aa5-a95a-be23f67cb20c',
     CURRENT_DATE - (5 * 5),
     CURRENT_DATE - (5 * 5) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 5),
     CURRENT_DATE - (5 * 5) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -727,7 +727,7 @@ VALUES
     'f65006c9-2d6f-49f9-a800-3e3b71b9db72',
     CURRENT_DATE - (5 * 6),
     CURRENT_DATE - (5 * 6) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 6),
     CURRENT_DATE - (5 * 6) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -799,7 +799,7 @@ VALUES
     '4096917e-42ff-4adb-b141-bbd39ac19ce7',
     CURRENT_DATE - (5 * 7),
     CURRENT_DATE - (5 * 7) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 7),
     CURRENT_DATE - (5 * 7) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -871,7 +871,7 @@ VALUES
     'c97bb88b-da6a-4a96-8c98-664b0bebd9e1',
     CURRENT_DATE - (5 * 8),
     CURRENT_DATE - (5 * 8) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 8),
     CURRENT_DATE - (5 * 8) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -943,7 +943,7 @@ VALUES
     '70ba95d6-d3e1-4a1b-85bc-8f37fbf8618f',
     CURRENT_DATE - (5 * 8),
     CURRENT_DATE - (5 * 8) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 8),
     CURRENT_DATE - (5 * 8) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -1015,7 +1015,7 @@ VALUES
     '9eec3324-c5db-4983-9907-cdd12890dd39',
     CURRENT_DATE - (5 * 9),
     CURRENT_DATE - (5 * 9) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 9),
     CURRENT_DATE - (5 * 9) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -1087,7 +1087,7 @@ VALUES
     '99d8f177-ab9a-4afc-a5b9-360ccd40c5dc',
     CURRENT_DATE - (5 * 10),
     CURRENT_DATE - (5 * 10) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 10),
     CURRENT_DATE - (5 * 10) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',
@@ -1159,7 +1159,7 @@ VALUES
     '541ab042-3b7b-4fb2-b1be-a36b42581ec3',
     CURRENT_DATE - (5 * 11),
     CURRENT_DATE - (5 * 11) - 2,
-    'X698334', -- Multiple offences
+    'X371199',
     CURRENT_DATE - (5 * 11),
     CURRENT_DATE - (5 * 11) - 2,
     'e2543d2f-33a9-454b-ae15-03ca0475faa3',


### PR DESCRIPTION
This PR is to change the CAS3 e2e test booking to use Non-LAO CRN to make the booking pagination to work in E2E.