### PR TITLE
Add Application Withdrawable Endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -426,6 +427,23 @@ class ApplicationsController(
     }
 
     return ResponseEntity.ok(placementApplications)
+  }
+
+  override fun applicationsApplicationIdWithdrawablesGet(applicationId: UUID): ResponseEntity<List<Withdrawable>> {
+    val user = userService.getUserForRequest()
+
+    when (
+      val applicationResult =
+        applicationService.getApplicationForUsername(applicationId, user.deliusUsername)
+    ) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> applicationResult.entity
+    }
+
+    val withdrawables = applicationService.getWithdrawables(applicationId)
+
+    return ResponseEntity.ok(withdrawables)
   }
 
   private fun getPersonDetailAndTransform(application: ApplicationEntity, user: UserEntity): Application {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1WithdrawableDateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1WithdrawableDateRepository.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Repository
+interface Cas1WithdrawableDateRepository : JpaRepository<Cas1WithdrawableDateRepository.Cas1WithdrawableDateEntity, Unit> {
+
+  @Query(
+    value = """
+        SELECT cast(pr.id as text) as id,
+               'PLACEMENT_REQUEST' as type,
+               pr.expected_arrival as startDate,
+               pr.expected_arrival + (interval '1' day * pr.duration) as endDate
+        FROM   placement_requests pr
+        WHERE  pr.application_id = :applicationId AND 
+               pr.reallocated_at IS NULL AND 
+               pr.booking_id IS NULL AND
+               pr.is_withdrawn IS FALSE
+      UNION ALL
+        SELECT cast(pa.id as text) as id,
+               'PLACEMENT_APPLICATION' as type,
+               pad.expected_arrival as startDate,
+               pad.expected_arrival + (interval '1' day * pad.duration) as endDate
+        FROM   placement_applications pa
+        INNER JOIN placement_application_dates pad ON pad.placement_application_id = pa.id 
+        WHERE  pa.application_id = :applicationId AND
+               pa.submitted_at IS NOT NULL AND
+               pa.reallocated_at IS NULL AND
+               pa.decision IS NULL
+      UNION ALL
+        SELECT cast(b.id as text) as id,
+               'BOOKING' as type,
+               b.arrival_date as startDate,
+               b.departure_date as endDate
+        FROM   bookings b       
+        WHERE  b.application_id = :applicationId AND
+               (b.status IS NULL or b.status NOT IN ('cancelled')) AND
+               NOT EXISTS (SELECT 1 from arrivals WHERE arrivals.booking_id = b.id)
+    """,
+    nativeQuery = true,
+  )
+  fun getWithdrawablesForApplication(applicationId: UUID): List<Cas1WithdrawableDate>
+
+  interface Cas1WithdrawableDate {
+    val id: UUID
+    val type: WithdrawableDateType
+    val startDate: LocalDate
+    val endDate: LocalDate
+  }
+
+  enum class WithdrawableDateType {
+    PLACEMENT_REQUEST,
+    PLACEMENT_APPLICATION,
+    BOOKING,
+  }
+
+  @Entity
+  data class Cas1WithdrawableDateEntity(
+    @Id
+    val id: UUID,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -137,7 +137,7 @@ data class PlacementApplicationEntity(
   @OneToMany(mappedBy = "placementApplication")
   var placementRequests: MutableList<PlacementRequestEntity>,
 ) {
-  fun canBeWithdrawn() = placementRequests.all { it.booking == null }
+  fun canBeWithdrawn() = decision == null
 
   override fun toString() = "PlacementApplicationEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -37,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1WithdrawableDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -58,6 +60,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Cas1WithdrawableDateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import java.time.Instant
@@ -101,6 +104,8 @@ class ApplicationService(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
   private val apAreaRepository: ApAreaRepository,
   private val applicationTimelineTransformer: ApplicationTimelineTransformer,
+  private val cas1WithdrawableDateRepository: Cas1WithdrawableDateRepository,
+  private val cas1WithdrawableDateTransformer: Cas1WithdrawableDateTransformer,
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationSummary> {
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
@@ -1070,5 +1075,11 @@ class ApplicationService(
   ): ApplicationTimelineNote {
     val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, note, user)
     return applicationTimelineNoteTransformer.transformJpaToApi(savedNote)
+  }
+
+  fun getWithdrawables(applicationId: UUID): List<Withdrawable> {
+    val withdrawableDate = cas1WithdrawableDateRepository.getWithdrawablesForApplication(applicationId)
+
+    return cas1WithdrawableDateTransformer.transformJpaToAPI(withdrawableDate)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/Cas1WithdrawableDateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/Cas1WithdrawableDateTransformer.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1WithdrawableDateRepository.Cas1WithdrawableDate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1WithdrawableDateRepository.WithdrawableDateType
+
+@Component
+class Cas1WithdrawableDateTransformer {
+
+  fun transformJpaToAPI(cas1WithdrawableDates: List<Cas1WithdrawableDate>): List<Withdrawable> {
+    return cas1WithdrawableDates
+      .groupingBy { it.id }
+      .fold(
+        initialValueSelector = { key, first -> Withdrawable(key, toType(first.type), emptyList()) },
+        operation = { _, accumulator, element -> accumulator.copy(dates = accumulator.dates + toDatePeriod(element)) },
+      ).values.toList()
+  }
+
+  private fun toDatePeriod(cas1WithdrawableDate: Cas1WithdrawableDate) =
+    DatePeriod(cas1WithdrawableDate.startDate, cas1WithdrawableDate.endDate)
+
+  private fun toType(type: WithdrawableDateType) = when (type) {
+    WithdrawableDateType.PLACEMENT_REQUEST -> WithdrawableType.placementRequest
+    WithdrawableDateType.PLACEMENT_APPLICATION -> WithdrawableType.placementApplication
+    WithdrawableDateType.BOOKING -> WithdrawableType.booking
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3981,6 +3981,40 @@ components:
         - UnknownPerson
         - FullPersonInfo
         - RestrictedPersonInfo
+    Withdrawable:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          $ref: '#/components/schemas/WithdrawableType'
+        dates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatePeriod'
+      required:
+        - id
+        - type
+        - dates
+    DatePeriod:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+        - startDate
+        - endDate
+    WithdrawableType:
+      type: string
+      enum:
+        - placement_request
+        - placement_application
+        - booking
     WithdrawalReason:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2193,6 +2193,34 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /applications/{applicationId}/withdrawables:
+    get:
+      tags:
+        - Operations on applications
+      summary: Get withdrawable items associated with this application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Withdrawable'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /beds/search:
     post:
       summary: Searches for available Beds within the given parameters

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2195,6 +2195,34 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/withdrawables:
+    get:
+      tags:
+        - Operations on applications
+      summary: Get withdrawable items associated with this application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Withdrawable'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /beds/search:
     post:
       summary: Searches for available Beds within the given parameters
@@ -8326,6 +8354,40 @@ components:
         - UnknownPerson
         - FullPersonInfo
         - RestrictedPersonInfo
+    Withdrawable:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          $ref: '#/components/schemas/WithdrawableType'
+        dates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatePeriod'
+      required:
+        - id
+        - type
+        - dates
+    DatePeriod:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+        - startDate
+        - endDate
+    WithdrawableType:
+      type: string
+      enum:
+        - placement_request
+        - placement_application
+        - booking
     WithdrawalReason:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4409,6 +4409,40 @@ components:
         - UnknownPerson
         - FullPersonInfo
         - RestrictedPersonInfo
+    Withdrawable:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          $ref: '#/components/schemas/WithdrawableType'
+        dates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatePeriod'
+      required:
+        - id
+        - type
+        - dates
+    DatePeriod:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+        - startDate
+        - endDate
+    WithdrawableType:
+      type: string
+      enum:
+        - placement_request
+        - placement_application
+        - booking
     WithdrawalReason:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementDateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementDateEntityFactory.kt
@@ -20,6 +20,14 @@ class PlacementDateEntityFactory : Factory<PlacementDateEntity> {
     this.placementApplication = { placementApplication }
   }
 
+  fun withExpectedArrival(expectedArrival: LocalDate) = apply {
+    this.expectedArrival = { expectedArrival }
+  }
+
+  fun withDuration(duration: Int) = apply {
+    this.duration = { duration }
+  }
+
   override fun produce(): PlacementDateEntity = PlacementDateEntity(
     id = this.id(),
     createdAt = this.createdAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1080,7 +1080,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `withdrawing a submitted placement request application returns successfully and updates placement request isWithdrawn`() {
+    fun `withdrawing a submitted placement request application returns successfully`() {
       `Given a User`(roles = listOf(UserRole.CAS1_MATCHER), qualifications = listOf()) { _, _ ->
         `Given a User` { user, jwt ->
           `Given a Placement Application`(
@@ -1091,26 +1091,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             decision = null,
             submittedAt = OffsetDateTime.now(),
           ) { placementApplicationEntity ->
-
-            val placementRequirements = placementRequirementsFactory.produceAndPersist {
-              withApplication(placementApplicationEntity.application)
-              withAssessment(placementApplicationEntity.application.assessments.first())
-              withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
-              withDesirableCriteria(
-                characteristicEntityFactory.produceAndPersistMultiple(5),
-              )
-              withEssentialCriteria(
-                characteristicEntityFactory.produceAndPersistMultiple(3),
-              )
-            }
-
-            val placementRequests = placementRequestFactory.produceAndPersistMultiple(4) {
-              withAllocatedToUser(user)
-              withPlacementApplication(placementApplicationEntity)
-              withApplication(placementApplicationEntity.application)
-              withAssessment(placementApplicationEntity.application.assessments.first())
-              withPlacementRequirements(placementRequirements)
-            }
 
             CommunityAPI_mockSuccessfulOffenderDetailsCall(
               OffenderDetailsSummaryFactory()
@@ -1137,12 +1117,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
                 placementApplicationEntity.schemaVersion.id == it.schemaVersion &&
                 placementApplicationEntity.createdAt.toInstant() == it.createdAt &&
                 serializableToJsonNode(placementApplicationEntity.document) == serializableToJsonNode(it.document)
-            }
-
-            placementRequests.map {
-              val request = placementRequestRepository.findByIdOrNull(it.id)
-              assertThat(request).isNotNull
-              assertThat(request?.isWithdrawn).isEqualTo(true)
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -63,6 +63,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1WithdrawableDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
@@ -89,6 +90,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Cas1WithdrawableDateTransformer
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
@@ -120,6 +122,8 @@ class ApplicationServiceTest {
   private val mockObjectMapper = mockk<ObjectMapper>()
   private val mockApAreaRepository = mockk<ApAreaRepository>()
   private val applicationTimelineTransformerMock = mockk<ApplicationTimelineTransformer>()
+  private val cas1WithdrawableDateRepository = mockk<Cas1WithdrawableDateRepository>()
+  private val cas1WithdrawableDateTransformer = mockk<Cas1WithdrawableDateTransformer>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
@@ -144,6 +148,8 @@ class ApplicationServiceTest {
     "http://frontend/applications/#id",
     mockApAreaRepository,
     applicationTimelineTransformerMock,
+    cas1WithdrawableDateRepository,
+    cas1WithdrawableDateTransformer,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/Cas1WithdrawableDateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/Cas1WithdrawableDateTransformerTest.kt
@@ -1,0 +1,170 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1WithdrawableDateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1WithdrawableDateRepository.WithdrawableDateType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Cas1WithdrawableDateTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1WithdrawableDateTransformerTest {
+
+  private val transformer = Cas1WithdrawableDateTransformer()
+
+  class Cas1WithdrawableDateImpl(
+    override val id: UUID,
+    override val type: WithdrawableDateType,
+    override val startDate: LocalDate,
+    override val endDate: LocalDate,
+  ) :
+    Cas1WithdrawableDateRepository.Cas1WithdrawableDate
+
+  @Test
+  fun `Should successfully transform withdrawable of type placement request`() {
+    val id = UUID.randomUUID()
+    val startDate = LocalDate.now().minusDays(1)
+    val endDate = LocalDate.now().plusDays(1)
+
+    val result = transformer.transformJpaToAPI(
+      listOf(
+        Cas1WithdrawableDateImpl(
+          id,
+          WithdrawableDateType.PLACEMENT_REQUEST,
+          startDate,
+          endDate,
+        ),
+      ),
+    )
+
+    assertThat(result).hasSize(1)
+    assertThat(result).contains(
+      Withdrawable(
+        id,
+        WithdrawableType.placementRequest,
+        listOf(DatePeriod(startDate, endDate)),
+      ),
+    )
+  }
+
+  @Test
+  fun `Should successfully transform withdrawable of type placement application`() {
+    val id = UUID.randomUUID()
+    val startDate = LocalDate.now().minusDays(1)
+    val endDate = LocalDate.now().plusDays(1)
+
+    val result = transformer.transformJpaToAPI(
+      listOf(
+        Cas1WithdrawableDateImpl(
+          id,
+          WithdrawableDateType.PLACEMENT_APPLICATION,
+          startDate,
+          endDate,
+        ),
+      ),
+    )
+
+    assertThat(result).hasSize(1)
+    assertThat(result).contains(
+      Withdrawable(
+        id,
+        WithdrawableType.placementApplication,
+        listOf(DatePeriod(startDate, endDate)),
+      ),
+    )
+  }
+
+  @Test
+  fun `Should successfully transform withdrawable of type booking`() {
+    val id = UUID.randomUUID()
+    val startDate = LocalDate.now().minusDays(1)
+    val endDate = LocalDate.now().plusDays(1)
+
+    val result = transformer.transformJpaToAPI(
+      listOf(
+        Cas1WithdrawableDateImpl(
+          id,
+          WithdrawableDateType.BOOKING,
+          startDate,
+          endDate,
+        ),
+      ),
+    )
+
+    assertThat(result).hasSize(1)
+    assertThat(result).contains(
+      Withdrawable(
+        id,
+        WithdrawableType.booking,
+        listOf(DatePeriod(startDate, endDate)),
+      ),
+    )
+  }
+
+  @Test
+  fun `Should successfully flatten withdrawable with multiple entries into single entry`() {
+    val id = UUID.randomUUID()
+    val startDate1 = LocalDate.now().minusDays(1)
+    val endDate1 = LocalDate.now().plusDays(1)
+    val startDate2 = LocalDate.now().minusDays(2)
+    val endDate2 = LocalDate.now().plusDays(2)
+    val startDate3 = LocalDate.now().minusDays(3)
+    val endDate3 = LocalDate.now().plusDays(3)
+
+    val otherId = UUID.randomUUID()
+    val otherStartDate = LocalDate.now().minusDays(10)
+    val otherEndDate = LocalDate.now().plusDays(10)
+
+    val result = transformer.transformJpaToAPI(
+      listOf(
+        Cas1WithdrawableDateImpl(
+          id,
+          WithdrawableDateType.PLACEMENT_APPLICATION,
+          startDate1,
+          endDate1,
+        ),
+        Cas1WithdrawableDateImpl(
+          id,
+          WithdrawableDateType.PLACEMENT_APPLICATION,
+          startDate2,
+          endDate2,
+        ),
+        Cas1WithdrawableDateImpl(
+          otherId,
+          WithdrawableDateType.PLACEMENT_REQUEST,
+          otherStartDate,
+          otherEndDate,
+        ),
+        Cas1WithdrawableDateImpl(
+          id,
+          WithdrawableDateType.PLACEMENT_APPLICATION,
+          startDate3,
+          endDate3,
+        ),
+      ),
+    )
+
+    assertThat(result).hasSize(2)
+    assertThat(result).contains(
+      Withdrawable(
+        id,
+        WithdrawableType.placementApplication,
+        listOf(
+          DatePeriod(startDate1, endDate1),
+          DatePeriod(startDate2, endDate2),
+          DatePeriod(startDate3, endDate3),
+        ),
+      ),
+      Withdrawable(
+        otherId,
+        WithdrawableType.placementRequest,
+        listOf(
+          DatePeriod(otherStartDate, otherEndDate),
+        ),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequire
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
 import java.time.OffsetDateTime
 
@@ -105,7 +106,7 @@ class PlacementApplicationTransformerTest {
   }
 
   @Test
-  fun `transformJpaToApi returns canBeWithdrawn when associated bookings are present`() {
+  fun `transformJpaToApi returns canBeWithdrawn false if a decision has been made`() {
     val data = "{\"data\": \"something\"}"
     val document = "{\"document\": \"something\"}"
     val placementApplication = PlacementApplicationEntityFactory()
@@ -113,37 +114,8 @@ class PlacementApplicationTransformerTest {
       .withApplication(applicationMock)
       .withData(data)
       .withDocument(document)
+      .withDecision(PlacementApplicationDecision.ACCEPTED)
       .produce()
-
-    val placementRequest = PlacementRequestEntityFactory()
-      .withPlacementRequirements(
-        PlacementRequirementsEntityFactory()
-          .withApplication(application)
-          .withAssessment(assessment)
-          .produce(),
-      )
-      .withApplication(application)
-      .withPlacementApplication(placementApplication)
-      .withAssessment(assessment)
-      .withAllocatedToUser(user)
-      .produce()
-
-    val premisesEntity = ApprovedPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
-
-    placementRequest.booking = BookingEntityFactory()
-      .withYieldedPremises { premisesEntity }
-      .produce()
-
-    placementApplication.placementRequests = mutableListOf(
-      placementRequest,
-    )
 
     val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
 


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-245

The /application/{application-id}/withdrawable endpoint can be used to provide a list of entities that can be withdrawn. These will be one of the following three types:

* Placement Request
* Placement Application
* Booking

There are also circumstances under which the Application itself can be withdrawn which should be considered before calling this endpoint (in those cases the endpoint would logically return an empty list).

As part of this change the placement application logic has also been simplified to only allow a placement application to be withdrawn if no decision has been made against it (previously it would allow ‘accepted’ applications if the associated placement requests had no bookings). Accordingly, we’ve removed the logic that would ‘cascade’ withdrawals from placement applications to placement request because withdrawals of these entities is now either/or.