### PR TITLE
Fix CAS2 e2e by matching versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
           template: basic_fail_1
   cas2_e2e_tests:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.39.0-focal
+      - image: mcr.microsoft.com/playwright:v1.40.0-focal
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:
@@ -267,7 +267,7 @@ jobs:
             git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e.git .
       - run:
           name: Update npm
-          command: 'npm install -g npm@9.8.1'
+          command: 'npm install -g npm@latest'
       - node/install-packages
       - run:
           name: E2E Check


### PR DESCRIPTION
Currently we’re seeing failed runs[2] with:

```
> hmpps-community-accommodation-tier-2-e2e@1.0.0 test
> npx playwright test --project=setupDev --project=dev

Running 4 tests using 1 worker
×

  1) [setupDev] › auth.setup.ts:5:6 › authenticate ─────────────────────────────────────────────────

    Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1091/chrome-linux/chrome
    ╔══════════════════════════════════════════════════════════════════════╗
    ║ Looks like Playwright Test or Playwright was just updated to 1.40.0. ║
    ║ Please update docker image as well.                                  ║
    ║ -  current: mcr.microsoft.com/playwright:v1.39.0-focal               ║
    ║ - required: mcr.microsoft.com/playwright:v1.40.0-focal               ║
    ║                                                                      ║
    ║ <3 Playwright Team                                                   ║
    ╚══════════════════════════════════════════════════════════════════════╝
```

This repo is run as part of the frontend CI run[1] so we copy the exact versions from there in an effort to address the error, rather than the above CAS1 tests which were doing a very similar thing.

[1] https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/main/.circleci/config.yml#L168
[2] https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-api/8946/workflows/8704b5d0-bd05-47d1-97e9-0304db8c6060/jobs/25825