### PR TITLE
Use `equals` to match `HttpStatus` in OffenderService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -186,7 +186,7 @@ class OffenderService(
         val access = when (val accessResponse = userAccessProducer()) {
           is ClientResult.Success -> accessResponse.body
           is ClientResult.Failure.StatusCode -> {
-            if (accessResponse.status.value() == HttpStatus.FORBIDDEN.value()) {
+            if (accessResponse.status.equals(HttpStatus.FORBIDDEN)) {
               try {
                 accessResponse.deserializeTo<UserOffenderAccess>()
                 return AuthorisableActionResult.Unauthorised()
@@ -224,7 +224,7 @@ class OffenderService(
     return when (val accessResponse = offenderDetailsDataSource.getUserAccessForOffenderCrn(username, crn)) {
       is ClientResult.Success -> !accessResponse.body.userExcluded && !accessResponse.body.userRestricted
       is ClientResult.Failure.StatusCode -> {
-        if (accessResponse.status.value() == HttpStatus.FORBIDDEN.value()) {
+        if (accessResponse.status.equals(HttpStatus.FORBIDDEN)) {
           try {
             accessResponse.deserializeTo<UserOffenderAccess>()
             return false
@@ -501,7 +501,7 @@ class OffenderService(
     val offender = when (offenderResponse) {
       is ClientResult.Success -> offenderResponse.body
 
-      is ClientResult.Failure.StatusCode -> if (offenderResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
+      is ClientResult.Failure.StatusCode -> if (offenderResponse.status.equals(HttpStatus.NOT_FOUND)) {
         return PersonInfoResult.NotFound(crn)
       } else {
         return PersonInfoResult.Unknown(crn, offenderResponse.toException())
@@ -516,7 +516,7 @@ class OffenderService(
           when (val accessResponse = offenderDetailsDataSource.getUserAccessForOffenderCrn(deliusUsername, crn)) {
             is ClientResult.Success -> accessResponse.body
             is ClientResult.Failure.StatusCode -> {
-              if (accessResponse.status.value() == HttpStatus.FORBIDDEN.value()) {
+              if (accessResponse.status.equals(HttpStatus.FORBIDDEN)) {
                 try {
                   accessResponse.deserializeTo<UserOffenderAccess>()
                   return PersonInfoResult.Success.Restricted(crn, offender.otherIds.nomsNumber)


### PR DESCRIPTION
In #1324 we introduced `equals` when matching `HttpStatus`. However, we missed this in the `OffenderService` class, which is the one we're currently experiencing bugs. I had changed this to match on the value, which should work, but we're still experiencing problems. I've not got much confidence this will fix the issue, but this will at least give us consistency.