### PR TITLE
(APS-165) Add new licence release type options

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2091,6 +2091,8 @@ components:
         - pss
         - in_community
         - not_applicable
+        - extendedDeterminateLicence
+        - paroleDirectedLicence
     SentenceTypeOption:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6430,6 +6430,8 @@ components:
         - pss
         - in_community
         - not_applicable
+        - extendedDeterminateLicence
+        - paroleDirectedLicence
     SentenceTypeOption:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2519,6 +2519,8 @@ components:
         - pss
         - in_community
         - not_applicable
+        - extendedDeterminateLicence
+        - paroleDirectedLicence
     SentenceTypeOption:
       type: string
       enum:


### PR DESCRIPTION
This is required to set the correct referral type values in Delius. Once this is in, we can update the frontend to allow the relevant types to be set.