### PR TITLE
(APS-66) Add new referrals report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReportsController.kt
@@ -109,6 +109,23 @@ class ReportsController(
     return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
   }
 
+  override fun reportsReferralsGet(xServiceName: ServiceName, year: Int, month: Int): ResponseEntity<Resource> {
+    if (!userAccessService.currentUserCanViewReport()) {
+      throw ForbiddenProblem()
+    }
+
+    val user = userService.getUserForRequest()
+
+    validateParameters(null, month)
+
+    val properties = ApplicationReportProperties(xServiceName, year, month, user.deliusUsername)
+    val outputStream = ByteArrayOutputStream()
+
+    reportService.createCas1ApplicationReferralsReport(properties, outputStream)
+
+    return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
+  }
+
   override fun reportsDailyMetricsGet(xServiceName: ServiceName, year: Int, month: Int): ResponseEntity<Resource> {
     if (!userAccessService.currentUserCanViewReport()) {
       throw ForbiddenProblem()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -91,6 +91,101 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
     nativeQuery = true,
   )
   fun generateApprovedPremisesReportRowsForCalendarMonth(month: Int, year: Int): List<ApplicationEntityReportRow>
+
+  @Query(
+    """
+    SELECT distinct
+      on (application.id) cast(application.id as TEXT) as id,
+      submission_event.data -> 'eventDetails' -> 'personReference' ->> 'crn' as crn,
+      assessments.allocated_at as lastAllocatedToAssessorDate,
+      cast(
+        assessment_event.data -> 'eventDetails' ->> 'assessedAt' as date
+      ) as applicationAssessedDate,
+      assessment_event.data -> 'eventDetails' -> 'assessedBy' -> 'cru' ->> 'name' as assessorCru,
+      assessment_event.data -> 'eventDetails' ->> 'decision' as assessmentDecision,
+      assessment_event.data -> 'eventDetails' ->> 'decisionRationale' as assessmentDecisionRationale,
+      submission_event.data -> 'eventDetails' ->> 'age' as ageInYears,
+      submission_event.data -> 'eventDetails' ->> 'gender' as gender,
+      submission_event.data -> 'eventDetails' ->> 'mappa' as mappa,
+      submission_event.data -> 'eventDetails' ->> 'offenceId' as offenceId,
+      submission_event.data -> 'eventDetails' -> 'personReference' ->> 'noms' as noms,
+      (
+        CASE
+          WHEN apa.is_pipe_application THEN 'pipe'
+          WHEN apa.is_esap_application THEN 'esap'
+          ELSE 'normal'
+        END
+      ) as premisesType,
+      application.data -> 'basic-information' -> 'sentence-type' ->> 'sentenceType' as sentenceType,
+      submission_event.data -> 'eventDetails' ->> 'releaseType' as releaseType,
+      cast(
+        submission_event.data -> 'eventDetails' ->> 'submittedAt' as date
+      ) as applicationSubmissionDate,
+      submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'ldu' ->> 'name' as referralLdu,
+      submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'team' ->> 'name' as referralTeam,
+      submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'region' ->> 'name' as referralRegion,
+      submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'staffMember' ->> 'username' as referrerUsername,
+      submission_event.data -> 'eventDetails' ->> 'targetLocation' as targetLocation,
+      cast(
+        withdrawl_event.data -> 'eventDetails' ->> 'withdrawnAt' as date
+      ) as applicationWithdrawalDate,
+      withdrawl_event.data -> 'eventDetails' ->> 'withdrawalReason' as applicationWithdrawalReason,
+      cast(booking_made_event.booking_id as text) as bookingID,
+      booking_cancelled_event.data -> 'eventDetails' ->> 'cancellationReason' as bookingCancellationReason,
+      cast(
+        booking_cancelled_event.data -> 'eventDetails' ->> 'cancelledAt' as date
+      ) as bookingCancellationDate,
+      cast(
+        booking_made_event.data -> 'eventDetails' ->> 'arrivalOn' as date
+      ) as expectedArrivalDate,
+      booking_made_event.data -> 'eventDetails' -> 'bookedBy' -> 'cru' ->> 'name' as matcherCru,
+      cast(
+        booking_made_event.data -> 'eventDetails' ->> 'departureOn' as date
+      ) as expectedDepartureDate,
+      booking_made_event.data -> 'eventDetails' -> 'premises' ->> 'name' as premisesName,
+      cast(
+        arrival_event.data -> 'eventDetails' ->> 'arrivedAt' as date
+      ) as actualArrivalDate,
+      cast(
+        departure_event.data -> 'eventDetails' ->> 'departedAt' as date
+      ) as actualDepartureDate,
+      departure_event.data -> 'eventDetails' ->> 'reason' as departureReason,
+      departure_event.data -> 'eventDetails' -> 'destination' -> 'moveOnCategory' ->> 'description' as departureMoveOnCategory,
+      non_arrival_event.data IS NOT NULL as hasNotArrived,
+      non_arrival_event.data -> 'eventDetails' ->> 'reason' as notArrivedReason
+    from
+      applications application
+      left join approved_premises_applications apa on application.id = apa.id
+      left join domain_events submission_event on submission_event.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED'
+      and application.id = submission_event.application_id
+      left join domain_events assessment_event on assessment_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED'
+      and application.id = assessment_event.application_id
+      left join domain_events withdrawl_event on withdrawl_event.type = 'APPROVED_PREMISES_APPLICATION_WITHDRAWN'
+      and application.id = withdrawl_event.application_id
+      left join domain_events booking_made_event on booking_made_event.type = 'APPROVED_PREMISES_BOOKING_MADE'
+      and application.id = booking_made_event.application_id
+      left join domain_events booking_cancelled_event on booking_cancelled_event.type = 'APPROVED_PREMISES_BOOKING_CANCELLED'
+      and application.id = booking_cancelled_event.application_id
+      left join domain_events arrival_event on arrival_event.type = 'APPROVED_PREMISES_PERSON_ARRIVED'
+      and application.id = arrival_event.application_id
+      left join domain_events departure_event on departure_event.type = 'APPROVED_PREMISES_PERSON_DEPARTED'
+      and application.id = departure_event.application_id
+      left join domain_events non_arrival_event on non_arrival_event.type = 'APPROVED_PREMISES_PERSON_NOT_ARRIVED'
+      and application.id = non_arrival_event.application_id
+      left join assessments on application.id = assessments.application_id
+      AND assessments.reallocated_at IS NULL
+    where
+      date_part('month', application.submitted_at) = :month
+      AND date_part('year', application.submitted_at) = :year
+      AND application.service = 'approved-premises'
+    order by
+      application.id,
+      submission_event.occurred_at, 
+      booking_made_event.occurred_at desc;
+    """,
+    nativeQuery = true,
+  )
+  fun generateApprovedPremisesReferralReportRowsForCalendarMonth(month: Int, year: Int): List<ApplicationEntityReportRow>
 }
 
 interface ApplicationEntityReportRow {
@@ -131,5 +226,5 @@ interface ApplicationEntityReportRow {
   fun getHasNotArrived(): Boolean?
   fun getNotArrivedReason(): String?
   fun getParoleDecisionDate(): Date?
-  fun getType(): String
+  fun getType(): String?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -40,5 +40,5 @@ data class ApplicationReportRow(
   val hasNotArrived: Boolean?,
   val notArrivedReason: String?,
   val paroleDecisionDate: LocalDate?,
-  val type: String,
+  val type: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ReportService.kt
@@ -115,6 +115,14 @@ class ReportService(
       }
   }
 
+  fun createCas1ApplicationReferralsReport(properties: ApplicationReportProperties, outputStream: OutputStream) {
+    ApplicationReportGenerator()
+      .createReport(applicationEntityReportRowRepository.generateApprovedPremisesReferralReportRowsForCalendarMonth(properties.month, properties.year), properties)
+      .writeExcel(outputStream) {
+        WorkbookFactory.create(true)
+      }
+  }
+
   fun createDailyMetricsReport(properties: DailyMetricReportProperties, outputStream: OutputStream) {
     val applications = applicationRepository.findAllApprovedPremisesApplicationsCreatedInMonth(properties.month, properties.year).map {
       ApprovedPremisesApplicationMetricsSummaryDto(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4040,6 +4040,38 @@ paths:
               schema:
                 type: string
                 format: binary
+  /reports/referrals:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet listing all of the submitted referrals for the month and associated booking
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Only applications for this service will be returned
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: year
+          in: query
+          required: true
+          description: Only referrals for this year will be returned
+          schema:
+            type: integer
+        - name: month
+          in: query
+          required: true
+          description: Only referrals for this month will be returned - must be provided with year
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Successfully retrieved the report
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
   /reports/referrals-by-tier:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4042,6 +4042,38 @@ paths:
               schema:
                 type: string
                 format: binary
+  /reports/referrals:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet listing all of the submitted referrals for the month and associated booking
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Only applications for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+        - name: year
+          in: query
+          required: true
+          description: Only referrals for this year will be returned
+          schema:
+            type: integer
+        - name: month
+          in: query
+          required: true
+          description: Only referrals for this month will be returned - must be provided with year
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Successfully retrieved the report
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
   /reports/referrals-by-tier:
     get:
       tags:


### PR DESCRIPTION
This returns a list of all unique applications made. If an application has an associated booking (i.e. it’s been made through the standard Apply - Assess - Placement flow), then we include information about the associated booking too. This is in addition to the main Applications report, which we’re keeping around for now as it contains more information. Once the Placement Requests report is done, we’ll remove the old-style Applications report.