### PR TITLE
(APS-219) Add migration job to add AP Areas to applications

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -15,6 +15,12 @@
     <ID>ForbiddenComment:AssessmentController.kt$AssessmentController$// TODO: We should carry out the pagination at the database level</ID>
     <ID>TooGenericExceptionThrown:ApplicationTimelineNoteEntityFactory.kt$ApplicationTimelineNoteEntityFactory$throw RuntimeException("Must provide a createdBy User")</ID>
     <ID>TooGenericExceptionThrown:UserTransformer.kt$UserTransformer$throw RuntimeException("CAS2 not supported")</ID>
+    <ID>TooGenericExceptionThrown:ProbationAreaMigrationJob.kt$ProbationAreaMigrationJob$throw RuntimeException("Cannot find probation region - East Midlands")</ID>
+    <ID>TooGenericExceptionThrown:ProbationAreaMigrationJob.kt$ProbationAreaMigrationJob$throw RuntimeException("Cannot find probation region - East of England")</ID>
+    <ID>TooGenericExceptionThrown:ProbationAreaMigrationJob.kt$ProbationAreaMigrationJob$throw RuntimeException("Cannot find probation region - Yorkshire &amp; The Humber")</ID>
+    <ID>TooGenericExceptionThrown:ApAreaMigrationJob.kt$ApAreaMigrationJob$throw RuntimeException("Cannot find probation region - Midlands")</ID>
+    <ID>TooGenericExceptionThrown:ApAreaMigrationJob.kt$ApAreaMigrationJob$throw RuntimeException("Cannot find probation region - North East")</ID>
+    <ID>TooGenericExceptionThrown:ApAreaMigrationJob.kt$ApAreaMigrationJob$throw RuntimeException("Cannot find probation region - South East &amp; Eastern")</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -9,7 +9,9 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
-interface ApAreaRepository : JpaRepository<ApAreaEntity, UUID>
+interface ApAreaRepository : JpaRepository<ApAreaEntity, UUID> {
+  fun findByName(name: String): ApAreaEntity?
+}
 
 @Entity
 @Table(name = "ap_areas")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApAreaMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/ApAreaMigrationJob.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import java.util.UUID
+
+@Repository
+interface ApAreaMigrationJobApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
+  @Modifying
+  @Query("UPDATE ApprovedPremisesApplicationEntity ap set ap.apArea = :apArea WHERE ap.id IN :applicationIds")
+  fun setApAreaOnApplications(applicationIds: List<UUID>, apArea: ApAreaEntity)
+
+  @Modifying
+  @Query(
+    """
+      UPDATE
+        approved_premises_applications
+      set
+        ap_area_id = (
+          SELECT
+            ap_area.id
+          from
+            users u
+            left join probation_regions pr on u.probation_region_id = pr.id
+            left join ap_areas ap_area on pr.ap_area_id = ap_area.id
+            left join applications a on a.created_by_user_id = u.id
+            left join approved_premises_applications apa on apa.id = a.id
+          where
+            a.id = approved_premises_applications.id
+        )
+      where
+        approved_premises_applications.ap_area_id is null
+    """,
+    nativeQuery = true,
+  )
+  fun setApAreaOnApplicationsFromUser()
+}
+
+val midlandsApplicationIds = listOf(
+  UUID.fromString("43cb06f2-b146-4919-9d3c-a153a79d7f36"),
+  UUID.fromString("446e01b0-8b0d-4bf7-aee8-28e1a0aeb99b"),
+  UUID.fromString("32d61661-3222-4c29-a156-acdd4d06b0b0"),
+  UUID.fromString("cabcfa1b-1929-42cc-a741-f88e108405d6"),
+)
+
+val seeApplicationIds = listOf(
+  UUID.fromString("b4b4e716-5767-4095-aea7-530c3890bea5"),
+  UUID.fromString("fab59535-8873-4ccb-a875-5fd23c4ecc63"),
+)
+
+val northEastApplicationIds = listOf(
+  UUID.fromString("8bb8342d-0432-4eb5-b977-8b58465fc329"),
+  UUID.fromString("2a7eb94f-fa8e-4038-871e-924286ea2c15"),
+  UUID.fromString("5f8be2be-7d3d-480b-998f-2b860d01cc14"),
+  UUID.fromString("72688238-8a86-4924-a560-e5bff167ebbf"),
+  UUID.fromString("ac36b31b-f384-48a3-9d30-210aea66b085"),
+  UUID.fromString("e13a6e07-4ed9-4b94-9eae-4719fbbd6eb3"),
+  UUID.fromString("e5d454b0-875b-4a2e-89d1-746c7e63f9d1"),
+  UUID.fromString("2b1b4be4-af12-4d7a-a4dc-0457e00b1975"),
+  UUID.fromString("2b76e00b-abb2-4f90-aa97-fa5244041b08"),
+  UUID.fromString("9975d567-c108-446a-9584-b0f017552bc8"),
+  UUID.fromString("a202a781-f26e-4855-90e9-152aa8ebad8e"),
+  UUID.fromString("c996ec67-def4-4e63-8a20-52affe9f4988"),
+  UUID.fromString("d620c1c3-e3de-4910-9532-e2b6128cd439"),
+)
+
+class ApAreaMigrationJob(
+  private val probationAreaMigrationJobApplicationRepository: ApAreaMigrationJobApplicationRepository,
+  private val apAreaRepository: ApAreaRepository,
+  private val transactionTemplate: TransactionTemplate,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+
+  override fun process() {
+    val midlands = apAreaRepository.findByName("Midlands") ?: throw RuntimeException("Cannot find probation region - Midlands")
+    val southEastAndEastern = apAreaRepository.findByName("South East & Eastern") ?: throw RuntimeException("Cannot find probation region - South East & Eastern")
+    val northEast = apAreaRepository.findByName("North East") ?: throw RuntimeException("Cannot find probation region - North East")
+
+    transactionTemplate.executeWithoutResult {
+      probationAreaMigrationJobApplicationRepository.setApAreaOnApplications(midlandsApplicationIds, midlands)
+      probationAreaMigrationJobApplicationRepository.setApAreaOnApplications(seeApplicationIds, southEastAndEastern)
+      probationAreaMigrationJobApplicationRepository.setApAreaOnApplications(northEastApplicationIds, northEast)
+    }
+
+    transactionTemplate.executeWithoutResult {
+      probationAreaMigrationJobApplicationRepository.setApAreaOnApplicationsFromUser()
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -8,9 +8,12 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJobApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.BookingStatusMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.InmateStatusOnSubmissionMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
@@ -56,6 +59,12 @@ class MigrationJobService(
           throttle,
           transactionTemplate,
           applicationContext.getBean(PrisonsApiClient::class.java),
+        )
+
+        MigrationJobType.applicationApAreas -> ApAreaMigrationJob(
+          applicationContext.getBean(ApAreaMigrationJobApplicationRepository::class.java),
+          applicationContext.getBean(ApAreaRepository::class.java),
+          transactionTemplate,
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3239,6 +3239,7 @@ components:
         - update_all_users_from_community_api
         - update_sentence_type_and_situation
         - update_booking_status
+        - update_application_ap_areas
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7578,6 +7578,7 @@ components:
         - update_all_users_from_community_api
         - update_sentence_type_and_situation
         - update_booking_status
+        - update_application_ap_areas
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3667,6 +3667,7 @@ components:
         - update_all_users_from_community_api
         - update_sentence_type_and_situation
         - update_booking_status
+        - update_application_ap_areas
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApAreaMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApAreaMigrationTest.kt
@@ -1,0 +1,136 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.midlandsApplicationIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.northEastApplicationIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.seeApplicationIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+import java.time.OffsetDateTime
+
+class ApAreaMigrationTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @Test
+  fun `it should migrate the AP Area of all applications`() {
+    probationAreaProbationRegionMappingRepository.deleteAll()
+    probationDeliveryUnitRepository.deleteAll()
+    probationRegionRepository.deleteAll()
+    apAreaRepository.deleteAll()
+
+    val apArea1 = apAreaEntityFactory.produceAndPersist()
+    val apArea2 = apAreaEntityFactory.produceAndPersist()
+
+    val probationRegion1 = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apArea1)
+    }
+
+    val probationRegion2 = probationRegionEntityFactory.produceAndPersist {
+      withApArea(apArea2)
+    }
+
+    val midlandsApArea = apAreaEntityFactory.produceAndPersist {
+      withName("Midlands")
+    }
+    val southEastAndEasternApArea = apAreaEntityFactory.produceAndPersist {
+      withName("South East & Eastern")
+    }
+    val northEastApArea = apAreaEntityFactory.produceAndPersist {
+      withName("North East")
+    }
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val midlandsApplications = midlandsApplicationIds.map {
+      approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withId(it)
+        withApplicationSchema(applicationSchema)
+        withApArea(null)
+        withYieldedCreatedByUser {
+          userEntityFactory.produceAndPersist {
+            withProbationRegion(probationRegion1)
+            withApArea(apArea1)
+          }
+        }
+      }
+    }
+
+    val seeApplications = seeApplicationIds.map {
+      approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withId(it)
+        withApplicationSchema(applicationSchema)
+        withApArea(null)
+        withYieldedCreatedByUser {
+          userEntityFactory.produceAndPersist {
+            withProbationRegion(probationRegion1)
+            withApArea(apArea1)
+          }
+        }
+      }
+    }
+
+    val northEastApplications = northEastApplicationIds.map {
+      approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withId(it)
+        withApplicationSchema(applicationSchema)
+        withApArea(null)
+        withYieldedCreatedByUser {
+          userEntityFactory.produceAndPersist {
+            withProbationRegion(probationRegion1)
+            withApArea(apArea1)
+          }
+        }
+      }
+    }
+
+    val apArea1Applications = approvedPremisesApplicationEntityFactory.produceAndPersistMultiple(3) {
+      withApplicationSchema(applicationSchema)
+      withApArea(null)
+      withSubmittedAt(OffsetDateTime.now())
+      withYieldedCreatedByUser {
+        userEntityFactory.produceAndPersist {
+          withProbationRegion(probationRegion1)
+          withApArea(apArea1)
+        }
+      }
+    }.toMutableList()
+
+    val apArea2Applications = approvedPremisesApplicationEntityFactory.produceAndPersistMultiple(5) {
+      withApplicationSchema(applicationSchema)
+      withApArea(null)
+      withSubmittedAt(OffsetDateTime.now())
+      withYieldedCreatedByUser {
+        userEntityFactory.produceAndPersist {
+          withProbationRegion(probationRegion2)
+          withApArea(apArea2)
+        }
+      }
+    }.toMutableList()
+
+    migrationJobService.runMigrationJob(MigrationJobType.applicationApAreas)
+
+    assertApplicationsHaveTheCorrectApArea(midlandsApplications, midlandsApArea)
+    assertApplicationsHaveTheCorrectApArea(seeApplications, southEastAndEasternApArea)
+    assertApplicationsHaveTheCorrectApArea(northEastApplications, northEastApArea)
+
+    assertApplicationsHaveTheCorrectApArea(apArea1Applications, apArea1)
+    assertApplicationsHaveTheCorrectApArea(apArea2Applications, apArea2)
+  }
+
+  private fun assertApplicationsHaveTheCorrectApArea(applications: List<ApprovedPremisesApplicationEntity>, apArea: ApAreaEntity) {
+    val apIds = applications.map { it.id }
+    val updatedApplications = approvedPremisesApplicationRepository.findAllById(apIds)
+
+    updatedApplications.forEach {
+      assertThat(it.apArea).isNotNull()
+      assertThat(it.apArea!!.id).isEqualTo(apArea.id)
+    }
+  }
+}


### PR DESCRIPTION
This adds a migration job to add an AP area to all Approved Premises applications. In most circumstances, these will be the AP Area of the submitting user, but there are a small subset of applications, where the user and area do not match up. After a review with Sararh, we’ve got a list of these handful of applications, and have the IDs of all the applications and associated AP Area.

Once these are run, we can then update the remaining applications with the AP area of the submitting user.