### PR TITLE
APS-193 add urls to timeline reponses

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -401,7 +401,6 @@
     <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException("Unsupported Application type: ${application::class.qualifiedName}")</ID>
     <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException("Unsupported SubmitApplication type: ${submitApplication::class.qualifiedName}")</ID>
     <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException("Unsupported UpdateApplication type: ${body::class.qualifiedName}")</ID>
-    <ID>TooGenericExceptionThrown:ApplicationsTransformer.kt$ApplicationsTransformer$throw RuntimeException("Only CAS1 is currently supported")</ID>
     <ID>TooGenericExceptionThrown:ApplicationsTransformer.kt$ApplicationsTransformer$throw RuntimeException("Unrecognised application type when transforming: ${domain::class.qualifiedName}")</ID>
     <ID>TooGenericExceptionThrown:ApplicationsTransformer.kt$ApplicationsTransformer$throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")</ID>
     <ID>TooGenericExceptionThrown:ApprovedPremisesApplicationEntityFactory.kt$ApprovedPremisesApplicationEntityFactory$throw RuntimeException("Must provide a createdByUser")</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/convert/UrlTemplateConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/convert/UrlTemplateConverter.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.convert
+
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.core.convert.converter.GenericConverter
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+
+@Component
+class UrlTemplateConverter : GenericConverter {
+  override fun getConvertibleTypes(): MutableSet<GenericConverter.ConvertiblePair> {
+    return mutableSetOf(GenericConverter.ConvertiblePair(String::class.java, UrlTemplate::class.java))
+  }
+
+  override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any {
+    val input = source as String
+    return UrlTemplate(input)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -46,6 +46,7 @@ data class DomainEventEntity(
   @Id
   val id: UUID,
   val applicationId: UUID?,
+  val assessmentId: UUID?,
   val bookingId: UUID?,
   val crn: String,
   @Enumerated(value = EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -28,7 +28,22 @@ import javax.persistence.Table
 @Repository
 interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
-  @Query("SELECT new uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary(cast(d.id as string), d.type, d.occurredAt)  FROM DomainEventEntity d WHERE d.applicationId = :applicationId")
+  @Query(
+    """
+      SELECT 
+        cast(d.id as TEXT), 
+        d.type, 
+        d.occurred_at as occurredAt,
+        cast(d.application_id as TEXT) as applicationId,
+        cast(d.assessment_id as TEXT) as assessmentId,
+        cast(d.booking_id as TEXT) as bookingId,
+        cast(b.premises_id as TEXT) as premisesId
+      FROM domain_events d 
+      LEFT OUTER JOIN bookings b ON b.id = d.booking_id
+      WHERE d.application_id = :applicationId
+    """,
+    nativeQuery = true,
+  )
   fun findAllTimelineEventsByApplicationId(applicationId: UUID): List<DomainEventSummary>
 
   @Query(
@@ -82,9 +97,11 @@ data class DomainEventEntity(
       else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${this.type.name}")
     }
 
+    checkNotNull(this.applicationId) { "application id should not be null" }
+
     return DomainEvent(
       id = this.id,
-      applicationId = this.applicationId!!,
+      applicationId = this.applicationId,
       crn = this.crn,
       occurredAt = this.occurredAt.toInstant(),
       data = data,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 data class DomainEvent<T> (
   val id: UUID,
   val applicationId: UUID? = null,
+  val assessmentId: UUID? = null,
   val bookingId: UUID? = null,
   val crn: String,
   val occurredAt: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
@@ -1,10 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import java.time.OffsetDateTime
+import java.sql.Timestamp
+import java.util.UUID
 
-data class DomainEventSummary(
-  val id: String,
-  val type: DomainEventType,
-  val occurredAt: OffsetDateTime,
-)
+interface DomainEventSummary {
+  val id: String
+  val type: DomainEventType
+  val occurredAt: Timestamp
+  val applicationId: UUID?
+  val assessmentId: UUID?
+  val bookingId: UUID?
+  val premisesId: UUID?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -56,7 +56,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
@@ -81,7 +81,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEvent
 class ApplicationService(
   private val userRepository: UserRepository,
   private val applicationRepository: ApplicationRepository,
-  private val applicationsTransformer: ApplicationsTransformer,
   private val jsonSchemaService: JsonSchemaService,
   private val offenderService: OffenderService,
   private val userService: UserService,
@@ -101,6 +100,7 @@ class ApplicationService(
   private val objectMapper: ObjectMapper,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
   private val probationRegionRepository: ProbationRegionRepository,
+  private val applicationTimelineTransformer: ApplicationTimelineTransformer,
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationSummary> {
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
@@ -1039,7 +1039,7 @@ class ApplicationService(
   fun getApplicationTimeline(applicationId: UUID): List<TimelineEvent> {
     val domainEvents = domainEventService.getAllDomainEventsForApplication(applicationId)
     val timelineEvents = domainEvents.map {
-      applicationsTransformer.transformDomainEventSummaryToTimelineEvent(it)
+      applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(it)
     }.toMutableList()
 
     timelineEvents += getAllInformationRequestEventsForApplication(applicationId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -452,6 +452,7 @@ class AssessmentService(
         DomainEvent(
           id = domainEventId,
           applicationId = application.id,
+          assessmentId = assessment.id,
           crn = application.crn,
           occurredAt = acceptedAt.toInstant(),
           data = ApplicationAssessedEnvelope(
@@ -594,6 +595,7 @@ class AssessmentService(
         DomainEvent(
           id = domainEventId,
           applicationId = application.id,
+          assessmentId = assessment.id,
           crn = application.crn,
           occurredAt = rejectedAt.toInstant(),
           data = ApplicationAssessedEnvelope(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -199,6 +199,7 @@ class DomainEventService(
       DomainEventEntity(
         id = domainEvent.id,
         applicationId = domainEvent.applicationId,
+        assessmentId = domainEvent.assessmentId,
         bookingId = bookingId,
         crn = domainEvent.crn,
         type = enumTypeFromDataType(domainEvent.data!!::class.java),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
@@ -99,6 +99,7 @@ class DomainEventService(
       DomainEventEntity(
         id = domainEvent.id,
         applicationId = domainEvent.applicationId,
+        assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
         crn = domainEvent.crn,
         type = enumTypeFromDataType(domainEvent.data::class),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -222,6 +222,7 @@ class DomainEventService(
       DomainEventEntity(
         id = domainEvent.id,
         applicationId = domainEvent.applicationId,
+        assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
         crn = domainEvent.crn,
         type = enumTypeFromDataType(domainEvent.data::class),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
@@ -22,5 +22,6 @@ class ApplicationTimelineNoteTransformer {
     occurredAt = jpa.createdAt.toInstant(),
     content = jpa.body,
     createdBy = jpa.createdBy.toString(),
+    associatedUrls = emptyList(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -1,20 +1,63 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 
 @Component
-class ApplicationTimelineTransformer {
+class ApplicationTimelineTransformer(
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.assessment}") private val assessmentUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
+) {
 
   fun transformDomainEventSummaryToTimelineEvent(domainEventSummary: DomainEventSummary): TimelineEvent {
+    val associatedUrls = listOfNotNull(
+      applicationUrlOrNull(domainEventSummary),
+      assessmentUrlOrNull(domainEventSummary),
+      bookingUrlOrNull(domainEventSummary),
+    )
+
     return TimelineEvent(
       id = domainEventSummary.id,
       type = transformDomainEventTypeToTimelineEventType(domainEventSummary.type),
       occurredAt = domainEventSummary.occurredAt.toInstant(),
+      associatedUrls = associatedUrls,
     )
+  }
+
+  private fun applicationUrlOrNull(domainEventSummary: DomainEventSummary) = domainEventSummary.applicationId?.let {
+    TimelineEventAssociatedUrl(
+      TimelineEventUrlType.application,
+      applicationUrlTemplate.resolve(mapOf("id" to domainEventSummary.applicationId.toString())),
+    )
+  }
+
+  private fun assessmentUrlOrNull(domainEventSummary: DomainEventSummary) = domainEventSummary.assessmentId?.let {
+    TimelineEventAssociatedUrl(
+      TimelineEventUrlType.assessment,
+      assessmentUrlTemplate.resolve(mapOf("id" to domainEventSummary.assessmentId.toString())),
+    )
+  }
+
+  private fun bookingUrlOrNull(domainEventSummary: DomainEventSummary) = domainEventSummary.bookingId?.let {
+    domainEventSummary.premisesId?.let {
+      TimelineEventAssociatedUrl(
+        TimelineEventUrlType.booking,
+        bookingUrlTemplate.resolve(
+          mapOf(
+            "premisesId" to domainEventSummary.premisesId.toString(),
+            "bookingId" to domainEventSummary.bookingId.toString(),
+          ),
+        ),
+      )
+    }
   }
 
   fun transformDomainEventTypeToTimelineEventType(domainEventType: DomainEventType): TimelineEventType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
+
+@Component
+class ApplicationTimelineTransformer {
+
+  fun transformDomainEventSummaryToTimelineEvent(domainEventSummary: DomainEventSummary): TimelineEvent {
+    return TimelineEvent(
+      id = domainEventSummary.id,
+      type = transformDomainEventTypeToTimelineEventType(domainEventSummary.type),
+      occurredAt = domainEventSummary.occurredAt.toInstant(),
+    )
+  }
+
+  fun transformDomainEventTypeToTimelineEventType(domainEventType: DomainEventType): TimelineEventType {
+    return when (domainEventType) {
+      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> TimelineEventType.approvedPremisesApplicationSubmitted
+      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> TimelineEventType.approvedPremisesApplicationAssessed
+      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> TimelineEventType.approvedPremisesBookingMade
+      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> TimelineEventType.approvedPremisesPersonArrived
+      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> TimelineEventType.approvedPremisesPersonNotArrived
+      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> TimelineEventType.approvedPremisesPersonDeparted
+      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> TimelineEventType.approvedPremisesBookingNotMade
+      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> TimelineEventType.approvedPremisesBookingCancelled
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> TimelineEventType.approvedPremisesBookingChanged
+      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> TimelineEventType.approvedPremisesApplicationWithdrawn
+      else -> throw IllegalArgumentException("Only CAS1 is currently supported")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -12,10 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
@@ -23,8 +21,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSum
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus as ApiApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary as ApiApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary as ApiTemporaryAccommodationApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent as APITimelineEvent
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType as APITimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary as DomainApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary as DomainApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary as DomainCas2ApplicationSummary
@@ -204,29 +200,5 @@ class ApplicationsTransformer(
     AssessmentDecision.ACCEPTED -> uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision.accepted
     AssessmentDecision.REJECTED -> uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision.rejected
     null -> null
-  }
-
-  fun transformDomainEventSummaryToTimelineEvent(domainEventSummary: DomainEventSummary): APITimelineEvent {
-    return APITimelineEvent(
-      id = domainEventSummary.id,
-      type = transformDomainEventTypeToTimelineEventType(domainEventSummary.type),
-      occurredAt = domainEventSummary.occurredAt.toInstant(),
-    )
-  }
-
-  fun transformDomainEventTypeToTimelineEventType(domainEventType: DomainEventType): APITimelineEventType {
-    return when (domainEventType) {
-      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> APITimelineEventType.approvedPremisesApplicationSubmitted
-      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> APITimelineEventType.approvedPremisesApplicationAssessed
-      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> APITimelineEventType.approvedPremisesBookingMade
-      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> APITimelineEventType.approvedPremisesPersonArrived
-      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> APITimelineEventType.approvedPremisesPersonNotArrived
-      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> APITimelineEventType.approvedPremisesPersonDeparted
-      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> APITimelineEventType.approvedPremisesBookingNotMade
-      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> APITimelineEventType.approvedPremisesBookingCancelled
-      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> APITimelineEventType.approvedPremisesBookingChanged
-      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> APITimelineEventType.approvedPremisesApplicationWithdrawn
-      else -> throw RuntimeException("Only CAS1 is currently supported")
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
@@ -21,5 +21,6 @@ class AssessmentClarificationNoteTransformer {
     id = jpa.id.toString(),
     type = TimelineEventType.approvedPremisesInformationRequest,
     occurredAt = jpa.createdAt.toInstant(),
+    associatedUrls = emptyList(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UrlTemplate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UrlTemplate.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+class UrlTemplate(val template: String) {
+  fun resolve(args: Map<String, String>) =
+    args.entries.fold(template) { acc, (key, value) -> acc.replace("#$key", value) }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -234,7 +234,7 @@ url-templates:
   frontend:
     application: http://localhost:3000/applications/#id
     assessment: http://localhost:3000/assessments/#id
-    booking: http://localhost:3000/premises/{premisesId}/bookings/{bookingId}
+    booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
     cas2:
       application: http://localhost:3000/applications/#id
       submitted-application-overview: http://localhost:3000/assess/applications/#applicationId/overview

--- a/src/main/resources/db/migration/all/20240117111637__add_assessment_id_to_domain_event.sql
+++ b/src/main/resources/db/migration/all/20240117111637__add_assessment_id_to_domain_event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events ADD COLUMN assessment_id UUID NULL;

--- a/src/main/resources/db/migration/all/20240117142156__backfill_domain_event_assessment_id.sql
+++ b/src/main/resources/db/migration/all/20240117142156__backfill_domain_event_assessment_id.sql
@@ -1,0 +1,34 @@
+UPDATE domain_events d
+SET assessment_id = a.id
+FROM assessments a
+WHERE d.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED' AND
+      d.assessment_id IS NULL AND
+      a.application_id = d.application_id AND
+      a.reallocated_at IS NULL AND
+      a.decision IS NOT NULL AND
+      a.submitted_at = d.occurred_at;
+
+-- there are a few domain events in prod that don't match the above rule
+-- for those we assign them a completed assessment related to the same
+-- application when there is one and only one such assessment
+
+UPDATE domain_events d
+SET assessment_id = a.id
+FROM assessments a
+WHERE
+    d.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED' AND
+    d.assessment_id IS NULL AND
+    a.application_id = d.application_id AND
+    a.reallocated_at IS NULL AND
+    a.decision IS NOT NULL AND
+    d.id IN (
+        SELECT d1.id
+        FROM domain_events d1
+        INNER JOIN assessments a1 ON a1.application_id = d1.application_id
+        WHERE d1.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED' AND
+            d1.assessment_id IS NULL AND
+            a1.reallocated_at IS NULL AND
+            a1.decision IS NOT NULL
+        GROUP BY d1.id
+        HAVING count(a1.id) = 1
+    );

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3139,6 +3139,20 @@ components:
           type: string
         createdBy:
           type: string
+        associatedUrls:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+    TimelineEventAssociatedUrl:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventUrlType'
+        url:
+          type: string
+      required:
+        - type
+        - url
     TimelineEventType:
       type: string
       enum:
@@ -3156,6 +3170,12 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+    TimelineEventUrlType:
+      type: string
+      enum:
+        - application
+        - booking
+        - assessment
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7419,6 +7419,20 @@ components:
           type: string
         createdBy:
           type: string
+        associatedUrls:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+    TimelineEventAssociatedUrl:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventUrlType'
+        url:
+          type: string
+      required:
+        - type
+        - url
     TimelineEventType:
       type: string
       enum:
@@ -7436,6 +7450,12 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+    TimelineEventUrlType:
+      type: string
+      enum:
+        - application
+        - booking
+        - assessment
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3567,6 +3567,20 @@ components:
           type: string
         createdBy:
           type: string
+        associatedUrls:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+    TimelineEventAssociatedUrl:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventUrlType'
+        url:
+          type: string
+      required:
+        - type
+        - url
     TimelineEventType:
       type: string
       enum:
@@ -3584,6 +3598,12 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+    TimelineEventUrlType:
+      type: string
+      enum:
+        - application
+        - booking
+        - assessment
     SeedRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var applicationId: Yielded<UUID?> = { UUID.randomUUID() }
-  private var assessmentId: Yielded<UUID?> = { UUID.randomUUID() }
+  private var assessmentId: Yielded<UUID?> = { null }
   private var bookingId: Yielded<UUID?> = { null }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var type: Yielded<DomainEventType> = { DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
@@ -27,11 +27,15 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.id = { id }
   }
 
-  fun withApplicationId(applicationId: UUID) = apply {
+  fun withApplicationId(applicationId: UUID?) = apply {
     this.applicationId = { applicationId }
   }
 
-  fun withBookingId(bookingId: UUID) = apply {
+  fun withAssessmentId(assessmentId: UUID?) = apply {
+    this.assessmentId = { assessmentId }
+  }
+
+  fun withBookingId(bookingId: UUID?) = apply {
     this.bookingId = { bookingId }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -14,6 +14,7 @@ import java.util.UUID
 class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var applicationId: Yielded<UUID?> = { UUID.randomUUID() }
+  private var assessmentId: Yielded<UUID?> = { UUID.randomUUID() }
   private var bookingId: Yielded<UUID?> = { null }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var type: Yielded<DomainEventType> = { DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
@@ -67,6 +68,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   override fun produce(): DomainEventEntity = DomainEventEntity(
     id = this.id(),
     applicationId = this.applicationId(),
+    assessmentId = this.assessmentId(),
     bookingId = this.bookingId(),
     crn = this.crn(),
     type = this.type(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -99,7 +99,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -116,7 +116,7 @@ class ApplicationTest : IntegrationTestBase() {
   lateinit var assessmentTransformer: AssessmentTransformer
 
   @Autowired
-  lateinit var applicationsTransformer: ApplicationsTransformer
+  lateinit var applicationTimelineTransformer: ApplicationTimelineTransformer
 
   @SpykBean
   lateinit var realApplicationTeamCodeRepository: ApplicationTeamCodeRepository
@@ -2423,7 +2423,7 @@ class ApplicationTest : IntegrationTestBase() {
         val domainEvents = createTenDomainEvents()
         val summaries = domainEvents.map {
           TimelineEvent(
-            applicationsTransformer.transformDomainEventTypeToTimelineEventType(it.type),
+            applicationTimelineTransformer.transformDomainEventTypeToTimelineEventType(it.type),
             it.id.toString(),
             it.occurredAt.toInstant(),
           )
@@ -2454,7 +2454,7 @@ class ApplicationTest : IntegrationTestBase() {
         val domainEvents = createTenDomainEvents()
         val summaries = domainEvents.map {
           TimelineEvent(
-            applicationsTransformer.transformDomainEventTypeToTimelineEventType(it.type),
+            applicationTimelineTransformer.transformDomainEventTypeToTimelineEventType(it.type),
             it.id.toString(),
             it.occurredAt.toInstant(),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -87,7 +87,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import java.sql.Timestamp
 import java.time.Instant
@@ -102,7 +102,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEvent
 class ApplicationServiceTest {
   private val mockUserRepository = mockk<UserRepository>()
   private val mockApplicationRepository = mockk<ApplicationRepository>()
-  private val applicationsTransformerMock = mockk<ApplicationsTransformer>()
   private val mockJsonSchemaService = mockk<JsonSchemaService>()
   private val mockOffenderService = mockk<OffenderService>()
   private val mockUserService = mockk<UserService>()
@@ -120,11 +119,11 @@ class ApplicationServiceTest {
   private val mockAssessmentClarificationNoteTransformer = mockk<AssessmentClarificationNoteTransformer>()
   private val mockObjectMapper = mockk<ObjectMapper>()
   private val mockProbationRegionRepository = mockk<ProbationRegionRepository>()
+  private val applicationTimelineTransformerMock = mockk<ApplicationTimelineTransformer>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
     mockApplicationRepository,
-    applicationsTransformerMock,
     mockJsonSchemaService,
     mockOffenderService,
     mockUserService,
@@ -144,6 +143,7 @@ class ApplicationServiceTest {
     mockObjectMapper,
     "http://frontend/applications/#id",
     mockProbationRegionRepository,
+    applicationTimelineTransformerMock,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1309,6 +1309,7 @@ class AssessmentServiceTest {
           val data = it.data.eventDetails
 
           it.applicationId == assessment.application.id &&
+            it.assessmentId == assessment.id &&
             it.crn == assessment.application.crn &&
             data.applicationId == assessment.application.id &&
             data.applicationUrl == "http://frontend/applications/${assessment.application.id}" &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -6,31 +6,55 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toTimestamp
+import java.sql.Timestamp
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class ApplicationTimelineTransformerTest {
 
-  private val applicationTimelineTransformer = ApplicationTimelineTransformer()
+  private val applicationTimelineTransformer = ApplicationTimelineTransformer(
+    UrlTemplate("http://somehost:3000/applications/#id"),
+    UrlTemplate("http://somehost:3000/assessments/#id"),
+    UrlTemplate("http://somehost:3000/premises/#premisesId/bookings/#bookingId"),
+  )
+
+  data class DomainEventSummaryImpl(
+    override val id: String,
+    override val type: DomainEventType,
+    override val occurredAt: Timestamp,
+    override val applicationId: UUID?,
+    override val assessmentId: UUID?,
+    override val bookingId: UUID?,
+    override val premisesId: UUID?,
+  ) : DomainEventSummary
 
   @ParameterizedTest
   @MethodSource("domainEventTypeArgs")
   fun `transformDomainEventSummaryToTimelineEvent transforms domain event correctly`(args: Pair<DomainEventType, TimelineEventType>) {
     val (domainEventType, timelineEventType) = args
-    val domainEvent = DomainEventSummary(
+    val domainEvent = DomainEventSummaryImpl(
       id = UUID.randomUUID().toString(),
       type = domainEventType,
-      occurredAt = OffsetDateTime.now(),
+      occurredAt = OffsetDateTime.now().toTimestamp(),
+      bookingId = null,
+      applicationId = null,
+      assessmentId = null,
+      premisesId = null,
     )
     Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
       TimelineEvent(
         id = domainEvent.id,
         type = timelineEventType,
         occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = emptyList(),
       ),
     )
   }
@@ -43,6 +67,112 @@ class ApplicationTimelineTransformerTest {
       applicationTimelineTransformer.transformDomainEventTypeToTimelineEventType(cas2DomainEventType)
     }
     Assertions.assertThat(exception.message).isEqualTo("Only CAS1 is currently supported")
+  }
+
+  @Test
+  fun `transformDomainEventSummaryToTimelineEvent adds applicationUrl if application id defined`() {
+    val applicationId = UUID.randomUUID()
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
+      occurredAt = OffsetDateTime.now().toTimestamp(),
+      bookingId = null,
+      applicationId = applicationId,
+      assessmentId = null,
+      premisesId = null,
+    )
+
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = TimelineEventType.approvedPremisesApplicationSubmitted,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = listOf(
+          TimelineEventAssociatedUrl(TimelineEventUrlType.application, "http://somehost:3000/applications/$applicationId"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformDomainEventSummaryToTimelineEvent adds bookingUrl if booking id defined`() {
+    val bookingId = UUID.randomUUID()
+    val premisesId = UUID.randomUUID()
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+      occurredAt = OffsetDateTime.now().toTimestamp(),
+      bookingId = bookingId,
+      applicationId = null,
+      assessmentId = null,
+      premisesId = premisesId,
+    )
+
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = TimelineEventType.approvedPremisesBookingMade,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = listOf(
+          TimelineEventAssociatedUrl(TimelineEventUrlType.booking, "http://somehost:3000/premises/$premisesId/bookings/$bookingId"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformDomainEventSummaryToTimelineEvent adds assessmentUrl if assessment id defined`() {
+    val assessmentId = UUID.randomUUID()
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
+      occurredAt = OffsetDateTime.now().toTimestamp(),
+      bookingId = null,
+      applicationId = null,
+      assessmentId = assessmentId,
+      premisesId = null,
+    )
+
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = TimelineEventType.approvedPremisesApplicationAssessed,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = listOf(
+          TimelineEventAssociatedUrl(TimelineEventUrlType.assessment, "http://somehost:3000/assessments/$assessmentId"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformDomainEventSummaryToTimelineEvent adds all possible url types`() {
+    val applicationId = UUID.randomUUID()
+    val assessmentId = UUID.randomUUID()
+    val bookingId = UUID.randomUUID()
+    val premisesId = UUID.randomUUID()
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+      occurredAt = OffsetDateTime.now().toTimestamp(),
+      bookingId = bookingId,
+      applicationId = applicationId,
+      assessmentId = assessmentId,
+      premisesId = premisesId,
+    )
+
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = TimelineEventType.approvedPremisesBookingMade,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = listOf(
+          TimelineEventAssociatedUrl(TimelineEventUrlType.application, "http://somehost:3000/applications/$applicationId"),
+          TimelineEventAssociatedUrl(TimelineEventUrlType.assessment, "http://somehost:3000/assessments/$assessmentId"),
+          TimelineEventAssociatedUrl(TimelineEventUrlType.booking, "http://somehost:3000/premises/$premisesId/bookings/$bookingId"),
+        ),
+      ),
+    )
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApplicationTimelineTransformerTest {
+
+  private val applicationTimelineTransformer = ApplicationTimelineTransformer()
+
+  @ParameterizedTest
+  @MethodSource("domainEventTypeArgs")
+  fun `transformDomainEventSummaryToTimelineEvent transforms domain event correctly`(args: Pair<DomainEventType, TimelineEventType>) {
+    val (domainEventType, timelineEventType) = args
+    val domainEvent = DomainEventSummary(
+      id = UUID.randomUUID().toString(),
+      type = domainEventType,
+      occurredAt = OffsetDateTime.now(),
+    )
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = timelineEventType,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformDomainEventTypeToTimelineEventType throws error if given CAS2 domain event type`() {
+    val cas2DomainEventType = DomainEventType.CAS2_APPLICATION_SUBMITTED
+
+    val exception = assertThrows<RuntimeException> {
+      applicationTimelineTransformer.transformDomainEventTypeToTimelineEventType(cas2DomainEventType)
+    }
+    Assertions.assertThat(exception.message).isEqualTo("Only CAS1 is currently supported")
+  }
+
+  private companion object {
+    @JvmStatic
+    fun domainEventTypeArgs() = listOf(
+      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED to TimelineEventType.approvedPremisesApplicationSubmitted,
+      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED to TimelineEventType.approvedPremisesApplicationAssessed,
+      DomainEventType.APPROVED_PREMISES_BOOKING_MADE to TimelineEventType.approvedPremisesBookingMade,
+      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED to TimelineEventType.approvedPremisesPersonArrived,
+      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED to TimelineEventType.approvedPremisesPersonNotArrived,
+      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED to TimelineEventType.approvedPremisesPersonDeparted,
+      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE to TimelineEventType.approvedPremisesBookingNotMade,
+      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED to TimelineEventType.approvedPremisesBookingCancelled,
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED to TimelineEventType.approvedPremisesBookingChanged,
+      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN to TimelineEventType.approvedPremisesApplicationWithdrawn,
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -151,7 +151,7 @@ url-templates:
   frontend:
     application: http://frontend/applications/#id
     assessment: http://frontend/assessments/#id
-    booking: http://frontend/premises/{premisesId}/bookings/{bookingId}
+    booking: http://frontend/premises/#premisesId/bookings/#bookingId
     cas2:
       application: http://cas2.frontend/applications/#id
       submitted-application-overview: http://cas2.frontend/assess/applications/#applicationId/overview


### PR DESCRIPTION
To support this change we need to add an assessment_id column to domain_events, and backfill it for existing entries