### PR TITLE
Placement Application Report Date Filter Fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntityReportRow.kt
@@ -99,8 +99,8 @@ interface PlacementApplicationEntityReportRowRepository : JpaRepository<Placemen
       where
         pa.reallocated_at is null
         AND pa.submitted_at is not null
-        AND date_part('month', application.submitted_at) = :month
-        AND date_part('year', application.submitted_at) = :year
+        AND date_part('month', pa.submitted_at) = :month
+        AND date_part('year', pa.submitted_at) = :year
         AND application.service = 'approved-premises';
     """,
     nativeQuery = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PlacementApplicationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PlacementApplicationTestRepository.kt
@@ -1,12 +1,24 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import java.time.OffsetDateTime
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Repository
 interface PlacementApplicationTestRepository : JpaRepository<PlacementApplicationEntity, UUID> {
   fun findByApplicationAndReallocatedAtNull(application: ApplicationEntity): PlacementApplicationEntity
+
+  @Transactional
+  @Modifying
+  @Query(
+    "UPDATE placement_applications SET submitted_at = :submittedAt WHERE id = :id",
+    nativeQuery = true,
+  )
+  fun updateSubmittedOn(id: UUID, submittedAt: OffsetDateTime)
 }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-222

Previously the placement application report query would filter on approved_premises_applications submitted on the given month/day. This is incorrect, it should of filtered on placement_applications submitted on the given month/day.