### PR TITLE
Fix time conversion test instability

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TimeExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TimeExtensions.kt
@@ -2,8 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import java.sql.Timestamp
 import java.time.OffsetDateTime
-
-const val NANO_MAX = 1E6
+import java.util.concurrent.TimeUnit
 
 fun OffsetDateTime?.toTimestampOrNull(): Timestamp? {
   return this?.toTimestamp()
@@ -14,7 +13,7 @@ fun OffsetDateTime.toTimestamp(): Timestamp {
 }
 
 fun OffsetDateTime.roundNanosToMillisToAccountForLossOfPrecisionInPostgres(): OffsetDateTime {
-  val millis = Math.round(this.nano / NANO_MAX)
-  val roundedNanos = (millis * NANO_MAX).toInt()
+  val millis = TimeUnit.NANOSECONDS.toMillis(this.nano.toLong())
+  val roundedNanos = TimeUnit.MILLISECONDS.toNanos(millis).toInt()
   return this.withNano(roundedNanos)
 }


### PR DESCRIPTION
There is a need to be able to remove the ‘nano-specific’ part of milliseconds in tests because this nano precision is lost when persisted to postgres, leading to dates not matching a copy of the same date retained in memory that still has nano-specific values.

The previous implementation of the method could lead to invalid nano values. This has been solved by instead using in-built TimeUnit conversion to deal with rounding.