### PR TITLE
Move `arrivalDate` to `eventDetails` part of `ApplicationAssessedEnvelope`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -457,8 +457,8 @@ class AssessmentService(
               ),
               decision = assessment.decision.toString(),
               decisionRationale = assessment.rejectionRationale,
+              arrivalDate = placementDates?.expectedArrival?.toLocalDateTime()?.toInstant(),
             ),
-            arrivalDate = placementDates?.expectedArrival?.toLocalDateTime()?.toInstant(),
           ),
         ),
       )
@@ -599,8 +599,8 @@ class AssessmentService(
               ),
               decision = assessment.decision.toString(),
               decisionRationale = assessment.rejectionRationale,
+              arrivalDate = null,
             ),
-            arrivalDate = null,
           ),
         ),
       )

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -589,10 +589,6 @@ components:
           example: approved-premises.application.assessed
         eventDetails:
           $ref: '#/components/schemas/ApplicationAssessed'
-        arrivalDate:
-          type: string
-          example: '2022-11-30T14:53:44'
-          format: date-time
       required:
         - id
         - timestamp
@@ -628,6 +624,10 @@ components:
         decisionRationale:
           type: string
           example: Risk too low
+        arrivalDate:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
       required:
         - applicationId
         - applicationUrl

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationAssessedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApplicationAssessedFactory.kt
@@ -19,6 +19,7 @@ class ApplicationAssessedFactory : Factory<ApplicationAssessed> {
   private var assessedBy: Yielded<ApplicationAssessedAssessedBy> = { ApplicationAssessedAssessedByFactory().produce() }
   private var decision: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var decisionRationale: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
+  private var arrivalDate: Yielded<Instant> = { Instant.now().randomDateTimeBefore(5) }
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
@@ -52,6 +53,10 @@ class ApplicationAssessedFactory : Factory<ApplicationAssessed> {
     this.decisionRationale = { decisionRationale }
   }
 
+  fun withArrivalDate(arrivalDate: Instant) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+
   override fun produce() = ApplicationAssessed(
     applicationId = this.applicationId(),
     applicationUrl = this.applicationUrl(),
@@ -61,5 +66,6 @@ class ApplicationAssessedFactory : Factory<ApplicationAssessed> {
     assessedBy = this.assessedBy(),
     decision = this.decision(),
     decisionRationale = this.decisionRationale(),
+    arrivalDate = this.arrivalDate(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
@@ -141,8 +141,8 @@ class DailyMetricsReportTest : IntegrationTestBase() {
                           ).produce(),
                       ).produce(),
                   )
+                  .withArrivalDate(LocalDate.of(year, month, 1).toLocalDateTime().toInstant())
                   .produce(),
-                arrivalDate = LocalDate.of(year, month, 1).toLocalDateTime().toInstant(),
               ),
             ),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -136,7 +136,6 @@ class DomainEventTest : IntegrationTestBase() {
       timestamp = Instant.now(),
       eventType = "approved-premises.application.assessed",
       eventDetails = ApplicationAssessedFactory().produce(),
-      arrivalDate = Instant.now(),
     )
 
     val event = domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
@@ -210,8 +210,8 @@ class DailyMetricsReportGeneratorTest {
                       ).produce(),
                   ).produce(),
               )
+              .withArrivalDate(date.toLocalDateTime().toInstant())
               .produce(),
-            arrivalDate = date.toLocalDateTime().toInstant(),
           ),
         ),
       ).produceMany().take(count).toList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -232,7 +232,6 @@ class DomainEventServiceTest {
       timestamp = occurredAt.toInstant(),
       eventType = "approved-premises.application.assessed",
       eventDetails = ApplicationAssessedFactory().produce(),
-      arrivalDate = occurredAt.toInstant(),
     )
 
     every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
@@ -275,7 +274,6 @@ class DomainEventServiceTest {
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.assessed",
         eventDetails = ApplicationAssessedFactory().produce(),
-        arrivalDate = occurredAt.toInstant(),
       ),
     )
 
@@ -331,7 +329,6 @@ class DomainEventServiceTest {
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.assessed",
         eventDetails = ApplicationAssessedFactory().produce(),
-        arrivalDate = occurredAt.toInstant(),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
@@ -125,7 +125,6 @@ class DomainEventWorkerTest {
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.assessed",
         eventDetails = ApplicationAssessedFactory().produce(),
-        arrivalDate = occurredAt.toInstant(),
       ),
     )
 
@@ -186,7 +185,6 @@ class DomainEventWorkerTest {
         timestamp = occurredAt.toInstant(),
         eventType = "approved-premises.application.assessed",
         eventDetails = ApplicationAssessedFactory().produce(),
-        arrivalDate = occurredAt.toInstant(),
       ),
     )
 


### PR DESCRIPTION
I missed that when reviewing. As this is information about the event itself, it should sit in the `eventDetails` object.