### PR TITLE
Show type as referral when no arrival date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -57,8 +57,8 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
       cast(placement_applications.data -> 'request-a-placement' -> 'decision-to-release' ->> 'decisionToReleaseDate' as date) as paroleDecisionDate,
       (
         CASE
-          WHEN placement_applications.id IS NULL THEN 'referral'
-          ELSE 'placement request'
+          WHEN apa.arrival_date IS NULL THEN 'placement request'
+          ELSE 'referral'
         END
       ) as type
     from

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -266,6 +266,11 @@ class ApplicationReportsTest : IntegrationTestBase() {
       val multipleBookings1 = createBookingForApplication(applicationWithMultipleBookings)
       val multipleBookings2 = createBookingForApplication(applicationWithMultipleBookings)
 
+      val applicationWithSubsequentPlacementApplications = createApplication()
+      acceptAssessmentForApplication(applicationWithSubsequentPlacementApplications)
+      createAndAcceptPlacementApplication(applicationWithSubsequentPlacementApplications)
+      createAndAcceptPlacementApplication(applicationWithSubsequentPlacementApplications)
+
       webTestClient.get()
         .uri("/reports/referrals?year=${LocalDate.now().year}&month=${LocalDate.now().monthValue}")
         .header("Authorization", "Bearer $jwt")
@@ -280,7 +285,7 @@ class ApplicationReportsTest : IntegrationTestBase() {
             .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
             .toList()
 
-          assertThat(actual.size).isEqualTo(7)
+          assertThat(actual.size).isEqualTo(8)
 
           assertApplicationRowHasCorrectData(actual, applicationWithBooking.id, arrivedBooking, userEntity, ApplicationFacets(reportType = ReportType.Referrals))
           assertApplicationRowHasCorrectData(actual, applicationWithDepartedBooking.id, departedBooking, userEntity, ApplicationFacets(hasDeparture = true, reportType = ReportType.Referrals))
@@ -289,6 +294,7 @@ class ApplicationReportsTest : IntegrationTestBase() {
           assertApplicationRowHasCorrectData(actual, applicationWithPlacementApplication.id, null, userEntity, ApplicationFacets(hasPlacementApplication = true, reportType = ReportType.Referrals))
           assertApplicationRowHasCorrectData(actual, applicationWithMultipleAssessments.id, null, userEntity, ApplicationFacets(isAssessed = false, reportType = ReportType.Referrals))
           assertApplicationRowHasCorrectData(actual, applicationWithMultipleBookings.id, multipleBookings2, userEntity, ApplicationFacets(reportType = ReportType.Referrals))
+          assertApplicationRowHasCorrectData(actual, applicationWithSubsequentPlacementApplications.id, null, userEntity, ApplicationFacets(reportType = ReportType.Referrals))
         }
     }
   }


### PR DESCRIPTION
Previously, we were returning `referral` for a type when a placement application is not present. There are some circumstances when an application can be made, but have subsequent placement applications made, so we need to change the rule to check for the presence of a start date.