### PR TITLE
Persist booking domain events when emit disabled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -863,7 +863,7 @@ class BookingService(
     booking.status = BookingStatus.arrived
     updateBooking(booking)
 
-    if (!arrivedAndDepartedDomainEventsDisabled && shouldCreateDomainEventForBooking(booking, user)) {
+    if (shouldCreateDomainEventForBooking(booking, user)) {
       val domainEventId = UUID.randomUUID()
 
       val offenderDetails =
@@ -882,7 +882,8 @@ class BookingService(
       val approvedPremises = booking.premises as ApprovedPremisesEntity
 
       domainEventService.savePersonArrivedEvent(
-        DomainEvent(
+        emit = !arrivedAndDepartedDomainEventsDisabled,
+        domainEvent = DomainEvent(
           id = domainEventId,
           applicationId = applicationId,
           crn = booking.crn,
@@ -1056,7 +1057,7 @@ class BookingService(
       ),
     )
 
-    if (!arrivedAndDepartedDomainEventsDisabled && shouldCreateDomainEventForBooking(booking, user)) {
+    if (shouldCreateDomainEventForBooking(booking, user)) {
       val domainEventId = UUID.randomUUID()
       val user = user as UserEntity
 
@@ -1078,11 +1079,12 @@ class BookingService(
         is ClientResult.Failure -> staffDetailsResult.throwException()
       }
 
-      val (applicationId, eventNumber, createdAt) = getApplicationDetailsForBooking(booking)
+      val (applicationId, eventNumber, _) = getApplicationDetailsForBooking(booking)
       val approvedPremises = booking.premises as ApprovedPremisesEntity
 
       domainEventService.savePersonNotArrivedEvent(
-        DomainEvent(
+        emit = !arrivedAndDepartedDomainEventsDisabled,
+        domainEvent = DomainEvent(
           id = domainEventId,
           applicationId = applicationId,
           crn = booking.crn,
@@ -1424,7 +1426,7 @@ class BookingService(
     updateBooking(booking)
     booking.departures += departureEntity
 
-    if (!arrivedAndDepartedDomainEventsDisabled && shouldCreateDomainEventForBooking(booking, user)) {
+    if (shouldCreateDomainEventForBooking(booking, user)) {
       val domainEventId = UUID.randomUUID()
       val user = user as UserEntity
 
@@ -1450,7 +1452,8 @@ class BookingService(
       val approvedPremises = booking.premises as ApprovedPremisesEntity
 
       domainEventService.savePersonDepartedEvent(
-        DomainEvent(
+        emit = !arrivedAndDepartedDomainEventsDisabled,
+        domainEvent = DomainEvent(
           id = domainEventId,
           applicationId = applicationId,
           crn = booking.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -99,7 +99,7 @@ class DomainEventService(
     )
 
   @Transactional
-  fun savePersonArrivedEvent(domainEvent: DomainEvent<PersonArrivedEnvelope>) =
+  fun savePersonArrivedEvent(domainEvent: DomainEvent<PersonArrivedEnvelope>, emit: Boolean) =
     saveAndEmit(
       domainEvent = domainEvent,
       typeName = "approved-premises.person.arrived",
@@ -108,10 +108,11 @@ class DomainEventService(
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
+      emit = emit,
     )
 
   @Transactional
-  fun savePersonNotArrivedEvent(domainEvent: DomainEvent<PersonNotArrivedEnvelope>) =
+  fun savePersonNotArrivedEvent(domainEvent: DomainEvent<PersonNotArrivedEnvelope>, emit: Boolean) =
     saveAndEmit(
       domainEvent = domainEvent,
       typeName = "approved-premises.person.not-arrived",
@@ -120,10 +121,11 @@ class DomainEventService(
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
+      emit = emit,
     )
 
   @Transactional
-  fun savePersonDepartedEvent(domainEvent: DomainEvent<PersonDepartedEnvelope>) =
+  fun savePersonDepartedEvent(domainEvent: DomainEvent<PersonDepartedEnvelope>, emit: Boolean) =
     saveAndEmit(
       domainEvent = domainEvent,
       typeName = "approved-premises.person.departed",
@@ -132,6 +134,7 @@ class DomainEventService(
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
+      emit = emit,
     )
 
   @Transactional
@@ -190,6 +193,7 @@ class DomainEventService(
     crn: String,
     nomsNumber: String,
     bookingId: UUID? = null,
+    emit: Boolean = true,
   ) {
     domainEventRepository.save(
       DomainEventEntity(
@@ -204,6 +208,10 @@ class DomainEventService(
         service = "CAS1",
       ),
     )
+
+    if (!emit) {
+      return
+    }
 
     if (!emitDomainEventsEnabled) {
       log.info("Not emitting SNS event for domain event because domain-events.cas1.emit-enabled is not enabled")


### PR DESCRIPTION
The ‘arrived-departed-domain-events-disabled’ configuration is used to determine if domain events should be emitted for arrival, non-arrivel and departure booking events.

Even if we don’t want to emit domain events to SNS, it’s still useful to persist them to the domain_events table as this information can be used for reporting purposes.

This change ensures that when arrived-departed-domain-events-disabled’ is true, we still persist the events