### PR TITLE
Specify cas2/reports endpoints with OpenAPI

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1805,6 +1805,15 @@ components:
         - id
         - person
         - createdAt
+    Cas2Report:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: '<application.submitted> domain events'
     Cas2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -391,3 +391,43 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /reports:
+    get:
+      tags:
+        - Reports
+      summary: Lists reports available to download in spreadsheet form
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Cas2Report'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /reports/{reportId}:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet of metrics
+      parameters:
+        - name: reportId
+          in: path
+          description: Id of the CAS2 Report to be downloaded
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6009,6 +6009,15 @@ components:
         - id
         - person
         - createdAt
+    Cas2Report:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: '<application.submitted> domain events'
     Cas2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -393,6 +393,46 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reports:
+    get:
+      tags:
+        - Reports
+      summary: Lists reports available to download in spreadsheet form
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas2Report'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /reports/{reportId}:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet of metrics
+      parameters:
+        - name: reportId
+          in: path
+          description: Id of the CAS2 Report to be downloaded
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
 components:
   responses:
     401Response:
@@ -2200,6 +2240,15 @@ components:
         - id
         - person
         - createdAt
+    Cas2Report:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: '<application.submitted> domain events'
     Cas2StatusUpdate:
       type: object
       properties:


### PR DESCRIPTION
This is largely superseded by https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1255

- `GET cas2/reports` to view a list of downloads
- `GET cas2/reports/{reportId}` to download a spreadsheet file

![cas2_reports](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/f7d6e6df-d628-4558-9c71-26c8b74db98c)
