### PR TITLE
(APS-214) Add AP Areas to premises summaries and allow filtering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -133,10 +133,10 @@ class PremisesController(
 ) : PremisesApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun premisesSummaryGet(xServiceName: ServiceName, probationRegionId: UUID?): ResponseEntity<List<PremisesSummary>> {
+  override fun premisesSummaryGet(xServiceName: ServiceName, probationRegionId: UUID?, apAreaId: UUID?): ResponseEntity<List<PremisesSummary>> {
     val transformedSummaries = when (xServiceName) {
       ServiceName.approvedPremises -> {
-        val summaries = premisesService.getAllApprovedPremisesSummaries(probationRegionId)
+        val summaries = premisesService.getAllApprovedPremisesSummaries(probationRegionId, apAreaId)
 
         summaries.map(premisesSummaryTransformer::transformDomainToApi)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReferenceDataApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NonArrivalReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationDeliveryUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
@@ -24,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
@@ -58,6 +61,8 @@ class ReferenceDataController(
   private val probationRegionTransformer: ProbationRegionTransformer,
   private val nonArrivalReasonTransformer: NonArrivalReasonTransformer,
   private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
+  private val apAreaRepository: ApAreaRepository,
+  private val apAreaTransformer: ApAreaTransformer,
 ) : ReferenceDataApiDelegate {
 
   override fun referenceDataCharacteristicsGet(xServiceName: ServiceName?, includeInactive: Boolean?): ResponseEntity<List<Characteristic>> {
@@ -145,6 +150,12 @@ class ReferenceDataController(
     val probationRegions = probationRegionRepository.findAll()
 
     return ResponseEntity.ok(probationRegions.map(probationRegionTransformer::transformJpaToApi))
+  }
+
+  override fun referenceDataApAreasGet(): ResponseEntity<List<ApArea>> {
+    val apAreas = apAreaRepository.findAll()
+
+    return ResponseEntity.ok(apAreas.map(apAreaTransformer::transformJpaToApi))
   }
 
   override fun referenceDataNonArrivalReasonsGet(): ResponseEntity<List<NonArrivalReason>> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -1,10 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.OneToMany
 import javax.persistence.Table
+
+@Repository
+interface ApAreaRepository : JpaRepository<ApAreaEntity, UUID>
 
 @Entity
 @Table(name = "ap_areas")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -71,14 +71,16 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
             p.status, 
             CAST(COUNT(b) as int), 
             p.apCode, 
-            region.name
+            region.name,
+            apArea.name
         ) 
         FROM ApprovedPremisesEntity p 
         LEFT JOIN p.rooms r 
         LEFT JOIN r.beds b 
         LEFT JOIN p.probationRegion region
+        LEFT JOIN region.apArea apArea
         WHERE(cast(:probationRegionId as text) IS NULL OR region.id = :probationRegionId)
-        GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status, region.name
+        GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status, region.name, apArea.name
   """,
   )
   fun findAllApprovedPremisesSummary(probationRegionId: UUID?): List<ApprovedPremisesSummary>
@@ -295,6 +297,7 @@ data class ApprovedPremisesSummary(
   val bedCount: Int,
   val apCode: String,
   val regionName: String,
+  val apAreaName: String,
 )
 
 data class TemporaryAccommodationPremisesSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -80,10 +80,11 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
         LEFT JOIN p.probationRegion region
         LEFT JOIN region.apArea apArea
         WHERE(cast(:probationRegionId as text) IS NULL OR region.id = :probationRegionId)
+        AND(cast(:apAreaId as text) IS NULL OR apArea.id = :apAreaId)
         GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, p.apCode, p.status, region.name, apArea.name
   """,
   )
-  fun findAllApprovedPremisesSummary(probationRegionId: UUID?): List<ApprovedPremisesSummary>
+  fun findAllApprovedPremisesSummary(probationRegionId: UUID?, apAreaId: UUID?): List<ApprovedPremisesSummary>
 
   @Query("SELECT p as premises, (SELECT CAST(COUNT(b) as int) FROM p.rooms r JOIN r.beds b WHERE r.premises = p GROUP BY p) as roomCount FROM PremisesEntity p WHERE TYPE(p) = :type")
   fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesWithRoomCount>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -62,8 +62,8 @@ class PremisesService(
     return premisesRepository.findAllTemporaryAccommodationSummary(regionId)
   }
 
-  fun getAllApprovedPremisesSummaries(probationRegionId: UUID?): List<ApprovedPremisesSummary> {
-    return premisesRepository.findAllApprovedPremisesSummary(probationRegionId)
+  fun getAllApprovedPremisesSummaries(probationRegionId: UUID?, apAreaId: UUID?): List<ApprovedPremisesSummary> {
+    return premisesRepository.findAllApprovedPremisesSummary(probationRegionId, apAreaId)
   }
 
   fun getAllPremisesInRegion(probationRegionId: UUID): List<PremisesWithRoomCount> = premisesRepository.findAllByProbationRegion(probationRegionId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesSummaryTransformer.kt
@@ -33,5 +33,6 @@ class PremisesSummaryTransformer() {
     apCode = domain.apCode,
     service = "CAS1",
     probationRegion = domain.regionName,
+    apArea = domain.apAreaName,
   )
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -169,9 +169,12 @@ components:
               example: NEHOPE1
             probationRegion:
               type: string
+            apArea:
+              type: string
       required:
         - apCode
         - probationRegion
+        - apArea
     TemporaryAccommodationPremisesSummary:
       allOf:
         - $ref: '#/components/schemas/PremisesSummary'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -94,6 +94,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: apAreaId
+          in: query
+          description: ID of the AP area to filter by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2542,6 +2542,26 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /reference-data/ap-areas:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all probation regions
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/ApArea'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /reference-data/characteristics:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4449,9 +4449,12 @@ components:
               example: NEHOPE1
             probationRegion:
               type: string
+            apArea:
+              type: string
       required:
         - apCode
         - probationRegion
+        - apArea
     TemporaryAccommodationPremisesSummary:
       allOf:
         - $ref: '#/components/schemas/PremisesSummary'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2544,6 +2544,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/ap-areas:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all probation regions
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApArea'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /reference-data/characteristics:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -96,6 +96,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: apAreaId
+          in: query
+          description: ID of the AP area to filter by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -597,9 +597,12 @@ components:
               example: NEHOPE1
             probationRegion:
               type: string
+            apArea:
+              type: string
       required:
         - apCode
         - probationRegion
+        - apArea
     TemporaryAccommodationPremisesSummary:
       allOf:
         - $ref: '#/components/schemas/PremisesSummary'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -83,12 +83,14 @@ class PremisesSummaryTest : IntegrationTestBase() {
   fun `Get all CAS1 Premises returns OK with correct body`() {
     `Given a User` { _, jwt ->
       val uuid = UUID.randomUUID()
+      val apArea = apAreaEntityFactory.produceAndPersist()
+      val probationRegion = probationRegionEntityFactory.produceAndPersist {
+        withApArea(apArea)
+      }
 
       val cas1Premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withProbationRegion(probationRegion)
         withId(uuid)
         withAddressLine1("221 Baker Street")
         withAddressLine2("221B")
@@ -121,6 +123,8 @@ class PremisesSummaryTest : IntegrationTestBase() {
         .jsonPath("$[0].status").isEqualTo("active")
         .jsonPath("$[0].apCode").isEqualTo("APCODE")
         .jsonPath("$[0].bedCount").isEqualTo(5)
+        .jsonPath("$[0].probationRegion").isEqualTo(probationRegion.name)
+        .jsonPath("$[0].apArea").isEqualTo(apArea.name)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesSummaryTransformerTest.kt
@@ -59,6 +59,7 @@ class PremisesSummaryTransformerTest {
       bedCount = 1,
       apCode = "APCODE",
       regionName = "Some region",
+      apAreaName = "Some AP Area name",
     )
 
     val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
@@ -75,6 +76,7 @@ class PremisesSummaryTransformerTest {
         apCode = "APCODE",
         service = "CAS1",
         probationRegion = "Some region",
+        apArea = "Some AP Area name",
       ),
     )
   }


### PR DESCRIPTION
This adds AP areas to premises summaries, and allows them to be filtered by the area. We've realised that this is a more appropriate thing to filter / group by, but have kept the legacy behaviour in too for compatibility reasons.