### PR TITLE
(APS-82) Optionally filter premises by probation region

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -133,10 +133,10 @@ class PremisesController(
 ) : PremisesApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun premisesSummaryGet(xServiceName: ServiceName): ResponseEntity<List<PremisesSummary>> {
+  override fun premisesSummaryGet(xServiceName: ServiceName, probationRegionId: UUID?): ResponseEntity<List<PremisesSummary>> {
     val transformedSummaries = when (xServiceName) {
       ServiceName.approvedPremises -> {
-        val summaries = premisesService.getAllApprovedPremisesSummaries()
+        val summaries = premisesService.getAllApprovedPremisesSummaries(probationRegionId)
 
         summaries.map(premisesSummaryTransformer::transformDomainToApi)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -77,10 +77,11 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
         LEFT JOIN p.rooms r 
         LEFT JOIN r.beds b 
         LEFT JOIN p.probationRegion region
+        WHERE(cast(:probationRegionId as text) IS NULL OR region.id = :probationRegionId)
         GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status, region.name
   """,
   )
-  fun findAllApprovedPremisesSummary(): List<ApprovedPremisesSummary>
+  fun findAllApprovedPremisesSummary(probationRegionId: UUID?): List<ApprovedPremisesSummary>
 
   @Query("SELECT p as premises, (SELECT CAST(COUNT(b) as int) FROM p.rooms r JOIN r.beds b WHERE r.premises = p GROUP BY p) as roomCount FROM PremisesEntity p WHERE TYPE(p) = :type")
   fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesWithRoomCount>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -62,8 +62,8 @@ class PremisesService(
     return premisesRepository.findAllTemporaryAccommodationSummary(regionId)
   }
 
-  fun getAllApprovedPremisesSummaries(): List<ApprovedPremisesSummary> {
-    return premisesRepository.findAllApprovedPremisesSummary()
+  fun getAllApprovedPremisesSummaries(probationRegionId: UUID?): List<ApprovedPremisesSummary> {
+    return premisesRepository.findAllApprovedPremisesSummary(probationRegionId)
   }
 
   fun getAllPremisesInRegion(probationRegionId: UUID): List<PremisesWithRoomCount> = premisesRepository.findAllByProbationRegion(probationRegionId)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -88,6 +88,12 @@ paths:
           description: If given, only premises for this service will be returned
           schema:
             $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: probationRegionId
+          in: query
+          description: ID of the probation region to filter by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -90,6 +90,12 @@ paths:
           description: If given, only premises for this service will be returned
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: probationRegionId
+          in: query
+          description: ID of the probation region to filter by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
This allows `/premises/summary` to filter by a probation region