### PR TITLE
Seed CAS2 domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
 import java.io.IOException
 import java.io.InputStreamReader
 import java.time.OffsetDateTime
@@ -42,6 +43,7 @@ class Cas2AutoScript(
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val jsonSchemaService: JsonSchemaService,
   private val applicationService: ApplicationService,
+  private val statusUpdateService: StatusUpdateService,
 ) {
   fun script() {
     seedLogger.info("Auto-Scripting for CAS2")
@@ -103,6 +105,7 @@ class Cas2AutoScript(
     )
     update.apply { this.createdAt = application.submittedAt!!.plusDays(idx + 1.toLong()) }
     statusUpdateRepository.save(update)
+    statusUpdateService.createStatusUpdatedDomainEvent(update)
   }
 
   private fun findStatusAtPosition(idx: Int): Cas2ApplicationStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import java.io.IOException
 import java.io.InputStreamReader
@@ -40,6 +41,7 @@ class Cas2AutoScript(
   private val externalUserRepository: ExternalUserRepository,
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val jsonSchemaService: JsonSchemaService,
+  private val applicationService: ApplicationService,
 ) {
   fun script() {
     seedLogger.info("Auto-Scripting for CAS2")
@@ -73,6 +75,11 @@ class Cas2AutoScript(
         schemaUpToDate = true,
       ),
     )
+
+    if (listOf("SUBMITTED", "IN_REVIEW").contains(state)) {
+      applicationService.createCas2ApplicationSubmittedEvent(application)
+    }
+
     if (state == "IN_REVIEW") {
       val quantity = randomInt(FEWEST_UPDATES, MOST_UPDATES)
       seedLogger.info("Auto-scripting $quantity status updates for application ${application.id}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -234,7 +234,7 @@ class ApplicationService(
 
   private fun createCas2ApplicationSubmittedEvent(application: Cas2ApplicationEntity) {
     val domainEventId = UUID.randomUUID()
-    val eventOccurredAt = OffsetDateTime.now()
+    val eventOccurredAt = application.submittedAt ?: OffsetDateTime.now()
 
     domainEventService.saveCas2ApplicationSubmittedDomainEvent(
       DomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -232,7 +232,7 @@ class ApplicationService(
     )
   }
 
-  private fun createCas2ApplicationSubmittedEvent(application: Cas2ApplicationEntity) {
+  fun createCas2ApplicationSubmittedEvent(application: Cas2ApplicationEntity) {
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = application.submittedAt ?: OffsetDateTime.now()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -76,7 +76,7 @@ class StatusUpdateService(
       .find { status -> status.name == statusName }
   }
 
-  private fun createStatusUpdatedDomainEvent(statusUpdate: Cas2StatusUpdateEntity) {
+  fun createStatusUpdatedDomainEvent(statusUpdate: Cas2StatusUpdateEntity) {
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = statusUpdate.createdAt ?: OffsetDateTime.now()
     val application = statusUpdate.application

--- a/src/main/resources/db/migration/dev+test/R__7_clear_cas2_domain_events.sql
+++ b/src/main/resources/db/migration/dev+test/R__7_clear_cas2_domain_events.sql
@@ -1,0 +1,3 @@
+DELETE FROM domain_events WHERE domain_events.type in (
+    'CAS2_APPLICATION_STATUS_UPDATED', 'CAS2_APPLICATION_SUBMITTED'
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
 import java.time.OffsetDateTime
@@ -44,6 +45,8 @@ class Cas2AutoScriptTest {
   private val mockJsonSchemaService = mockk<JsonSchemaService>()
   private val mockJsonSchemaEntity = mockk<JsonSchemaEntity>()
 
+  private val mockApplicationService = mockk<ApplicationService>()
+
   private val autoScript = Cas2AutoScript(
     mockSeedLogger,
     mockSeedConfig,
@@ -52,6 +55,7 @@ class Cas2AutoScriptTest {
     mockExternalUserRepository,
     mockStatusUpdateRepository,
     mockJsonSchemaService,
+    mockApplicationService,
   )
 
   @BeforeEach
@@ -79,6 +83,8 @@ class Cas2AutoScriptTest {
 
     every { mockStatusUpdateRepository.save(any()) } answers { mockStatusUpdateEntity }
     every { mockStatusUpdateEntity.createdAt = (any()) } answers { mockStatusUpdateEntity }
+
+    every { mockApplicationService.createCas2ApplicationSubmittedEvent(any()) } answers { }
   }
 
   @Test
@@ -100,5 +106,12 @@ class Cas2AutoScriptTest {
     autoScript.script()
 
     verify(atLeast = 1) { mockStatusUpdateRepository.save(any()) }
+  }
+
+  @Test
+  fun `creates at application-submitted domain event`() {
+    autoScript.script()
+
+    verify(atLeast = 1) { mockApplicationService.createCas2ApplicationSubmittedEvent(any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -46,6 +47,7 @@ class Cas2AutoScriptTest {
   private val mockJsonSchemaEntity = mockk<JsonSchemaEntity>()
 
   private val mockApplicationService = mockk<ApplicationService>()
+  private val mockStatusUpdateService = mockk<StatusUpdateService>()
 
   private val autoScript = Cas2AutoScript(
     mockSeedLogger,
@@ -56,6 +58,7 @@ class Cas2AutoScriptTest {
     mockStatusUpdateRepository,
     mockJsonSchemaService,
     mockApplicationService,
+    mockStatusUpdateService,
   )
 
   @BeforeEach
@@ -85,6 +88,7 @@ class Cas2AutoScriptTest {
     every { mockStatusUpdateEntity.createdAt = (any()) } answers { mockStatusUpdateEntity }
 
     every { mockApplicationService.createCas2ApplicationSubmittedEvent(any()) } answers { }
+    every { mockStatusUpdateService.createStatusUpdatedDomainEvent(any()) } answers { }
   }
 
   @Test
@@ -113,5 +117,12 @@ class Cas2AutoScriptTest {
     autoScript.script()
 
     verify(atLeast = 1) { mockApplicationService.createCas2ApplicationSubmittedEvent(any()) }
+  }
+
+  @Test
+  fun `creates at application-status-updated domain event`() {
+    autoScript.script()
+
+    verify(atLeast = 1) { mockStatusUpdateService.createStatusUpdatedDomainEvent(any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
@@ -118,7 +118,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
-          occurredAt = Instant.now(),
+          occurredAt = occurredAt.toInstant(),
           data = Cas2ApplicationSubmittedEvent(
             id = id,
             timestamp = occurredAt.toInstant(),


### PR DESCRIPTION
This PR extends the existing "auto-script" seeding of CAS2 applications to include CAS2 domain events:

- `application.submitted`
- `application.status-updated`

This will make it easier to test management information reporting which relies on these domain events.