### PR TITLE
(APS-206) Remove middle names from tasks endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
@@ -18,7 +18,6 @@ fun getNameFromPersonSummaryInfoResult(result: PersonSummaryInfoResult): String 
   is PersonSummaryInfoResult.Success.Full -> {
     listOf(
       listOf(result.summary.name.forename),
-      result.summary.name.middleNames,
       listOf(result.summary.name.surname),
     ).flatten().joinToString(" ")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CalendarServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CalendarServiceTest.kt
@@ -247,7 +247,7 @@ class CalendarServiceTest {
       listOf(
         PersonSummaryInfoResult.Success.Full(
           crn,
-          CaseSummaryFactory().withName(NameFactory().withForename("Firstname").withMiddleNames(listOf("Middle")).withSurname("Lastname").produce()).produce(),
+          CaseSummaryFactory().withName(NameFactory().withForename("Firstname").withSurname("Lastname").produce()).produce(),
         ),
       )
 
@@ -261,7 +261,7 @@ class CalendarServiceTest {
             endDate = endDate,
             bookingId = booking.id,
             crn = crn,
-            personName = "Firstname Middle Lastname",
+            personName = "Firstname Lastname",
           ),
         ),
       ),


### PR DESCRIPTION
This is confusing to users, so we need to be consistent.