### PR TITLE
(APS-253) Ensure filtering by role returns distinct users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
@@ -76,6 +76,7 @@ fun hasQualificationsAndRoles(
       )
     }
 
+    query.distinct(true)
     criteriaBuilder.and(*predicates.toTypedArray())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -467,8 +467,8 @@ class UsersTest : IntegrationTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
     fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER allows filtering by roles`(role: UserRole) {
-      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER, UserRole.CAS1_MATCHER)) { matcher, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { _, _ ->
             `Given a User`(roles = listOf(role)) { _, jwt ->
               webTestClient.get()


### PR DESCRIPTION
When filtering by role, the search sometimes returns multiple users as roles/qualifications can sometimes be applied multiple times. This adds a `distinct` option to the `UserSpecification` to ensure that users are only returned once.