### PR TITLE
Return full User on CAS2 Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -7,12 +7,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 
 @Component("Cas2ApplicationsTransformer")
 class ApplicationsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
+  private val nomisUserTransformer: NomisUserTransformer,
 ) {
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult):
@@ -20,7 +22,7 @@ class ApplicationsTransformer(
     return Cas2Application(
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
-      createdByUserId = jpa.createdByUser.id,
+      createdBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
       createdAt = jpa.createdAt.toInstant(),

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1573,9 +1573,8 @@ components:
         - $ref: '#/components/schemas/Application'
         - type: object
           properties:
-            createdByUserId:
-              type: string
-              format: uuid
+            createdBy:
+              $ref: '#/components/schemas/NomisUser'
             schemaVersion:
               type: string
               format: uuid
@@ -1591,7 +1590,7 @@ components:
               type: string
               format: date-time
           required:
-            - createdByUserId
+            - createdBy
             - schemaVersion
             - outdatedSchema
             - status

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5745,9 +5745,8 @@ components:
         - $ref: '#/components/schemas/Application'
         - type: object
           properties:
-            createdByUserId:
-              type: string
-              format: uuid
+            createdBy:
+              $ref: '#/components/schemas/NomisUser'
             schemaVersion:
               type: string
               format: uuid
@@ -5763,7 +5762,7 @@ components:
               type: string
               format: date-time
           required:
-            - createdByUserId
+            - createdBy
             - schemaVersion
             - outdatedSchema
             - status

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1968,9 +1968,8 @@ components:
         - $ref: '#/components/schemas/Application'
         - type: object
           properties:
-            createdByUserId:
-              type: string
-              format: uuid
+            createdBy:
+              $ref: '#/components/schemas/NomisUser'
             schemaVersion:
               type: string
               format: uuid
@@ -1986,7 +1985,7 @@ components:
               type: string
               format: date-time
           required:
-            - createdByUserId
+            - createdBy
             - schemaVersion
             - outdatedSchema
             - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -329,7 +329,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             applicationEntity.id == it.id &&
               applicationEntity.crn == it.person.crn &&
               applicationEntity.createdAt.toInstant() == it.createdAt &&
-              applicationEntity.createdByUser.id == it.createdByUserId &&
+              applicationEntity.createdByUser.id == it.createdBy.id &&
               applicationEntity.submittedAt?.toInstant() == it.submittedAt &&
               serializableToJsonNode(applicationEntity.data) == serializableToJsonNode(it.data) &&
               newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema


### PR DESCRIPTION
We need to display the user's email address and name on Applications, so we are now returning the full user rather than just the id.