### PR TITLE
(775) CAS2: Limit MI reports to last 12 months

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationStatusUpdatesReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationStatusUpdatesReport.kt
@@ -23,6 +23,7 @@ interface Cas2ApplicationStatusUpdatesReportRepository : JpaRepository<DomainEve
 
       FROM domain_events events
       WHERE events.type = 'CAS2_APPLICATION_STATUS_UPDATED'
+        AND events.occurred_at  > CURRENT_DATE - 365
       ORDER BY updatedAt DESC;
     """,
     nativeQuery = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -24,6 +24,7 @@ interface Cas2SubmittedApplicationReportRepository : JpaRepository<DomainEventEn
          as TEXT) as submittedAt
       FROM domain_events events
       WHERE events.type = 'CAS2_APPLICATION_SUBMITTED'
+        AND events.occurred_at  > CURRENT_DATE - 365
       ORDER BY submittedAt DESC;
     """,
     nativeQuery = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
@@ -19,6 +19,7 @@ interface Cas2UnsubmittedApplicationsReportRepository : JpaRepository<Cas2Applic
       FROM cas_2_applications applications
       JOIN nomis_users users ON users.id = applications.created_by_user_id
       WHERE applications.submitted_at IS NULL
+        AND applications.created_at  > CURRENT_DATE - 365
       ORDER BY startedAt DESC;
     """,
     nativeQuery = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -340,6 +340,10 @@ class Cas2ReportsTest : IntegrationTestBase() {
   inner class UnSubmittedApplications {
     @Test
     fun `streams spreadsheet of data from un-submitted CAS2 applications, newest first`() {
+      val old = Instant.now().minusSeconds(daysInSeconds(365))
+      val newer = Instant.now().minusSeconds(daysInSeconds(100))
+      val tooOld = Instant.now().minusSeconds(daysInSeconds(366))
+
       val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
         withAddedAt(OffsetDateTime.now())
         withId(UUID.randomUUID())
@@ -358,7 +362,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedByUser(user1)
         withCrn("CRN_1")
         withNomsNumber("NOMS_1")
-        withCreatedAt(Instant.now().atOffset(ZoneOffset.ofHoursMinutes(0, 0)).minusDays(100))
+        withCreatedAt(old.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
         withData("{}")
         withSubmittedAt(null)
       }
@@ -368,7 +372,16 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedByUser(user2)
         withCrn("CRN_2")
         withNomsNumber("NOMS_2")
-        withCreatedAt(Instant.now().atOffset(ZoneOffset.ofHoursMinutes(0, 0)).minusDays(99))
+        withCreatedAt(newer.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withData("{}")
+        withSubmittedAt(null)
+      }
+
+      // outside time limit -- should not feature in report
+      cas2ApplicationEntityFactory.produceAndPersist {
+        withApplicationSchema(applicationSchema)
+        withCreatedByUser(user2)
+        withCreatedAt(tooOld.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
         withData("{}")
         withSubmittedAt(null)
       }


### PR DESCRIPTION
This PR should be merged after:

- https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1315
- https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1322

To avoid any potential performance (slow query or memory) issues in the future, we limit the size of these reports to the most recent 12 months.

These reports do not, in any case, do anything complex or expensive.