### PR TITLE
Emit CAS2 domain events in prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -29,7 +29,7 @@ generic-service:
     SENTRY_ENVIRONMENT: preprod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
-    DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
+    DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,bookingCancelledUpdated,personDepartureUpdated,personArrivedUpdated
     DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -37,7 +37,7 @@ generic-service:
     SENTRY_ENVIRONMENT: prod
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
-    DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
+    DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated
     DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false


### PR DESCRIPTION
We don’t believe these are being consumed yet and that this work is in progress after specs have been exchanged[1].

We leave the test environment as having these domain events off as I think the dev and test environments probably send events to the same queue and may cause odd behaviour (such as duplicate contacts) in downstream systems like nDelius?

[1] https://mojdt.slack.com/archives/C05GEPLBRN3/p1705400557152239