### PR TITLE
Don’t attempt pagination on an empty resultset

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -92,7 +92,7 @@ class AssessmentController(
       .filterByStatuses(statuses)
 
     // TODO: We should carry out the pagination at the database level
-    if (page !== null) {
+    if (page !== null && filteredSummaries.isNotEmpty()) {
       val pageSize = perPage ?: defaultPageSize
       val chunkedSummaries = filteredSummaries.chunked(pageSize)
       val pageIndex = page - 1


### PR DESCRIPTION
This logic will be going away soon, but dev and preprod are broken at the mo, so let’s get this in