### PR TITLE
CircleCI runs CAS2 e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,33 @@ jobs:
           event: fail
           channel: << pipeline.parameters.alerts-slack-channel >>
           template: basic_fail_1
+  cas2_e2e_tests:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.39.0-focal
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    steps:
+      - run:
+          name: Clone E2E repo
+          command: |
+            git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e.git .
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@9.8.1'
+      - node/install-packages
+      - run:
+          name: E2E Check
+          command: |
+            npm run test
+      - store_artifacts:
+          path: playwright-report
+          destination: playwright-report
+      - store_artifacts:
+          path: test-results
+          destination: test-results
+      - slack/notify:
+          event: fail
+          channel: << pipeline.parameters.alerts-slack-channel >>
+          template: basic_fail_1
   cas3_e2e_tests:
     parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
@@ -348,6 +375,7 @@ workflows:
           requires:
 #            TODO: Uncomment this when we have confirmed the e2es work correctly
 #            - cas1_e2e_tests
+#            - cas2_e2e_tests
 #            - cas3_e2e_tests
             - deploy_dev
       - hmpps/deploy_env:
@@ -373,6 +401,11 @@ workflows:
           requires:
             - request-prod-approval
       - cas1_e2e_tests:
+          context:
+            - hmpps-community-accommodation
+          requires:
+            - deploy_dev
+      - cas2_e2e_tests:
           context:
             - hmpps-community-accommodation
           requires:


### PR DESCRIPTION
We should circle back and make these mandatory for the release pipeline once CAS2 get this green.

