### PR TITLE
Depduplicate roles when listing users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -33,15 +33,15 @@ class UserTransformer(
       numTasksPending = userWorkload.numTasksPending,
       numTasksCompleted7Days = userWorkload.numTasksCompleted7Days,
       numTasksCompleted30Days = userWorkload.numTasksCompleted30Days,
-      qualifications = jpa.qualifications.distinct().map(::transformQualificationToApi),
-      roles = jpa.roles.distinct().mapNotNull(::transformApprovedPremisesRoleToApi),
+      qualifications = jpa.qualifications.distinctBy { it.qualification }.map(::transformQualificationToApi),
+      roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToApi),
     )
   }
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {
     ServiceName.approvedPremises, ServiceName.cas2 -> ApprovedPremisesUser(
       id = jpa.id,
       deliusUsername = jpa.deliusUsername,
-      roles = jpa.roles.mapNotNull(::transformApprovedPremisesRoleToApi),
+      roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToApi),
       email = jpa.email,
       name = jpa.name,
       telephoneNumber = jpa.telephoneNumber,
@@ -57,7 +57,7 @@ class UserTransformer(
       name = jpa.name,
       telephoneNumber = jpa.telephoneNumber,
       isActive = jpa.isActive,
-      roles = jpa.roles.mapNotNull(::transformTemporaryAccommodationRoleToApi),
+      roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformTemporaryAccommodationRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       service = ServiceName.temporaryAccommodation.value,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -8,12 +8,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole.matcher
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole.workflowManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.approvedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.temporaryAccommodation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole.referrer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole.reporter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserWithWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -21,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REFERRER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addQualificationForUnitTest
@@ -68,6 +71,69 @@ class UserTransformerTest {
     assertThat(result.roles).contains(matcher)
     assertThat(result.service).isEqualTo(approvedPremises.value)
     verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
+  }
+
+  @Test
+  fun `should return distinct roles for Approved Premises`() {
+    val user = buildUserEntity(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
+
+    val result =
+      userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
+
+    assertThat(result.roles).isEqualTo(
+      listOf(
+        matcher,
+        workflowManager,
+      ),
+    )
+  }
+
+  @Test
+  fun `should return distinct roles for Temporary Accommodation`() {
+    val user = buildUserEntity(UserRole.CAS3_REFERRER)
+    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
+    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
+    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
+    user.addRoleForUnitTest(UserRole.CAS3_REPORTER)
+
+    val result =
+      userTransformer.transformJpaToApi(user, temporaryAccommodation) as TemporaryAccommodationUser
+
+    assertThat(result.roles).isEqualTo(
+      listOf(
+        referrer,
+        reporter,
+      ),
+    )
+  }
+
+  @Test
+  fun `transformJpaToAPIUserWithWorkload should return distinct roles`() {
+    val user = buildUserEntity(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
+    user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
+
+    val workload = UserWorkload(
+      0,
+      0,
+      0,
+    )
+
+    val result =
+      userTransformer.transformJpaToAPIUserWithWorkload(user, workload) as UserWithWorkload
+
+    assertThat(result.roles).isEqualTo(
+      listOf(
+        matcher,
+        workflowManager,
+      ),
+    )
   }
 
   private fun buildUserEntity(


### PR DESCRIPTION
Ocassionally roles are duplicated when listing users - here we unique by the role’s name when listing. There’s an open question about whether this can be avoided (partially addressed by https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1296) but this solves the initial issue.