### PR TITLE
593 pt 2 CAS2 "auto-script" seeding for dev test

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -37,6 +37,7 @@ generic-service:
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
+    SEED_AUTO-SCRIPT_ENABLED: true
     NOTIFY_MODE: TEST_AND_GUEST_LIST
     HMPPS_SQS_USE_WEB_TOKEN: true
 

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -32,6 +32,7 @@ generic-service:
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,bookingCancelledUpdated,personDepartureUpdated,personArrivedUpdated
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
+    SEED_AUTO-SCRIPT_ENABLED: true
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/SeedConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/SeedConfig.kt
@@ -8,9 +8,14 @@ import org.springframework.context.annotation.Configuration
 class SeedConfig {
   lateinit var filePrefix: String
   var auto: AutoSeedConfig = AutoSeedConfig()
+  var autoScript: AutoScriptConfig = AutoScriptConfig()
 }
 
 class AutoSeedConfig {
   var enabled: Boolean = false
   var filePrefixes: List<String> = listOf()
+}
+
+class AutoScriptConfig {
+  var enabled: Boolean = false
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -1,13 +1,145 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2
 
+import org.springframework.core.io.DefaultResourceLoader
 import org.springframework.stereotype.Component
+import org.springframework.util.FileCopyUtils
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
+import java.io.IOException
+import java.io.InputStreamReader
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import kotlin.random.Random
+
+const val EARLIEST_CREATION = 45
+const val LATEST_CREATION = 15
+const val EARLIEST_SUBMISSION = 1
+const val LATEST_SUBMISSION = 5
+const val FEWEST_UPDATES = 1
+const val MOST_UPDATES = 6
+const val MINUTES_PER_DAY = 60 * 24
 
 @Component
 class Cas2AutoScript(
-
+  private val seedLogger: SeedLogger,
+  private val nomisUserRepository: NomisUserRepository,
+  private val applicationRepository: Cas2ApplicationRepository,
+  private val externalUserRepository: ExternalUserRepository,
+  private val statusUpdateRepository: Cas2StatusUpdateRepository,
+  private val jsonSchemaService: JsonSchemaService,
 ) {
   fun script() {
-    // noop
+    seedLogger.info("Auto-Scripting for CAS2")
+    scriptApplications()
   }
 
+  private fun scriptApplications() {
+    seedLogger.info("Auto-Scripting CAS2 applications")
+    nomisUserRepository.findAll().forEach { user ->
+      listOf("IN_PROGRESS", "SUBMITTED", "IN_REVIEW").forEach { state ->
+        createApplicationFor(applicant = user, state = state)
+      }
+    }
+  }
+
+  private fun createApplicationFor(applicant: NomisUserEntity, state: String) {
+    seedLogger.info("Auto-scripting application for ${applicant.nomisUsername}, in state $state")
+    val createdAt = randomDateTime()
+    val submittedAt = if (state == "IN_PROGRESS") null else createdAt.plusDays(randomInt(EARLIEST_SUBMISSION, LATEST_SUBMISSION).toLong())
+    val application = applicationRepository.save(
+      Cas2ApplicationEntity(
+        id = UUID.randomUUID(),
+        crn = "X320741",
+        nomsNumber = "G9542VP",
+        createdAt = createdAt,
+        createdByUser = applicant,
+        data = dataFor(state = state, nomsNumber = "A1234AI"),
+        document = documentFor(state = state, nomsNumber = "A1234AI"),
+        submittedAt = submittedAt,
+        schemaVersion = jsonSchemaService.getNewestSchema(Cas2ApplicationJsonSchemaEntity::class.java),
+        schemaUpToDate = true,
+      ),
+    )
+    if (state == "IN_REVIEW") {
+      val quantity = randomInt(FEWEST_UPDATES, MOST_UPDATES)
+      seedLogger.info("Auto-scripting $quantity status updates for application ${application.id}")
+      repeat(quantity) { idx -> createStatusUpdate(idx, application) }
+    }
+  }
+
+  private fun createStatusUpdate(idx: Int, application: Cas2ApplicationEntity) {
+    seedLogger.info("Auto-scripting status update $idx for application ${application.id}")
+    val assessor = externalUserRepository.findAll().random()
+    val status = findStatusAtPosition(idx)
+    val update = statusUpdateRepository.save(
+      Cas2StatusUpdateEntity(
+        id = UUID.randomUUID(),
+        application = application,
+        assessor = assessor,
+        description = status.description,
+        label = status.label,
+        statusId = status.id,
+      ),
+    )
+    update.apply { this.createdAt = application.submittedAt!!.plusDays(idx + 1.toLong()) }
+    statusUpdateRepository.save(update)
+  }
+
+  private fun findStatusAtPosition(idx: Int): Cas2ApplicationStatus {
+    return Cas2ApplicationStatusSeeding.statusList()[idx]
+  }
+
+  private fun randomDateTime(minDays: Int = LATEST_CREATION, maxDays: Int = EARLIEST_CREATION): OffsetDateTime {
+    return OffsetDateTime.now()
+      .minusMinutes(randomInt(MINUTES_PER_DAY * minDays, MINUTES_PER_DAY * maxDays).toLong())
+      .truncatedTo(ChronoUnit.SECONDS)
+  }
+
+  private fun randomInt(min: Int, max: Int) = Random.nextInt(min, max)
+
+  private fun dataFor(state: String, nomsNumber: String): String {
+    if (state != "NOT_STARTED") {
+      return dataFixtureFor(nomsNumber)
+    }
+    return "{}"
+  }
+
+  private fun documentFor(state: String, nomsNumber: String): String {
+    if (listOf("SUBMITTED", "IN_REVIEW").contains(state)) {
+      return documentFixtureFor(nomsNumber)
+    }
+    return "{}"
+  }
+
+  private fun dataFixtureFor(nomsNumber: String): String {
+    return loadFixtureAsResource("data_$nomsNumber.json")
+  }
+
+  private fun documentFixtureFor(nomsNumber: String): String {
+    return loadFixtureAsResource("document_$nomsNumber.json")
+  }
+
+  private fun loadFixtureAsResource(filename: String): String {
+    val path = "db/seed/local+dev+test/cas2_application_data/$filename"
+    val loader = DefaultResourceLoader()
+    return try {
+      val resource = loader.getResource(path)
+      val reader = InputStreamReader(resource.inputStream, "UTF-8")
+      FileCopyUtils.copyToString(reader)
+    } catch (e: IOException) {
+      seedLogger.warn("FAILED to load seed fixture: " + e.message!!)
+      "{}"
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2
+
+import org.springframework.stereotype.Component
+
+@Component
+class Cas2AutoScript(
+
+) {
+  fun script() {
+    // noop
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.NomisUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
@@ -56,7 +57,9 @@ class SeedService(
   private val applicationContext: ApplicationContext,
   private val transactionTemplate: TransactionTemplate,
   private val seedLogger: SeedLogger,
+  private val cas2AutoScript: Cas2AutoScript,
 ) {
+
   @PostConstruct
   fun autoSeed() {
     if (!seedConfig.auto.enabled) {
@@ -99,6 +102,15 @@ class SeedService(
         }
       }
     }
+
+    if (seedConfig.autoScript.enabled) {
+      this.autoScript()
+    }
+  }
+
+  fun autoScript() {
+    seedLogger.info("**Auto-scripting**")
+    cas2AutoScript.script()
   }
 
   @Async

--- a/src/main/resources/db/migration/dev+test/R__6_clear_cas2_applications.sql
+++ b/src/main/resources/db/migration/dev+test/R__6_clear_cas2_applications.sql
@@ -1,0 +1,3 @@
+-- ${flyway:timestamp}
+
+TRUNCATE TABLE cas_2_applications CASCADE;


### PR DESCRIPTION
This is a reprise of https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1207 which was reverted due to a problem loading fixture files from the "resources" bundle.

In this version of the PR the loading of files is:

- done using a "resource loader"
- wrapped in a "try" block to avoid causing a error which blocks deployment

See https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/bde98f81a698c61a979a498f4831f569759bf5d1/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt#L133-L144