### PR TITLE
(Fix) Open timeline endpoint up to all roles

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -30,12 +30,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotImplementedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
@@ -303,10 +303,8 @@ class ApplicationsController(
   override fun applicationsApplicationIdTimelineGet(applicationId: UUID, xServiceName: ServiceName):
     ResponseEntity<List<TimelineEvent>> {
     val user = userService.getUserForRequest()
-    if (xServiceName != ServiceName.approvedPremises ||
-      !user.hasAnyRole(UserRole.CAS1_ADMIN, UserRole.CAS1_WORKFLOW_MANAGER)
-    ) {
-      throw ForbiddenProblem()
+    if (xServiceName != ServiceName.approvedPremises) {
+      throw NotImplementedProblem("Timeline is only supported for Approved Premises applications")
     }
     val events = applicationService.getApplicationTimeline(applicationId)
     return ResponseEntity(events, HttpStatus.OK)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2394,7 +2394,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get application timeline returns 403 forbidden when not approved premises service`() {
+    fun `Get application timeline returns 501 not implemented when not approved premises service`() {
       `Given a User`(roles = listOf(UserRole.CAS1_ADMIN)) { _, jwt ->
         webTestClient.get()
           .uri("/applications/$applicationId/timeline")
@@ -2402,13 +2402,13 @@ class ApplicationTest : IntegrationTestBase() {
           .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .exchange()
           .expectStatus()
-          .isForbidden
+          .isEqualTo(HttpStatus.NOT_IMPLEMENTED)
       }
     }
 
     @Test
     fun `Get application timeline returns 200 when user has permission and approved premises service`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_ADMIN)) { _, jwt ->
+      `Given a User` { _, jwt ->
         webTestClient.get()
           .uri("/applications/$applicationId/timeline")
           .header("Authorization", "Bearer $jwt")
@@ -2421,7 +2421,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get application timeline returns correct ten DomainEvents when no information requests`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_ADMIN)) { _, jwt ->
+      `Given a User` { _, jwt ->
 
         val domainEvents = createTenDomainEvents()
         val summaries = domainEvents.map {
@@ -2451,7 +2451,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get application timeline returns correct twenty DomainEvents when we have ten information requests`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+      `Given a User` { user, jwt ->
 
         val assessment = createAssessment(user)
 
@@ -2494,7 +2494,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get application timeline returns correct manually added application timeline notes`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+      `Given a User` { user, jwt ->
         val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
           withPermissiveSchema()
         }
@@ -2545,7 +2545,7 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get application timeline includes URLs where applicable`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User` { _, jwt ->
 
         val applicationId = UUID.randomUUID()
         val assessmentId = UUID.randomUUID()


### PR DESCRIPTION
We originally locked this down to only admins and workflow managers, but there is no need to do this, and users are getting kicked out. I’ve also changed the endpoint to return a 501 if the service is not CAS1, which seems more appropriate.