### PR TITLE
Replace `sortBy` and `sortField` in /assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
@@ -53,8 +53,8 @@ class AssessmentController(
   @Suppress("NAME_SHADOWING")
   override fun assessmentsGet(
     xServiceName: ServiceName,
-    sortOrder: SortOrder?,
-    sortField: AssessmentSortField?,
+    sortDirection: SortDirection?,
+    sortBy: AssessmentSortField?,
     statuses: List<AssessmentStatus>?,
     crn: String?,
   ): ResponseEntity<List<AssessmentSummary>> {
@@ -65,14 +65,14 @@ class AssessmentController(
       else -> assessmentService.getVisibleAssessmentSummariesForUser(user, xServiceName)
     }
 
-    val sortOrder = when {
-      xServiceName == ServiceName.temporaryAccommodation && sortOrder == null -> SortOrder.ascending
-      else -> sortOrder
+    val sortDirection = when {
+      xServiceName == ServiceName.temporaryAccommodation && sortDirection == null -> SortDirection.asc
+      else -> sortDirection
     }
 
-    val sortField = when {
-      xServiceName == ServiceName.temporaryAccommodation && sortField == null -> AssessmentSortField.assessmentArrivalDate
-      else -> sortField
+    val sortBy = when {
+      xServiceName == ServiceName.temporaryAccommodation && sortBy == null -> AssessmentSortField.assessmentArrivalDate
+      else -> sortBy
     }
 
     return ResponseEntity.ok(
@@ -83,7 +83,7 @@ class AssessmentController(
           it,
           personInfo,
         )
-      }.sort(sortOrder, sortField)
+      }.sort(sortDirection, sortBy)
         .filterByStatuses(statuses),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -6,11 +6,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentSummary
 
-fun List<AssessmentSummary>.sort(sortOrder: SortOrder?, sortField: AssessmentSortField?): List<AssessmentSummary> {
+fun List<AssessmentSummary>.sort(sortDirection: SortDirection?, sortField: AssessmentSortField?): List<AssessmentSummary> {
   if (sortField != null) {
     val comparator = Comparator<AssessmentSummary> { a, b ->
       val ascendingCompare = when (sortField) {
@@ -25,9 +25,9 @@ fun List<AssessmentSummary>.sort(sortOrder: SortOrder?, sortField: AssessmentSor
         AssessmentSortField.assessmentCreatedAt -> compareValues(a.createdAt, b.createdAt)
       }
 
-      when (sortOrder) {
-        SortOrder.ascending, null -> ascendingCompare
-        SortOrder.descending -> -ascendingCompare
+      when (sortDirection) {
+        SortDirection.asc, null -> ascendingCompare
+        SortDirection.desc -> -ascendingCompare
       }
     }
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3252,13 +3252,13 @@ paths:
           description: Only assessments for this service will be returned
           schema:
             $ref: '_shared.yml#/components/schemas/ServiceName'
-        - name: sortOrder
+        - name: sortDirection
           in: query
           description: If provided, return results in the given order
           required: false
           schema:
-            $ref: "_shared.yml#/components/schemas/SortOrder"
-        - name: sortField
+            $ref: "_shared.yml#/components/schemas/SortDirection"
+        - name: sortBy
           in: query
           description: If provided, return results ordered by the given field name
           required: false

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3254,13 +3254,13 @@ paths:
           description: Only assessments for this service will be returned
           schema:
             $ref: '#/components/schemas/ServiceName'
-        - name: sortOrder
+        - name: sortDirection
           in: query
           description: If provided, return results in the given order
           required: false
           schema:
-            $ref: "#/components/schemas/SortOrder"
-        - name: sortField
+            $ref: "#/components/schemas/SortDirection"
+        - name: sortBy
           in: query
           description: If provided, return results ordered by the given field name
           required: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -274,7 +274,7 @@ class AssessmentTest : IntegrationTestBase() {
 
   @ParameterizedTest
   @EnumSource
-  fun `Get all assessments sorts correctly when 'sortOrder' and 'sortField' query parameters are provided`(sortField: AssessmentSortField) {
+  fun `Get all assessments sorts correctly when 'sortDirection' and 'sortBy' query parameters are provided`(sortBy: AssessmentSortField) {
     `Given a User` { user, jwt ->
       `Given Some Offenders` { offenderSequence ->
         val offenders = offenderSequence.take(5).toList()
@@ -314,7 +314,7 @@ class AssessmentTest : IntegrationTestBase() {
           AssessmentParams(assessment, offenderDetails, inmateDetails)
         }
 
-        val expectedAssessments = when (sortField) {
+        val expectedAssessments = when (sortBy) {
           AssessmentSortField.personName -> assessments.sortedByDescending { "${it.offenderDetails.firstName} ${it.offenderDetails.surname}" }
           AssessmentSortField.personCrn -> assessments.sortedByDescending { it.assessment.application.crn }
           AssessmentSortField.assessmentArrivalDate -> assessments.sortedByDescending { (it.assessment.application as TemporaryAccommodationApplicationEntity).arrivalDate }
@@ -328,7 +328,7 @@ class AssessmentTest : IntegrationTestBase() {
         }.map { assessmentTransformer.transformDomainToApiSummary(toAssessmentSummaryEntity(it.assessment), PersonInfoResult.Success.Full(it.offenderDetails.otherIds.crn, it.offenderDetails, it.inmateDetails)) }
 
         webTestClient.get()
-          .uri("/assessments?sortOrder=descending&sortField=${sortField.value}")
+          .uri("/assessments?sortDirection=desc&sortBy=${sortBy.value}")
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .exchange()


### PR DESCRIPTION
This is to be consistent with other CAS1 endpoints. `SortOrder` is also used in the `/bookings/search` endpoint, which is used by CAS3, but I’ve kept this in so we don’t have to make UI changes to CAS3