### PR TITLE
(APS 153) Add sorting to the reallocatable tasks endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -432,13 +432,7 @@ class TasksController(
       sortDirection,
     )
 
-    val crns = allocatedTasks.map {
-      when (it) {
-        is TypedTask.Assessment -> it.entity.application.crn
-        is TypedTask.PlacementRequest -> it.entity.application.crn
-        is TypedTask.PlacementApplication -> it.entity.application.crn
-      }
-    }
+    val crns = allocatedTasks.map { it.crn }
 
     val offenderSummaries = getOffenderSummariesForCrns(crns, user)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Repository
+interface TaskRespository : JpaRepository<Task, UUID> {
+  companion object {
+    private const val ALLOCATABLE_QUERY = """
+      SELECT
+        cast(assessment.id as TEXT) as id,
+        assessment.created_at as created_at,
+        'assessment' as type
+      from
+        assessments assessment
+        left join applications application on assessment.application_id = application.id
+      where
+        application.service = 'approved-premises'
+        and assessment.is_withdrawn is not true
+        and assessment.reallocated_at is null
+        and assessment.submitted_at is null
+        and (
+              (:isAllocated is null) OR 
+              (
+                (:isAllocated = true and assessment.allocated_to_user_id is not null) or
+                (:isAllocated = false and assessment.allocated_to_user_id is null)
+              )
+        )
+      UNION ALL
+      SELECT
+        cast(placement_application.id as TEXT) as id,
+        placement_application.created_at as created_at,
+        'placement_application' as type
+      from
+        placement_applications placement_application
+      where
+        placement_application.submitted_at is not null
+        and placement_application.reallocated_at is null
+        and placement_application.decision is null
+        and (
+                (:isAllocated is null) OR 
+                (
+                    (:isAllocated = true and placement_application.allocated_to_user_id is not null) or
+                    (:isAllocated = false and placement_application.allocated_to_user_id is null)
+                )
+            )
+      UNION ALL
+      SELECT
+        cast(placement_request.id as TEXT) as id,
+        placement_request.created_at as created_at,
+        'placement_request' as type
+      from
+        placement_requests placement_request
+        left join booking_not_mades booking_not_made on booking_not_made.placement_request_id = placement_request.id
+      where
+        placement_request.booking_id IS NULL
+        AND placement_request.reallocated_at IS NULL
+        AND placement_request.is_withdrawn is false
+        AND booking_not_made.id IS NULL
+        AND (
+                (:isAllocated is null) OR 
+                (
+                    (:isAllocated = true and placement_request.allocated_to_user_id is not null) or
+                    (:isAllocated = false and placement_request.allocated_to_user_id is null)
+                )
+            )
+    """
+  }
+
+  @Query(
+    ALLOCATABLE_QUERY,
+    countQuery = "SELECT COUNT(1) FROM ($ALLOCATABLE_QUERY) as count",
+    nativeQuery = true,
+  )
+  fun getAllReallocatable(isAllocated: Boolean?, pageable: Pageable?): Page<Task>
+}
+
+@Entity
+data class Task(
+  @Id
+  val id: UUID,
+  val createdAt: LocalDateTime,
+  val type: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+
+sealed class TypedTask {
+  data class Assessment(val entity: ApprovedPremisesAssessmentEntity) : TypedTask()
+  data class PlacementRequest(val entity: PlacementRequestEntity) : TypedTask()
+  data class PlacementApplication(val entity: PlacementApplicationEntity) : TypedTask()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
@@ -3,9 +3,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import java.time.OffsetDateTime
 
-sealed class TypedTask {
-  data class Assessment(val entity: ApprovedPremisesAssessmentEntity) : TypedTask()
-  data class PlacementRequest(val entity: PlacementRequestEntity) : TypedTask()
-  data class PlacementApplication(val entity: PlacementApplicationEntity) : TypedTask()
+sealed class TypedTask(
+  val createdAt: OffsetDateTime,
+  val crn: String,
+) {
+  data class Assessment(val entity: ApprovedPremisesAssessmentEntity) : TypedTask(entity.createdAt, entity.application.crn)
+  data class PlacementRequest(val entity: PlacementRequestEntity) : TypedTask(entity.createdAt, entity.application.crn)
+  data class PlacementApplication(val entity: PlacementApplicationEntity) : TypedTask(entity.createdAt, entity.application.crn)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
@@ -83,12 +84,12 @@ class AssessmentService(
 
   fun getAllReallocatable(
     page: Int?,
+    sortField: TaskSortField,
     sortDirection: SortDirection?,
     allocatedFilter: AllocatedFilter?,
   ): Pair<List<AssessmentEntity>, PaginationMetadata?> {
     val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)
-    val sortField = "createdAt"
-    val pageable = getPageable(sortField, sortDirection, page)
+    val pageable = getPageable(sortField.value, sortDirection, page)
     var assessments: Page<AssessmentEntity>?
 
     when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AllocatedFilter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
@@ -346,11 +347,11 @@ class PlacementApplicationService(
 
   fun getAllReallocatable(
     page: Int?,
+    sortField: TaskSortField,
     sortDirection: SortDirection?,
     allocatedFilter: AllocatedFilter?,
   ): Pair<List<PlacementApplicationEntity>, PaginationMetadata?> {
-    val sortField = "createdAt"
-    val pageable = getPageable(sortField, sortDirection, page)
+    val pageable = getPageable(sortField.value, sortDirection, page)
     var allReallocatable: Page<PlacementApplicationEntity>?
 
     when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
@@ -75,11 +76,18 @@ class PlacementRequestService(
 
   fun getAllReallocatable(
     page: Int?,
+    sortField: TaskSortField,
     sortDirection: SortDirection?,
     allocatedFilter: AllocatedFilter?,
   ): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
-    val sortField = "created_at"
-    val pageable = getPageable(sortField, sortDirection, page)
+    val pageable = getPageable(
+      // Convert to snake_case, because the findAllReallocatable* methods are native SQL queries
+      when (sortField) {
+        TaskSortField.createdAt -> "created_at"
+      },
+      sortDirection,
+      page,
+    )
     val allReallocatable: Page<PlacementRequestEntity>?
 
     when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -1,18 +1,28 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AllocatedFilter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Reallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskRespository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.TypedTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import java.util.UUID
 
 @Service
@@ -23,7 +33,37 @@ class TaskService(
   private val placementRequestService: PlacementRequestService,
   private val userTransformer: UserTransformer,
   private val placementApplicationService: PlacementApplicationService,
+  private val taskRespository: TaskRespository,
+  private val assessmentRepository: AssessmentRepository,
+  private val placementApplicationRepository: PlacementApplicationRepository,
+  private val placementRequestRepository: PlacementRequestRepository,
 ) {
+  fun getAllReallocatable(
+    allocatedFilter: AllocatedFilter?,
+    page: Int?,
+  ): Pair<List<TypedTask>, PaginationMetadata?> {
+    val pageSize = 10
+    val pageable = if (page != null) { PageRequest.of(page - 1, pageSize) } else { null }
+
+    val isAllocated = if (allocatedFilter == null) { null } else { allocatedFilter == AllocatedFilter.allocated }
+    val reallocatableTaskResult = taskRespository.getAllReallocatable(isAllocated, pageable)
+    val reallocatableTasks = reallocatableTaskResult.content
+
+    val assessmentIds = reallocatableTasks.filter { it.type == "assessment" }.map { it.id }
+    val placementApplicationIds = reallocatableTasks.filter { it.type == "placement_application" }.map { it.id }
+    val placementRequestIds = reallocatableTasks.filter { it.type == "placement_request" }.map { it.id }
+
+    val tasks = listOf(
+      assessmentRepository.findAllById(assessmentIds).map { TypedTask.Assessment(it as ApprovedPremisesAssessmentEntity) },
+      placementApplicationRepository.findAllById(placementApplicationIds).map { TypedTask.PlacementApplication(it) },
+      placementRequestRepository.findAllById(placementRequestIds).map { TypedTask.PlacementRequest(it) },
+    ).flatten()
+
+    val metadata = getMetadata(reallocatableTaskResult, page)
+
+    return Pair(tasks, metadata)
+  }
+
   fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, id: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
     if (!userAccessService.userCanReallocateTask(requestUser)) {
       return AuthorisableActionResult.Unauthorised()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -71,11 +71,7 @@ class TaskService(
 
     tasks = tasks.sortedBy {
       when (sortField) {
-        TaskSortField.createdAt -> when (it) {
-          is TypedTask.Assessment -> it.entity.createdAt
-          is TypedTask.PlacementApplication -> it.entity.createdAt
-          is TypedTask.PlacementRequest -> it.entity.createdAt
-        }
+        TaskSortField.createdAt -> it.createdAt
       }
     }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -280,6 +280,10 @@ components:
         - not_started
         - in_progress
         - complete
+    TaskSortField:
+      type: string
+      enum:
+        - createdAt
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2674,9 +2674,14 @@ paths:
           description: Page number of results to return.
           schema:
             type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '_shared.yml#/components/schemas/TaskSortField'
         - name: sortDirection
           in: query
-          description: The direction to sort the results by. If blank eill sort by descending order
+          description: The direction to sort the results by. If blank will sort by descending order
           schema:
             $ref: '_shared.yml#/components/schemas/SortDirection'
         - name: allocatedFilter

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2676,9 +2676,14 @@ paths:
           description: Page number of results to return.
           schema:
             type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '#/components/schemas/TaskSortField'
         - name: sortDirection
           in: query
-          description: The direction to sort the results by. If blank eill sort by descending order
+          description: The direction to sort the results by. If blank will sort by descending order
           schema:
             $ref: '#/components/schemas/SortDirection'
         - name: allocatedFilter
@@ -4516,6 +4521,10 @@ components:
         - not_started
         - in_progress
         - complete
+    TaskSortField:
+      type: string
+      enum:
+        - createdAt
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -688,6 +688,10 @@ components:
         - not_started
         - in_progress
         - complete
+    TaskSortField:
+      type: string
+      enum:
+        - createdAt
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -330,13 +330,7 @@ class TaskServiceTest {
       assessments.map { TypedTask.Assessment(it) },
       placementApplications.map { TypedTask.PlacementApplication(it) },
       placementRequests.map { TypedTask.PlacementRequest(it) },
-    ).flatten().sortedBy {
-      when (it) {
-        is TypedTask.Assessment -> it.entity.createdAt
-        is TypedTask.PlacementApplication -> it.entity.createdAt
-        is TypedTask.PlacementRequest -> it.entity.createdAt
-      }
-    }
+    ).flatten().sortedBy { it.createdAt }
 
     Assertions.assertThat(result.first).isEqualTo(expectedTasks)
     Assertions.assertThat(result.second).isEqualTo(metadata)


### PR DESCRIPTION
This adds sorting and native SQL pagination to the `/tasks/reallocatable` endpoint. This is a bit tricky as we have to fetch three different entity types. Before we've been a bit manual with our approach, but this makes pagination and sorting tricky because we have to load all the entities into memory to do the sort. This will only get harder once the service gets opened to more regions, and the Tasks page is already incredibly slow.

I've got around this by having a `UNION` query that fetches the bare minimum of fields from all the taskable tables, then fetching the entities by their ID in three separate queries. We then have to re-sort the fields after fetching to ensure the sort order is preserved.