### PR TITLE
Hide withdrawn placement requests for `notMatched`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -124,7 +124,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
             WHERE
               bnm.placement_request_id = pq.id
           ) > 0 THEN 'unableToMatch'
-          ELSE 'notMatched'
+          WHEN pq.is_withdrawn IS FALSE THEN 'notMatched'
         END
       ) = :#{#status?.toString()})
       AND (:crn IS NULL OR (SELECT COUNT(1) FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn)) = 1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -211,7 +211,6 @@ class PlacementRequestsTest : IntegrationTestBase() {
             createdByUser = user,
             crn = unmatchedOffender.otherIds.crn,
           ) { unmatchedPlacementRequest, _ ->
-
             val withdrawnPlacementRequest = createPlacementRequest(unmatchedOffender, user, isWithdrawn = true)
 
             webTestClient.get()
@@ -241,7 +240,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It returns the unmatched placement requests when the user is a manager`() {
+    fun `It returns the unmatched placement requests and ignores the withdrawn placement requests when the user is a manager`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given an Offender` { unmatchedOffender, unmatchedInmate ->
           `Given a Placement Request`(
@@ -250,6 +249,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
             createdByUser = user,
             crn = unmatchedOffender.otherIds.crn,
           ) { unmatchedPlacementRequest, _ ->
+            createPlacementRequest(unmatchedOffender, user, isWithdrawn = true)
+
             webTestClient.get()
               .uri("/placement-requests/dashboard?status=notMatched")
               .header("Authorization", "Bearer $jwt")


### PR DESCRIPTION
When looking at not matched placement requests, it's showing withdrawn placement requests too, which is not what we want at all. When `notMatched` is provided we need to filter out placement requests that are withdrawn.