### PR TITLE
(781) CAS2: Present submittedAt as timestamp rather than date in 'Submitted applications' report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -19,9 +19,10 @@ interface Cas2SubmittedApplicationReportRepository : JpaRepository<DomainEventEn
         events.data -> 'eventDetails' ->> 'preferredAreas' AS preferredAreas,
         CAST(events.data -> 'eventDetails' ->> 'hdcEligibilityDate' as DATE) AS hdcEligibilityDate,
         CAST(events.data -> 'eventDetails' ->> 'conditionalReleaseDate' as DATE) AS conditionalReleaseDate,
-        CAST(
-          CAST(events.data -> 'eventDetails' ->> 'submittedAt' as DATE) 
-         as TEXT) as submittedAt
+        TO_CHAR(
+          CAST(events.data -> 'eventDetails' ->> 'submittedAt' AS TIMESTAMP),
+          'YYYY-MM-DD"T"HH24:MI:SS'
+        ) AS submittedAt
       FROM domain_events events
       WHERE events.type = 'CAS2_APPLICATION_SUBMITTED'
         AND events.occurred_at  > CURRENT_DATE - 365

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -184,7 +184,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           preferredAreas = event2Details.preferredAreas.toString(),
           hdcEligibilityDate = event2Details.hdcEligibilityDate.toString(),
           conditionalReleaseDate = event2Details.conditionalReleaseDate.toString(),
-          submittedAt = event2Details.submittedAt.toString().split("T").first(),
+          submittedAt = event2Details.submittedAt.toString().split(".").first(),
           submittedBy = event2Details.submittedBy.staffMember.username.toString(),
         ),
         SubmittedApplicationReportRow(
@@ -196,7 +196,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           preferredAreas = event1Details.preferredAreas.toString(),
           hdcEligibilityDate = event1Details.hdcEligibilityDate.toString(),
           conditionalReleaseDate = event1Details.conditionalReleaseDate.toString(),
-          submittedAt = event1Details.submittedAt.toString().split("T").first(),
+          submittedAt = event1Details.submittedAt.toString().split(".").first(),
           submittedBy = event1Details.submittedBy.staffMember.username.toString(),
         ),
       )


### PR DESCRIPTION
[Trello 781](https://trello.com/c/9XR5doJr/781-change-submittedon-to-submittedat-in-submitted-applications-mi-report)

In the CAS2 "Submitted applications" MI report we've decided that we need the timestamp of submission rather than just the date.

See https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/457 for the accompanying tweak to the report 'details' provided in the UI.