### PR TITLE
Fix placement_application_dates backfill migration

### DIFF
--- a/src/main/resources/db/migration/all/20231215134241__backfill_placement_date_to_request_fk.sql
+++ b/src/main/resources/db/migration/all/20231215134241__backfill_placement_date_to_request_fk.sql
@@ -1,1 +1,1 @@
-UPDATE placement_application_dates pa_dates SET placement_request_id = (SELECT pr.id FROM placement_requests pr WHERE pr.placement_application_id = pa_dates.placement_application_id AND pr.expected_arrival = pa_dates.expected_arrival);
+UPDATE placement_application_dates pa_dates SET placement_request_id = (SELECT pr.id FROM placement_requests pr WHERE pr.placement_application_id = pa_dates.placement_application_id AND pr.expected_arrival = pa_dates.expected_arrival AND pr.reallocated_at IS NULL);


### PR DESCRIPTION
The placement_application_dates.placement_request_id backfill script should of excluded placement_requests that have been realloacted. Otherwise it can fail (and has) as the subquery matches on more than one row