### PR TITLE
Remove ResultSetMapping for Assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -162,7 +162,7 @@ class AssessmentTransformer(
     ase.decision == "REJECTED" -> TemporaryAccommodationAssessmentStatus.rejected
     ase.decision == "ACCEPTED" && ase.completed -> TemporaryAccommodationAssessmentStatus.closed
     ase.decision == "ACCEPTED" -> TemporaryAccommodationAssessmentStatus.readyToPlace
-    ase.isAllocated -> TemporaryAccommodationAssessmentStatus.inReview
+    ase.allocated -> TemporaryAccommodationAssessmentStatus.inReview
     else -> TemporaryAccommodationAssessmentStatus.unallocated
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentSummaryQueryTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toTimestamp
 import java.time.OffsetDateTime
 
 class AssessmentSummaryQueryTest : IntegrationTestBase() {
@@ -131,14 +132,14 @@ class AssessmentSummaryQueryTest : IntegrationTestBase() {
     assertThat(summary.id).isEqualTo(assessment.id)
     val application = assessment.application
     assertThat(summary.applicationId).isEqualTo(application.id)
-    assertThat(summary.createdAt).isEqualTo(assessment.createdAt)
-    assertThat(summary?.decision).isEqualTo(assessment.decision?.name)
+    assertThat(summary.createdAt).isEqualTo(assessment.createdAt.toTimestamp())
+    assertThat(summary.decision).isEqualTo(assessment.decision?.name)
     assertThat(summary.crn).isEqualTo(application.crn)
     when (application) {
       is ApprovedPremisesApplicationEntity -> {
         assertThat(summary.type).isEqualTo("approved-premises")
         assertThat(summary.completed).isEqualTo(assessment.decision != null)
-        assertThat(summary.arrivalDate).isEqualTo(application.arrivalDate)
+        assertThat(summary.arrivalDate).isEqualTo(application.arrivalDate?.toTimestamp())
         assertThat(summary.riskRatings).isEqualTo("""{"roshRisks":{"status":"NotFound","value":null},"mappa":{"status":"NotFound","value":null},"tier":{"status":"NotFound","value":null},"flags":{"status":"NotFound","value":null}}""")
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -48,6 +48,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toTimestamp
+import java.sql.Timestamp
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -349,17 +351,17 @@ class AssessmentTransformerTest {
 
   @Test
   fun `transform domain to api summary - temporary application`() {
-    val domainSummary = DomainAssessmentSummary(
+    val domainSummary = DomainAssessmentSummaryImpl(
       type = "temporary-accommodation",
       id = UUID.randomUUID(),
       applicationId = UUID.randomUUID(),
-      createdAt = OffsetDateTime.now(),
+      createdAt = OffsetDateTime.now().toTimestamp(),
       riskRatings = null,
       arrivalDate = null,
       completed = false,
       decision = null,
       crn = randomStringMultiCaseWithNumbers(6),
-      isAllocated = true,
+      allocated = true,
       status = null,
     )
 
@@ -380,18 +382,18 @@ class AssessmentTransformerTest {
   @Test
   fun `transform domain to api summary - approved premises`() {
     val personRisks = PersonRisksFactory().produce()
-    val domainSummary = DomainAssessmentSummary(
+    val domainSummary = DomainAssessmentSummaryImpl(
       type = "approved-premises",
       id = UUID.randomUUID(),
       applicationId = UUID.randomUUID(),
-      createdAt = OffsetDateTime.now(),
+      createdAt = OffsetDateTime.now().toTimestamp(),
       riskRatings = objectMapper.writeValueAsString(personRisks),
-      arrivalDate = OffsetDateTime.now().randomDateTimeBefore(),
+      arrivalDate = OffsetDateTime.now().randomDateTimeBefore().toTimestamp(),
       completed = false,
       decision = "ACCEPTED",
       crn = randomStringMultiCaseWithNumbers(6),
-      isAllocated = true,
-      status = DomainAssessmentSummaryStatus.AWAITING_RESPONSE.name,
+      allocated = true,
+      status = DomainAssessmentSummaryStatus.AWAITING_RESPONSE,
     )
 
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
@@ -407,4 +409,19 @@ class AssessmentTransformerTest {
     assertThat(apiSummary.risks).isEqualTo(risksTransformer.transformDomainToApi(personRisks, domainSummary.crn))
     assertThat(apiSummary.person).isNotNull
   }
+
+  @SuppressWarnings("LongParameterList")
+  class DomainAssessmentSummaryImpl(
+    override val type: String,
+    override val id: UUID,
+    override val applicationId: UUID,
+    override val createdAt: Timestamp,
+    override val riskRatings: String?,
+    override val arrivalDate: Timestamp?,
+    override val completed: Boolean,
+    override val allocated: Boolean,
+    override val decision: String?,
+    override val crn: String,
+    override val status: DomainAssessmentSummaryStatus?,
+  ) : DomainAssessmentSummary
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TimeExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TimeExtensions.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import java.sql.Timestamp
+import java.time.OffsetDateTime
+
+const val NANO_MAX = 1E6
+
+fun OffsetDateTime?.toTimestampOrNull(): Timestamp? {
+  return this?.toTimestamp()
+}
+
+fun OffsetDateTime.toTimestamp(): Timestamp {
+  return Timestamp.from(this.toInstant())
+}
+
+fun OffsetDateTime.roundNanosToMillisToAccountForLossOfPrecisionInPostgres(): OffsetDateTime {
+  val millis = Math.round(this.nano / NANO_MAX)
+  val roundedNanos = (millis * NANO_MAX).toInt()
+  return this.withNano(roundedNanos)
+}


### PR DESCRIPTION
Before this change @SqlResultSetMapping was used to map results from several native queries in the AssessmentRepository into instances of DomainAssessmentSummary, via a @NamedNativeQuery definition

Whilst use of ResultSetMapping helps overcome issues mapping some SQL types into their equivalent kotlin-native types (1), the convention in all other repositories is to use Spring Data’s interface-based projection and work around the aforementioned mapping issues by mapping UUIDs to text in the SQL, or mapping timestamptz to Timestamp instead of OffsetDateTime.

Furthermore, Spring Data’s automated paging functionality does not fully work when using @NamedNativeQuery. On startup you see warning logs as follows:

“Finder [insert method name] is backed by a NamedQuery but contains a Pageable parameter! Sorting delivered via this Pageable will not be applied!”

Therefore, to enable database-based paging and improve repository consistency, all usages of @SqlResultSetMapping and @NamedNativeQuery in the Assessment Repository have been changed to instead use interface-based projection on a self-defined @Query annotation

1. See https://github.com/spring-projects/spring-data-jpa/issues/1796