### PR TITLE
[APS-67] Implement AP Delius Context API offender risks data source

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Primary
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
@@ -17,6 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
 
 interface OffenderRisksDataSource {
   val name: OffenderRisksDataSourceName
@@ -195,11 +198,112 @@ class CommunityApiOffenderRisksDataSource(
 }
 
 @Component
-class ApDeliusContextApiOffenderRisksDataSource : OffenderRisksDataSource {
+class ApDeliusContextApiOffenderRisksDataSource(
+  private val apDeliusContextApiClient: ApDeliusContextApiClient,
+  private val apOASysContextApiClient: ApOASysContextApiClient,
+  private val hmppsTierApiClient: HMPPSTierApiClient,
+) : OffenderRisksDataSource {
+
+  private val ignoredRegisterTypesForFlags = listOf("RVHR", "RHRH", "RMRH", "RLRH", "MAPP")
+
   override val name: OffenderRisksDataSourceName
     get() = OffenderRisksDataSourceName.AP_DELIUS_CONTEXT_API
 
   override fun getPersonRisks(crn: String): PersonRisks {
-    throw NotImplementedError("Getting risks for individual offenders from the AP Delius Context API is not currently supported")
+    val caseDetailResponse = apDeliusContextApiClient.getCaseDetail(crn)
+
+    return PersonRisks(
+      roshRisks = getRoshRisksEnvelope(crn),
+      mappa = caseDetailResponse.toMappa(),
+      tier = getRiskTierEnvelope(crn),
+      flags = caseDetailResponse.toRiskFlags(),
+    )
+  }
+
+  private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> {
+    return when (val roshRisksResponse = apOASysContextApiClient.getRoshRatings(crn)) {
+      is ClientResult.Success -> {
+        val summary = roshRisksResponse.body.rosh
+
+        when (summary.anyRisksAreNull()) {
+          true -> RiskWithStatus(status = RiskStatus.NotFound)
+          false -> RiskWithStatus(
+            value = RoshRisks(
+              overallRisk = summary.determineOverallRiskLevel().text,
+              riskToChildren = summary.riskChildrenCommunity!!.text,
+              riskToPublic = summary.riskPublicCommunity!!.text,
+              riskToKnownAdult = summary.riskKnownAdultCommunity!!.text,
+              riskToStaff = summary.riskStaffCommunity!!.text,
+              lastUpdated = roshRisksResponse.body.dateCompleted?.toLocalDate()
+                ?: roshRisksResponse.body.initiationDate.toLocalDate(),
+            ),
+          )
+        }
+      }
+      is ClientResult.Failure.StatusCode -> when (roshRisksResponse.status) {
+        HttpStatus.NOT_FOUND -> RiskWithStatus(status = RiskStatus.NotFound)
+        else -> RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> RiskWithStatus(status = RiskStatus.Error)
+    }
+  }
+
+  private fun getRiskTierEnvelope(crn: String): RiskWithStatus<RiskTier> =
+    when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
+      is ClientResult.Success -> RiskWithStatus(
+        value = RiskTier(
+          level = tierResponse.body.tierScore,
+          lastUpdated = tierResponse.body.calculationDate.toLocalDate(),
+        ),
+      )
+      is ClientResult.Failure.StatusCode -> when (tierResponse.status) {
+        HttpStatus.NOT_FOUND -> RiskWithStatus(status = RiskStatus.NotFound)
+        else -> RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> RiskWithStatus(status = RiskStatus.Error)
+    }
+
+  fun ClientResult<CaseDetail>.toMappa(): RiskWithStatus<Mappa> = when (this) {
+    is ClientResult.Success -> this.body.toMappa()
+    is ClientResult.Failure.StatusCode -> when (this.status) {
+      HttpStatus.NOT_FOUND -> RiskWithStatus(status = RiskStatus.NotFound)
+      else -> RiskWithStatus(status = RiskStatus.Error)
+    }
+    is ClientResult.Failure -> RiskWithStatus(status = RiskStatus.Error)
+  }
+
+  fun CaseDetail.toMappa(): RiskWithStatus<Mappa> = when (this.mappaDetail) {
+    null -> RiskWithStatus(status = RiskStatus.NotFound)
+    else -> {
+      when (this.mappaDetail.isMissingMandatoryProperties()) {
+        true -> RiskWithStatus(status = RiskStatus.NotFound)
+        else -> RiskWithStatus(
+          value = Mappa(
+            "CAT ${this.mappaDetail.categoryDescription!!}/LEVEL ${this.mappaDetail.levelDescription!!}",
+            this.mappaDetail.lastUpdated.toLocalDate(),
+          ),
+        )
+      }
+    }
+  }
+
+  private fun MappaDetail.isMissingMandatoryProperties(): Boolean = this.categoryDescription == null || this.levelDescription == null
+
+  fun ClientResult<CaseDetail>.toRiskFlags(): RiskWithStatus<List<String>> = when (this) {
+    is ClientResult.Success -> this.body.toRiskFlags()
+    is ClientResult.Failure.StatusCode -> when (this.status) {
+      HttpStatus.NOT_FOUND -> RiskWithStatus(status = RiskStatus.NotFound)
+      else -> RiskWithStatus(status = RiskStatus.Error)
+    }
+    is ClientResult.Failure -> RiskWithStatus(status = RiskStatus.Error)
+  }
+
+  fun CaseDetail.toRiskFlags(): RiskWithStatus<List<String>> {
+    val registrations = this.registrations.filter { !ignoredRegisterTypesForFlags.contains(it.code) }
+
+    return when (registrations.isEmpty()) {
+      true -> RiskWithStatus(status = RiskStatus.NotFound)
+      else -> RiskWithStatus(value = registrations.map { it.description })
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -59,6 +59,7 @@ data class Offence(
 )
 
 data class Registration(
+  val code: String,
   val description: String,
   val startDate: LocalDate,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
@@ -28,6 +28,14 @@ class CaseDetailFactory : Factory<CaseDetail> {
     this.case = { case }
   }
 
+  fun withRegistrations(registrations: List<Registration>) = apply {
+    this.registrations = { registrations }
+  }
+
+  fun withMappaDetail(mappaDetail: MappaDetail) = apply {
+    this.mappaDetail = { mappaDetail }
+  }
+
   override fun produce(): CaseDetail = CaseDetail(
     case = this.case(),
     offences = this.offences(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
@@ -51,10 +51,12 @@ class CaseDetailOffenceFactory : Factory<Offence> {
 }
 
 class RegistrationFactory : Factory<Registration> {
+  var code: Yielded<String> = { randomStringLowerCase(6) }
   var description: Yielded<String> = { randomStringLowerCase(10) }
   var startDate: Yielded<LocalDate> = { LocalDate.now() }
 
   override fun produce(): Registration = Registration(
+    code = this.code(),
     description = this.description(),
     startDate = this.startDate(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderRisksDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderRisksDataSourceTest.kt
@@ -1,0 +1,307 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.ApDeliusContextApiOffenderRisksDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Registration
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshRatings
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.util.UUID
+
+class ApDeliusContextApiOffenderRisksDataSourceTest {
+  private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
+  private val mockApOASysContextApiClient = mockk<ApOASysContextApiClient>()
+  private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
+
+  private val apDeliusContextApiOffenderRisksDataSource = ApDeliusContextApiOffenderRisksDataSource(
+    mockApDeliusContextApiClient,
+    mockApOASysContextApiClient,
+    mockHMPPSTierApiClient,
+  )
+
+  @Test
+  fun `getPersonRisks returns NotFound envelopes for RoSH, Tier, Mappa & flags when respective Clients return 404`() {
+    val crn = "a-crn"
+
+    mock404RoSH(crn)
+    mock404Tier(crn)
+    mock404CaseDetail(crn)
+
+    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.tier.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.flags.status).isEqualTo(RiskStatus.NotFound)
+  }
+
+  @Test
+  fun `getPersonRisks returns Error envelopes for RoSH, Tier, Mappa & flags when respective Clients return 500`() {
+    val crn = "a-crn"
+
+    mock500RoSH(crn)
+    mock500Tier(crn)
+    mock500CaseDetail(crn)
+
+    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Error)
+  }
+
+  @Test
+  fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier, Mappa & flags when respective Clients return 200`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200CaseDetail(
+      crn,
+      CaseDetailFactory()
+        .withRegistrations(
+          listOf(
+            Registration(
+              code = "MAPP",
+              description = "MAPPA",
+              startDate = LocalDate.parse("2022-09-06"),
+            ),
+            Registration(
+              code = "FLAG",
+              description = "RISK FLAG",
+              startDate = LocalDate.parse("2022-09-06"),
+            ),
+          ),
+        )
+        .withMappaDetail(
+          MappaDetail(
+            level = 1,
+            levelDescription = "L1",
+            category = 1,
+            categoryDescription = "C1",
+            startDate = LocalDate.parse("2022-09-06"),
+            lastUpdated = ZonedDateTime.parse("2022-09-06T00:00:00Z"),
+          ),
+        )
+        .produce(),
+    )
+
+    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Very High")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Retrieved)
+    result.mappa.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("CAT C1/LEVEL L1")
+    }
+
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.value).contains("RISK FLAG")
+  }
+
+  @Test
+  fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier, Mappa & flags when Mappa is missing required information`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200CaseDetail(
+      crn,
+      CaseDetailFactory()
+        .withRegistrations(
+          listOf(
+            Registration(
+              code = "MAPP",
+              description = "MAPPA",
+              startDate = LocalDate.parse("2022-09-06"),
+            ),
+            Registration(
+              code = "FLAG",
+              description = "RISK FLAG",
+              startDate = LocalDate.parse("2022-09-06"),
+            ),
+          ),
+        )
+        .withMappaDetail(
+          MappaDetail(
+            level = null,
+            levelDescription = null,
+            category = null,
+            categoryDescription = null,
+            startDate = LocalDate.parse("2022-09-06"),
+            lastUpdated = ZonedDateTime.parse("2022-09-06T00:00:00Z"),
+          ),
+        )
+        .produce(),
+    )
+
+    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Very High")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.mappa.value).isNull()
+
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.value).contains("RISK FLAG")
+  }
+
+  private fun mock404RoSH(crn: String) {
+    every { mockApOASysContextApiClient.getRoshRatings(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/rosh/a-crn",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+  }
+
+  private fun mock404Tier(crn: String) {
+    every { mockHMPPSTierApiClient.getTier(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/crn/a-crn/tier",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+  }
+
+  private fun mock404CaseDetail(crn: String) {
+    every { mockApDeliusContextApiClient.getCaseDetail(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/probation-cases/$crn/details",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+  }
+
+  private fun mock500RoSH(crn: String) {
+    every { mockApOASysContextApiClient.getRoshRatings(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/rosh/a-crn",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        body = null,
+      )
+  }
+
+  private fun mock500Tier(crn: String) {
+    every { mockHMPPSTierApiClient.getTier(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/crn/a-crn/tier",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        body = null,
+      )
+  }
+
+  private fun mock500CaseDetail(crn: String) {
+    every { mockApDeliusContextApiClient.getCaseDetail(crn) } returns
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/probation-cases/$crn/details",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        body = null,
+      )
+  }
+
+  private fun mock200RoSH(crn: String, body: RoshRatings) {
+    every { mockApOASysContextApiClient.getRoshRatings(crn) } returns
+      ClientResult.Success(HttpStatus.OK, body = body)
+  }
+
+  private fun mock200Tier(crn: String, body: Tier) {
+    every { mockHMPPSTierApiClient.getTier(crn) } returns
+      ClientResult.Success(HttpStatus.OK, body = body)
+  }
+
+  private fun mock200CaseDetail(crn: String, body: CaseDetail) {
+    every { mockApDeliusContextApiClient.getCaseDetail(crn) } returns
+      ClientResult.Success(HttpStatus.OK, body = body)
+  }
+}


### PR DESCRIPTION
> See [APS-67 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-67).

This PR provides the ability to use the AP Delius Context API as a data source for offender risks. This is achieved by implementing the `ApDeliusContextApiOffenderRisksDataSource` class.

This PR does not change the data source for offender risks as this is down to the individual configuration for each environment.

**NB**: The behaviour for retrieving the MAPPA details has changed - the current behaviour in the Community API implementation is derived from be95ffa, which ensures a registration exists that corresponds to the MAPPA details and returns an error if not. However, the structure of registrations from the AP Delius Context API is different, and does not include the necessary information to perform this check, and so it has been omitted.