### PR TITLE
aps-48 stop using static total_beds column and calculate on-the-fly

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -7,7 +7,8 @@
     <ID>FunctionNaming:PlacementApplicationEntity.kt$PlacementApplicationRepository$fun findAllByAllocatedToUser_IdAndReallocatedAtNullAndDecisionNull(userId: UUID): List&lt;PlacementApplicationEntity></ID>
     <ID>CyclomaticComplexMethod:ApplicationServiceTest.kt$ApplicationServiceTest.SubmitApplication$@ParameterizedTest @EnumSource(value = SituationOption::class) @NullSource fun `submitApprovedPremisesApplication returns Success, creates assessment and stores event, sends confirmation email`(situation: SituationOption?)</ID>
     <ID>CyclomaticComplexMethod:OffenderService.kt$OffenderService$fun getOffenderSummariesByCrns(crns: List&lt;String>, userDistinguishedName: String, ignoreLao: Boolean = false): List&lt;PersonSummaryInfoResult></ID>
-   </ManuallySuppressedIssues>
+    <ID>TooManyFunctions:PremisesEntity.kt$PremisesRepository : JpaRepository</ID>
+  </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>
     <ID>ConstructorParameterNaming:ApplicationTest.kt$EventType$val Type: String</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -17,7 +17,7 @@ class PremisesTransformer(
   private val characteristicTransformer: CharacteristicTransformer,
   private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
 ) {
-  fun transformJpaToApi(jpa: PremisesEntity, availableBedsForToday: Int): Premises = when (jpa) {
+  fun transformJpaToApi(jpa: PremisesEntity, totalBeds: Int, availableBedsForToday: Int): Premises = when (jpa) {
     is ApprovedPremisesEntity -> ApprovedPremises(
       id = jpa.id,
       name = jpa.name,
@@ -26,7 +26,7 @@ class PremisesTransformer(
       addressLine2 = jpa.addressLine2,
       town = jpa.town,
       postcode = jpa.postcode,
-      bedCount = jpa.totalBeds,
+      bedCount = totalBeds,
       service = ServiceName.approvedPremises.value,
       notes = jpa.notes,
       availableBedsForToday = availableBedsForToday,
@@ -43,7 +43,7 @@ class PremisesTransformer(
       addressLine2 = jpa.addressLine2,
       town = jpa.town,
       postcode = jpa.postcode,
-      bedCount = jpa.rooms.flatMap { it.beds }.size,
+      bedCount = totalBeds,
       service = ServiceName.temporaryAccommodation.value,
       notes = jpa.notes,
       availableBedsForToday = availableBedsForToday,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -83,10 +83,6 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.longitude = { longitude }
   }
 
-  fun withTotalBeds(totalBeds: Int) = apply {
-    this.totalBeds = { totalBeds }
-  }
-
   fun withProbationRegion(probationRegion: ProbationRegionEntity) = apply {
     this.probationRegion = { probationRegion }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExternalUserEntityFactory.kt
@@ -33,7 +33,7 @@ class ExternalUserEntityFactory : Factory<ExternalUserEntity> {
   fun withOrigin(origin: String) = apply {
     this.origin = { origin }
   }
-  
+
   override fun produce(): ExternalUserEntity = ExternalUserEntity(
     id = this.id(),
     username = this.username(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -64,10 +64,6 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     this.postcode = { postcode }
   }
 
-  fun withTotalBeds(totalBeds: Int) = apply {
-    this.totalBeds = { totalBeds }
-  }
-
   fun withProbationRegion(probationRegion: ProbationRegionEntity) = apply {
     this.probationRegion = { probationRegion }
   }
@@ -98,6 +94,10 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
 
   fun withTurnaroundWorkingDayCount(turnaroundWorkingDayCount: Int) = apply {
     this.turnaroundWorkingDayCount = { turnaroundWorkingDayCount }
+  }
+
+  fun withYieldedRooms(probationRegion: Yielded<ProbationRegionEntity>) = apply {
+    this.probationRegion = probationRegion
   }
 
   fun withUnitTestControlTestProbationAreaAndLocalAuthority() = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -47,13 +47,16 @@ class CapacityTest : IntegrationTestBase() {
   fun `Get Capacity with no bookings or lost beds on Approved Premises returns OK with empty list body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(30)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist {
             withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
           }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(30) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       webTestClient.get()
@@ -72,11 +75,14 @@ class CapacityTest : IntegrationTestBase() {
   fun `Get Capacity for Approved Premises with booking in past returns OK with empty list body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(30)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(30) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val keyWorker = ContextStaffMemberFactory().produce()
@@ -104,11 +110,14 @@ class CapacityTest : IntegrationTestBase() {
   fun `Get Capacity for Approved Premises with booking in future returns OK with list entry for each day until the booking ends when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(30)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(30) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val keyWorker = ContextStaffMemberFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -195,6 +195,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PostCodeDistr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationAreaProbationRegionMappingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationDeliveryUnitTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.RoomTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationAssessmentJsonSchemaTestRepository
@@ -465,6 +466,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var probationAreaProbationRegionMappingRepository: ProbationAreaProbationRegionMappingTestRepository
+
+  @Autowired
+  lateinit var roomTestRepository: RoomTestRepository
 
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -375,11 +375,7 @@ class LostBedsTest : IntegrationTestBase() {
     }
 
     val bed = bedEntityFactory.produceAndPersist {
-      withYieldedRoom {
-        roomEntityFactory.produceAndPersist {
-          withYieldedPremises { premises }
-        }
-      }
+      withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
     }
 
     webTestClient.post()
@@ -444,11 +440,14 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Create Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(3)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(3) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val reason = lostBedReasonEntityFactory.produceAndPersist {
@@ -495,13 +494,16 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Bed on Approved Premises succeeds even if overlapping with Booking`() {
-    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
+    `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(3)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(2) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val reason = lostBedReasonEntityFactory.produceAndPersist {
@@ -664,11 +666,14 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Create Lost Beds on Approved Premises for current day does not break GET all Premises endpoint`() {
     `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(3)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(2) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val lostBed = lostBedsEntityFactory.produceAndPersist {
@@ -807,11 +812,14 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Update Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(3)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(2) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -1063,11 +1071,14 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Cancel Lost Bed on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withTotalBeds(3)
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(2) {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
       }
 
       val lostBeds = lostBedsEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -28,7 +28,6 @@ class PremisesSummaryTest : IntegrationTestBase() {
           }
         }
         withService("CAS3")
-        withTotalBeds(0) // A static legacy column that we don't use
       }
 
       // unexpectedCas3Premises that's in a different region
@@ -100,7 +99,6 @@ class PremisesSummaryTest : IntegrationTestBase() {
         withStatus(PropertyStatus.active)
         withApCode("APCODE")
         withService("CAS3")
-        withTotalBeds(0) // A static legacy column that we don't use
       }
 
       val room = roomEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -31,6 +31,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
@@ -183,7 +185,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -232,7 +233,6 @@ class PremisesTest : IntegrationTestBase() {
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(user.probationRegion)
@@ -291,7 +291,6 @@ class PremisesTest : IntegrationTestBase() {
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(user.probationRegion)
@@ -355,7 +354,6 @@ class PremisesTest : IntegrationTestBase() {
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(otherProbationRegion)
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(otherProbationRegion)
@@ -427,7 +425,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -465,7 +462,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -501,7 +497,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -539,7 +534,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -580,7 +574,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -621,7 +614,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[0]
@@ -663,7 +655,6 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withName("old-premises-name")
-        withTotalBeds(20)
       }
 
       webTestClient.put()
@@ -712,7 +703,6 @@ class PremisesTest : IntegrationTestBase() {
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(user.probationRegion)
@@ -774,7 +764,6 @@ class PremisesTest : IntegrationTestBase() {
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(user.probationRegion)
@@ -1179,8 +1168,7 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS1")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 5, bedsPerRoom = 4) }
 
       val cas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1188,14 +1176,13 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS3")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 4, bedsPerRoom = 5) }
 
       val premises = cas1Premises + cas3Premises
 
       val expectedJson = objectMapper.writeValueAsString(
         premises.map {
-          premisesTransformer.transformJpaToApi(it, 20)
+          premisesTransformer.transformJpaToApi(it, 20, 20)
         },
       )
 
@@ -1219,8 +1206,7 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS1")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 5, bedsPerRoom = 4) }
 
       // Add some extra premises for the other service that shouldn't be returned
       temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
@@ -1229,12 +1215,11 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS3")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 6, bedsPerRoom = 4) }
 
       val expectedJson = objectMapper.writeValueAsString(
         premises.map {
-          premisesTransformer.transformJpaToApi(it, 20)
+          premisesTransformer.transformJpaToApi(it, 20, 20)
         },
       )
 
@@ -1291,20 +1276,18 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { region }
         withService("CAS3")
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(region)
           }
         }
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 10) }
 
       val cas1Premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { region }
         withService("CAS1")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 2, 10) }
 
       // Add some extra premises in both services for other regions that shouldn't be returned
       val otherRegion = probationRegionEntityFactory.produceAndPersist {
@@ -1317,26 +1300,24 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { otherRegion }
         withService("CAS3")
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(otherRegion)
           }
         }
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 2, 10) }
 
       approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { otherRegion }
         withService("CAS1")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 1, 20) }
 
       val expectedPremises = cas1Premises + cas3Premises
 
       val expectedJson = objectMapper.writeValueAsString(
         expectedPremises.map {
-          premisesTransformer.transformJpaToApi(it, 20)
+          premisesTransformer.transformJpaToApi(it, 20, 20)
         },
       )
 
@@ -1359,21 +1340,19 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
         withService("CAS3")
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(user.probationRegion)
           }
         }
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 20, 1) }
 
       // Add some extra premises in the same region but in Approved Premises that shouldn't be returned
       approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
         withService("CAS1")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 5, 4) }
 
       // Add some extra premises in both services for other regions that shouldn't be returned
       val otherProbationRegion = probationRegionEntityFactory.produceAndPersist {
@@ -1386,24 +1365,22 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(otherProbationRegion)
         withService("CAS3")
-        withTotalBeds(20)
         withYieldedProbationDeliveryUnit {
           probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(otherProbationRegion)
           }
         }
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
 
       approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(otherProbationRegion)
         withService("CAS1")
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
 
       val expectedJson = objectMapper.writeValueAsString(
         premises.map {
-          premisesTransformer.transformJpaToApi(it, 20)
+          premisesTransformer.transformJpaToApi(it, 20, 20)
         },
       )
 
@@ -1428,11 +1405,10 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
 
       val premisesToGet = premises[2]
-      val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 20))
+      val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 20, 20))
 
       webTestClient.get()
         .uri("/premises/${premisesToGet.id}")
@@ -1453,8 +1429,7 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
-      }
+      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
 
       val keyWorker = ContextStaffMemberFactory().produce()
       premises.forEach {
@@ -1469,7 +1444,7 @@ class PremisesTest : IntegrationTestBase() {
       }
 
       val premisesToGet = premises[2]
-      val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 19))
+      val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 20, 19))
 
       webTestClient.get()
         .uri("/premises/${premisesToGet.id}")
@@ -1509,7 +1484,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val premisesToGet = premises[2]
@@ -1566,21 +1540,14 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
+
+      val rooms = addRoomsAndBeds(premises, roomCount = 4, 5)
 
       val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
         withNomsNumber("26")
         withPremises(premises)
-        withBed(
-          bedEntityFactory.produceAndPersist() {
-            withRoom(
-              roomEntityFactory.produceAndPersist() {
-                withPremises(premises)
-              },
-            )
-          },
-        )
+        withBed(rooms.first().beds.first())
       }
 
       bookings.forEach {
@@ -1653,7 +1620,7 @@ class PremisesTest : IntegrationTestBase() {
         .jsonPath("$.name").isEqualTo("${premises.name}")
         .jsonPath("$.apCode").isEqualTo("${premises.apCode}")
         .jsonPath("$.postcode").isEqualTo("${premises.postcode}")
-        .jsonPath("$.bedCount").isEqualTo("${premises.totalBeds}")
+        .jsonPath("$.bedCount").isEqualTo("20")
         .jsonPath("$.availableBedsForToday").isEqualTo("17")
         .jsonPath("$.bookings").isArray
         .jsonPath("$.bookings[0].id").isEqualTo(bookings[0].id.toString())
@@ -1705,8 +1672,10 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
+
+      val totalBeds = 20
+      val rooms = addRoomsAndBeds(premises, roomCount = 4, 5)
 
       val startDate = LocalDate.now()
 
@@ -1723,30 +1692,14 @@ class PremisesTest : IntegrationTestBase() {
           withStartDate(startDate.plusDays(1))
           withEndDate(startDate.plusDays(2))
           withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
-          withBed(
-            bedEntityFactory.produceAndPersist {
-              withYieldedRoom {
-                roomEntityFactory.produceAndPersist {
-                  withYieldedPremises { premises }
-                }
-              }
-            },
-          )
+          withBed(rooms[0].beds[0])
         },
         lostBedsEntityFactory.produceAndPersist {
           withPremises(premises)
           withStartDate(startDate.plusDays(1))
           withEndDate(startDate.plusDays(2))
           withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
-          withBed(
-            bedEntityFactory.produceAndPersist {
-              withYieldedRoom {
-                roomEntityFactory.produceAndPersist {
-                  withYieldedPremises { premises }
-                }
-              }
-            },
-          )
+          withBed(rooms[1].beds[0])
         },
       )
 
@@ -1755,15 +1708,7 @@ class PremisesTest : IntegrationTestBase() {
         withStartDate(startDate.plusDays(1))
         withEndDate(startDate.plusDays(2))
         withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
-        withBed(
-          bedEntityFactory.produceAndPersist {
-            withYieldedRoom {
-              roomEntityFactory.produceAndPersist {
-                withYieldedPremises { premises }
-              }
-            }
-          },
-        )
+        withBed(rooms[2].beds[0])
       }
 
       cancelledLostBed.cancellation = lostBedCancellationEntityFactory.produceAndPersist {
@@ -1853,8 +1798,10 @@ class PremisesTest : IntegrationTestBase() {
         val bookingsForToday = bookings
           .filter { it.cancellation == null && it.nonArrival == null }
           .filter { it.arrivalDate <= date && it.departureDate > date }
-        (premises.totalBeds - bookingsForToday.count()) - lostBedsForToday.count()
+        (totalBeds - bookingsForToday.count()) - lostBedsForToday.count()
       }
+
+      println(responseBody.dateCapacities)
 
       assertThat(responseBody.dateCapacities?.get(0)).isEqualTo(
         DateCapacity(date = startDate, getTotalBedsForDate(startDate)),
@@ -2134,15 +2081,7 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-      }
-
-      val room = roomEntityFactory.produceAndPersist {
-        withYieldedPremises { premises }
-      }
-
-      bedEntityFactory.produceAndPersistMultiple(5) {
-        withYieldedRoom { room }
-      }
+      }.also { addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 5) }
 
       webTestClient.get()
         .uri("/premises/${premises.id}")
@@ -2151,7 +2090,7 @@ class PremisesTest : IntegrationTestBase() {
         .expectStatus()
         .isOk
         .expectBody()
-        .jsonPath("$.bedCount").isEqualTo(5)
+        .jsonPath("$.bedCount").isEqualTo(10)
     }
   }
 
@@ -2647,7 +2586,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -2780,7 +2718,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -2809,7 +2746,6 @@ class PremisesTest : IntegrationTestBase() {
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-      withTotalBeds(20)
     }
 
     val room = roomEntityFactory.produceAndPersist {
@@ -2843,7 +2779,6 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-        withTotalBeds(20)
       }
 
       val roomIdToRequest = UUID.randomUUID().toString()
@@ -2984,5 +2919,17 @@ class PremisesTest : IntegrationTestBase() {
       Arguments.of(0, "isNotAPositiveInteger"),
       Arguments.of(-4, "isNotAPositiveInteger"),
     )
+  }
+
+  fun addRoomsAndBeds(premises: PremisesEntity, roomCount: Int, bedsPerRoom: Int): List<RoomEntity> {
+    return roomEntityFactory.produceAndPersistMultiple(roomCount) {
+      withYieldedPremises { premises }
+    }.onEach {
+      bedEntityFactory.produceAndPersistMultiple(bedsPerRoom) {
+        withYieldedRoom { it }
+      }
+    }.map {
+      roomTestRepository.getReferenceById(it.id)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/RoomTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/RoomTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import java.util.UUID
+
+@Repository
+interface RoomTestRepository : JpaRepository<RoomEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderRisksDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderRisksDataSourceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.ConfiguredOffenderRisksDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSourceName

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -86,9 +86,7 @@ class PremisesServiceTest {
     val startDate = LocalDate.now()
     val endDate = LocalDate.now().plusDays(3)
 
-    val premises = approvedPremisesFactory
-      .withTotalBeds(30)
-      .produce()
+    val premises = approvedPremisesFactory.produce()
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf()
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, startDate, endDate) } returns mutableListOf()
@@ -107,9 +105,7 @@ class PremisesServiceTest {
     val startDate = LocalDate.now()
     val endDate = LocalDate.now().plusDays(6)
 
-    val premises = approvedPremisesFactory
-      .withTotalBeds(30)
-      .produce()
+    val premises = approvedPremisesFactory.produce()
 
     val lostBedEntityOne = LostBedsEntityFactory()
       .withPremises(premises)
@@ -203,9 +199,7 @@ class PremisesServiceTest {
     val startDate = LocalDate.now()
     val endDate = LocalDate.now().plusDays(6)
 
-    val premises = approvedPremisesFactory
-      .withTotalBeds(30)
-      .produce()
+    val premises = approvedPremisesFactory.produce()
 
     val lostBedEntity = LostBedsEntityFactory()
       .withPremises(premises)
@@ -625,6 +619,7 @@ class PremisesServiceTest {
 
     every { premisesService.getLastBookingDate(premises) } answers { ninetyNineYearsFromNow }
     every { premisesService.getLastLostBedsDate(premises) } answers { ninetyNineYearsFromNow }
+    every { premisesService.getBedCount(premises) } answers { 30 }
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, oneYearFromNow) } answers { emptyList() }
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, oneYearFromNow) } answers { emptyList() }
@@ -649,6 +644,7 @@ class PremisesServiceTest {
 
     every { premisesService.getLastBookingDate(premises) } answers { today.plusWeeks(2) }
     every { premisesService.getLastLostBedsDate(premises) } answers { fourMonthsFromNow }
+    every { premisesService.getBedCount(premises) } answers { 30 }
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, fourMonthsFromNow) } answers { emptyList() }
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, fourMonthsFromNow) } answers { emptyList() }
@@ -671,6 +667,7 @@ class PremisesServiceTest {
 
     every { premisesService.getLastBookingDate(premises) } answers { fourMonthsFromNow }
     every { premisesService.getLastLostBedsDate(premises) } answers { today.plusWeeks(2) }
+    every { premisesService.getBedCount(premises) } answers { 30 }
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, fourMonthsFromNow) } answers { emptyList() }
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, fourMonthsFromNow) } answers { emptyList() }
@@ -693,6 +690,7 @@ class PremisesServiceTest {
 
     every { premisesService.getLastBookingDate(premises) } answers { fourMonthsFromNow }
     every { premisesService.getLastLostBedsDate(premises) } answers { null }
+    every { premisesService.getBedCount(premises) } answers { 30 }
 
     every { bookingRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, fourMonthsFromNow) } answers { emptyList() }
     every { lostBedsRepositoryMock.findAllByPremisesIdAndOverlappingDate(premises.id, today, fourMonthsFromNow) } answers { emptyList() }


### PR DESCRIPTION
Before this commit, the bed count shown when listing premises did not match the number of beds configured in the system. This was because the count was being populated from premises.total_beds, which was not neccessarily being kept in sync with the number of beds registered in the system (e.g. when a new bed was added via the API, the count was not being modified).

This commit removes all code relying on the premises.total_bed column and instead always calculates the bed count on-the-fly.

When performing find operations in the PremisesRepository, a sub-query is used to determine the bed count. Whilst this does not create a particularly performant execution plan (a subplan us executed for each row), this was deemed acceptable given that the size of the premises table is small, and if performance was an issue we could add paging to the find operations.

I attempted to find a way to make JPA/Hibernate return the total bed count alongside the PremisesEntity when performing get operations in the PremisesRepository, but this was outside the capabilities of JPQL without resorting to listing out all entity fields in the SELECT, which would be cumbersome and hard to maintain. Therefore, we make a separate SQL call to count the number of beds once we have retrieved the PremisesEntity. This is preferable to using lazy loads over the premises->rooms->beds relationship which would trigger multiple SQL calls.

This commit does not remove the column as this would complicate rollback/rollforward fixing if there’s any issues. Instead the column will be removed once we’re happy that this change is stable.