### PR TITLE
(APS-214) Change Probation Region ID to AP Area ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -321,18 +321,18 @@ class ApplicationsController(
 
     val submitResult = when (submitApplication) {
       is SubmitApprovedPremisesApplication -> {
-        var probationRegionId = submitApplication.probationRegionId
+        var apAreaId = submitApplication.apAreaId
 
-        if (probationRegionId == null) {
+        if (apAreaId == null) {
           val user = userService.getUserForRequest()
-          probationRegionId = user.probationRegion.id
+          apAreaId = user.probationRegion.apArea.id
         }
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           submitApplication,
           username,
           deliusPrincipal.token.tokenValue,
-          probationRegionId,
+          apAreaId,
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -309,8 +309,8 @@ class ApprovedPremisesApplicationEntity(
   var status: ApprovedPremisesApplicationStatus,
   var inmateInOutStatusOnSubmission: String?,
   @ManyToOne
-  @JoinColumn(name = "probation_region_id")
-  var probationRegion: ProbationRegionEntity?,
+  @JoinColumn(name = "ap_area_id")
+  var apArea: ApAreaEntity?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -51,11 +51,10 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
     """
       SELECT pa FROM PlacementApplicationEntity pa
       JOIN pa.application a
-      LEFT OUTER JOIN a.probationRegion region
-      LEFT OUTER JOIN region.apArea area
+      LEFT OUTER JOIN a.apArea apArea
       WHERE 
         pa.allocatedToUser.id = :userId AND 
-        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR area.id = :apAreaId) AND
+        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR apArea.id = :apAreaId) AND
         pa.reallocatedAt IS NULL AND 
         pa.decision IS NULL
     """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -27,11 +27,10 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
     """
       SELECT p FROM PlacementRequestEntity p
       JOIN p.application a
-      LEFT OUTER JOIN a.probationRegion region
-      LEFT OUTER JOIN region.apArea area
+      LEFT OUTER JOIN a.apArea apArea
       WHERE
         p.allocatedToUser.id = :userId AND
-        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR area.id = :apAreaId) AND
+        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR apArea.id = :apAreaId) AND
         p.reallocatedAt IS NULL AND 
         p.isWithdrawn IS FALSE
     """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary
@@ -38,7 +39,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -99,7 +99,7 @@ class ApplicationService(
   private val assessmentClarificationNoteTransformer: AssessmentClarificationNoteTransformer,
   private val objectMapper: ObjectMapper,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
-  private val probationRegionRepository: ProbationRegionRepository,
+  private val apAreaRepository: ApAreaRepository,
   private val applicationTimelineTransformer: ApplicationTimelineTransformer,
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationSummary> {
@@ -343,7 +343,7 @@ class ApplicationService(
       sentenceType = null,
       situation = null,
       inmateInOutStatusOnSubmission = null,
-      probationRegion = null,
+      apArea = null,
     )
   }
 
@@ -706,7 +706,7 @@ class ApplicationService(
     submitApplication: SubmitApprovedPremisesApplication,
     username: String,
     jwt: String,
-    probationRegionId: UUID?,
+    apAreaId: UUID?,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     var application = applicationRepository.findByIdOrNullWithWriteLock(
       applicationId,
@@ -774,7 +774,7 @@ class ApplicationService(
       sentenceType = submitApplication.sentenceType.toString()
       situation = submitApplication.situation?.toString()
       inmateInOutStatusOnSubmission = inmateDetails?.inOutStatus?.name
-      probationRegion = probationRegionRepository.findByIdOrNull(probationRegionId)
+      apArea = apAreaRepository.findByIdOrNull(apAreaId)
     }
 
     assessmentService.createApprovedPremisesAssessment(application)

--- a/src/main/resources/db/migration/all/20240123091639__change_application_probation_id_to_ap_area_id.sql
+++ b/src/main/resources/db/migration/all/20240123091639__change_application_probation_id_to_ap_area_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE approved_premises_applications
+    ADD COLUMN ap_area_id uuid NULL;
+
+ALTER TABLE approved_premises_applications
+    ADD CONSTRAINT approved_premises_applications_ap_area_id_fkey FOREIGN KEY (ap_area_id) REFERENCES ap_areas (id) DEFERRABLE;

--- a/src/main/resources/db/migration/all/20240123104559__migrate_application_probation_ids_to_ap_area_ids.sql
+++ b/src/main/resources/db/migration/all/20240123104559__migrate_application_probation_ids_to_ap_area_ids.sql
@@ -1,0 +1,13 @@
+UPDATE
+    approved_premises_applications
+set
+    ap_area_id = (
+        SELECT
+            ap_area_id
+        from
+            probation_regions
+        where
+                id = approved_premises_applications.probation_region_id
+    )
+where
+    approved_premises_applications.probation_region_id is not null;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2014,7 +2014,7 @@ components:
             arrivalDate:
               type: string
               format: date
-            probationRegionId:
+            apAreaId:
               type: string
               format: uuid
           required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6346,7 +6346,7 @@ components:
             arrivalDate:
               type: string
               format: date
-            probationRegionId:
+            apAreaId:
               type: string
               format: uuid
           required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2442,7 +2442,7 @@ components:
             arrivalDate:
               type: string
               format: date
-            probationRegionId:
+            apAreaId:
               type: string
               format: uuid
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -2,12 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -52,7 +52,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var targetLocation: Yielded<String?> = { null }
   private var status: Yielded<ApprovedPremisesApplicationStatus> = { ApprovedPremisesApplicationStatus.STARTED }
   private var inmateInOutStatusOnSubmission: Yielded<String?> = { null }
-  private var probationRegion: Yielded<ProbationRegionEntity?> = { null }
+  private var apArea: Yielded<ApAreaEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -186,8 +186,8 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.inmateInOutStatusOnSubmission = { inmateInOutStatusOnSubmission }
   }
 
-  fun withProbationRegion(probationRegion: ProbationRegionEntity?) = apply {
-    this.probationRegion = { probationRegion }
+  fun withApArea(apArea: ApAreaEntity?) = apply {
+    this.apArea = { apArea }
   }
 
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
@@ -224,6 +224,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     status = this.status(),
     situation = this.situation(),
     inmateInOutStatusOnSubmission = this.inmateInOutStatusOnSubmission(),
-    probationRegion = this.probationRegion(),
+    apArea = this.apArea(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1879,7 +1879,7 @@ class ApplicationTest : IntegrationTestBase() {
           assertThat(persistedApplication?.isPipeApplication).isTrue
           assertThat(persistedApplication?.targetLocation).isEqualTo("SW1A 1AA")
           assertThat(persistedApplication?.sentenceType).isEqualTo(SentenceTypeOption.nonStatutory.toString())
-          assertThat(persistedApplication?.probationRegion?.id).isEqualTo(submittingUser.probationRegion.id)
+          assertThat(persistedApplication?.apArea?.id).isEqualTo(submittingUser.probationRegion.apArea.id)
 
           val createdAssessment =
             approvedPremisesAssessmentRepository.findAll().first { it.application.id == applicationId }
@@ -2021,7 +2021,7 @@ class ApplicationTest : IntegrationTestBase() {
                 releaseType = ReleaseTypeOption.licence,
                 sentenceType = SentenceTypeOption.nonStatutory,
                 type = "CAS1",
-                probationRegionId = probationRegion.id,
+                apAreaId = apArea.id,
               ),
             )
             .exchange()
@@ -2035,7 +2035,7 @@ class ApplicationTest : IntegrationTestBase() {
           assertThat(persistedApplication?.isPipeApplication).isTrue
           assertThat(persistedApplication?.targetLocation).isEqualTo("SW1A 1AA")
           assertThat(persistedApplication?.sentenceType).isEqualTo(SentenceTypeOption.nonStatutory.toString())
-          assertThat(persistedApplication?.probationRegion?.id).isEqualTo(probationRegion.id)
+          assertThat(persistedApplication?.apArea?.id).isEqualTo(apArea.id)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskWrapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
@@ -1227,16 +1226,13 @@ class TasksTest : IntegrationTestBase() {
           val apArea1 = `Given an AP Area`()
           val apArea2 = `Given an AP Area`()
 
-          val probationRegion1 = `Given a Probation Region`(apArea = apArea1) { }
-          val probationRegion2 = `Given a Probation Region`(apArea = apArea2) { }
-
           `Given an Offender` { offenderDetails, _ ->
             val (placementRequestAllocatedToMe) = `Given a Placement Request`(
               placementRequestAllocatedTo = user,
               assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion2,
+              apArea = apArea2,
             )
 
             val placementApplicationAllocatedToMe = `Given a Placement Application`(
@@ -1246,7 +1242,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion2,
+              apArea = apArea2,
             )
 
             `Given a Placement Request`(
@@ -1254,7 +1250,7 @@ class TasksTest : IntegrationTestBase() {
               assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion1,
+              apArea = apArea1,
             )
 
             `Given a Placement Application`(
@@ -1264,7 +1260,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion1,
+              apArea = apArea1,
             )
 
             `Given a Placement Request`(
@@ -1282,7 +1278,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion2,
+              apArea = apArea2,
             )
 
             `Given a Placement Application`(
@@ -1942,23 +1938,20 @@ class TasksTest : IntegrationTestBase() {
             val apArea1 = `Given an AP Area`()
             val apArea2 = `Given an AP Area`()
 
-            val probationRegion1 = `Given a Probation Region`(apArea = apArea1) { }
-            val probationRegion2 = `Given a Probation Region`(apArea = apArea2) { }
-
             `Given a Placement Request`(
               placementRequestAllocatedTo = user,
               assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion1,
+              apArea = apArea1,
             )
 
-            val (placementRequestRegion2AllocatedToMe, _) = `Given a Placement Request`(
+            val (apArea2AllocatedToMe, _) = `Given a Placement Request`(
               placementRequestAllocatedTo = user,
               assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion2,
+              apArea = apArea2,
             )
 
             `Given a Placement Request`(
@@ -1966,7 +1959,7 @@ class TasksTest : IntegrationTestBase() {
               assessmentAllocatedTo = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              probationRegion = probationRegion1,
+              apArea = apArea1,
             )
 
             webTestClient.get()
@@ -1980,7 +1973,7 @@ class TasksTest : IntegrationTestBase() {
                 objectMapper.writeValueAsString(
                   listOf(
                     taskTransformer.transformPlacementRequestToTask(
-                      placementRequestRegion2AllocatedToMe,
+                      apArea2AllocatedToMe,
                       "${offenderDetails.firstName} ${offenderDetails.surname}",
                     ),
                   ),
@@ -2131,10 +2124,7 @@ class TasksTest : IntegrationTestBase() {
           val apArea1 = `Given an AP Area`()
           val apArea2 = `Given an AP Area`()
 
-          val probationRegion1 = `Given a Probation Region`(apArea = apArea1) { }
-          val probationRegion2 = `Given a Probation Region`(apArea = apArea2) { }
-
-          val placementApplicationAllocatedToMeInRegion1 = `Given a Placement Application`(
+          val placementApplicationAllocatedToMeInApArea1 = `Given a Placement Application`(
             createdByUser = user,
             allocatedToUser = user,
             schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -2142,7 +2132,7 @@ class TasksTest : IntegrationTestBase() {
             },
             crn = offenderDetails.otherIds.crn,
             decision = null,
-            probationRegion = probationRegion1,
+            apArea = apArea1,
           )
 
           `Given a Placement Application`(
@@ -2153,7 +2143,7 @@ class TasksTest : IntegrationTestBase() {
             },
             crn = offenderDetails.otherIds.crn,
             decision = null,
-            probationRegion = probationRegion2,
+            apArea = apArea2,
           )
 
           `Given a Placement Application`(
@@ -2164,7 +2154,7 @@ class TasksTest : IntegrationTestBase() {
             },
             crn = offenderDetails.otherIds.crn,
             reallocated = true,
-            probationRegion = probationRegion1,
+            apArea = apArea1,
           )
 
           webTestClient.get()
@@ -2178,7 +2168,7 @@ class TasksTest : IntegrationTestBase() {
               objectMapper.writeValueAsString(
                 listOf(
                   taskTransformer.transformPlacementApplicationToTask(
-                    placementApplicationAllocatedToMeInRegion1,
+                    placementApplicationAllocatedToMeInApArea1,
                     "${offenderDetails.firstName} ${offenderDetails.surname}",
                   ),
                 ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
@@ -22,7 +22,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
-  probationRegion: ProbationRegionEntity? = null,
+  apArea: ApAreaEntity? = null,
 ): PlacementApplicationEntity {
   val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
@@ -42,7 +42,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
         }
       }
     },
-    probationRegionEntity = probationRegion,
+    apAreaEntity = apArea,
   )
 
   return placementApplicationFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -2,11 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
@@ -33,7 +33,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   mappa: String? = null,
   applicationSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
   booking: BookingEntity? = null,
-  probationRegion: ProbationRegionEntity? = null,
+  apArea: ApAreaEntity? = null,
 ): Pair<PlacementRequestEntity, ApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -71,7 +71,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
     withRiskRatings(
       risksFactory.produce(),
     )
-    withProbationRegion(probationRegion)
+    withApArea(apArea)
   }
 
   val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -23,7 +23,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   submittedAt: OffsetDateTime? = null,
   createdAt: OffsetDateTime? = null,
   isWithdrawn: Boolean = false,
-  probationRegionEntity: ProbationRegionEntity? = null,
+  apAreaEntity: ApAreaEntity? = null,
 ): Pair<AssessmentEntity, ApprovedPremisesApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -41,7 +41,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withSubmittedAt(OffsetDateTime.now())
     withReleaseType("licence")
     withIsWithdrawn(isWithdrawn)
-    withProbationRegion(probationRegionEntity)
+    withApArea(apAreaEntity)
   }
 
   val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -55,6 +55,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
@@ -63,7 +64,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
@@ -118,7 +118,7 @@ class ApplicationServiceTest {
   private val mockEmailNotificationService = mockk<EmailNotificationService>()
   private val mockAssessmentClarificationNoteTransformer = mockk<AssessmentClarificationNoteTransformer>()
   private val mockObjectMapper = mockk<ObjectMapper>()
-  private val mockProbationRegionRepository = mockk<ProbationRegionRepository>()
+  private val mockApAreaRepository = mockk<ApAreaRepository>()
   private val applicationTimelineTransformerMock = mockk<ApplicationTimelineTransformer>()
 
   private val applicationService = ApplicationService(
@@ -142,7 +142,7 @@ class ApplicationServiceTest {
     mockAssessmentClarificationNoteTransformer,
     mockObjectMapper,
     "http://frontend/applications/#id",
-    mockProbationRegionRepository,
+    mockApAreaRepository,
     applicationTimelineTransformerMock,
   )
 
@@ -1225,7 +1225,7 @@ class ApplicationServiceTest {
         InmateDetailFactory().withInOutStatus(InOutStatus.OUT).produce(),
       )
 
-      every { mockProbationRegionRepository.findByIdOrNull(any()) } returns null
+      every { mockApAreaRepository.findByIdOrNull(any()) } returns null
 
       every { mockAssessmentService.createApprovedPremisesAssessment(application) } returns ApprovedPremisesAssessmentEntityFactory()
         .withApplication(application)


### PR DESCRIPTION
This updates the `ApprovedPremisesApplicationEntity` to take an `apArea`, rather than a `probationRegion`. This has resulted in some changes to the queries when filtering tasks, as well as changes to the submission endpoint.

I've kept the legacy `probation_region_id` in the database for now (there's a migration to backfill any applications that already have probation regions), but once all applications have AP Areas by way of a backfill, we can remove this column. 