### PR TITLE
Delete two production CAS2 applications used for testing

### DIFF
--- a/src/main/resources/db/migration/all/20240123121855__delete_cas_2_applications_used_for_production_test_run.sql
+++ b/src/main/resources/db/migration/all/20240123121855__delete_cas_2_applications_used_for_production_test_run.sql
@@ -1,0 +1,21 @@
+BEGIN TRANSACTION;
+
+DELETE FROM cas_2_status_updates
+WHERE application_id IN (
+  'a0cca0dc-2fad-4286-b380-4585e8a88bc0',
+  '323b4ae1-d63e-4af8-9f5e-010148cac334'
+);
+
+DELETE FROM domain_events
+WHERE application_id IN (
+  'a0cca0dc-2fad-4286-b380-4585e8a88bc0',
+  '323b4ae1-d63e-4af8-9f5e-010148cac334'
+);
+
+DELETE FROM cas_2_applications
+WHERE id IN (
+  'a0cca0dc-2fad-4286-b380-4585e8a88bc0',
+  '323b4ae1-d63e-4af8-9f5e-010148cac334'
+);
+
+COMMIT;


### PR DESCRIPTION
We had planned to use realistic referral data and leave these referrals in the service. In practice there were a couple of problems with this which mean we want to remove these:

1. Authorship was from the team
2. These referrals might not receive update from Nacro
3. The referral might be double counted somewhere downstream in reporting

We could delete this manually on the prod command line but want to get this more sensitive change in as code where it can be reviewed.

The application IDs are taken from prod:
<img width="811" alt="Screenshot 2024-01-23 at 16 09 30" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/1ce6f281-1fc8-4247-9643-4e55f70b56a9">



Are there any associations I've missed?

[Testing recording in Slack](https://mojdt.slack.com/archives/C05GEPLBRN3/p1706026107319099?thread_ts=1706026069.051109&cid=C05GEPLBRN3).