### PR TITLE
Seed all roles for a new load test user

### DIFF
--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -7,9 +7,9 @@ INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probati
     ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
     ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
     ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
-    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
     ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE') -- Wales
     ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE'), -- North East
+    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'BERNARD.BEAKS', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
 ON CONFLICT (id) DO NOTHING;
 
 UPDATE
@@ -83,36 +83,6 @@ VALUES
     '0621c5b0-0028-40b7-87fb-53ec65704314'
   ),
   (
-    '739b27c5-d17b-4fe7-d0a4-162eb3268e1b',
-    'CAS1_ASSESSOR',
-    '695ba399-c407-4b66-aafc-e8835d72b8a7'
-  ),
-  (
-    '77635823-d53c-4e2e-b388-d120107f23c3',
-    'CAS1_MATCHER',
-    '695ba399-c407-4b66-aafc-e8835d72b8a7'
-  ),
-  (
-    '15c9393a-c0fb-4506-b56a-e2b0054bb166',
-    'CAS1_MANAGER',
-    '695ba399-c407-4b66-aafc-e8835d72b8a7'
-  ),
-  (
-    'b58c7932-4925-4fc5-c6bf-c1a7a34ce4ed',
-    'CAS1_WORKFLOW_MANAGER',
-    '695ba399-c407-4b66-aafc-e8835d72b8a7'
-  ),
-  (
-    'cd8a76d2-35ff-4d9b-bf62-1e26911e8ada',
-    'CAS1_APPLICANT',
-    '695ba399-c407-4b66-aafc-e8835d72b8a7'
-  ),
-  (
-    '28b39733-8955-4465-dd8d-4a58e2fba753',
-    'CAS1_ADMIN',
-    '695ba399-c407-4b66-aafc-e8835d72b8a7'
-  ),
-  (
     '38f7f97a-c9d0-4521-dbf1-79acafe8a20f',
     'CAS1_ASSESSOR',
     '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
@@ -167,6 +137,21 @@ SELECT
   gen_random_uuid() AS id,
   role AS role,
   (SELECT id FROM users where delius_username='TESTER.TESTY') AS user_id
+FROM
+  "user_role_assignments"
+WHERE
+  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+ON CONFLICT (id)
+DO
+  NOTHING;
+
+-- Copy all roles from JIMSNOWLDAP to BERNARD.BEAKS
+INSERT INTO
+  "user_role_assignments" ("id", "role", "user_id")
+SELECT
+  gen_random_uuid() AS id,
+  role AS role,
+  (SELECT id FROM users where delius_username='BERNARD.BEAKS') AS user_id
 FROM
   "user_role_assignments"
 WHERE

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -51,7 +51,23 @@ VALUES
     '81e7c996-4e20-4c4f-94c4-1acd4e5bce33',
     'CAS1_ADMIN',
     'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
-  ) ON CONFLICT (id)
+  ),
+  (
+    'f1118a4e-bb6f-4b16-83ad-08ef92314610',
+    'CAS3_ASSESSOR',
+    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
+  ),
+  (
+    '77c6cc54-5d01-41d2-9987-5b293d6d2e07',
+    'CAS3_REFERRER',
+    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
+  ),
+  (
+    '482a4ab7-a6e4-4bf8-a0fc-8516eca9efa2',
+    'CAS3_REPORTER',
+    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
+  )
+   ON CONFLICT (id)
 DO
   NOTHING;
 

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -7,9 +7,9 @@ INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probati
     ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
     ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
     ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
-    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'tester.testy', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE'), -- North East
     ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
     ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE') -- Wales
+    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE'), -- North East
 ON CONFLICT (id) DO NOTHING;
 
 UPDATE
@@ -83,36 +83,6 @@ VALUES
     '0621c5b0-0028-40b7-87fb-53ec65704314'
   ),
   (
-    '14bcef1a-fc78-4c42-f8d4-e35da461b837',
-    'CAS1_ASSESSOR',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae'
-  ),
-  (
-    'eec1afe7-4659-4ed5-d83f-a13ee89641b0',
-    'CAS1_MATCHER',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae'
-  ),
-  (
-    'e2dc3c5c-c9b7-4754-941d-c6e6043a7b26',
-    'CAS1_MANAGER',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae'
-  ),
-  (
-    '2d8000ed-67f9-4370-adac-234e1f4264a5',
-    'CAS1_WORKFLOW_MANAGER',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae'
-  ),
-  (
-    '50b8779d-487e-494f-dff5-f9958b9d0eae',
-    'CAS1_APPLICANT',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae'
-  ),
-  (
-    'afa2bec7-2820-4fd8-bd6d-fc1f610442f3',
-    'CAS1_ADMIN',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae'
-  ),
-  (
     '739b27c5-d17b-4fe7-d0a4-162eb3268e1b',
     'CAS1_ASSESSOR',
     '695ba399-c407-4b66-aafc-e8835d72b8a7'
@@ -182,6 +152,21 @@ SELECT
   gen_random_uuid() AS id,
   role AS role,
   (SELECT id FROM users where delius_username='APPROVEDPREMISESTESTUSER') AS user_id
+FROM
+  "user_role_assignments"
+WHERE
+  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+ON CONFLICT (id)
+DO
+  NOTHING;
+
+-- Copy all roles from JIMSNOWLDAP to TESTER.TESTY
+INSERT INTO
+  "user_role_assignments" ("id", "role", "user_id")
+SELECT
+  gen_random_uuid() AS id,
+  role AS role,
+  (SELECT id FROM users where delius_username='TESTER.TESTY') AS user_id
 FROM
   "user_role_assignments"
 WHERE

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -7,9 +7,9 @@ INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probati
     ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
     ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
     ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
-    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE') -- Wales
     ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE'), -- North East
     ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'BERNARD.BEAKS', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
+    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'PANESAR.JASPAL', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE') -- Wales
 ON CONFLICT (id) DO NOTHING;
 
 UPDATE
@@ -81,36 +81,6 @@ VALUES
     '29ffb4f6-d72a-47e0-9ece-0797c5ff2169',
     'CAS1_ADMIN',
     '0621c5b0-0028-40b7-87fb-53ec65704314'
-  ),
-  (
-    '38f7f97a-c9d0-4521-dbf1-79acafe8a20f',
-    'CAS1_ASSESSOR',
-    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
-  ),
-  (
-    '26dd8587-20a3-4925-c6fa-db15c57b41dd',
-    'CAS1_MATCHER',
-    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
-  ),
-  (
-    'b0392e1e-c200-46eb-e42c-04d89f48febb',
-    'CAS1_MANAGER',
-    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
-  ),
-  (
-    '60b95db2-bd09-4d7d-ca29-356b962e99c6',
-    'CAS1_WORKFLOW_MANAGER',
-    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
-  ),
-  (
-    '2ec8c941-18e1-4715-8b4c-2a0d51050dfa',
-    'CAS1_APPLICANT',
-    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
-  ),
-  (
-    'c3205409-b5d8-4945-ed5f-8ee9dba4ebe3',
-    'CAS1_ADMIN',
-    '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
   ) ON CONFLICT (id)
 DO
   NOTHING;
@@ -152,6 +122,21 @@ SELECT
   gen_random_uuid() AS id,
   role AS role,
   (SELECT id FROM users where delius_username='BERNARD.BEAKS') AS user_id
+FROM
+  "user_role_assignments"
+WHERE
+  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+ON CONFLICT (id)
+DO
+  NOTHING;
+
+-- Copy all roles from JIMSNOWLDAP to PANESAR.JASPAL
+INSERT INTO
+  "user_role_assignments" ("id", "role", "user_id")
+SELECT
+  gen_random_uuid() AS id,
+  role AS role,
+  (SELECT id FROM users where delius_username='PANESAR.JASPAL') AS user_id
 FROM
   "user_role_assignments"
 WHERE

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -51,36 +51,6 @@ VALUES
     '81e7c996-4e20-4c4f-94c4-1acd4e5bce33',
     'CAS1_ADMIN',
     'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
-  ),
-  (
-    '28f03d11-c430-4dea-e0e3-bec6ea67d2d9',
-    'CAS1_ASSESSOR',
-    '0621c5b0-0028-40b7-87fb-53ec65704314'
-  ),
-  (
-    '8adb9e9b-fd29-475d-e603-bf231500a3e7',
-    'CAS1_MATCHER',
-    '0621c5b0-0028-40b7-87fb-53ec65704314'
-  ),
-  (
-    '208f58d7-2979-4cea-acb9-1c54e9d66193',
-    'CAS1_MANAGER',
-    '0621c5b0-0028-40b7-87fb-53ec65704314'
-  ),
-  (
-    '492d40dc-5554-4476-e8ad-1ec0f309450a',
-    'CAS1_WORKFLOW_MANAGER',
-    '0621c5b0-0028-40b7-87fb-53ec65704314'
-  ),
-  (
-    '830d7aab-96e1-4056-be91-045e089378b8',
-    'CAS1_APPLICANT',
-    '0621c5b0-0028-40b7-87fb-53ec65704314'
-  ),
-  (
-    '29ffb4f6-d72a-47e0-9ece-0797c5ff2169',
-    'CAS1_ADMIN',
-    '0621c5b0-0028-40b7-87fb-53ec65704314'
   ) ON CONFLICT (id)
 DO
   NOTHING;
@@ -92,6 +62,21 @@ SELECT
   gen_random_uuid() AS id,
   role AS role,
   (SELECT id FROM users where delius_username='APPROVEDPREMISESTESTUSER') AS user_id
+FROM
+  "user_role_assignments"
+WHERE
+  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+ON CONFLICT (id)
+DO
+  NOTHING;
+
+-- Copy all roles from JIMSNOWLDAP to TEMPORARY-ACCOMMODATION-E2E-TESTER
+INSERT INTO
+  "user_role_assignments" ("id", "role", "user_id")
+SELECT
+  gen_random_uuid() AS id,
+  role AS role,
+  (SELECT id FROM users where delius_username='TEMPORARY-ACCOMMODATION-E2E-TESTER') AS user_id
 FROM
   "user_role_assignments"
 WHERE

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -53,36 +53,6 @@ VALUES
     'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
   ),
   (
-    'c729526f-1135-4383-ee7b-4326e5517ba0',
-    'CAS1_ASSESSOR',
-    'f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d'
-  ),
-  (
-    'ac554076-cb51-454d-ae1e-ba466971dfe2',
-    'CAS1_MATCHER',
-    'f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d'
-  ),
-  (
-    '7a88a8db-4ced-49a0-e4a4-45fce098d7e4',
-    'CAS1_MANAGER',
-    'f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d'
-  ),
-  (
-    '71290b6b-67e1-4747-f6db-e389a83433dc',
-    'CAS1_WORKFLOW_MANAGER',
-    'f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d'
-  ),
-  (
-    'd7d7ffe2-e975-4655-fb8b-96f2f23be682',
-    'CAS1_APPLICANT',
-    'f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d'
-  ),
-  (
-    '80c184f8-43f3-4ccb-e726-77d9b89a8b2a',
-    'CAS1_ADMIN',
-    'f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d'
-  ),
-  (
     '28f03d11-c430-4dea-e0e3-bec6ea67d2d9',
     'CAS1_ASSESSOR',
     '0621c5b0-0028-40b7-87fb-53ec65704314'
@@ -202,5 +172,20 @@ VALUES
     'CAS1_ADMIN',
     '045b71d3-9845-49b3-a79b-c7799a6bc7bc'
   ) ON CONFLICT (id)
+DO
+  NOTHING;
+
+-- Copy all roles from JIMSNOWLDAP to APPROVEDPREMISESTESTUSER
+INSERT INTO
+  "user_role_assignments" ("id", "role", "user_id")
+SELECT
+  gen_random_uuid() AS id,
+  role AS role,
+  (SELECT id FROM users where delius_username='APPROVEDPREMISESTESTUSER') AS user_id
+FROM
+  "user_role_assignments"
+WHERE
+  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+ON CONFLICT (id)
 DO
   NOTHING;

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -97,6 +97,7 @@ FROM
   "user_role_assignments"
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+  AND ("role" = 'CAS3_ASSESSOR' OR "role" = 'CAS3_REPORTER')
 ON CONFLICT (id)
 DO
   NOTHING;

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -5,6 +5,7 @@
 INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id, delius_staff_code) VALUES
     ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', 2500041001, '43606be0-9836-441d-9bc1-5586de9ac931', 'STAFFCODE'), -- South West
     ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
+    ('9807de9d-05b3-49e2-84b8-529790a299cc', 'C. Load-Tester', 'CAS-LOAD-TESTER', 2500041004, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
     ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
     ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
     ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE'), -- North East
@@ -139,6 +140,21 @@ SELECT
   gen_random_uuid() AS id,
   role AS role,
   (SELECT id FROM users where delius_username='PANESAR.JASPAL') AS user_id
+FROM
+  "user_role_assignments"
+WHERE
+  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
+ON CONFLICT (id)
+DO
+  NOTHING;
+
+-- Copy all roles from JIMSNOWLDAP to CAS-LOAD-TESTER
+INSERT INTO
+  "user_role_assignments" ("id", "role", "user_id")
+SELECT
+  gen_random_uuid() AS id,
+  role AS role,
+  (SELECT id FROM users where delius_username='CAS-LOAD-TESTER') AS user_id
 FROM
   "user_role_assignments"
 WHERE


### PR DESCRIPTION
## Why?

We've asked for the user CAS-LOAD-TESTER to be created for us. The intention of this user is that any CAS service can use it with Gatling to do load testing on our dev environment.

Roles should continue to be tested in the rest of the test suite with the existing users that are currently provisioned. This new user will be the only one that's role agnostic so they can more efficiently exercise all endpoints.

## How?

We do a refactoring of the user and role seeding so we have a single definition of all roles. We continue to use JIMSNOWLDAP for this.

We then do a bit more work in these dev migrations to go and select them and copy them across. For dev this feels like a reasonable compromise so we can more clearly see who has which role and create new users quickly.

Two examples of roles after this migration is changed locally:

![Screenshot 2023-12-13 at 16 38 39](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/6a8e1ae8-528e-4711-ab73-c5a6a37996d1)

## Notes

You may spot that there is no provision for `TEMPORARY-ACCOMMODATION-E2E-REFERRER` which is deliberate. The default CAS3 role is set as `CAS3_REFERRER` if no role exists.

`TEMPORARY-ACCOMMODATION-E2E-REFERRER` loses CAS1 roles that it doesn't actually need to make it more realistic.