### PR TITLE
[CAS-182]-CAS3 booking search query to use 'status' column in the query

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -141,34 +141,59 @@ class BookingSearchTest : IntegrationTestBase() {
 
         val allBookings = mutableListOf<BookingEntity>()
         allBeds.forEachIndexed { index, bed ->
-          val booking = bookingEntityFactory.produceAndPersist {
-            withPremises(bed.room.premises)
-            withCrn(offenderDetails.otherIds.crn)
-            withBed(bed)
-            withServiceName(ServiceName.temporaryAccommodation)
-          }
-
           when (index % 5) {
             // Provisional
-            0 -> {}
+            0 -> {
+              val booking = bookingEntityFactory.produceAndPersist {
+                withPremises(bed.room.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBed(bed)
+                withStatus(BookingStatus.provisional)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+              allBookings += booking
+            }
             // Confirmed
             1 -> {
+              val booking = bookingEntityFactory.produceAndPersist {
+                withPremises(bed.room.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBed(bed)
+                withStatus(BookingStatus.confirmed)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
               val confirmation = confirmationEntityFactory.produceAndPersist {
                 withBooking(booking)
               }
 
               booking.confirmation = confirmation
+              allBookings += booking
             }
             // Active
             2 -> {
+              val booking = bookingEntityFactory.produceAndPersist {
+                withPremises(bed.room.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBed(bed)
+                withStatus(BookingStatus.arrived)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
               val arrival = arrivalEntityFactory.produceAndPersist {
                 withBooking(booking)
               }
 
               booking.arrivals.add(arrival)
+              allBookings += booking
             }
             // Closed
             3 -> {
+              val booking = bookingEntityFactory.produceAndPersist {
+                withPremises(bed.room.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBed(bed)
+                withStatus(BookingStatus.closed)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
               val departure = departureEntityFactory.produceAndPersist {
                 withBooking(booking)
                 withYieldedReason {
@@ -180,9 +205,17 @@ class BookingSearchTest : IntegrationTestBase() {
               }
 
               booking.departures.add(departure)
+              allBookings += booking
             }
             // Cancelled
             4 -> {
+              val booking = bookingEntityFactory.produceAndPersist {
+                withPremises(bed.room.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBed(bed)
+                withStatus(BookingStatus.cancelled)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
               val cancellation = cancellationEntityFactory.produceAndPersist {
                 withBooking(booking)
                 withYieldedReason {
@@ -191,10 +224,9 @@ class BookingSearchTest : IntegrationTestBase() {
               }
 
               booking.cancellations.add(cancellation)
+              allBookings += booking
             }
           }
-
-          allBookings += booking
         }
 
         val expectedBookings = allBookings.filter { it.cancellation != null }
@@ -612,6 +644,7 @@ class BookingSearchTest : IntegrationTestBase() {
         withPremises(bed.room.premises)
         withCrn(offenderDetails.otherIds.crn)
         withBed(bed)
+        withStatus(BookingStatus.provisional)
         withServiceName(ServiceName.temporaryAccommodation)
         withArrivalDate(LocalDate.now().minusDays((60 - index).toLong()))
         withDepartureDate(LocalDate.now().minusDays((30 - index).toLong()))


### PR DESCRIPTION
# Changes in this PR
Refer ticket [cas-182](https://dsdmoj.atlassian.net/browse/CAS-182) for more information

This PR is to change the CAS3 booking search query to use `status` column in `bookings` table instead of inferring the status from multiple table.

Note: The `status` column is populate for cas3 booking journey with different dates.
# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.