### PR TITLE
APS-196 add optional AP Area ID filtering to tasks endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -51,7 +51,6 @@ class PlacementRequestsController(
   private val bookingConfirmationTransformer: NewPlacementRequestBookingConfirmationTransformer,
   private val bookingNotMadeTransformer: BookingNotMadeTransformer,
 ) : PlacementRequestsApiDelegate {
-  private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun placementRequestsGet(): ResponseEntity<List<PlacementRequest>> {
     val user = userService.getUserForRequest()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -97,25 +97,21 @@ class TasksController(
     }
   }
 
-  override fun tasksGet(): ResponseEntity<List<Task>> = runBlocking {
+  override fun tasksGet(apAreaId: UUID?): ResponseEntity<List<Task>> = runBlocking {
     val user = userService.getUserForRequest()
     var tasks = listOf<Task>()
 
     if (user.hasRole(UserRole.CAS1_MATCHER)) {
       val placementRequests =
         placementRequestService.getVisiblePlacementRequestsForUser(
-          user,
-          null,
-          null,
-          null,
+          user = user,
+          apAreaId = apAreaId,
         )
 
       val placementApplications =
         placementApplicationService.getVisiblePlacementApplicationsForUser(
-          user,
-          null,
-          null,
-          null,
+          user = user,
+          apAreaId = apAreaId,
         )
 
       val crns = listOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromPersonSu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.kebabCaseToPascalCase
 import java.util.UUID
 import javax.transaction.Transactional
+
 @Service
 class TasksController(
   private val userService: UserService,
@@ -106,11 +107,13 @@ class TasksController(
           user,
           null,
           null,
+          null,
         )
 
       val placementApplications =
         placementApplicationService.getVisiblePlacementApplicationsForUser(
           user,
+          null,
           null,
           null,
         )
@@ -141,6 +144,7 @@ class TasksController(
     taskType: String,
     page: Int?,
     sortDirection: SortDirection?,
+    apAreaId: UUID?,
   ): ResponseEntity<List<Task>> = runBlocking {
     val user = userService.getUserForRequest()
     val tasks = mutableListOf<Task>()
@@ -158,6 +162,7 @@ class TasksController(
               user,
               page,
               sortDirection,
+              apAreaId,
             )
           val crns = placementApplications.map { it.application.crn }
           val offenderSummaries = getOffenderSummariesForCrns(crns, user)
@@ -170,12 +175,14 @@ class TasksController(
             )
           }
         }
+
         TaskType.placementRequest -> {
           val (placementRequests, metaData) =
             placementRequestService.getVisiblePlacementRequestsForUser(
               user,
               page,
               sortDirection,
+              apAreaId,
             )
           val crns = placementRequests.map { it.application.crn }
           val offenderSummaries = getOffenderSummariesForCrns(crns, user)
@@ -188,6 +195,7 @@ class TasksController(
             )
           }
         }
+
         else -> {
           throw BadRequestProblem()
         }
@@ -228,6 +236,7 @@ class TasksController(
         requiredQualifications = assessment.application.getRequiredQualifications()
         allocationType = AllocationType.Assessment
       }
+
       TaskType.placementRequest -> {
         val (placementRequest) = extractEntityFromAuthorisableActionResult(
           placementRequestService.getPlacementRequestForUser(user, id),
@@ -242,6 +251,7 @@ class TasksController(
         requiredQualifications = emptyList()
         allocationType = AllocationType.PlacementRequest
       }
+
       TaskType.placementApplication -> {
         val placementApplication = extractEntityFromAuthorisableActionResult(
           placementApplicationService.getApplication(id),
@@ -255,7 +265,9 @@ class TasksController(
         crn = placementApplication.application.crn
         requiredQualifications = placementApplication.application.getRequiredQualifications()
         allocationType = AllocationType.PlacementApplication
-      } else -> {
+      }
+
+      else -> {
         throw NotAllowedProblem(detail = "The Task Type $taskType is not currently supported")
       }
     }
@@ -297,6 +309,7 @@ class TasksController(
       body?.userId == null -> throw BadRequestProblem(
         invalidParams = ValidationErrors(mutableMapOf("$.userId" to "empty")),
       )
+
       else -> body.userId
     }
 
@@ -310,13 +323,16 @@ class TasksController(
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(
         errorDetail = validationResult.message,
       )
+
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(
         invalidParams = validationResult.validationMessages,
       )
+
       is ValidatableActionResult.ConflictError -> throw ConflictProblem(
         id = validationResult.conflictingEntityId,
         conflictReason = validationResult.message,
       )
+
       is ValidatableActionResult.Success -> validationResult.entity
     }
 
@@ -341,13 +357,16 @@ class TasksController(
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(
         errorDetail = validationResult.message,
       )
+
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(
         invalidParams = validationResult.validationMessages,
       )
+
       is ValidatableActionResult.ConflictError -> throw ConflictProblem(
         id = validationResult.conflictingEntityId,
         conflictReason = validationResult.message,
       )
+
       is ValidatableActionResult.Success -> validationResult.entity
     }
 
@@ -435,9 +454,11 @@ class TasksController(
         is TypedTask.Assessment -> getAssessmentTask(it.entity) { assessment ->
           getPersonNameFromApplication(assessment.application, offenderSummaries)
         }
+
         is TypedTask.PlacementRequest -> getPlacementRequestTask(it.entity) { placementRequest ->
           getPersonNameFromApplication(placementRequest.application, offenderSummaries)
         }
+
         is TypedTask.PlacementApplication -> getPlacementApplicationTask(it.entity) { placementApplication ->
           getPersonNameFromApplication(placementApplication.application, offenderSummaries)
         }
@@ -529,7 +550,10 @@ class TasksController(
     )
   }
 
-  private fun getPersonNameFromApplication(application: ApplicationEntity, offenderSummaries: List<PersonSummaryInfoResult>): String {
+  private fun getPersonNameFromApplication(
+    application: ApplicationEntity,
+    offenderSummaries: List<PersonSummaryInfoResult>,
+  ): String {
     val crn = application.crn
     val offenderSummary = offenderSummaries.first { it.crn == crn }
     return getNameFromPersonSummaryInfoResult(offenderSummary)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -27,8 +27,22 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   fun findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNullAndAllocatedToUserNull(pageable: Pageable?): Page<PlacementApplicationEntity>
 
-  fun findAllByAllocatedToUser_IdAndReallocatedAtNullAndDecisionNull(
+  @Query(
+    """
+      SELECT pa FROM PlacementApplicationEntity pa
+      JOIN pa.application a
+      LEFT OUTER JOIN a.probationRegion region
+      LEFT OUTER JOIN region.apArea area
+      WHERE 
+        pa.allocatedToUser.id = :userId AND 
+        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR area.id = :apAreaId) AND
+        pa.reallocatedAt IS NULL AND 
+        pa.decision IS NULL
+    """,
+  )
+  fun findOpenRequestsAssignedToUser(
     userId: UUID,
+    apAreaId: UUID?,
     pageable: Pageable?,
   ): Page<PlacementApplicationEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -22,8 +22,22 @@ import javax.persistence.Table
 @Suppress("FunctionNaming")
 @Repository
 interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUID> {
-  fun findAllByAllocatedToUser_IdAndReallocatedAtNullAndIsWithdrawnFalse(
+  @Query(
+    """
+      SELECT p FROM PlacementRequestEntity p
+      JOIN p.application a
+      LEFT OUTER JOIN a.probationRegion region
+      LEFT OUTER JOIN region.apArea area
+      WHERE
+        p.allocatedToUser.id = :userId AND
+        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR area.id = :apAreaId) AND
+        p.reallocatedAt IS NULL AND 
+        p.isWithdrawn IS FALSE
+    """,
+  )
+  fun findOpenRequestsAssignedToUser(
     userId: UUID,
+    apAreaId: UUID?,
     pageable: Pageable?,
   ): Page<PlacementRequestEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -54,8 +54,8 @@ class PlacementApplicationService(
 
   fun getVisiblePlacementApplicationsForUser(
     user: UserEntity,
-    page: Int?,
-    sortDirection: SortDirection?,
+    page: Int? = null,
+    sortDirection: SortDirection? = null,
     apAreaId: UUID?,
   ): Pair<List<PlacementApplicationEntity>, PaginationMetadata?> {
     val sortField = "createdAt"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -56,19 +56,23 @@ class PlacementApplicationService(
     user: UserEntity,
     page: Int?,
     sortDirection: SortDirection?,
+    apAreaId: UUID?,
   ): Pair<List<PlacementApplicationEntity>, PaginationMetadata?> {
     val sortField = "createdAt"
     val pageable = getPageable(sortField, sortDirection, page)
     val response =
-      placementApplicationRepository.findAllByAllocatedToUser_IdAndReallocatedAtNullAndDecisionNull(
+      placementApplicationRepository.findOpenRequestsAssignedToUser(
         user.id,
+        apAreaId,
         pageable,
       )
     return Pair(response.content, getMetadata(response, page))
   }
 
   fun getAllPlacementApplicationEntitiesForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
-    return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(applicationId)
+    return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(
+      applicationId,
+    )
   }
 
   fun createApplication(
@@ -363,12 +367,14 @@ class PlacementApplicationService(
             .findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNullAndAllocatedToUserNull(
               pageable,
             )
+
       allocatedFilter == AllocatedFilter.allocated ->
         allReallocatable =
           placementApplicationRepository
             .findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNullAndAllocatedToUserIsNotNull(
               pageable,
             )
+
       else ->
         allReallocatable =
           placementApplicationRepository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -64,8 +64,8 @@ class PlacementRequestService(
 
   fun getVisiblePlacementRequestsForUser(
     user: UserEntity,
-    page: Int?,
-    sortDirection: SortDirection?,
+    page: Int? = null,
+    sortDirection: SortDirection? = null,
     apAreaId: UUID? = null,
   ): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
     val sortField = "createdAt"

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2662,9 +2662,16 @@ paths:
             type: integer
         - name: sortDirection
           in: query
-          description: The direction to sort the results by. If blank eill sort by descending order
+          description: The direction to sort the results by. If blank, will sort by descending order
           schema:
             $ref: '_shared.yml#/components/schemas/SortDirection'
+        - name: apAreaId
+          in: query
+          required: false
+          description: If provided, only tasks for this area will be returned
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2628,6 +2628,14 @@ paths:
       tags:
         - Task data
       summary: List all tasks
+      parameters:
+        - name: apAreaId
+          in: query
+          required: false
+          description: If provided, only tasks for this area will be returned
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2630,6 +2630,14 @@ paths:
       tags:
         - Task data
       summary: List all tasks
+      parameters:
+        - name: apAreaId
+          in: query
+          required: false
+          description: If provided, only tasks for this area will be returned
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2664,9 +2664,16 @@ paths:
             type: integer
         - name: sortDirection
           in: query
-          description: The direction to sort the results by. If blank eill sort by descending order
+          description: The direction to sort the results by. If blank, will sort by descending order
           schema:
             $ref: '#/components/schemas/SortDirection'
+        - name: apAreaId
+          in: query
+          required: false
+          description: If provided, only tasks for this area will be returned
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -51,6 +52,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var targetLocation: Yielded<String?> = { null }
   private var status: Yielded<ApprovedPremisesApplicationStatus> = { ApprovedPremisesApplicationStatus.STARTED }
   private var inmateInOutStatusOnSubmission: Yielded<String?> = { null }
+  private var probationRegion: Yielded<ProbationRegionEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -184,6 +186,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.inmateInOutStatusOnSubmission = { inmateInOutStatusOnSubmission }
   }
 
+  fun withProbationRegion(probationRegion: ProbationRegionEntity?) = apply {
+    this.probationRegion = { probationRegion }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -218,6 +224,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     status = this.status(),
     situation = this.situation(),
     inmateInOutStatusOnSubmission = this.inmateInOutStatusOnSubmission(),
-    probationRegion = null,
+    probationRegion = this.probationRegion(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -109,8 +109,6 @@ class PlacementRequestsTest : IntegrationTestBase() {
               )
             }
 
-            val postcodeDistrict = postCodeDistrictRepository.findAll()[0]
-
             val placementRequest = placementRequestFactory.produceAndPersist {
               withAllocatedToUser(user)
               withApplication(application1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -22,7 +22,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
-  probationRegionEntity: ProbationRegionEntity? = null,
+  probationRegion: ProbationRegionEntity? = null,
 ): PlacementApplicationEntity {
   val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
@@ -42,7 +42,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
         }
       }
     },
-    probationRegionEntity = probationRegionEntity,
+    probationRegionEntity = probationRegion,
   )
 
   return placementApplicationFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -6,10 +6,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given a Placement Application`(
   assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
   createdByUser: UserEntity,
@@ -20,6 +22,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
+  probationRegionEntity: ProbationRegionEntity? = null,
 ): PlacementApplicationEntity {
   val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
@@ -39,6 +42,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
         }
       }
     },
+    probationRegionEntity = probationRegionEntity,
   )
 
   return placementApplicationFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
@@ -32,6 +33,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   mappa: String? = null,
   applicationSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
   booking: BookingEntity? = null,
+  probationRegion: ProbationRegionEntity? = null,
 ): Pair<PlacementRequestEntity, ApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -53,7 +55,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
         status = RiskStatus.Retrieved,
         value = Mappa(
           level = "CAT M2/LEVEL M2",
-          lastUpdated = java.time.LocalDate.now(),
+          lastUpdated = LocalDate.now(),
         ),
       ),
     )
@@ -69,6 +71,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withRiskRatings(
       risksFactory.produce(),
     )
+    withProbationRegion(probationRegion)
   }
 
   val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAProbationRegion.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAProbationRegion.kt
@@ -11,7 +11,7 @@ fun IntegrationTestBase.`Given a Probation Region`(
   apArea: ApAreaEntity? = null,
   deliusCode: String? = null,
   block: (probationRegion: ProbationRegionEntity) -> Unit,
-) {
+): ProbationRegionEntity {
   val probationRegion = probationRegionEntityFactory.produceAndPersist {
     withId(id)
     if (name != null) {
@@ -30,4 +30,6 @@ fun IntegrationTestBase.`Given a Probation Region`(
   }
 
   block(probationRegion)
+
+  return probationRegion
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import java.util.UUID
+
+fun IntegrationTestBase.`Given an AP Area`(
+  id: UUID = UUID.randomUUID(),
+): ApAreaEntity {
+  val probationRegion = apAreaEntityFactory.produceAndPersist {
+    withId(id)
+  }
+
+  return probationRegion
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -22,6 +23,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   submittedAt: OffsetDateTime? = null,
   createdAt: OffsetDateTime? = null,
   isWithdrawn: Boolean = false,
+  probationRegionEntity: ProbationRegionEntity? = null,
 ): Pair<AssessmentEntity, ApprovedPremisesApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -39,6 +41,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withSubmittedAt(OffsetDateTime.now())
     withReleaseType("licence")
     withIsWithdrawn(isWithdrawn)
+    withProbationRegion(probationRegionEntity)
   }
 
   val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-196

Add optional AP Area ID filtering to /tasks and /tasks/{taskType}

/tasks/reallocatable will be updated in a subsequent PR