### PR TITLE
pin gatling to a specific version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   kotlin("plugin.spring") version "1.9.21"
   id("org.openapi.generator") version "5.4.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.21"
-  id("io.gatling.gradle") version "3.10.2"
+  id("io.gatling.gradle") version "3.10.3"
   id("io.gitlab.arturbosch.detekt") version "1.23.4"
 }
 
@@ -339,6 +339,7 @@ tasks {
 tasks.getByName("runKtlintCheckOverMainSourceSet").dependsOn("openApiGenerate", "openApiGenerateDomainEvents")
 
 gatling {
+  gatlingVersion = "3.9.5"
   // WARNING: options below only work when logback config file isn't provided
   logLevel = "WARN" // logback root level
   logHttp =


### PR DESCRIPTION
By default the gradle gatling plugin will automatically chose with version of gatling to use. Gatling >= 3.10 is incompatible with the version of Jackson used by Spring Webflux. This causes a ClassNotFoundException when running load tests.

The workaround applied on this commit is to pin the version of gatling used by the plugin to a version < 3.10.

We can consider unpinning the version once we have upgraded to a later version of webflux (and even, this is assuming at some point spring boot 3 will use jackson >= 2.16.0, see notes below)

Specific details on the incompatibility:

* Gatling >= 3.10 uses jackson 2.16.0
* Earlier versions of Gatling use jackson 2.15.0
* It appears that Gatling is using jackson 2.16.0 in such a way that will fail if 2.15.0 is used at runtime
* We currently use jackson 2.13.5 at runtime, provided as a transitive dependency from spring webflux
* Even if we try to force spring webflux to it’s latest version, it still only uses jackson 2.15.0
* If there is ever a version of spring webflux that uses jackson >= 2.16.0 we can consider unpinning the gatling version