### PR TITLE
(Fix) Update tasks endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -33,8 +33,8 @@ class UserTransformer(
       numAssessmentsPending = userWorkload.numAssessmentsPending,
       numAssessmentsCompleted30Days = userWorkload.numAssessmentsCompleted30Days,
       numAssessmentsCompleted7Days = userWorkload.numAssessmentsCompleted7Days,
-      qualifications = jpa.qualifications.map(::transformQualificationToApi),
-      roles = jpa.roles.mapNotNull(::transformApprovedPremisesRoleToApi),
+      qualifications = jpa.qualifications.distinct().map(::transformQualificationToApi),
+      roles = jpa.roles.distinct().mapNotNull(::transformApprovedPremisesRoleToApi),
     )
   }
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -231,7 +231,7 @@ components:
         users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: '#/components/schemas/UserWithWorkload'
       required:
         - task
         - users

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4467,7 +4467,7 @@ components:
         users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: '#/components/schemas/UserWithWorkload'
       required:
         - task
         - users

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -639,7 +639,7 @@ components:
         users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: '#/components/schemas/UserWithWorkload'
       required:
         - task
         - users

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1186,9 +1186,13 @@ class TasksTest : IntegrationTestBase() {
                             "${offenderDetails.firstName} ${offenderDetails.surname}",
                           ),
                           users = listOf(
-                            userTransformer.transformJpaToApi(
+                            userTransformer.transformJpaToAPIUserWithWorkload(
                               allocatableUser,
-                              ServiceName.approvedPremises,
+                              UserWorkload(
+                                0,
+                                0,
+                                0,
+                              ),
                             ),
                           ),
                         ),
@@ -1234,9 +1238,9 @@ class TasksTest : IntegrationTestBase() {
                           "${offenderDetails.firstName} ${offenderDetails.surname}",
                         ),
                         users = listOf(
-                          userTransformer.transformJpaToApi(
+                          userTransformer.transformJpaToAPIUserWithWorkload(
                             allocatableUser,
-                            ServiceName.approvedPremises,
+                            UserWorkload(0, 0, 0),
                           ),
                         ),
                       ),
@@ -1283,9 +1287,9 @@ class TasksTest : IntegrationTestBase() {
                           "${offenderDetails.firstName} ${offenderDetails.surname}",
                         ),
                         users = listOf(
-                          userTransformer.transformJpaToApi(
+                          userTransformer.transformJpaToAPIUserWithWorkload(
                             allocatableUser,
-                            ServiceName.approvedPremises,
+                            UserWorkload(0, 0, 0),
                           ),
                         ),
                       ),
@@ -1332,13 +1336,13 @@ class TasksTest : IntegrationTestBase() {
                           "${offenderDetails.firstName} ${offenderDetails.surname}",
                         ),
                         users = listOf(
-                          userTransformer.transformJpaToApi(
-                            allocatableUser,
-                            ServiceName.approvedPremises,
-                          ),
-                          userTransformer.transformJpaToApi(
+                          userTransformer.transformJpaToAPIUserWithWorkload(
                             user,
-                            ServiceName.approvedPremises,
+                            UserWorkload(0, 0, 0),
+                          ),
+                          userTransformer.transformJpaToAPIUserWithWorkload(
+                            allocatableUser,
+                            UserWorkload(0, 0, 0),
                           ),
                         ),
                       ),


### PR DESCRIPTION
`TaskWrapper` now returns a `UserWithWorkload` array, but the spec wasn’t updated. For some reason we weren’t getting compilation errors!