### PR TITLE
Add telephone number as "first class" field to CAS2 Applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -103,6 +103,7 @@ data class Cas2ApplicationEntity(
   var preferredAreas: String? = null,
   var hdcEligibilityDate: LocalDate? = null,
   var conditionalReleaseDate: LocalDate? = null,
+  var telephoneNumber: String? = null,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -98,6 +98,7 @@ class Cas2AutoScript(
         preferredAreas = "Luton | Hertford"
         hdcEligibilityDate = LocalDate.parse("2024-02-28")
         conditionalReleaseDate = LocalDate.parse("2024-02-22")
+        telephoneNumber = "0800 123 456"
       },
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -114,6 +114,7 @@ class ApplicationService(
           submittedAt = null,
           schemaUpToDate = true,
           nomsNumber = offenderDetails.otherIds.nomsNumber,
+          telephoneNumber = null,
         ),
       )
 
@@ -219,6 +220,7 @@ class ApplicationService(
       preferredAreas = submitApplication.preferredAreas
       hdcEligibilityDate = submitApplication.hdcEligibilityDate
       conditionalReleaseDate = submitApplication.conditionalReleaseDate
+      telephoneNumber = submitApplication.telephoneNumber
     }
 
     application = applicationRepository.save(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -296,6 +296,7 @@ class ApplicationService(
         "name" to user.name,
         "email" to user.email,
         "prisonNumber" to application.nomsNumber,
+        "telephoneNumber" to application.telephoneNumber,
         "applicationUrl" to submittedApplicationUrlTemplate.replace("#applicationId", application.id.toString()),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -31,6 +31,7 @@ class ApplicationsTransformer(
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       status = getStatus(jpa),
       type = "CAS2",
+      telephoneNumber = jpa.telephoneNumber,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -37,6 +37,7 @@ class SubmittedApplicationTransformer(
       createdAt = jpa.createdAt.toInstant(),
       submittedAt = jpa.submittedAt?.toInstant(),
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
+      telephoneNumber = jpa.telephoneNumber,
     )
   }
 

--- a/src/main/resources/db/migration/all/20240118100212__add_telephone_number_to_cas2_applications.sql
+++ b/src/main/resources/db/migration/all/20240118100212__add_telephone_number_to_cas2_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas_2_applications ADD COLUMN telephone_number TEXT;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1599,6 +1599,8 @@ components:
             submittedAt:
               type: string
               format: date-time
+            telephoneNumber:
+              type: string
           required:
             - createdBy
             - schemaVersion
@@ -2032,9 +2034,12 @@ components:
           type: string
           example: '2023-04-30'
           format: date
+        telephoneNumber:
+          type: string
       required:
         - translatedDocument
         - applicationId
+        - telephoneNumber
     SubmitTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/SubmitApplication'

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1633,6 +1633,8 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
+        telephoneNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5879,6 +5879,8 @@ components:
             submittedAt:
               type: string
               format: date-time
+            telephoneNumber:
+              type: string
           required:
             - createdBy
             - schemaVersion
@@ -6312,9 +6314,12 @@ components:
           type: string
           example: '2023-04-30'
           format: date
+        telephoneNumber:
+          type: string
       required:
         - translatedDocument
         - applicationId
+        - telephoneNumber
     SubmitTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/SubmitApplication'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5913,6 +5913,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas2StatusUpdate'
+        telephoneNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2027,6 +2027,8 @@ components:
             submittedAt:
               type: string
               format: date-time
+            telephoneNumber:
+              type: string
           required:
             - createdBy
             - schemaVersion
@@ -2460,9 +2462,12 @@ components:
           type: string
           example: '2023-04-30'
           format: date
+        telephoneNumber:
+          type: string
       required:
         - translatedDocument
         - applicationId
+        - telephoneNumber
     SubmitTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/SubmitApplication'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2061,6 +2061,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas2StatusUpdate'
+        telephoneNumber:
+          type: string
       required:
         - id
         - person

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.OffsetDateTime
@@ -27,6 +28,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var statusUpdates: Yielded<MutableList<Cas2StatusUpdateEntity>> = { mutableListOf() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+  private var telephoneNumber: Yielded<String?> = { randomNumberChars(12) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -92,5 +94,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     statusUpdates = this.statusUpdates(),
     schemaUpToDate = false,
     nomsNumber = this.nomsNumber(),
+    telephoneNumber = this.telephoneNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -645,6 +645,7 @@ class Cas2SubmissionTest(
                   preferredAreas = "Leeds | Bradford",
                   hdcEligibilityDate = LocalDate.parse("2023-03-30"),
                   conditionalReleaseDate = LocalDate.parse("2023-04-29"),
+                  telephoneNumber = "123 456 7891",
                 ),
               )
               .exchange()
@@ -725,6 +726,7 @@ class Cas2SubmissionTest(
                   SubmitCas2Application(
                     applicationId = applicationId,
                     translatedDocument = {},
+                    telephoneNumber = "123 456 7891",
                   ),
                 )
                 .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -663,6 +663,7 @@ class ApplicationServiceTest {
             it["name"] == user.name &&
               it["email"] == user.email &&
               it["prisonNumber"] == application.nomsNumber &&
+              it["telephoneNumber"] == application.telephoneNumber &&
               it["applicationUrl"] == "http://frontend/assess/applications/$applicationId/overview"
           },
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -408,6 +408,7 @@ class ApplicationServiceTest {
       preferredAreas = "Leeds | Bradford",
       hdcEligibilityDate = hdcEligibilityDate,
       conditionalReleaseDate = conditionalReleaseDate,
+      telephoneNumber = "123",
     )
 
     @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -83,6 +83,7 @@ class ApplicationsTransformerTest {
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+      assertThat(result.telephoneNumber).isEqualTo(application.telephoneNumber)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -88,6 +88,7 @@ class SubmittedApplicationTransformerTest {
         "statusUpdates",
         "submittedAt",
         "submittedBy",
+        "telephoneNumber",
       )
     }
   }


### PR DESCRIPTION
We would like to save the referrer's telephone number as a "first class"
field when a CAS2 Application is submitted, and surface it when a submitted application is viewed. 

This will allow us to surface it on submitted applications to Assessors, without having to dig
into the document JSON blob.

