### PR TITLE
Creating CAS3 bookings within load tests no longer 403s

### DIFF
--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Bookings.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/Bookings.kt
@@ -6,12 +6,13 @@ import io.gatling.javaapi.http.HttpDsl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.CRN
 import java.time.LocalDate
 import java.util.UUID
 
 fun createTemporaryAccommodationBooking(
   bedId: (Session) -> UUID,
-  crn: (Session) -> String = { _ -> "X320741" },
+  crn: (Session) -> String = { _ -> CRN },
   arrivalDate: (Session) -> LocalDate = { _ -> LocalDate.now() },
   departureDate: (Session) -> LocalDate = { session -> arrivalDate(session).plusDays(84) },
   saveBookingIdAs: String? = null,


### PR DESCRIPTION
Depending on the user being used, they will have access to different CRNs in different environments.

Jimsnowldap can see X320741 locally.

However we want to use a dedicated load test on a real environment. This means our user won’t have access to both crn so we need to make this configurable to avoid 403s during the booking create process.

We've provisioned this variable before, over here https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1250