### PR TITLE
Fix/user role seed duplication

### DIFF
--- a/src/main/resources/db/migration/all/20240105113951__user_role_assignments_unique_by_role_and_user_id.sql
+++ b/src/main/resources/db/migration/all/20240105113951__user_role_assignments_unique_by_role_and_user_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_role_assignments
+ADD CONSTRAINT unique_role_user_constraint
+UNIQUE (role, user_id);

--- a/src/main/resources/db/migration/local+dev+test/20240105113742__remove_duplicate_user_role_assignments.sql
+++ b/src/main/resources/db/migration/local+dev+test/20240105113742__remove_duplicate_user_role_assignments.sql
@@ -1,0 +1,16 @@
+-- Duplicates have been inserted into dev. Before we can add a database
+-- constraint we need to remove these. The create_dev_users migration will put
+-- them back.
+
+DELETE FROM user_role_assignments
+WHERE user_id IN (
+  SELECT id FROM users WHERE delius_username IN (
+    'JIMSNOWLDAP',
+    'APPROVEDPREMISESTESTUSER',
+    'TEMPORARY-ACCOMMODATION-E2E-TESTER',
+    'TESTER.TESTY',
+    'BERNARD.BEAKS',
+    'PANESAR.JASPAL',
+    'CAS-LOAD-TESTER'
+    )
+);

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -83,7 +83,7 @@ FROM
   "user_role_assignments"
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
+ON CONFLICT
 DO
   NOTHING;
 
@@ -99,7 +99,7 @@ FROM
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
   AND ("role" = 'CAS3_ASSESSOR' OR "role" = 'CAS3_REPORTER')
-ON CONFLICT (id)
+ON CONFLICT
 DO
   NOTHING;
 
@@ -114,7 +114,7 @@ FROM
   "user_role_assignments"
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
+ON CONFLICT
 DO
   NOTHING;
 
@@ -129,7 +129,7 @@ FROM
   "user_role_assignments"
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
+ON CONFLICT
 DO
   NOTHING;
 
@@ -144,7 +144,7 @@ FROM
   "user_role_assignments"
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
+ON CONFLICT
 DO
   NOTHING;
 
@@ -159,6 +159,6 @@ FROM
   "user_role_assignments"
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
+ON CONFLICT
 DO
   NOTHING;


### PR DESCRIPTION
[We noticed today that seeded dev roles had many duplicate roles](https://mojdt.slack.com/archives/C03K0HB0LBE/p1704448977587099):

![image (2)](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/a8964ec0-aa80-4779-b455-26363b8e2d93)

This looks to be due to role inserts not conflicting properly on insert and so were reinserting themselves on every server start.

We had this protection in create_dev_users:

```
ON CONFLICT (id)
DO
  NOTHING;
```

I don't think this was doing anything because in this context the `id` was a randomly generated uuid and so would never conflict.

This dev seeding issue could be hacked together by removing each set of roles before insertion each time however I think this actually highlights a more general problem: the database can allow users to have duplicate roles. I suspect this is never a situation we expect to get into and so I'm proposing we add a uniqueness constraint, which will then raise a conflict correctly and prevent future duplicates.

I have some recordings on Slack of me testing these that I'll put in [the original thread](https://mojdt.slack.com/archives/C03K0HB0LBE/p1704448977587099) since they're too big to upload to GitHub.

