### PR TITLE
778 CAS2: improve seeding to include first class fields on submitted applications

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
@@ -35,7 +35,7 @@ class Cas2AutoScriptTest {
   private val mockNomisUserEntity = mockk<NomisUserEntity>()
 
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
-  private val mockApplicationEntity = mockk<Cas2ApplicationEntity>()
+  private val mockApplicationEntity = mockk<Cas2ApplicationEntity>(relaxed = true)
 
   private val mockExternalUserRepository = mockk<ExternalUserRepository>()
   private val mockExternalUserEntity = mockk<ExternalUserEntity>()
@@ -79,6 +79,7 @@ class Cas2AutoScriptTest {
     } answers { mockJsonSchemaEntity }
 
     every { mockApplicationRepository.save(any()) } answers { mockApplicationEntity }
+    every { mockApplicationRepository.saveAndFlush(any()) } answers { mockApplicationEntity }
     every { mockApplicationEntity.id } answers {
       UUID.fromString("6c8d4bbb-72e6-47fe-9cde-ca2eefc5274b")
     }


### PR DESCRIPTION
These properties are set on submission of the application in
`ApplicationService.submitApplication()`:

"promoted" up out of the application.data JSON blob:

- `preferredAreas`
- `hdcEligibilityDate`
- `conditionalReleaseDate`

and also `referringPrisonCode` which is looked up from the
Prison API.

Another property (`telephoneNumber`) will be added soon.

These first-class properties are used in the 'metadata'
which is shown in the "application summary" which
accompanies a submitted application. They are also included
in the submitted.application domain event and through this,
the "Submitted applications" management information report.