### PR TITLE
Enable `ap_delius_context_api` in Dev and Preprod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -74,8 +74,8 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
-    DATA-SOURCES_OFFENDER-DETAILS: community_api
-    DATA-SOURCES_OFFENDER-RISKS: community_api
+    DATA-SOURCES_OFFENDER-DETAILS: ap_delius_context_api
+    DATA-SOURCES_OFFENDER-RISKS: ap_delius_context_api
 
     USER-ALLOCATIONS_RULES_LEGACY-ALLOCATOR_ENABLED: true
     USER-ALLOCATIONS_RULES_LEGACY-ALLOCATOR_PRIORITY: -1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -66,8 +66,8 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
-    DATA-SOURCES_OFFENDER-DETAILS: community_api
-    DATA-SOURCES_OFFENDER-RISKS: community_api
+    DATA-SOURCES_OFFENDER-DETAILS: ap_delius_context_api
+    DATA-SOURCES_OFFENDER-RISKS: ap_delius_context_api
 
     PAGINATION_CAS3_BOOKING-SEARCH-PAGE-SIZE: 100
 


### PR DESCRIPTION
This will allow us to confirm the new endpoints work as expected before retiring the Community API endpoints for getting offender details