### PR TITLE
(APS-175) Return region name with premises summaries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -59,7 +59,27 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
   )
   fun findAllTemporaryAccommodationSummary(regionId: UUID): List<TemporaryAccommodationPremisesSummary>
 
-  @Query("SELECT new uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesSummary(p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.status, CAST(COUNT(b) as int), p.apCode) FROM ApprovedPremisesEntity p LEFT JOIN p.rooms r LEFT JOIN r.beds b GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status")
+  @Query(
+    """
+    SELECT 
+        new uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesSummary(
+            p.id, 
+            p.name, 
+            p.addressLine1, 
+            p.addressLine2, 
+            p.postcode, 
+            p.status, 
+            CAST(COUNT(b) as int), 
+            p.apCode, 
+            region.name
+        ) 
+        FROM ApprovedPremisesEntity p 
+        LEFT JOIN p.rooms r 
+        LEFT JOIN r.beds b 
+        LEFT JOIN p.probationRegion region
+        GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status, region.name
+  """,
+  )
   fun findAllApprovedPremisesSummary(): List<ApprovedPremisesSummary>
 
   @Query("SELECT p as premises, (SELECT CAST(COUNT(b) as int) FROM p.rooms r JOIN r.beds b WHERE r.premises = p GROUP BY p) as roomCount FROM PremisesEntity p WHERE TYPE(p) = :type")
@@ -273,6 +293,7 @@ data class ApprovedPremisesSummary(
   val status: PropertyStatus,
   val bedCount: Int,
   val apCode: String,
+  val regionName: String,
 )
 
 data class TemporaryAccommodationPremisesSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesSummaryTransformer.kt
@@ -32,5 +32,6 @@ class PremisesSummaryTransformer() {
     bedCount = domain.bedCount,
     apCode = domain.apCode,
     service = "CAS1",
+    probationRegion = domain.regionName,
   )
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -167,8 +167,11 @@ components:
             apCode:
               type: string
               example: NEHOPE1
+            probationRegion:
+              type: string
       required:
         - apCode
+        - probationRegion
     TemporaryAccommodationPremisesSummary:
       allOf:
         - $ref: '#/components/schemas/PremisesSummary'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4408,8 +4408,11 @@ components:
             apCode:
               type: string
               example: NEHOPE1
+            probationRegion:
+              type: string
       required:
         - apCode
+        - probationRegion
     TemporaryAccommodationPremisesSummary:
       allOf:
         - $ref: '#/components/schemas/PremisesSummary'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -575,8 +575,11 @@ components:
             apCode:
               type: string
               example: NEHOPE1
+            probationRegion:
+              type: string
       required:
         - apCode
+        - probationRegion
     TemporaryAccommodationPremisesSummary:
       allOf:
         - $ref: '#/components/schemas/PremisesSummary'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
@@ -58,6 +58,7 @@ class PremisesSummaryTransformerTest {
       status = PropertyStatus.active,
       bedCount = 1,
       apCode = "APCODE",
+      regionName = "Some region",
     )
 
     val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
@@ -73,6 +74,7 @@ class PremisesSummaryTransformerTest {
         bedCount = 1,
         apCode = "APCODE",
         service = "CAS1",
+        probationRegion = "Some region",
       ),
     )
   }


### PR DESCRIPTION
When we start rolling out to multiple regions, we’re going to want to group/filter by region, so this will make it easier.