### PR TITLE
Don’t show reallocated placement applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -36,6 +36,7 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
     """
       SELECT a from PlacementApplicationEntity a where a.application.id = :applicationId
       AND a.submittedAt is not null
+      AND a.reallocatedAt is null
       AND 
         (
             a.decision != uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.WITHDRAWN_BY_PP
@@ -44,7 +45,7 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
         )
     """,
   )
-  fun findAllSubmittedAndNonWithdrawnApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity>
+  fun findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -65,7 +65,7 @@ class PlacementApplicationService(
   }
 
   fun getAllPlacementApplicationEntitiesForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
-    return placementApplicationRepository.findAllSubmittedAndNonWithdrawnApplicationsForApplicationId(applicationId)
+    return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(applicationId)
   }
 
   fun createApplication(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1158,31 +1158,41 @@ class ApplicationTest : IntegrationTestBase() {
           schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           },
+          reallocated = true,
           decision = decision,
           submittedAt = OffsetDateTime.now(),
-        ) { placementApplicationEntity ->
+        ) { _ ->
+          `Given a Placement Application`(
+            createdByUser = user,
+            schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withPermissiveSchema()
+            },
+            decision = decision,
+            submittedAt = OffsetDateTime.now(),
+          ) { placementApplicationEntity ->
 
-          val applicationId = placementApplicationEntity.application.id
-          val rawResult = webTestClient.get()
-            .uri("/applications/$applicationId/placement-applications")
-            .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.approvedPremises.value)
-            .exchange()
-            .expectStatus()
-            .isOk
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
+            val applicationId = placementApplicationEntity.application.id
+            val rawResult = webTestClient.get()
+              .uri("/applications/$applicationId/placement-applications")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.approvedPremises.value)
+              .exchange()
+              .expectStatus()
+              .isOk
+              .returnResult<String>()
+              .responseBody
+              .blockFirst()
 
-          val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
+            val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
 
-          assertThat(body.size).isEqualTo(1)
-          assertThat(body[0].id).isEqualTo(placementApplicationEntity.id)
-          assertThat(body[0].applicationId).isEqualTo(placementApplicationEntity.application.id)
-          assertThat(body[0].createdByUserId).isEqualTo(placementApplicationEntity.createdByUser.id)
-          assertThat(body[0].schemaVersion).isEqualTo(placementApplicationEntity.schemaVersion.id)
-          assertThat(body[0].createdAt).isEqualTo(placementApplicationEntity.createdAt.toInstant())
-          assertThat(body[0].submittedAt).isCloseTo(placementApplicationEntity.submittedAt!!.toInstant(), within(1, ChronoUnit.SECONDS))
+            assertThat(body.size).isEqualTo(1)
+            assertThat(body[0].id).isEqualTo(placementApplicationEntity.id)
+            assertThat(body[0].applicationId).isEqualTo(placementApplicationEntity.application.id)
+            assertThat(body[0].createdByUserId).isEqualTo(placementApplicationEntity.createdByUser.id)
+            assertThat(body[0].schemaVersion).isEqualTo(placementApplicationEntity.schemaVersion.id)
+            assertThat(body[0].createdAt).isEqualTo(placementApplicationEntity.createdAt.toInstant())
+            assertThat(body[0].submittedAt).isCloseTo(placementApplicationEntity.submittedAt!!.toInstant(), within(1, ChronoUnit.SECONDS))
+          }
         }
       }
     }


### PR DESCRIPTION
When viewing placement applications for an application, we should only show ones that haven’t been reallocated. I’ve updated the query, as well as updated the test to confirm that reallocated placement applications don’t show.