### PR TITLE
(766) Stream CAS2 'unsubmitted-applications' report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
@@ -22,6 +22,7 @@ class ReportsController(private val reportService: ReportsService) : ReportsCas2
     when (reportName) {
       "submitted-applications" -> reportService.createSubmittedApplicationsReport(outputStream)
       "application-status-updates" -> reportService.createApplicationStatusUpdatesReport(outputStream)
+      "unsubmitted-applications" -> reportService.createUnsubmittedApplicationsReport(outputStream)
     }
     return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface Cas2UnsubmittedApplicationsReportRepository : JpaRepository<Cas2ApplicationEntity, UUID> {
+  @Query(
+    """
+      SELECT
+        CAST(applications.id AS TEXT) AS applicationId,
+        applications.crn AS personCrn,
+        applications.noms_number AS personNoms,
+        to_char(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS startedAt,
+        users.nomis_username AS startedBy
+
+      FROM cas_2_applications applications
+      JOIN nomis_users users ON users.id = applications.created_by_user_id
+      WHERE applications.submitted_at IS NULL
+      ORDER BY startedAt DESC;
+    """,
+    nativeQuery = true,
+  )
+  fun generateUnsubmittedApplicationsReportRows(): List<Cas2UnsubmittedApplicationReportRow>
+}
+
+interface Cas2UnsubmittedApplicationReportRow {
+  fun getApplicationId(): String
+  fun getPersonNoms(): String
+  fun getPersonCrn(): String
+  fun getStartedBy(): String
+  fun getStartedAt(): String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/UnsubmittedApplicationsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/UnsubmittedApplicationsReportRow.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2
+
+class UnsubmittedApplicationsReportRow(
+  val applicationId: String,
+  val personCrn: String,
+  val personNoms: String,
+  val startedAt: String,
+  val startedBy: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -6,15 +6,18 @@ import org.jetbrains.kotlinx.dataframe.io.writeExcel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationStatusUpdatesReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2SubmittedApplicationReportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2UnsubmittedApplicationsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas2ExampleMetricsRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.ApplicationStatusUpdatesReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.SubmittedApplicationReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.UnsubmittedApplicationsReportRow
 import java.io.OutputStream
 
 @Service
 class ReportsService(
   private val submittedApplicationReportRepository: Cas2SubmittedApplicationReportRepository,
   private val applicationStatusUpdatesReportRepository: Cas2ApplicationStatusUpdatesReportRepository,
+  private val unsubmittedApplicationsReportRepository: Cas2UnsubmittedApplicationsReportRepository,
 ) {
   fun createCas2ExampleReport(outputStream: OutputStream) {
     // TODO replace this with a real report
@@ -58,6 +61,23 @@ class ReportsService(
         newStatus = row.getNewStatus(),
         updatedBy = row.getUpdatedBy(),
         updatedAt = row.getUpdatedAt(),
+      )
+    }
+
+    reportData.toDataFrame()
+      .writeExcel(outputStream) {
+        WorkbookFactory.create(true)
+      }
+  }
+
+  fun createUnsubmittedApplicationsReport(outputStream: OutputStream) {
+    val reportData = unsubmittedApplicationsReportRepository.generateUnsubmittedApplicationsReportRows().map { row ->
+      UnsubmittedApplicationsReportRow(
+        applicationId = row.getApplicationId(),
+        personCrn = row.getPersonCrn(),
+        personNoms = row.getPersonNoms(),
+        startedBy = row.getStartedBy(),
+        startedAt = row.getStartedAt(),
       )
     }
 


### PR DESCRIPTION
This PR follows on from https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1315 which should be merged first.

The new `unsubmitted-applications` report included here comprises the following fields:

```
applicationId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
personCrn: "X320741"
personNoms: "A1234AI"
startedAt: "2024-01-09T09:17:55"
startedBy "POM_USER"
```

This category of application (unsubmitted) will include:

- abandoned applications where the POM or person has decided
  not to proceed

- abandoned applications where a different application for
  this person has been submitted

- recently created in-progress applications which have not
  yet been submitted

The analysts using this data can perform further analysis,
linking with data from the "Submitted applications" report
as necessary.