### PR TITLE
Return entire user object when returning timeline notes

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -13,6 +13,7 @@
     <ID>CyclomaticComplexMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `savePersonNotArrivedEvent persists event, emits event to SNS`()</ID>
     <ID>CyclomaticComplexMethod:DomainEventServiceTest.kt$DomainEventServiceTest$@Test fun `savePersonDepartedEvent persists event, emits event to SNS`()</ID>
     <ID>ForbiddenComment:AssessmentController.kt$AssessmentController$// TODO: We should carry out the pagination at the database level</ID>
+    <ID>TooGenericExceptionThrown:ApplicationTimelineNoteEntityFactory.kt$ApplicationTimelineNoteEntityFactory$throw RuntimeException("Must provide a createdBy User")</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Document
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplicationTimelineNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -279,10 +280,10 @@ class ApplicationsController(
 
   override fun applicationsApplicationIdNotesPost(
     applicationId: UUID,
-    body: ApplicationTimelineNote,
+    body: NewApplicationTimelineNote,
   ): ResponseEntity<ApplicationTimelineNote> {
     val user = userService.getUserForRequest()
-    val savedNote = applicationService.addNoteToApplication(applicationId, body, user)
+    val savedNote = applicationService.addNoteToApplication(applicationId, body.note, user)
     return ResponseEntity.ok(savedNote)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -281,7 +281,8 @@ class ApplicationsController(
     applicationId: UUID,
     body: ApplicationTimelineNote,
   ): ResponseEntity<ApplicationTimelineNote> {
-    val savedNote = applicationService.addNoteToApplication(applicationId, body)
+    val user = userService.getUserForRequest()
+    val savedNote = applicationService.addNoteToApplication(applicationId, body, user)
     return ResponseEntity.ok(savedNote)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
@@ -5,6 +5,8 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 interface ApplicationTimelineNoteRepository : JpaRepository<ApplicationTimelineNoteEntity, UUID> {
@@ -18,7 +20,9 @@ data class ApplicationTimelineNoteEntity(
   @Id
   val id: UUID,
   val applicationId: UUID,
-  val createdBy: UUID,
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdBy: UserEntity,
   val createdAt: OffsetDateTime,
   val body: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -1066,9 +1066,9 @@ class ApplicationService(
   fun addNoteToApplication(
     applicationId: UUID,
     applicationTimelineNote: ApplicationTimelineNote,
+    user: UserEntity,
   ): ApplicationTimelineNote {
-    println("$applicationId, $applicationTimelineNote")
-    val savedNote = applicationTimelineNoteService.saveApplicationTimelineNotes(applicationId, applicationTimelineNote)
+    val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, applicationTimelineNote, user)
     return applicationTimelineNoteTransformer.transformJpaToApi(savedNote)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -1065,10 +1065,10 @@ class ApplicationService(
 
   fun addNoteToApplication(
     applicationId: UUID,
-    applicationTimelineNote: ApplicationTimelineNote,
+    note: String,
     user: UserEntity,
   ): ApplicationTimelineNote {
-    val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, applicationTimelineNote, user)
+    val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, note, user)
     return applicationTimelineNoteTransformer.transformJpaToApi(savedNote)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -15,13 +16,13 @@ class ApplicationTimelineNoteService(
   fun getApplicationTimelineNotesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity> =
     applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
 
-  fun saveApplicationTimelineNotes(applicationId: UUID, applicationTimelineNote: ApplicationTimelineNote):
+  fun saveApplicationTimelineNote(applicationId: UUID, applicationTimelineNote: ApplicationTimelineNote, user: UserEntity):
     ApplicationTimelineNoteEntity {
     return applicationTimelineNoteRepository.save(
       ApplicationTimelineNoteEntity(
         id = UUID.randomUUID(),
         applicationId = applicationId,
-        createdBy = applicationTimelineNote.createdByUserId,
+        createdBy = user,
         createdAt = OffsetDateTime.now(),
         body = applicationTimelineNote.note,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -16,7 +15,7 @@ class ApplicationTimelineNoteService(
   fun getApplicationTimelineNotesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity> =
     applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
 
-  fun saveApplicationTimelineNote(applicationId: UUID, applicationTimelineNote: ApplicationTimelineNote, user: UserEntity):
+  fun saveApplicationTimelineNote(applicationId: UUID, note: String, user: UserEntity):
     ApplicationTimelineNoteEntity {
     return applicationTimelineNoteRepository.save(
       ApplicationTimelineNoteEntity(
@@ -24,7 +23,7 @@ class ApplicationTimelineNoteService(
         applicationId = applicationId,
         createdBy = user,
         createdAt = OffsetDateTime.now(),
-        body = applicationTimelineNote.note,
+        body = note,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
@@ -24,7 +24,7 @@ class ApplicationTimelineNoteTransformer(
     id = jpa.id.toString(),
     occurredAt = jpa.createdAt.toInstant(),
     content = jpa.body,
-    createdBy = jpa.createdBy.toString(),
+    createdBy = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
     associatedUrls = emptyList(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
@@ -2,17 +2,20 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
 
 @Component
-class ApplicationTimelineNoteTransformer {
+class ApplicationTimelineNoteTransformer(
+  private val userTransformer: UserTransformer,
+) {
 
   fun transformJpaToApi(jpa: ApplicationTimelineNoteEntity) = ApplicationTimelineNote(
     id = jpa.id,
     createdAt = jpa.createdAt.toInstant(),
-    createdByUserId = jpa.createdBy,
+    createdByUser = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
     note = jpa.body,
   )
 

--- a/src/main/resources/db/migration/all/20240122082355__change_created_by_to_created_by_user_id.sql
+++ b/src/main/resources/db/migration/all/20240122082355__change_created_by_to_created_by_user_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE application_timeline_notes RENAME COLUMN "created_by" TO "created_by_user_id";

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1879,9 +1879,8 @@ components:
         id:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
         note:
           type: string
         createdAt:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3152,7 +3152,7 @@ components:
         content:
           type: string
         createdBy:
-          type: string
+          $ref: '#/components/schemas/User'
         associatedUrls:
           type: array
           items:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1890,6 +1890,14 @@ components:
         - createdByUserId
         - note
       description: Notes added to an application
+    NewApplicationTimelineNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
     NewApplication:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1951,7 +1951,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '_shared.yml#/components/schemas/ApplicationTimelineNote'
+              $ref: '_shared.yml#/components/schemas/NewApplicationTimelineNote'
         required: true
       responses:
         200:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6159,9 +6159,8 @@ components:
         id:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
         note:
           type: string
         createdAt:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1953,7 +1953,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/ApplicationTimelineNote'
+              $ref: '#/components/schemas/NewApplicationTimelineNote'
         required: true
       responses:
         200:
@@ -6170,6 +6170,14 @@ components:
         - createdByUserId
         - note
       description: Notes added to an application
+    NewApplicationTimelineNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
     NewApplication:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7432,7 +7432,7 @@ components:
         content:
           type: string
         createdBy:
-          type: string
+          $ref: '#/components/schemas/User'
         associatedUrls:
           type: array
           items:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3580,7 +3580,7 @@ components:
         content:
           type: string
         createdBy:
-          type: string
+          $ref: '#/components/schemas/User'
         associatedUrls:
           type: array
           items:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2318,6 +2318,14 @@ components:
         - createdByUserId
         - note
       description: Notes added to an application
+    NewApplicationTimelineNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
     NewApplication:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2307,9 +2307,8 @@ components:
         id:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
         note:
           type: string
         createdAt:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
-  private var createdBy: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdBy: Yielded<UserEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var body: Yielded<String> = { randomStringUpperCase(12) }
 
@@ -25,7 +25,7 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
   }
 
   fun withCreatedBy(createdBy: UserEntity) = apply {
-    this.createdBy = { createdBy.id }
+    this.createdBy = { createdBy }
   }
 
   fun withCreatedAt(createdAt: OffsetDateTime) = apply {
@@ -39,7 +39,7 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
   override fun produce(): ApplicationTimelineNoteEntity = ApplicationTimelineNoteEntity(
     id = this.id(),
     applicationId = this.applicationId(),
-    createdBy = this.createdBy(),
+    createdBy = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy User"),
     createdAt = this.createdAt(),
     body = this.body(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2765,7 +2765,7 @@ class ApplicationTest : IntegrationTestBase() {
           withCreatedByUser(user)
           withApplicationSchema(applicationSchema)
         }
-        val body = ApplicationTimelineNote(user.id, "some note")
+        val body = ApplicationTimelineNote(note = "some note")
         webTestClient.post()
           .uri("/applications/$applicationId/notes")
           .header("Authorization", "Bearer $jwt")
@@ -2781,7 +2781,7 @@ class ApplicationTest : IntegrationTestBase() {
         savedNote.map {
           assertThat(it.body).isEqualTo("some note")
           assertThat(it.applicationId).isEqualTo(applicationId)
-          assertThat(it.createdBy).isEqualTo(user.id)
+          assertThat(it.createdBy.id).isEqualTo(user.id)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
@@ -103,6 +104,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -117,6 +119,9 @@ class ApplicationTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var assessmentTransformer: AssessmentTransformer
+
+  @Autowired
+  lateinit var userTransformer: UserTransformer
 
   @Autowired
   lateinit var applicationTimelineTransformer: ApplicationTimelineTransformer
@@ -2529,7 +2534,7 @@ class ApplicationTest : IntegrationTestBase() {
           withCreatedBy(user)
         }
 
-        val notes = createThreeTimelineEventsOfType(user.id.toString())
+        val notes = createThreeTimelineEventsOfType(userTransformer.transformJpaToApi(user, ServiceName.approvedPremises))
 
         webTestClient.get()
           .uri("/applications/$applicationId/timeline")
@@ -2617,14 +2622,14 @@ class ApplicationTest : IntegrationTestBase() {
       }
     }
 
-    private fun createThreeTimelineEventsOfType(userId: String): List<TimelineEvent> {
+    private fun createThreeTimelineEventsOfType(user: User): List<TimelineEvent> {
       return listOf(
         TimelineEvent(
           TimelineEventType.applicationTimelineNote,
           note1Id.toString(),
           note1CreatedAt.toInstant(),
           "note1",
-          userId,
+          user,
           associatedUrls = emptyList(),
         ),
         TimelineEvent(
@@ -2632,7 +2637,7 @@ class ApplicationTest : IntegrationTestBase() {
           note2Id.toString(),
           note2CreatedAt.toInstant(),
           "note2",
-          userId,
+          user,
           associatedUrls = emptyList(),
         ),
         TimelineEvent(
@@ -2640,7 +2645,7 @@ class ApplicationTest : IntegrationTestBase() {
           note3Id.toString(),
           note3CreatedAt.toInstant(),
           "note3",
-          userId,
+          user,
           associatedUrls = emptyList(),
         ),
       )


### PR DESCRIPTION
This updates the timeline notes and timeline events to return an entire user object, rather than the user ID. There's also a couple of refactors/tweaks I discovered on the way.