### PR TITLE
[APS-67] Implement AP Delius Context API offender details data source

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
 import java.time.LocalDate
 
 data class OffenderDetailSummary(
-  val offenderId: Long,
+  val offenderId: Long?,
   val title: String?,
   val firstName: String,
   val middleNames: List<String>?,
@@ -15,11 +15,11 @@ data class OffenderDetailSummary(
   val otherIds: OffenderIds,
   val offenderProfile: OffenderProfile,
   val softDeleted: Boolean?,
-  val currentDisposal: String,
+  val currentDisposal: String?,
   val partitionArea: String?,
   val currentRestriction: Boolean,
   val currentExclusion: Boolean,
-  val isActiveProbationManagedSentence: Boolean,
+  val isActiveProbationManagedSentence: Boolean?,
 )
 
 data class OffenderIds(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLanguages
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderProfile
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Ldu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Manager
@@ -57,4 +60,52 @@ fun OffenderDetailSummary.asCaseSummary() = CaseSummary(
   ),
   currentExclusion = this.currentExclusion,
   currentRestriction = this.currentRestriction,
+)
+
+fun CaseSummary.asOffenderDetailSummary() = OffenderDetailSummary(
+  offenderId = null,
+  title = null,
+  firstName = this.name.forename,
+  middleNames = this.name.middleNames,
+  surname = this.name.surname,
+  previousSurname = null,
+  preferredName = null,
+  dateOfBirth = this.dateOfBirth,
+  gender = this.gender ?: "unknown",
+  otherIds = OffenderIds(
+    crn = this.crn,
+    croNumber = null,
+    immigrationNumber = null,
+    mostRecentPrisonNumber = null,
+    niNumber = null,
+    nomsNumber = this.nomsId,
+    pncNumber = this.pnc,
+  ),
+  offenderProfile = OffenderProfile(
+    ethnicity = this.profile?.ethnicity,
+    nationality = this.profile?.nationality,
+    secondaryNationality = null,
+    notes = null,
+    immigrationStatus = null,
+    offenderLanguages = OffenderLanguages(
+      primaryLanguage = null,
+      otherLanguages = null,
+      languageConcerns = null,
+      requiresInterpreter = null,
+    ),
+    religion = this.profile?.religion,
+    sexualOrientation = null,
+    offenderDetails = null,
+    remandStatus = null,
+    riskColour = null,
+    disabilities = null,
+    genderIdentity = this.profile?.genderIdentity,
+    selfDescribedGender = null,
+  ),
+  softDeleted = false,
+  currentDisposal = null,
+  partitionArea = null,
+  currentRestriction = this.currentRestriction ?: false,
+  currentExclusion = this.currentExclusion ?: false,
+  isActiveProbationManagedSentence = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
@@ -5,6 +5,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Offender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderIds
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLanguages
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderProfile
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Ldu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Manager
@@ -108,4 +110,18 @@ fun CaseSummary.asOffenderDetailSummary() = OffenderDetailSummary(
   currentRestriction = this.currentRestriction ?: false,
   currentExclusion = this.currentExclusion ?: false,
   isActiveProbationManagedSentence = null,
+)
+
+fun CaseAccess.asUserOffenderAccess() = UserOffenderAccess(
+  userRestricted = this.userRestricted,
+  userExcluded = this.userExcluded,
+  restrictionMessage = this.restrictionMessage,
+)
+
+fun UserOffenderAccess.asCaseAccess(crn: String) = CaseAccess(
+  crn = crn,
+  userExcluded = this.userExcluded,
+  userRestricted = this.userRestricted,
+  exclusionMessage = null,
+  restrictionMessage = this.restrictionMessage,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderDetailsDataSourceTest.kt
@@ -1,0 +1,162 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.ApDeliusContextApiOffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummaries
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.UserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asOffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asUserOffenderAccess
+import java.util.stream.Stream
+
+class ApDeliusContextApiOffenderDetailsDataSourceTest {
+  private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
+
+  private val apDeliusContextApiOffenderDetailsDataSource = ApDeliusContextApiOffenderDetailsDataSource(mockApDeliusContextApiClient)
+
+  @ParameterizedTest
+  @MethodSource("cacheableOffenderDetailSummaryClientResults")
+  fun `getOffenderDetailSummary returns response from AP Delius Context API call`(
+    expectedResult: ClientResult<OffenderDetailSummary>,
+  ) {
+    every { mockApDeliusContextApiClient.getSummariesForCrns(listOf("SOME-CRN")) } returns
+      expectedResult.map { CaseSummaries(listOf(it.asCaseSummary())) }
+
+    val result = apDeliusContextApiOffenderDetailsDataSource.getOffenderDetailSummary("SOME-CRN")
+
+    assertThat(result).isEqualTo(expectedResult)
+  }
+
+  @Test
+  fun `getOffenderDetailSummaries returns transformed response from AP Delius Context API call`() {
+    val crns = listOf("CRN-A", "CRN-B", "CRN-C")
+
+    val caseSummaries = listOf(
+      CaseSummaryFactory()
+        .withCrn("CRN-A")
+        .produce(),
+      CaseSummaryFactory()
+        .withCrn("CRN-B")
+        .produce(),
+      CaseSummaryFactory()
+        .withCrn("CRN-C")
+        .produce(),
+    )
+
+    val expectedResults = caseSummaries.map { ClientResult.Success(HttpStatus.OK, it.asOffenderDetailSummary(), false) }
+
+    every { mockApDeliusContextApiClient.getSummariesForCrns(crns) } returns ClientResult.Success(
+      HttpStatus.OK,
+      CaseSummaries(caseSummaries),
+      false,
+    )
+
+    val results = apDeliusContextApiOffenderDetailsDataSource.getOffenderDetailSummaries(crns)
+
+    assertThat(results).isEqualTo(expectedResults)
+  }
+
+  @ParameterizedTest
+  @MethodSource("userOffenderAccessClientResults")
+  fun `getUserAccessForOffenderCrn returns transformed response from AP Delius Context API call`(
+    expectedResult: ClientResult<UserOffenderAccess>,
+  ) {
+    every { mockApDeliusContextApiClient.getUserAccessForCrns("DELIUS-USER", listOf("SOME-CRN")) } returns
+      expectedResult.map { UserAccess(listOf(it.asCaseAccess("SOME-CRN"))) }
+
+    val result = apDeliusContextApiOffenderDetailsDataSource.getUserAccessForOffenderCrn("DELIUS-USER", "SOME-CRN")
+
+    assertThat(result).isEqualTo(expectedResult)
+  }
+
+  @Test
+  fun `getUserAccessForOffenderCrns returns transformed response from AP Delius Context API`() {
+    val crns = listOf("CRN-A", "CRN-B", "CRN-C")
+    val caseAccesses = listOf(
+      CaseAccessFactory()
+        .withCrn("CRN-A")
+        .produce(),
+      CaseAccessFactory()
+        .withCrn("CRN-B")
+        .produce(),
+      CaseAccessFactory()
+        .withCrn("CRN-C")
+        .produce(),
+    )
+    val expectedResults = caseAccesses.map { ClientResult.Success(HttpStatus.OK, it.asUserOffenderAccess(), false) }
+
+    every { mockApDeliusContextApiClient.getUserAccessForCrns("DELIUS-USER", crns) } returns ClientResult.Success(
+      HttpStatus.OK,
+      UserAccess(caseAccesses),
+      false,
+    )
+
+    val results = apDeliusContextApiOffenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
+
+    assertThat(results).isEqualTo(expectedResults)
+  }
+
+  private companion object {
+    @JvmStatic
+    fun cacheableOffenderDetailSummaryClientResults(): Stream<Arguments> {
+      val successBody = CaseSummaryFactory()
+        .withCrn("SOME-CRN")
+        .produce()
+        .asOffenderDetailSummary()
+
+      return allClientResults(successBody)
+        .filter { it !is ClientResult.Failure.PreemptiveCacheTimeout }
+        .intoArgumentStream()
+    }
+
+    @JvmStatic
+    fun <T> cacheTimeoutClientResult() =
+      ClientResult.Failure.PreemptiveCacheTimeout<T>("some-cache", "some-cache-key", 1000)
+
+    @JvmStatic
+    fun userOffenderAccessClientResults(): Stream<Arguments> {
+      val successBody = UserOffenderAccess(
+        userRestricted = false,
+        userExcluded = false,
+        restrictionMessage = null,
+      )
+
+      return allClientResults(successBody).intoArgumentStream()
+    }
+
+    private fun <T> allClientResults(successBody: T): List<ClientResult<T>> = listOf(
+      ClientResult.Failure.CachedValueUnavailable("some-cache-key"),
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/",
+        HttpStatus.NOT_FOUND,
+        null,
+        false,
+      ),
+      ClientResult.Failure.Other(
+        HttpMethod.POST,
+        "/",
+        RuntimeException("Some error"),
+      ),
+      cacheTimeoutClientResult(),
+      ClientResult.Success(HttpStatus.OK, successBody, true),
+    )
+
+    private fun <T> List<ClientResult<T>>.intoArgumentStream(): Stream<Arguments> = this.stream().map { Arguments.of(it) }
+  }
+}


### PR DESCRIPTION
> See [APS-67 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-67).

This PR provides the ability to use the AP Delius Context API as a data source for offender details. This is achieved by implementing the `ApDeliusContextApiOffenderDetailsDataSource` class.

The `ApDeliusContextApiOffenderDetailsDataSource` class performs transformations of the data in order to match the same data structure used by the Community API for backwards compatibility. These are enabled by various utility methods in the `OffenderDetailsUtils.kt` and `BaseHMPPSClient.kt` files.

This PR does not change the data source for offender details as this is down to the individual configuration for each environment.