### PR TITLE
API prod deploys require all frontend e2e to pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,11 +373,9 @@ workflows:
       - request-preprod-approval:
           type: approval
           requires:
-#            TODO: Uncomment this when we have confirmed the e2es work correctly
-#            - cas1_e2e_tests
-#            - cas2_e2e_tests
-#            - cas3_e2e_tests
-            - deploy_dev
+           - cas1_e2e_tests
+           - cas2_e2e_tests
+           - cas3_e2e_tests
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"


### PR DESCRIPTION
Previously this was an informational step to alert the person releasing that their might be an issue.

We are now in the position where CAS1&3 are in public beta and CAS2 is about to go into private beta. The risk of deploying a breaking API change has increased to a point where we should now make this a required step when deploying to preprod and prod.

Instead we now run the risk of flakey e2e tests from any of the projects from failing with false positives and blocking an API deploy.