### PR TITLE
(Chore) Get all task counts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -123,7 +123,8 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 
   @Query(
     """
-      SELECT
+    SELECT
+      CAST(u.id as TEXT) as userId,
       (
         SELECT
           count(*)
@@ -156,11 +157,12 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
       ) as completedAssessmentsInTheLastThirtyDays
     FROM
       users u
-      WHERE u.id = :userId
+    WHERE
+      u.id IN (:userIds)
     """,
     nativeQuery = true,
   )
-  fun findWorkloadForUserId(userId: UUID): UserWorkload
+  fun findWorkloadForUserIds(userIds: List<UUID>): List<UserWorkload>
 }
 
 @Entity
@@ -257,6 +259,7 @@ enum class UserQualification {
 }
 
 interface UserWorkload {
+  fun getUserId(): UUID
   fun getPendingAssessments(): Int
 
   fun getCompletedAssessmentsInTheLastSevenDays(): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/UserWorkload.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/UserWorkload.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 data class UserWorkload(
-  var numAssessmentsPending: Int,
-  var numAssessmentsCompleted7Days: Int,
-  var numAssessmentsCompleted30Days: Int,
+  var numTasksPending: Int,
+  var numTasksCompleted7Days: Int,
+  var numTasksCompleted30Days: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -245,9 +245,21 @@ class UserService(
   fun getUserWorkloads(userIds: List<UUID>): Map<UUID, UserWorkload> {
     return userRepository.findWorkloadForUserIds(userIds).associate {
       it.getUserId() to UserWorkload(
-        it.getPendingAssessments(),
-        it.getCompletedAssessmentsInTheLastSevenDays(),
-        it.getCompletedAssessmentsInTheLastThirtyDays(),
+        numTasksPending = listOf(
+          it.getPendingAssessments(),
+          it.getPendingPlacementRequests(),
+          it.getPendingPlacementApplications(),
+        ).sum(),
+        numTasksCompleted7Days = listOf(
+          it.getCompletedAssessmentsInTheLastSevenDays(),
+          it.getCompletedPlacementApplicationsInTheLastSevenDays(),
+          it.getCompletedPlacementRequestsInTheLastSevenDays(),
+        ).sum(),
+        numTasksCompleted30Days = listOf(
+          it.getCompletedAssessmentsInTheLastThirtyDays(),
+          it.getCompletedPlacementApplicationsInTheLastThirtyDays(),
+          it.getCompletedPlacementRequestsInTheLastThirtyDays(),
+        ).sum(),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -242,14 +242,14 @@ class UserService(
     return AuthorisableActionResult.Success(user)
   }
 
-  fun getUserWorkload(userId: UUID): UserWorkload {
-    val jpa = userRepository.findWorkloadForUserId(userId)
-    val apiWorkload = UserWorkload(
-      jpa.getPendingAssessments(),
-      jpa.getCompletedAssessmentsInTheLastSevenDays(),
-      jpa.getCompletedAssessmentsInTheLastThirtyDays(),
-    )
-    return apiWorkload
+  fun getUserWorkloads(userIds: List<UUID>): Map<UUID, UserWorkload> {
+    return userRepository.findWorkloadForUserIds(userIds).associate {
+      it.getUserId() to UserWorkload(
+        it.getPendingAssessments(),
+        it.getCompletedAssessmentsInTheLastSevenDays(),
+        it.getCompletedAssessmentsInTheLastThirtyDays(),
+      )
+    }
   }
 
   fun getUserForUsername(username: String, throwProblemOn404: Boolean = false): UserEntity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -30,9 +30,9 @@ class UserTransformer(
       isActive = jpa.isActive,
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       service = ServiceName.approvedPremises.value,
-      numAssessmentsPending = userWorkload.numAssessmentsPending,
-      numAssessmentsCompleted30Days = userWorkload.numAssessmentsCompleted30Days,
-      numAssessmentsCompleted7Days = userWorkload.numAssessmentsCompleted7Days,
+      numTasksPending = userWorkload.numTasksPending,
+      numTasksCompleted7Days = userWorkload.numTasksCompleted7Days,
+      numTasksCompleted30Days = userWorkload.numTasksCompleted30Days,
       qualifications = jpa.qualifications.distinct().map(::transformQualificationToApi),
       roles = jpa.roles.distinct().mapNotNull(::transformApprovedPremisesRoleToApi),
     )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2589,11 +2589,11 @@ components:
         - $ref: '#/components/schemas/User'
         - type: object
           properties:
-            numAssessmentsPending:
+            numTasksPending:
               type: integer
-            numAssessmentsCompleted7Days:
+            numTasksCompleted7Days:
               type: integer
-            numAssessmentsCompleted30Days:
+            numTasksCompleted30Days:
               type: integer
             qualifications:
               type: array

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6830,11 +6830,11 @@ components:
         - $ref: '#/components/schemas/User'
         - type: object
           properties:
-            numAssessmentsPending:
+            numTasksPending:
               type: integer
-            numAssessmentsCompleted7Days:
+            numTasksCompleted7Days:
               type: integer
-            numAssessmentsCompleted30Days:
+            numTasksCompleted30Days:
               type: integer
             qualifications:
               type: array

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3017,11 +3017,11 @@ components:
         - $ref: '#/components/schemas/User'
         - type: object
           properties:
-            numAssessmentsPending:
+            numTasksPending:
               type: integer
-            numAssessmentsCompleted7Days:
+            numTasksCompleted7Days:
               type: integer
-            numAssessmentsCompleted30Days:
+            numTasksCompleted30Days:
               type: integer
             qualifications:
               type: array

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
@@ -30,6 +31,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   tier: String? = null,
   mappa: String? = null,
   applicationSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
+  booking: BookingEntity? = null,
 ): Pair<PlacementRequestEntity, ApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -77,9 +79,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withAssessmentSchema(assessmentSchema)
     withApplication(application)
     withSubmittedAt(OffsetDateTime.now())
-    if (placementRequestAllocatedTo != null) {
-      withAllocatedToUser(placementRequestAllocatedTo)
-    }
+    withAllocatedToUser(assessmentAllocatedTo)
     withDecision(AssessmentDecision.ACCEPTED)
   }
 
@@ -109,7 +109,9 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withIsWithdrawn(isWithdrawn)
     withIsParole(isParole)
     withPlacementRequirements(placementRequirements)
-
+    if (booking != null) {
+      withBooking(booking)
+    }
     if (expectedArrival != null) {
       withExpectedArrival(expectedArrival)
     }


### PR DESCRIPTION
Now we're surfacing workload data, it occurred to me that we're only surfacing assessments, not the other types of task. This PR refactors the workload fetching service method to fetch all workloads in one query and fetches all other task types, summing them at the end.