### PR TITLE
CAS2 Reports: MI User downloads an example report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -61,6 +61,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
+        authorize(HttpMethod.GET, "/cas2/reports/example-report", hasRole("CAS2_MI"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
+
+import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.Resource
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.ReportsCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ReportsService
+import java.io.ByteArrayOutputStream
+
+@Service("Cas2ReportsController")
+class ReportsController(private val reportService: ReportsService) : ReportsCas2Delegate {
+
+  override fun reportsExampleReportGet(): ResponseEntity<Resource> {
+    val outputStream = ByteArrayOutputStream()
+    reportService.createCas2ExampleReport(outputStream)
+    return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/Cas2ExampleMetricsRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/Cas2ExampleMetricsRow.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+data class Cas2ExampleMetricsRow(val id: String, val data: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
+
+import org.apache.poi.ss.usermodel.WorkbookFactory
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.io.writeExcel
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas2ExampleMetricsRow
+import java.io.OutputStream
+
+@Service
+class ReportsService {
+  fun createCas2ExampleReport(outputStream: OutputStream) {
+    // TODO replace this with a real report
+    val exampleData = listOf(Cas2ExampleMetricsRow(id = "123", data = "example"))
+
+    exampleData.toDataFrame()
+      .writeExcel(outputStream) {
+        WorkbookFactory.create(true)
+      }
+  }
+}

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -391,3 +391,16 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /reports/example-report:
+    get:
+      tags:
+        - Reports
+      summary: Returns an example spreadsheet of metrics
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -393,6 +393,19 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reports/example-report:
+    get:
+      tags:
+        - Reports
+      summary: Returns an example spreadsheet of metrics
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
 components:
   responses:
     401Response:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -1,8 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
 
+import org.assertj.core.api.Assertions
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas2ExampleMetricsRow
 
 class Cas2ReportsTest : IntegrationTestBase() {
 
@@ -86,5 +94,32 @@ class Cas2ReportsTest : IntegrationTestBase() {
         .expectStatus()
         .isOk
     }
+  }
+
+  @Test
+  fun `downloaded report is streamed as a spreadsheet`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "nomis",
+      roles = listOf("ROLE_PRISON", "ROLE_CAS2_MI"),
+    )
+
+    val expectedDataFrame = listOf(Cas2ExampleMetricsRow(id = "123", data = "example"))
+      .toDataFrame()
+
+    webTestClient.get()
+      .uri("/cas2/reports/example-report")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .consumeWith {
+        val actual = DataFrame
+          .readExcel(it.responseBody!!.inputStream())
+          .convertTo<Cas2ExampleMetricsRow>(ExcessiveColumns.Remove)
+          .sortBy(Cas2ExampleMetricsRow::id)
+        Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
+      }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -1,0 +1,90 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+
+class Cas2ReportsTest : IntegrationTestBase() {
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `downloading report is forbidden to external users without MI role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "auth",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/reports/example-report")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `downloading report is permitted to external users with MI role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "auth",
+        roles = listOf("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_MI"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/reports/example-report")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+    }
+  }
+
+  @Nested
+  inner class MissingJwt {
+    @Test
+    fun `Downloading report without JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas2/reports/example-report")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+  }
+
+  @Nested
+  inner class ControlsOnInternalUsers {
+    @Test
+    fun `downloading report is forbidden to NOMIS users without MI role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_PRISON"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/reports/example-report")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `downloading report is permitted to NOMIS users with MI role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_PRISON", "ROLE_CAS2_MI"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/reports/example-report")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+    }
+  }
+}


### PR DESCRIPTION
In this PR we expose a CAS2 endpoint for downloading a spreadsheet "report" containing metrics.

Our initial endpoint is a example report to demonstrate the user-journey and verify that the correct authorisation controls are in place:

`cas2/reports/example-report`

This download is only available to users with the `CAS2_MI` role.

See related PRs:

- AP Tools [PR 55](https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/55) - adds a Nomis user with the `CAS_MI` role to the local development environment
- CAS2 UI [PR 376](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/376) - adds user-interface to GET the example report

![cas2_example_report](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/69f5108c-ef6d-46d8-82f6-15743e1bfcd0)
