### PR TITLE
Serve CAS2 domain event spec via Swagger UI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -49,6 +49,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/cas2-api.yml", permitAll)
         authorize(HttpMethod.GET, "/_shared.yml", permitAll)
         authorize(HttpMethod.GET, "/domain-events-api.yml", permitAll)
+        authorize(HttpMethod.GET, "/cas2-domain-events-api.yml", permitAll)
         authorize(HttpMethod.GET, "/favicon.ico", permitAll)
         authorize(HttpMethod.GET, "/info", permitAll)
         authorize(HttpMethod.POST, "/seed", permitAll)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,6 +101,8 @@ springdoc:
         url: "cas2-api.yml"
       - name: Domain events
         url: "domain-events-api.yml"
+      - name: CAS2 Domain events
+        url: "cas2-domain-events-api.yml"
 
 server:
   port: 8080


### PR DESCRIPTION
The CAS2 domain event OpenApi spec was not being served up via the SwaggerUI interface.

![cas2_domain_events_swagger_ui](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/4fb0d3bf-f2cb-41c6-a568-c1fc75da132c)
