### PR TITLE
Fix: CAS2: add magic flyway timestamp to make migration 'repeatable'

### DIFF
--- a/src/main/resources/db/migration/dev+test/R__7_clear_cas2_domain_events.sql
+++ b/src/main/resources/db/migration/dev+test/R__7_clear_cas2_domain_events.sql
@@ -1,3 +1,5 @@
+-- ${flyway:timestamp}
+
 DELETE FROM domain_events WHERE domain_events.type in (
     'CAS2_APPLICATION_STATUS_UPDATED', 'CAS2_APPLICATION_SUBMITTED'
 );


### PR DESCRIPTION
This "repeatable" migration was not running as expected on each deployment to dev and to test.

This is because it was missing the magic "timestamp" placeholder which is used to make migrations repeat.

See https://flywaydb.org/blog/flyway-timestampsandrepeatables

This came to our attention because the domain events table on 'dev' contained old `cas2.application.submitted` events which were missing certain attributes which are required by our CAS 'Submitted applications' MI report.