### PR TITLE
Simplified Reallocated Task Logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -171,31 +171,30 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   ): Page<DomainAssessmentSummary>
 
   @Query(
-    "SELECT a FROM AssessmentEntity a WHERE a.reallocatedAt IS NULL " +
-      "AND a.isWithdrawn != true AND a.submittedAt IS NULL AND TYPE(a) = :type AND a.allocatedToUser IS NULL",
+    """
+      SELECT a FROM AssessmentEntity a 
+      WHERE TYPE(a) = :type AND
+            a.reallocatedAt IS NULL AND  
+            a.isWithdrawn != true AND 
+            a.submittedAt IS NULL AND 
+            (
+              (:#{#allocationStatus?.toString()} = 'ALLOCATED' AND a.allocatedToUser IS NOT NULL) OR
+              (:#{#allocationStatus?.toString()} = 'UNALLOCATED' AND a.allocatedToUser IS NULL) OR
+              (:#{#allocationStatus?.toString()} = 'EITHER')
+            )
+    """,
   )
-  fun <T : AssessmentEntity> findAllByReallocatedAtNullAndSubmittedAtNullAndTypeAndAllocatedToUserNull(
+  fun <T : AssessmentEntity> findByAllocationStatus(
     type: Class<T>,
+    allocationStatus: AllocationStatus,
     pageable: Pageable?,
   ): Page<AssessmentEntity>
 
-  @Query(
-    "SELECT a FROM AssessmentEntity a WHERE a.reallocatedAt IS NULL " +
-      "AND a.isWithdrawn != true AND a.submittedAt IS NULL AND TYPE(a) = :type AND a.allocatedToUser IS NOT NULL",
-  )
-  fun <T : AssessmentEntity> findAllByReallocatedAtNullAndSubmittedAtNullAndTypeAndAllocatedToUser(
-    type: Class<T>,
-    pageable: Pageable?,
-  ): Page<AssessmentEntity>
-
-  @Query(
-    "SELECT a FROM AssessmentEntity a WHERE a.reallocatedAt IS NULL " +
-      "AND a.isWithdrawn != true AND a.submittedAt IS NULL AND TYPE(a) = :type",
-  )
-  fun <T : AssessmentEntity> findAllByReallocatedAtNullAndSubmittedAtNullAndType(
-    type: Class<T>,
-    pageable: Pageable?,
-  ): Page<AssessmentEntity>
+  enum class AllocationStatus {
+    ALLOCATED,
+    UNALLOCATED,
+    EITHER,
+  }
 
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -21,11 +21,31 @@ import javax.persistence.Table
 @Suppress("FunctionNaming")
 @Repository
 interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEntity, UUID> {
-  fun findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNull(pageable: Pageable?): Page<PlacementApplicationEntity>
 
-  fun findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNullAndAllocatedToUserIsNotNull(pageable: Pageable?): Page<PlacementApplicationEntity>
+  @Query(
+    """
+    SELECT
+      pa
+    FROM
+      PlacementApplicationEntity pa
+    where
+      pa.submittedAt IS NOT NULL AND
+      pa.reallocatedAt IS NULL AND
+      pa.decision IS NULL AND 
+      (
+        (:#{#allocationStatus?.toString()} = 'ALLOCATED' AND pa.allocatedToUser IS NOT NULL) OR
+        (:#{#allocationStatus?.toString()} = 'UNALLOCATED' AND pa.allocatedToUser IS NULL) OR
+        (:#{#allocationStatus?.toString()} = 'EITHER')
+      )
+    """,
+  )
+  fun findByAllocationStatus(allocationStatus: AllocationStatus, pageable: Pageable?): Page<PlacementApplicationEntity>
 
-  fun findAllBySubmittedAtNotNullAndReallocatedAtNullAndDecisionNullAndAllocatedToUserNull(pageable: Pageable?): Page<PlacementApplicationEntity>
+  enum class AllocationStatus {
+    ALLOCATED,
+    UNALLOCATED,
+    EITHER,
+  }
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PaginationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PaginationUtils.kt
@@ -72,7 +72,12 @@ fun getPageableOrAllPages(criteria: PageCriteria<String>): Pageable? =
     criteria.perPage,
   )
 
-fun <T> getMetadata(response: Page<T>, pageCriteria: PageCriteria<*>): PaginationMetadata? = getMetadataWithSize(response, pageCriteria.page, pageCriteria.perPage)
+fun <T> wrapWithMetadata(page: Page<T>, pageCriteria: PageCriteria<*>): Pair<List<T>, PaginationMetadata?> {
+  return Pair(page.content, getMetadata(page, pageCriteria))
+}
+
+fun <T> getMetadata(response: Page<T>, pageCriteria: PageCriteria<*>): PaginationMetadata? =
+  getMetadataWithSize(response, pageCriteria.page, pageCriteria.perPage)
 
 fun <T> getMetadata(response: Page<T>, page: Int?): PaginationMetadata? {
   return getMetadataWithSize(response, page, 10)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -45,7 +45,7 @@ class TasksTest : IntegrationTestBase() {
 
   @Nested
   inner class GetAllReallocatableTest {
-    val pageSize = 10
+    private val pageSize = 10
 
     @Test
     fun `Get all reallocatable tasks without JWT returns 401`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -47,6 +47,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import java.util.UUID
@@ -325,9 +326,11 @@ class TaskServiceTest {
     every { placementApplicationRepositoryMock.findAllById(placementApplications.map { it.id }) } returns placementApplications
     every { placementRequestRepositoryMock.findAllById(placementRequests.map { it.id }) } returns placementRequests
 
-    every { getMetadata(page, 1) } returns metadata
+    val pageCriteria = PageCriteria(TaskSortField.createdAt, SortDirection.asc, 1)
 
-    val result = taskService.getAllReallocatable(AllocatedFilter.allocated, 1, TaskSortField.createdAt, SortDirection.asc)
+    every { getMetadata(page, pageCriteria) } returns metadata
+
+    val result = taskService.getAllReallocatable(AllocatedFilter.allocated, pageCriteria)
 
     val expectedTasks = listOf(
       assessments.map { TypedTask.Assessment(it) },


### PR DESCRIPTION
This commits simplifies the reallocation code In preparation for adding filtering on AP Area ID.

The 3 ‘allocation queries’ for placement requests, placement applications and assessments have been flattened into a single query per entity type.

This commit has no functional change, just refactoring