### PR TITLE
Restrict CAS2 referrer users to ROLE_POM

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -62,7 +62,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
-        authorize(HttpMethod.GET, "/cas2/reports/example-report", hasRole("CAS2_MI"))
+        authorize(HttpMethod.GET, "/cas2/reports/**", hasRole("CAS2_MI"))
         authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -61,9 +61,9 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
-        authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "PRISON"))
+        authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM"))
         authorize(HttpMethod.GET, "/cas2/reports/**", hasRole("CAS2_MI"))
-        authorize("/cas2/**", hasAuthority("ROLE_PRISON"))
+        authorize("/cas2/**", hasAuthority("ROLE_POM"))
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
@@ -57,11 +57,11 @@ class PersonOASysRiskToSelfTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Getting oasys sections for a CRN with ROLE_PRISON returns 403`() {
+  fun `Getting oasys sections for a CRN with ROLE_POM returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
       authSource = "delius",
-      roles = listOf("ROLE_PRISON"),
+      roles = listOf("ROLE_POM"),
     )
 
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
@@ -72,11 +72,11 @@ class PersonOASysRoshTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Getting RoSH for a CRN with ROLE_PRISON returns 403`() {
+  fun `Getting RoSH for a CRN with ROLE_POM returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
       authSource = "delius",
-      roles = listOf("ROLE_PRISON"),
+      roles = listOf("ROLE_POM"),
     )
 
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -54,11 +54,11 @@ class PersonSearchTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Searching for a CRN with ROLE_PRISON returns 403`() {
+  fun `Searching for a CRN with ROLE_POM returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
       authSource = "delius",
-      roles = listOf("ROLE_PRISON"),
+      roles = listOf("ROLE_POM"),
     )
 
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -67,11 +67,11 @@ class UsersTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Getting a user with the PRISON role returns 403`() {
+  fun `Getting a user with the POM role returns 403`() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
       authSource = "nomis",
-      roles = listOf("ROLE_PRISON"),
+      roles = listOf("ROLE_POM"),
     )
 
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRiskToSelfTest.kt
@@ -42,7 +42,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Getting oasys sections for a CRN without ROLE_PROBATION or ROLE_PRISON returns 403`
+  fun `Getting oasys sections for a CRN without ROLE_PROBATION or ROLE_POM returns 403`
   () {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRoshTest.kt
@@ -42,7 +42,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Getting RoSH for a CRN without ROLE_PROBATION or ROLE_PRISON returns 403`() {
+  fun `Getting RoSH for a CRN without ROLE_PROBATION or ROLE_POM returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
       authSource = "nomis",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonRisksTest.kt
@@ -44,11 +44,11 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Getting risks for a CRN without ROLE_PRISON returns 403`() {
+  fun `Getting risks for a CRN without ROLE_POM returns 403`() {
     val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
       subject = "username",
       authSource = "nomis",
-      roles = listOf("ROLE_PROBATION"),
+      roles = listOf("ROLE_OTHER"),
     )
 
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -50,7 +50,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Searching for a NOMIS ID without ROLE_PRISON returns 403`() {
+    fun `Searching for a NOMIS ID without ROLE_POM returns 403`() {
       val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
         subject = "username",
         authSource = "nomis",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -79,7 +79,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
-        roles = listOf("ROLE_PRISON"),
+        roles = listOf("ROLE_POM"),
       )
 
       webTestClient.get()
@@ -95,7 +95,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
-        roles = listOf("ROLE_PRISON", "ROLE_CAS2_MI"),
+        roles = listOf("ROLE_POM", "ROLE_CAS2_MI"),
       )
 
       webTestClient.get()
@@ -178,7 +178,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
-        roles = listOf("ROLE_PRISON", "ROLE_CAS2_MI"),
+        roles = listOf("ROLE_CAS2_MI"),
       )
 
       webTestClient.get()
@@ -375,7 +375,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
       authSource = "nomis",
-      roles = listOf("ROLE_PRISON", "ROLE_CAS2_MI"),
+      roles = listOf("ROLE_CAS2_MI"),
     )
 
     val expectedDataFrame = listOf(Cas2ExampleMetricsRow(id = "123", data = "example"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
@@ -35,7 +35,7 @@ class Cas2StatusUpdateTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
-        roles = listOf("ROLE_PRISON"),
+        roles = listOf("ROLE_POM"),
       )
 
       webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -59,7 +59,7 @@ class Cas2SubmissionTest : IntegrationTestBase() {
     fun `submitting an application is forbidden to external users based on role`() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
-        authSource = "nomis",
+        authSource = "auth",
         roles = listOf("ROLE_CAS2_ASSESSOR"),
       )
 
@@ -76,7 +76,7 @@ class Cas2SubmissionTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
-        roles = listOf("ROLE_PRISON"),
+        roles = listOf("ROLE_POM"),
       )
 
       webTestClient.get()
@@ -92,7 +92,7 @@ class Cas2SubmissionTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
-        roles = listOf("ROLE_PRISON"),
+        roles = listOf("ROLE_POM"),
       )
 
       webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -67,7 +67,7 @@ class JwtAuthHelper {
     createAuthorizationCodeJwt(
       subject = username,
       authSource = "nomis",
-      roles = listOf("ROLE_PRISON"),
+      roles = listOf("ROLE_POM"),
     )
 
   internal fun createValidExternalAuthorisationCodeJwt(username: String = "username") =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -81,7 +81,7 @@ class JwtAuthHelper {
     createAuthorizationCodeJwt(
       subject = username,
       authSource = "nomis",
-      roles = listOf("ROLE_PRISON", "ROLE_CAS2_ADMIN"),
+      roles = listOf("ROLE_CAS2_ADMIN"),
     )
 
   internal fun createValidAuthorizationCodeJwt(username: String = "username") = createAuthorizationCodeJwt(


### PR DESCRIPTION
Previously on CAS2 we were granting access to all users with ROLE_PRISON, a role
granted automatically to all nomis authorised users. This is too broad a
restriction, because it means any users logging in via nomis will be
able to search for prisoners and make applications.

As our referrer users for private beta will be POMs, we should restrict
to the POM role for now. This can be assigned to devs to test in
different environments. 

There is some question around whether our users 
in production will definitely have this role, but we've been told that this should
be the role applied to all POMs. We can mitigate this risk by testing with a trusted
user shortly before going live.

Contract managers will be given the role CAS2_ADMIN so they can see
submitted applications, but they shouldn't need ability to create
applications.