### PR TITLE
Booking search query optimisations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -129,17 +129,15 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       LEFT JOIN (
         SELECT
           b.id,
-          (
-            CASE
-              WHEN (SELECT COUNT(1) FROM cancellations c WHERE c.booking_id = b.id) > 0 THEN 'cancelled'
-              WHEN (SELECT COUNT(1) FROM departures d WHERE d.booking_id = b.id) > 0 THEN 'departed'
-              WHEN (SELECT COUNT(1) FROM arrivals a WHERE a.booking_id = b.id) > 0 THEN 'arrived'
-              WHEN (SELECT COUNT(1) FROM confirmations c2 WHERE c2.booking_id = b.id) > 0 THEN 'confirmed'
-              WHEN (SELECT COUNT(1) FROM non_arrivals n WHERE n.booking_id = n.id) > 0 THEN 'not-arrived'
+          CASE
+              WHEN EXISTS (SELECT 1 FROM cancellations c WHERE c.booking_id = b.id) THEN 'cancelled'
+              WHEN EXISTS (SELECT 1 FROM departures d WHERE d.booking_id = b.id) THEN 'departed'
+              WHEN EXISTS (SELECT 1 FROM arrivals a WHERE a.booking_id = b.id) THEN 'arrived'
+              WHEN EXISTS (SELECT 1 FROM confirmations c2 WHERE c2.booking_id = b.id) THEN 'confirmed'
+              WHEN EXISTS (SELECT 1 FROM non_arrivals n WHERE n.booking_id = n.id) THEN 'not-arrived'
               WHEN :serviceName = 'approved-premises' THEN 'awaiting-arrival'
               ELSE 'provisional'
-            END
-          ) AS booking_status
+          END AS booking_status
         FROM bookings b
       ) as s ON b.id = s.id
       LEFT JOIN beds b2 ON b.bed_id = b2.id

--- a/src/main/resources/db/migration/all/20231212162909__add_incidies_for_booking_search.sql
+++ b/src/main/resources/db/migration/all/20231212162909__add_incidies_for_booking_search.sql
@@ -1,0 +1,5 @@
+CREATE INDEX idx_cancellations_booking_id ON cancellations (booking_id);
+CREATE INDEX idx_departures_booking_id ON departures (booking_id);
+CREATE INDEX idx_arrivals_booking_id ON arrivals (booking_id);
+CREATE INDEX idx_confirmations_booking_id ON confirmations (booking_id);
+CREATE INDEX idx_non_arrivals_booking_id ON non_arrivals (booking_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 
 class BookingSearchTest : IntegrationTestBase() {
   @Test
@@ -614,6 +615,7 @@ class BookingSearchTest : IntegrationTestBase() {
         withServiceName(ServiceName.temporaryAccommodation)
         withArrivalDate(LocalDate.now().minusDays((60 - index).toLong()))
         withDepartureDate(LocalDate.now().minusDays((30 - index).toLong()))
+        withCreatedAt(LocalDate.now().minusDays((30 - index).toLong()).toLocalDateTime())
       }
 
       allBookings += booking


### PR DESCRIPTION
- Exists should stop counting when it matches the condition. Using ‘Select 1’ instead of ‘count 1’ should return the first record in a simpler way
- Add a database index for each subquery, it didn't seem like we had these indexes:

![Screenshot 2023-12-12 at 16 34 04](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/cd91adc2-a6f0-4778-87b1-f871055c3b99)

This isn't going to get us out of the N+5 problem we have but it might buy us some time.