### PR TITLE
Adding tests for all possible assessment statuses

### DIFF
--- a/script/test_database
+++ b/script/test_database
@@ -6,6 +6,8 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+script/utils/launch-docker.sh
+
 echo "==> Starting integration test database..."
 if [ "$(uname -m)" = "arm64" ]; then
   docker-compose -f docker-compose.test.yml -f docker-compose.test.arm64.yml up -d

--- a/script/utils/launch-docker.sh
+++ b/script/utils/launch-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if (! docker stats --no-stream > /dev/null 2>&1  ); then
+  echo "==> Launching Docker..."
+
+  # On Mac OS this would be the terminal command to launch Docker
+  open /Applications/Docker.app
+  printf "Waiting for Docker to launch..."
+ #Wait until Docker daemon is running and has completed initialisation
+while (! docker stats --no-stream > /dev/null 2>&1 ); do
+  # Docker takes a few seconds to initialize
+  printf '.'
+  sleep 1
+done
+fi


### PR DESCRIPTION
As part of the work to update the assessment endpoint to use ‘in database’ paging, we need to move the logic that filters on status into the database queries.

As a pre-requisite to this work this commit ensures there is an integration test for each possible CAS1/CAS3 status, and tests to ensure multiple statuses can be used for filtering

This commit also adds a script to ensure docker is running locally before starting starting the test database