### PR TITLE
[APS-192] Add descriptions to timeline for domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.domainevents
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Component
+class DomainEventDescriber(
+  private val domainEventService: DomainEventService,
+) {
+  fun getDescription(domainEventSummary: DomainEventSummary): String? {
+    return when (domainEventSummary.type) {
+      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> "The application was submitted"
+      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> buildApplicationAssessedDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> buildBookingMadeDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> buildPersonArrivedDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> buildPersonNotArrivedDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> buildPersonDepartedDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> buildBookingNotMadeDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> buildBookingCancelledDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> "The booking had its arrival or departure date changed"
+      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> "The application was withdrawn"
+      else -> throw IllegalArgumentException("Only CAS1 is currently supported")
+    }
+  }
+
+  private fun buildApplicationAssessedDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getApplicationAssessedDomainEvent(domainEventSummary.id())
+    return event.describe { "The application was assessed and ${it.eventDetails.decision.lowercase()}" }
+  }
+
+  private fun buildBookingMadeDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getBookingMadeEvent(domainEventSummary.id())
+    return event.describe { "A booking was made for between ${it.eventDetails.arrivalOn} and ${it.eventDetails.departureOn}" }
+  }
+
+  private fun buildPersonArrivedDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getPersonArrivedEvent(domainEventSummary.id())
+    return event.describe { "The person moved into the premises on ${LocalDate.ofInstant(it.eventDetails.arrivedAt, ZoneOffset.UTC)}" }
+  }
+
+  private fun buildPersonNotArrivedDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getPersonNotArrivedEvent(domainEventSummary.id())
+    return event.describe { "The person was due to move into the premises on ${it.eventDetails.expectedArrivalOn} but did not arrive" }
+  }
+
+  private fun buildPersonDepartedDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getPersonDepartedEvent(domainEventSummary.id())
+    return event.describe { "The person moved out of the premises on ${LocalDate.ofInstant(it.eventDetails.departedAt, ZoneOffset.UTC)}" }
+  }
+
+  private fun buildBookingNotMadeDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getBookingNotMadeEvent(domainEventSummary.id())
+    return event.describe { "A booking was not made for the placement request. The reason was: ${it.eventDetails.failureDescription}" }
+  }
+
+  private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
+    return event.describe { "The booking was cancelled. The reason was: ${it.eventDetails.cancellationReason}" }
+  }
+
+  private fun DomainEventSummary.id(): UUID = UUID.fromString(this.id)
+  private fun <T> DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.domainevents.DomainEventDescriber
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -15,6 +16,7 @@ class ApplicationTimelineTransformer(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.assessment}") private val assessmentUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
+  private val domainEventDescriber: DomainEventDescriber,
 ) {
 
   fun transformDomainEventSummaryToTimelineEvent(domainEventSummary: DomainEventSummary): TimelineEvent {
@@ -29,6 +31,7 @@ class ApplicationTimelineTransformer(
       type = transformDomainEventTypeToTimelineEventType(domainEventSummary.type),
       occurredAt = domainEventSummary.occurredAt.toInstant(),
       associatedUrls = associatedUrls,
+      content = domainEventDescriber.getDescription(domainEventSummary),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -57,6 +58,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
 
   fun withData(data: String) = apply {
     this.data = { data }
+  }
+
+  fun withData(data: Any) = apply {
+    this.data = { ObjectMapper().findAndRegisterModules().writeValueAsString(data) }
   }
 
   fun withService(service: ServiceName) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -1,0 +1,248 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingNotMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.domainevents.DomainEventDescriber
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationAssessedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonArrivedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonDepartedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonNotArrivedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+class DomainEventDescriberTest {
+  private val mockDomainEventService = mockk<DomainEventService>()
+
+  private val domainEventDescriber = DomainEventDescriber(mockDomainEventService)
+
+  @Test
+  fun `Returns expected description for application submitted event`() {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED)
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The application was submitted")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["accepted", "rejected"])
+  fun `Returns expected description for application assessed event`(decision: String) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED)
+
+    every { mockDomainEventService.getApplicationAssessedDomainEvent(any()) } returns buildDomainEvent {
+      ApplicationAssessedEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.application.assessed",
+        eventDetails = ApplicationAssessedFactory()
+          .withDecision(decision)
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The application was assessed and $decision")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["2024-01-01,2024-04-01", "2024-01-02,2024-04-02"])
+  fun `Returns expected description for booking made event`(arrivalDate: LocalDate, departureDate: LocalDate) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_MADE)
+
+    every { mockDomainEventService.getBookingMadeEvent(any()) } returns buildDomainEvent {
+      BookingMadeEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.booking.made",
+        eventDetails = BookingMadeFactory()
+          .withArrivalOn(arrivalDate)
+          .withDepartureOn(departureDate)
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("A booking was made for between $arrivalDate and $departureDate")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["2024-01-01", "2024-01-02"])
+  fun `Returns expected description for person arrived event`(arrivalDate: LocalDate) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED)
+
+    every { mockDomainEventService.getPersonArrivedEvent(any()) } returns buildDomainEvent {
+      PersonArrivedEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.person.arrived",
+        eventDetails = PersonArrivedFactory()
+          .withArrivedAt(arrivalDate.atTime(12, 34, 56).toInstant(ZoneOffset.UTC))
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The person moved into the premises on $arrivalDate")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["2024-01-01", "2024-01-02"])
+  fun `Returns expected description for person not arrived event`(expectedArrivalDate: LocalDate) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED)
+
+    every { mockDomainEventService.getPersonNotArrivedEvent(any()) } returns buildDomainEvent {
+      PersonNotArrivedEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.person.not-arrived",
+        eventDetails = PersonNotArrivedFactory()
+          .withExpectedArrivalOn(expectedArrivalDate)
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The person was due to move into the premises on $expectedArrivalDate but did not arrive")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["2024-04-01", "2024-04-02"])
+  fun `Returns expected description for person departed event`(departureDate: LocalDate) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
+
+    every { mockDomainEventService.getPersonDepartedEvent(any()) } returns buildDomainEvent {
+      PersonDepartedEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.person.departed",
+        eventDetails = PersonDepartedFactory()
+          .withDepartedAt(departureDate.atTime(12, 34, 56).toInstant(ZoneOffset.UTC))
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The person moved out of the premises on $departureDate")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["Reason A", "Reason B"])
+  fun `Returns expected description for booking not made event`(reason: String) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE)
+
+    every { mockDomainEventService.getBookingNotMadeEvent(any()) } returns buildDomainEvent {
+      BookingNotMadeEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.booking.not-made",
+        eventDetails = BookingNotMadeFactory()
+          .withFailureDescription(reason)
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("A booking was not made for the placement request. The reason was: $reason")
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["Reason A", "Reason B"])
+  fun `Returns expected description for booking cancelled event`(reason: String) {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
+
+    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
+      BookingCancelledEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = "approved-premises.booking.cancelled",
+        eventDetails = BookingCancelledFactory()
+          .withCancellationReason(reason)
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The booking was cancelled. The reason was: $reason")
+  }
+
+  @Test
+  fun `Returns expected description for booking changed event`() {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED)
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The booking had its arrival or departure date changed")
+  }
+
+  @Test
+  fun `Returns expected description for application withdrawn event`() {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN)
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("The application was withdrawn")
+  }
+
+  private fun <T> buildDomainEvent(builder: (UUID) -> T): DomainEvent<T> {
+    val id = UUID.randomUUID()
+    val applicationId = UUID.randomUUID()
+
+    return DomainEvent(
+      id = id,
+      applicationId = applicationId,
+      crn = "SOME-CRN",
+      occurredAt = Instant.now(),
+      data = builder(id),
+    )
+  }
+}
+
+data class DomainEventSummaryImpl(
+  override val id: String,
+  override val type: DomainEventType,
+  override val occurredAt: Timestamp,
+  override val applicationId: UUID?,
+  override val assessmentId: UUID?,
+  override val bookingId: UUID?,
+  override val premisesId: UUID?,
+) : DomainEventSummary {
+  companion object {
+    fun ofType(type: DomainEventType) = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = type,
+      occurredAt = Timestamp.from(Instant.now()),
+      applicationId = null,
+      assessmentId = null,
+      bookingId = null,
+      premisesId = null,
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 
+import io.mockk.every
+import io.mockk.mockk
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -9,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.domainevents.DomainEventDescriber
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
@@ -19,11 +22,13 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 class ApplicationTimelineTransformerTest {
+  private val mockDomainEventDescriber = mockk<DomainEventDescriber>()
 
   private val applicationTimelineTransformer = ApplicationTimelineTransformer(
     UrlTemplate("http://somehost:3000/applications/#id"),
     UrlTemplate("http://somehost:3000/assessments/#id"),
     UrlTemplate("http://somehost:3000/premises/#premisesId/bookings/#bookingId"),
+    mockDomainEventDescriber,
   )
 
   data class DomainEventSummaryImpl(
@@ -49,12 +54,16 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
     )
+
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
     Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
       TimelineEvent(
         id = domainEvent.id,
         type = timelineEventType,
         occurredAt = domainEvent.occurredAt.toInstant(),
         associatedUrls = emptyList(),
+        content = "Some event",
       ),
     )
   }
@@ -82,6 +91,8 @@ class ApplicationTimelineTransformerTest {
       premisesId = null,
     )
 
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
     Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
       TimelineEvent(
         id = domainEvent.id,
@@ -90,6 +101,7 @@ class ApplicationTimelineTransformerTest {
         associatedUrls = listOf(
           TimelineEventAssociatedUrl(TimelineEventUrlType.application, "http://somehost:3000/applications/$applicationId"),
         ),
+        content = "Some event",
       ),
     )
   }
@@ -108,6 +120,8 @@ class ApplicationTimelineTransformerTest {
       premisesId = premisesId,
     )
 
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
     Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
       TimelineEvent(
         id = domainEvent.id,
@@ -116,6 +130,7 @@ class ApplicationTimelineTransformerTest {
         associatedUrls = listOf(
           TimelineEventAssociatedUrl(TimelineEventUrlType.booking, "http://somehost:3000/premises/$premisesId/bookings/$bookingId"),
         ),
+        content = "Some event",
       ),
     )
   }
@@ -133,6 +148,8 @@ class ApplicationTimelineTransformerTest {
       premisesId = null,
     )
 
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
     Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
       TimelineEvent(
         id = domainEvent.id,
@@ -141,6 +158,7 @@ class ApplicationTimelineTransformerTest {
         associatedUrls = listOf(
           TimelineEventAssociatedUrl(TimelineEventUrlType.assessment, "http://somehost:3000/assessments/$assessmentId"),
         ),
+        content = "Some event",
       ),
     )
   }
@@ -161,6 +179,8 @@ class ApplicationTimelineTransformerTest {
       premisesId = premisesId,
     )
 
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
     Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
       TimelineEvent(
         id = domainEvent.id,
@@ -171,6 +191,7 @@ class ApplicationTimelineTransformerTest {
           TimelineEventAssociatedUrl(TimelineEventUrlType.assessment, "http://somehost:3000/assessments/$assessmentId"),
           TimelineEventAssociatedUrl(TimelineEventUrlType.booking, "http://somehost:3000/premises/$premisesId/bookings/$bookingId"),
         ),
+        content = "Some event",
       ),
     )
   }


### PR DESCRIPTION
> See [APS-192 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-192).

This PR introduces a human-readable description for each domain event presented in the application timeline (`GET /applications/{applicationId}/timeline`).

This description is generated by the `DomainEventDescriber` class. Currently, this only supports CAS1 events.