### PR TITLE
/placement-requests/dashboard now allows filtering on ap area id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -74,6 +74,7 @@ class PlacementRequestsController(
     arrivalDateStart: LocalDate?,
     arrivalDateEnd: LocalDate?,
     requestType: PlacementRequestRequestType?,
+    apAreaId: UUID?,
     page: Int?,
     sortBy: PlacementRequestSortField?,
     sortDirection: SortDirection?,
@@ -86,13 +87,14 @@ class PlacementRequestsController(
 
     val (requests, metadata) = placementRequestService.getAllActive(
       PlacementRequestService.AllActiveSearchCriteria(
-        status,
-        crn,
-        crnOrName,
-        tier?.value,
-        arrivalDateStart,
-        arrivalDateEnd,
-        requestType,
+        status = status,
+        crn = crn,
+        crnOrName = crnOrName,
+        tier = tier?.value,
+        arrivalDateStart = arrivalDateStart,
+        arrivalDateEnd = arrivalDateEnd,
+        requestType = requestType,
+        apAreaId = apAreaId,
       ),
       PageCriteria(
         sortBy = sortBy ?: PlacementRequestSortField.createdAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -84,6 +84,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
       placement_requests pq
       left join applications application on application.id = pq.application_id
       left join approved_premises_applications apa on apa.id = pq.application_id
+      left join ap_areas area on area.id = apa.ap_area_id
     where
       pq.reallocated_at IS NULL 
       AND (:status IS NULL OR pq.is_withdrawn IS FALSE)
@@ -130,6 +131,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
             (:#{#requestType?.toString()} = 'standardRelease' AND pq.is_parole IS FALSE)
         )
       )
+      AND ((CAST(:apAreaId AS pg_catalog.uuid) IS NULL) OR area.id = :apAreaId)
   """,
     nativeQuery = true,
   )
@@ -141,6 +143,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
     arrivalDateFrom: LocalDate? = null,
     arrivalDateTo: LocalDate? = null,
     requestType: PlacementRequestRequestType? = null,
+    apAreaId: UUID? = null,
     pageable: Pageable? = null,
   ): Page<PlacementRequestEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -125,6 +125,7 @@ class PlacementRequestService(
       arrivalDateFrom = searchCriteria.arrivalDateStart,
       arrivalDateTo = searchCriteria.arrivalDateEnd,
       requestType = searchCriteria.requestType,
+      apAreaId = searchCriteria.apAreaId,
       pageable = pageable,
     )
 
@@ -139,6 +140,7 @@ class PlacementRequestService(
     val arrivalDateStart: LocalDate? = null,
     val arrivalDateEnd: LocalDate? = null,
     val requestType: PlacementRequestRequestType? = null,
+    val apAreaId: UUID? = null,
   )
 
   fun getPlacementRequestForUser(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2939,6 +2939,13 @@ paths:
           description: filter by request type
           schema:
             $ref: '_shared.yml#/components/schemas/PlacementRequestRequestType'
+        - name: apAreaId
+          in: query
+          required: false
+          description: filter by approved premises area ID
+          schema:
+            type: string
+            format: uuid
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2941,6 +2941,13 @@ paths:
           description: filter by request type
           schema:
             $ref: '#/components/schemas/PlacementRequestRequestType'
+        - name: apAreaId
+          in: query
+          required: false
+          description: filter by approved premises area ID
+          schema:
+            type: string
+            format: uuid
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results


### PR DESCRIPTION
This supersedes Gareth's PR here -> https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1353 as we're now using AP Area ID instead of Probation Region ID, and it was easier to cherry pick changes into a new branch