### PR TITLE
Allow a CAS2 Admin to view submitted applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -58,7 +58,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
-        authorize(HttpMethod.GET, "/cas2/submissions/**", hasRole("CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -128,3 +128,28 @@ fun IntegrationTestBase.`Given a CAS2 Assessor`(
 
   block(user, jwt)
 }
+
+fun IntegrationTestBase.`Given a CAS2 Admin`(
+  id: UUID = UUID.randomUUID(),
+  nomisUserDetailsConfigBlock: (NomisUserDetailFactory.() -> Unit)? = null,
+  block: (nomisUserEntity: NomisUserEntity, jwt: String) -> Unit,
+) {
+  val nomisUserDetailsFactory = NomisUserDetailFactory()
+
+  if (nomisUserDetailsConfigBlock != null) {
+    nomisUserDetailsConfigBlock(nomisUserDetailsFactory)
+  }
+
+  val nomisUserDetails = nomisUserDetailsFactory.produce()
+
+  val user = nomisUserEntityFactory.produceAndPersist {
+    withId(id)
+    withNomisUsername(nomisUserDetails.username)
+    withEmail(nomisUserDetails.primaryEmail)
+    withName("${nomisUserDetails.firstName} ${nomisUserDetails.lastName}")
+  }
+
+  val jwt = jwtAuthHelper.createValidAdminAuthorisationCodeJwt(nomisUserDetails.username)
+
+  block(user, jwt)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -77,6 +77,13 @@ class JwtAuthHelper {
       roles = listOf("ROLE_CAS2_ASSESSOR"),
     )
 
+  internal fun createValidAdminAuthorisationCodeJwt(username: String = "username") =
+    createAuthorizationCodeJwt(
+      subject = username,
+      authSource = "nomis",
+      roles = listOf("ROLE_PRISON", "ROLE_CAS2_ADMIN"),
+    )
+
   internal fun createValidAuthorizationCodeJwt(username: String = "username") = createAuthorizationCodeJwt(
     subject = username,
     authSource = "delius",


### PR DESCRIPTION
We have the need on CAS2 for an admin account who can view any submitted application This is likely to be an internal user, so I am assuming they will be using a NOMIS account to login.