### PR TITLE
Fix frontend CAS2 `applicationUrl` in application.status-updated domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -27,7 +27,7 @@ class StatusUpdateService(
   private val applicationRepository: Cas2ApplicationRepository,
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val domainEventService: DomainEventService,
-  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.cas2.application}") private val applicationUrlTemplate: String,
 ) {
 
   fun isValidStatus(statusUpdate: Cas2ApplicationStatusUpdate): Boolean {
@@ -95,7 +95,7 @@ class StatusUpdateService(
           eventType = EventType.applicationStatusUpdated,
           eventDetails = Cas2ApplicationStatusUpdatedEventDetails(
             applicationId = application.id,
-            applicationUrl = applicationUrlTemplate.replace("id", application.id.toString()),
+            applicationUrl = applicationUrlTemplate.replace("#id", application.id.toString()),
             personReference = PersonReference(
               crn = application.crn,
               noms = application.nomsNumber.toString(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
@@ -6,4 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEn
 import java.util.UUID
 
 @Repository
-interface DomainEventTestRepository : JpaRepository<DomainEventEntity, UUID>
+interface DomainEventTestRepository : JpaRepository<DomainEventEntity, UUID> {
+  fun findFirstByOrderByCreatedAtDesc(): DomainEventEntity?
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -153,8 +153,8 @@ url-templates:
     assessment: http://frontend/assessments/#id
     booking: http://frontend/premises/{premisesId}/bookings/{bookingId}
     cas2:
-      application: http://frontend/applications/#id
-      submitted-application-overview: http://frontend/assess/applications/#applicationId/overview
+      application: http://cas2.frontend/applications/#id
+      submitted-application-overview: http://cas2.frontend/assess/applications/#applicationId/overview
 
 preemptive-cache-delay-ms: 250
 preemptive-cache-lock-duration-ms: 10000


### PR DESCRIPTION
The CAS2 `StatusUpdateService` was using the `url-templates.frontend.application` (Approved Premises/CAS1) setting rather than CAS2's `url-templates.frontend.cas2.application`.

In this PR we:

- set the test config to a clear literal value (`http://cas2.frontend/applications/#id`)
- extend our integration tests to verify that the expected value has been used in the creation of both `application.submitted` and `application.status-updated` events