### PR TITLE
(Fix) Use `equals` to match `HttpStatus`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
@@ -101,7 +101,7 @@ class CommunityApiOffenderRisksDataSource(
           ),
         )
       }
-      is ClientResult.Failure.StatusCode -> return if (roshRisksResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> return if (roshRisksResponse.status.equals(HttpStatus.NOT_FOUND)) {
         RiskWithStatus(
           status = RiskStatus.NotFound,
           value = null,
@@ -137,7 +137,7 @@ class CommunityApiOffenderRisksDataSource(
           )
         }
       }
-      is ClientResult.Failure.StatusCode -> return if (registrationsResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> return if (registrationsResponse.status.equals(HttpStatus.NOT_FOUND)) {
         RiskWithStatus(status = RiskStatus.NotFound)
       } else {
         RiskWithStatus(status = RiskStatus.Error)
@@ -159,7 +159,7 @@ class CommunityApiOffenderRisksDataSource(
           ),
         )
       }
-      is ClientResult.Failure.StatusCode -> if (tierResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> if (tierResponse.status.equals(HttpStatus.NOT_FOUND)) {
         RiskWithStatus(status = RiskStatus.NotFound)
       } else {
         RiskWithStatus(status = RiskStatus.Error)
@@ -178,7 +178,7 @@ class CommunityApiOffenderRisksDataSource(
         )
       }
 
-      is ClientResult.Failure.StatusCode -> if (registrationsResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> if (registrationsResponse.status.equals(HttpStatus.NOT_FOUND)) {
         RiskWithStatus(status = RiskStatus.NotFound)
       } else {
         RiskWithStatus(status = RiskStatus.Error)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/InmateStatusOnSubmissionMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/InmateStatusOnSubmissionMigrationJob.kt
@@ -71,7 +71,7 @@ class InmateStatusOnSubmissionMigrationJob(
       }
 
       is ClientResult.Failure -> {
-        if (timelineResult is ClientResult.Failure.StatusCode && timelineResult.status == HttpStatus.NOT_FOUND) {
+        if (timelineResult is ClientResult.Failure.StatusCode && timelineResult.status.equals(HttpStatus.NOT_FOUND)) {
           log.info("404 retrieving prison timeline for application ${application.id} will mark status as IN")
           InOutStatus.IN
         } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -186,7 +186,7 @@ class OffenderService(
         val access = when (val accessResponse = userAccessProducer()) {
           is ClientResult.Success -> accessResponse.body
           is ClientResult.Failure.StatusCode -> {
-            if (accessResponse.status == HttpStatus.FORBIDDEN) {
+            if (accessResponse.status.value() == HttpStatus.FORBIDDEN.value()) {
               try {
                 accessResponse.deserializeTo<UserOffenderAccess>()
                 return AuthorisableActionResult.Unauthorised()
@@ -224,7 +224,7 @@ class OffenderService(
     return when (val accessResponse = offenderDetailsDataSource.getUserAccessForOffenderCrn(username, crn)) {
       is ClientResult.Success -> !accessResponse.body.userExcluded && !accessResponse.body.userRestricted
       is ClientResult.Failure.StatusCode -> {
-        if (accessResponse.status == HttpStatus.FORBIDDEN) {
+        if (accessResponse.status.value() == HttpStatus.FORBIDDEN.value()) {
           try {
             accessResponse.deserializeTo<UserOffenderAccess>()
             return false
@@ -501,7 +501,7 @@ class OffenderService(
     val offender = when (offenderResponse) {
       is ClientResult.Success -> offenderResponse.body
 
-      is ClientResult.Failure.StatusCode -> if (offenderResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> if (offenderResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
         return PersonInfoResult.NotFound(crn)
       } else {
         return PersonInfoResult.Unknown(crn, offenderResponse.toException())
@@ -516,7 +516,7 @@ class OffenderService(
           when (val accessResponse = offenderDetailsDataSource.getUserAccessForOffenderCrn(deliusUsername, crn)) {
             is ClientResult.Success -> accessResponse.body
             is ClientResult.Failure.StatusCode -> {
-              if (accessResponse.status == HttpStatus.FORBIDDEN) {
+              if (accessResponse.status.value() == HttpStatus.FORBIDDEN.value()) {
                 try {
                   accessResponse.deserializeTo<UserOffenderAccess>()
                   return PersonInfoResult.Success.Restricted(crn, offender.otherIds.nomsNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/StaffMemberService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/StaffMemberService.kt
@@ -26,7 +26,7 @@ class StaffMemberService(private val apDeliusContextApiClient: ApDeliusContextAp
 
   fun getStaffMembersForQCode(qCode: String) = when (val staffMembersResponse = apDeliusContextApiClient.getStaffMembers(qCode)) {
     is ClientResult.Success -> AuthorisableActionResult.Success(staffMembersResponse.body)
-    is ClientResult.Failure.StatusCode -> if (staffMembersResponse.status == HttpStatus.NOT_FOUND) AuthorisableActionResult.NotFound() else staffMembersResponse.throwException()
+    is ClientResult.Failure.StatusCode -> if (staffMembersResponse.status.equals(HttpStatus.NOT_FOUND)) AuthorisableActionResult.NotFound() else staffMembersResponse.throwException()
     is ClientResult.Failure -> staffMembersResponse.throwException()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -276,7 +276,7 @@ class UserService(
     val staffUserDetails = when (staffUserDetailsResponse) {
       is ClientResult.Success -> staffUserDetailsResponse.body
       is ClientResult.Failure.StatusCode -> {
-        if (throwProblemOn404 && staffUserDetailsResponse.status === HttpStatus.NOT_FOUND) {
+        if (throwProblemOn404 && staffUserDetailsResponse.status.equals(HttpStatus.NOT_FOUND)) {
           throw NotFoundProblem(username, "user", "username")
         } else {
           staffUserDetailsResponse.throwException()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -85,7 +85,7 @@ class OffenderService(
     val offender = when (offenderResponse) {
       is ClientResult.Success -> offenderResponse.body
 
-      is ClientResult.Failure.StatusCode -> if (offenderResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> if (offenderResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
         return PersonInfoResult.NotFound(crn)
       } else {
         return PersonInfoResult.Unknown(crn, offenderResponse.toException())
@@ -145,7 +145,7 @@ class OffenderService(
 
     val offender = when (offenderResponse) {
       is ClientResult.Success -> offenderResponse.body
-      is ClientResult.Failure.StatusCode -> if (offenderResponse.status == HttpStatus.NOT_FOUND) return AuthorisableActionResult.NotFound() else offenderResponse.throwException()
+      is ClientResult.Failure.StatusCode -> if (offenderResponse.status.equals(HttpStatus.NOT_FOUND)) return AuthorisableActionResult.NotFound() else offenderResponse.throwException()
       is ClientResult.Failure -> offenderResponse.throwException()
     }
 
@@ -198,7 +198,7 @@ class OffenderService(
           ),
         )
       }
-      is ClientResult.Failure.StatusCode -> return if (roshRisksResponse.status == HttpStatus.NOT_FOUND) {
+      is ClientResult.Failure.StatusCode -> return if (roshRisksResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
         RiskWithStatus(
           status = RiskStatus.NotFound,
           value = null,


### PR DESCRIPTION
We’ve been having an issue when a user hits the `userAccess` endpoint, but gets an error. `canAccessOffender` should be catching when the endpoint returns a 403, but the conditional is not working as expected.

After some research, I’ve discovered that `HttpStatus` is an enum, so `==` is using reference equality, not value equality. However, using `equals` uses the value, so will match predictably [1]

[1]: https://stackoverflow.com/questions/45975550/using-equal-sign-for-httpstatus-bad-request-not-working