### PR TITLE
Move get booking logic from controller into booking service

### DIFF
--- a/detekt-baseline-main.xml
+++ b/detekt-baseline-main.xml
@@ -1,0 +1,1443 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>AvoidReferentialEquality:AssessmentService.kt$AssessmentService$clarificationNoteEntity.response !== null</ID>
+    <ID>AvoidReferentialEquality:UserService.kt$UserService$deliusUser.email !== user.email</ID>
+    <ID>AvoidReferentialEquality:UserService.kt$UserService$deliusUser.telephoneNumber !== user.telephoneNumber</ID>
+    <ID>CouldBeSequence:BookingSearchService.kt$BookingSearchService$map { result -&gt; result to offenderSummaries.first { it.crn == result.personCrn } }</ID>
+    <ID>CyclomaticComplexMethod:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$private fun createBooking( row: ApprovedPremisesBookingSeedCsvRow, )</ID>
+    <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$@Transactional fun createApprovedPremisesBookingFromPlacementRequest( user: UserEntity, placementRequestId: UUID, bedId: UUID?, premisesId: UUID?, arrivalDate: LocalDate, departureDate: LocalDate, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;BookingEntity&gt;&gt;</ID>
+    <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$private fun createCas1Cancellation( user: UserEntity?, booking: BookingEntity, cancelledAt: LocalDate, reasonId: UUID, notes: String?, )</ID>
+    <ID>CyclomaticComplexMethod:BookingService.kt$BookingService$private fun createCas1Departure( user: UserEntity?, booking: BookingEntity, dateTime: OffsetDateTime, reasonId: UUID, moveOnCategoryId: UUID, destinationProviderId: UUID?, notes: String?, )</ID>
+    <ID>CyclomaticComplexMethod:BookingTransformer.kt$BookingTransformer$private fun determineTemporaryAccommodationStatus(jpa: BookingEntity): BookingStatus</ID>
+    <ID>CyclomaticComplexMethod:DeserializationValidationService.kt$DeserializationValidationService$fun validateObject(path: String = "$", targetType: KClass&lt;*&gt;, jsonObject: ObjectNode): Map&lt;String, String&gt;</ID>
+    <ID>CyclomaticComplexMethod:DomainEventEntity.kt$DomainEventEntity$final inline fun &lt;reified T&gt; toDomainEvent(objectMapper: ObjectMapper): DomainEvent&lt;T&gt;</ID>
+    <ID>CyclomaticComplexMethod:OASysSectionsTransformer.kt$OASysSectionsTransformer$private fun transformSupportingInformation(needsDetails: NeedsDetails, requestedOptionalSections: List&lt;Int&gt;): List&lt;OASysSupportingInformationQuestion&gt;</ID>
+    <ID>CyclomaticComplexMethod:OffenderService.kt$OffenderService$fun getInfoForPerson(crn: String, deliusUsername: String, ignoreLao: Boolean): PersonInfoResult</ID>
+    <ID>CyclomaticComplexMethod:PremisesController.kt$PremisesController$@Transactional override fun premisesPremisesIdBookingsPost(premisesId: UUID, body: NewBooking): ResponseEntity&lt;Booking&gt;</ID>
+    <ID>CyclomaticComplexMethod:PremisesController.kt$PremisesController$@Transactional override fun premisesPremisesIdPut(premisesId: UUID, body: UpdatePremises): ResponseEntity&lt;Premises&gt;</ID>
+    <ID>CyclomaticComplexMethod:PremisesService.kt$PremisesService$fun createNewPremises( addressLine1: String, addressLine2: String?, town: String?, postcode: String, latitude: Double?, longitude: Double?, service: String, localAuthorityAreaId: UUID?, probationRegionId: UUID, name: String, notes: String?, characteristicIds: List&lt;UUID&gt;, status: PropertyStatus, probationDeliveryUnitIdentifier: Either&lt;String, UUID&gt;?, turnaroundWorkingDayCount: Int?, )</ID>
+    <ID>CyclomaticComplexMethod:PremisesService.kt$PremisesService$fun updatePremises( premisesId: UUID, addressLine1: String, addressLine2: String?, town: String?, postcode: String, localAuthorityAreaId: UUID?, probationRegionId: UUID, characteristicIds: List&lt;UUID&gt;, notes: String?, status: PropertyStatus, probationDeliveryUnitIdentifier: Either&lt;String, UUID&gt;?, turnaroundWorkingDayCount: Int?, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;PremisesEntity&gt;&gt;</ID>
+    <ID>CyclomaticComplexMethod:SeedService.kt$SeedService$private fun seedData(seedFileType: SeedFileType, filename: String, resolveCsvPath: SeedJob&lt;*&gt;.() -&gt; String)</ID>
+    <ID>CyclomaticComplexMethod:SeedUtils.kt$fun getCanonicalRegionName(regionName: String): String</ID>
+    <ID>CyclomaticComplexMethod:TaskService.kt$TaskService$fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, id: UUID): AuthorisableActionResult&lt;ValidatableActionResult&lt;Reallocation&gt;&gt;</ID>
+    <ID>EmptyClassBlock:ActiveOffence.kt$ActiveOffence${ }</ID>
+    <ID>EmptyClassBlock:Adjudication.kt$Adjudication${ }</ID>
+    <ID>EmptyClassBlock:ApArea.kt$ApArea${ }</ID>
+    <ID>EmptyClassBlock:ApplicationAssessed.kt$ApplicationAssessed${ }</ID>
+    <ID>EmptyClassBlock:ApplicationAssessedAssessedBy.kt$ApplicationAssessedAssessedBy${ }</ID>
+    <ID>EmptyClassBlock:ApplicationAssessedEnvelope.kt$ApplicationAssessedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:ApplicationSubmittedEnvelope.kt$ApplicationSubmittedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:ApplicationSubmittedSubmittedBy.kt$ApplicationSubmittedSubmittedBy${ }</ID>
+    <ID>EmptyClassBlock:ApplicationTimelineNote.kt$ApplicationTimelineNote${ }</ID>
+    <ID>EmptyClassBlock:ApplicationWithdrawn.kt$ApplicationWithdrawn${ }</ID>
+    <ID>EmptyClassBlock:ApplicationWithdrawnEnvelope.kt$ApplicationWithdrawnEnvelope${ }</ID>
+    <ID>EmptyClassBlock:ApplicationWithdrawnWithdrawnBy.kt$ApplicationWithdrawnWithdrawnBy${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremises.kt$ApprovedPremises${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesAllOf.kt$ApprovedPremisesAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesApplication.kt$ApprovedPremisesApplication${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesApplicationAllOf.kt$ApprovedPremisesApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesApplicationSummary.kt$ApprovedPremisesApplicationSummary${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesApplicationSummaryAllOf.kt$ApprovedPremisesApplicationSummaryAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesAssessment.kt$ApprovedPremisesAssessment${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesAssessmentAllOf.kt$ApprovedPremisesAssessmentAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesAssessmentSummary.kt$ApprovedPremisesAssessmentSummary${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesAssessmentSummaryAllOf.kt$ApprovedPremisesAssessmentSummaryAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesBedSearchParameters.kt$ApprovedPremisesBedSearchParameters${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesBedSearchParametersAllOf.kt$ApprovedPremisesBedSearchParametersAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesBedSearchResult.kt$ApprovedPremisesBedSearchResult${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesBedSearchResultAllOf.kt$ApprovedPremisesBedSearchResultAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesSummary.kt$ApprovedPremisesSummary${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesSummaryAllOf.kt$ApprovedPremisesSummaryAllOf${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesUser.kt$ApprovedPremisesUser${ }</ID>
+    <ID>EmptyClassBlock:ApprovedPremisesUserAllOf.kt$ApprovedPremisesUserAllOf${ }</ID>
+    <ID>EmptyClassBlock:Arrival.kt$Arrival${ }</ID>
+    <ID>EmptyClassBlock:AssessmentAcceptance.kt$AssessmentAcceptance${ }</ID>
+    <ID>EmptyClassBlock:AssessmentRejection.kt$AssessmentRejection${ }</ID>
+    <ID>EmptyClassBlock:AssessmentTask.kt$AssessmentTask${ }</ID>
+    <ID>EmptyClassBlock:Bed.kt$Bed${ }</ID>
+    <ID>EmptyClassBlock:BedDetail.kt$BedDetail${ }</ID>
+    <ID>EmptyClassBlock:BedDetailAllOf.kt$BedDetailAllOf${ }</ID>
+    <ID>EmptyClassBlock:BedOccupancyBookingEntry.kt$BedOccupancyBookingEntry${ }</ID>
+    <ID>EmptyClassBlock:BedOccupancyBookingEntryAllOf.kt$BedOccupancyBookingEntryAllOf${ }</ID>
+    <ID>EmptyClassBlock:BedOccupancyLostBedEntry.kt$BedOccupancyLostBedEntry${ }</ID>
+    <ID>EmptyClassBlock:BedOccupancyLostBedEntryAllOf.kt$BedOccupancyLostBedEntryAllOf${ }</ID>
+    <ID>EmptyClassBlock:BedOccupancyOpenEntry.kt$BedOccupancyOpenEntry${ }</ID>
+    <ID>EmptyClassBlock:BedOccupancyRange.kt$BedOccupancyRange${ }</ID>
+    <ID>EmptyClassBlock:BedSearchResultBedSummary.kt$BedSearchResultBedSummary${ }</ID>
+    <ID>EmptyClassBlock:BedSearchResultPremisesSummary.kt$BedSearchResultPremisesSummary${ }</ID>
+    <ID>EmptyClassBlock:BedSearchResultRoomSummary.kt$BedSearchResultRoomSummary${ }</ID>
+    <ID>EmptyClassBlock:BedSearchResults.kt$BedSearchResults${ }</ID>
+    <ID>EmptyClassBlock:BedSummary.kt$BedSummary${ }</ID>
+    <ID>EmptyClassBlock:Booking.kt$Booking${ }</ID>
+    <ID>EmptyClassBlock:BookingAllOf.kt$BookingAllOf${ }</ID>
+    <ID>EmptyClassBlock:BookingAppealTask.kt$BookingAppealTask${ }</ID>
+    <ID>EmptyClassBlock:BookingBody.kt$BookingBody${ }</ID>
+    <ID>EmptyClassBlock:BookingCancelled.kt$BookingCancelled${ }</ID>
+    <ID>EmptyClassBlock:BookingCancelledEnvelope.kt$BookingCancelledEnvelope${ }</ID>
+    <ID>EmptyClassBlock:BookingChanged.kt$BookingChanged${ }</ID>
+    <ID>EmptyClassBlock:BookingChangedEnvelope.kt$BookingChangedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:BookingExtended.kt$BookingExtended${ }</ID>
+    <ID>EmptyClassBlock:BookingExtendedEnvelope.kt$BookingExtendedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:BookingMade.kt$BookingMade${ }</ID>
+    <ID>EmptyClassBlock:BookingMadeBookedBy.kt$BookingMadeBookedBy${ }</ID>
+    <ID>EmptyClassBlock:BookingMadeEnvelope.kt$BookingMadeEnvelope${ }</ID>
+    <ID>EmptyClassBlock:BookingNotMade.kt$BookingNotMade${ }</ID>
+    <ID>EmptyClassBlock:BookingNotMadeEnvelope.kt$BookingNotMadeEnvelope${ }</ID>
+    <ID>EmptyClassBlock:BookingPremisesSummary.kt$BookingPremisesSummary${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResult.kt$BookingSearchResult${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResultBedSummary.kt$BookingSearchResultBedSummary${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResultBookingSummary.kt$BookingSearchResultBookingSummary${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResultPersonSummary.kt$BookingSearchResultPersonSummary${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResultPremisesSummary.kt$BookingSearchResultPremisesSummary${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResultRoomSummary.kt$BookingSearchResultRoomSummary${ }</ID>
+    <ID>EmptyClassBlock:BookingSearchResults.kt$BookingSearchResults${ }</ID>
+    <ID>EmptyClassBlock:BookingSummary.kt$BookingSummary${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingCancelledEvent.kt$CAS3BookingCancelledEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingCancelledEventAllOf.kt$CAS3BookingCancelledEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingCancelledEventDetails.kt$CAS3BookingCancelledEventDetails${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingCancelledUpdatedEvent.kt$CAS3BookingCancelledUpdatedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingConfirmedEvent.kt$CAS3BookingConfirmedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingConfirmedEventAllOf.kt$CAS3BookingConfirmedEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingConfirmedEventDetails.kt$CAS3BookingConfirmedEventDetails${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingProvisionallyMadeEvent.kt$CAS3BookingProvisionallyMadeEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingProvisionallyMadeEventAllOf.kt$CAS3BookingProvisionallyMadeEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:CAS3BookingProvisionallyMadeEventDetails.kt$CAS3BookingProvisionallyMadeEventDetails${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonArrivedEvent.kt$CAS3PersonArrivedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonArrivedEventAllOf.kt$CAS3PersonArrivedEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonArrivedEventDetails.kt$CAS3PersonArrivedEventDetails${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonArrivedUpdatedEvent.kt$CAS3PersonArrivedUpdatedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonDepartedEvent.kt$CAS3PersonDepartedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonDepartedEventAllOf.kt$CAS3PersonDepartedEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonDepartedEventDetails.kt$CAS3PersonDepartedEventDetails${ }</ID>
+    <ID>EmptyClassBlock:CAS3PersonDepartureUpdatedEvent.kt$CAS3PersonDepartureUpdatedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3ReferralSubmittedEvent.kt$CAS3ReferralSubmittedEvent${ }</ID>
+    <ID>EmptyClassBlock:CAS3ReferralSubmittedEventAllOf.kt$CAS3ReferralSubmittedEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:CAS3ReferralSubmittedEventDetails.kt$CAS3ReferralSubmittedEventDetails${ }</ID>
+    <ID>EmptyClassBlock:Cancellation.kt$Cancellation${ }</ID>
+    <ID>EmptyClassBlock:CancellationReason.kt$CancellationReason${ }</ID>
+    <ID>EmptyClassBlock:Cas2Application.kt$Cas2Application${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationAllOf.kt$Cas2ApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationStatus.kt$Cas2ApplicationStatus${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationStatusUpdate.kt$Cas2ApplicationStatusUpdate${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationStatusUpdatedEvent.kt$Cas2ApplicationStatusUpdatedEvent${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationStatusUpdatedEventAllOf.kt$Cas2ApplicationStatusUpdatedEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationStatusUpdatedEventDetails.kt$Cas2ApplicationStatusUpdatedEventDetails${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationSubmittedEvent.kt$Cas2ApplicationSubmittedEvent${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationSubmittedEventAllOf.kt$Cas2ApplicationSubmittedEventAllOf${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationSubmittedEventDetails.kt$Cas2ApplicationSubmittedEventDetails${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationSubmittedEventDetailsSubmittedBy.kt$Cas2ApplicationSubmittedEventDetailsSubmittedBy${ }</ID>
+    <ID>EmptyClassBlock:Cas2ApplicationSummary.kt$Cas2ApplicationSummary${ }</ID>
+    <ID>EmptyClassBlock:Cas2StaffMember.kt$Cas2StaffMember${ }</ID>
+    <ID>EmptyClassBlock:Cas2Status.kt$Cas2Status${ }</ID>
+    <ID>EmptyClassBlock:Cas2StatusUpdate.kt$Cas2StatusUpdate${ }</ID>
+    <ID>EmptyClassBlock:Cas2SubmittedApplication.kt$Cas2SubmittedApplication${ }</ID>
+    <ID>EmptyClassBlock:Cas2SubmittedApplicationSummary.kt$Cas2SubmittedApplicationSummary${ }</ID>
+    <ID>EmptyClassBlock:CharacteristicPair.kt$CharacteristicPair${ }</ID>
+    <ID>EmptyClassBlock:ClarificationNote.kt$ClarificationNote${ }</ID>
+    <ID>EmptyClassBlock:Confirmation.kt$Confirmation${ }</ID>
+    <ID>EmptyClassBlock:Cru.kt$Cru${ }</ID>
+    <ID>EmptyClassBlock:DateCapacity.kt$DateCapacity${ }</ID>
+    <ID>EmptyClassBlock:DateChange.kt$DateChange${ }</ID>
+    <ID>EmptyClassBlock:DatePeriod.kt$DatePeriod${ }</ID>
+    <ID>EmptyClassBlock:Departure.kt$Departure${ }</ID>
+    <ID>EmptyClassBlock:DepartureReason.kt$DepartureReason${ }</ID>
+    <ID>EmptyClassBlock:DestinationPremises.kt$DestinationPremises${ }</ID>
+    <ID>EmptyClassBlock:DestinationProvider.kt$DestinationProvider${ }</ID>
+    <ID>EmptyClassBlock:Document.kt$Document${ }</ID>
+    <ID>EmptyClassBlock:ExtendedPremisesSummary.kt$ExtendedPremisesSummary${ }</ID>
+    <ID>EmptyClassBlock:Extension.kt$Extension${ }</ID>
+    <ID>EmptyClassBlock:ExternalUser.kt$ExternalUser${ }</ID>
+    <ID>EmptyClassBlock:FlagsEnvelope.kt$FlagsEnvelope${ }</ID>
+    <ID>EmptyClassBlock:FullPerson.kt$FullPerson${ }</ID>
+    <ID>EmptyClassBlock:FullPersonAllOf.kt$FullPersonAllOf${ }</ID>
+    <ID>EmptyClassBlock:InvalidParam.kt$InvalidParam${ }</ID>
+    <ID>EmptyClassBlock:Ldu.kt$Ldu${ }</ID>
+    <ID>EmptyClassBlock:LocalAuthorityArea.kt$LocalAuthorityArea${ }</ID>
+    <ID>EmptyClassBlock:LostBed.kt$LostBed${ }</ID>
+    <ID>EmptyClassBlock:LostBedCancellation.kt$LostBedCancellation${ }</ID>
+    <ID>EmptyClassBlock:LostBedReason.kt$LostBedReason${ }</ID>
+    <ID>EmptyClassBlock:Mappa.kt$Mappa${ }</ID>
+    <ID>EmptyClassBlock:MappaEnvelope.kt$MappaEnvelope${ }</ID>
+    <ID>EmptyClassBlock:MigrationJobRequest.kt$MigrationJobRequest${ }</ID>
+    <ID>EmptyClassBlock:MoveOnCategory.kt$MoveOnCategory${ }</ID>
+    <ID>EmptyClassBlock:NewApplication.kt$NewApplication${ }</ID>
+    <ID>EmptyClassBlock:NewApplicationTimelineNote.kt$NewApplicationTimelineNote${ }</ID>
+    <ID>EmptyClassBlock:NewBedMove.kt$NewBedMove${ }</ID>
+    <ID>EmptyClassBlock:NewBooking.kt$NewBooking${ }</ID>
+    <ID>EmptyClassBlock:NewBookingNotMade.kt$NewBookingNotMade${ }</ID>
+    <ID>EmptyClassBlock:NewCancellation.kt$NewCancellation${ }</ID>
+    <ID>EmptyClassBlock:NewCas1Arrival.kt$NewCas1Arrival${ }</ID>
+    <ID>EmptyClassBlock:NewCas1ArrivalAllOf.kt$NewCas1ArrivalAllOf${ }</ID>
+    <ID>EmptyClassBlock:NewCas2Arrival.kt$NewCas2Arrival${ }</ID>
+    <ID>EmptyClassBlock:NewCas2ArrivalAllOf.kt$NewCas2ArrivalAllOf${ }</ID>
+    <ID>EmptyClassBlock:NewCas3Arrival.kt$NewCas3Arrival${ }</ID>
+    <ID>EmptyClassBlock:NewClarificationNote.kt$NewClarificationNote${ }</ID>
+    <ID>EmptyClassBlock:NewConfirmation.kt$NewConfirmation${ }</ID>
+    <ID>EmptyClassBlock:NewDateChange.kt$NewDateChange${ }</ID>
+    <ID>EmptyClassBlock:NewDeparture.kt$NewDeparture${ }</ID>
+    <ID>EmptyClassBlock:NewExtension.kt$NewExtension${ }</ID>
+    <ID>EmptyClassBlock:NewLostBed.kt$NewLostBed${ }</ID>
+    <ID>EmptyClassBlock:NewLostBedCancellation.kt$NewLostBedCancellation${ }</ID>
+    <ID>EmptyClassBlock:NewNonarrival.kt$NewNonarrival${ }</ID>
+    <ID>EmptyClassBlock:NewPlacementApplication.kt$NewPlacementApplication${ }</ID>
+    <ID>EmptyClassBlock:NewPlacementRequestBooking.kt$NewPlacementRequestBooking${ }</ID>
+    <ID>EmptyClassBlock:NewPlacementRequestBookingConfirmation.kt$NewPlacementRequestBookingConfirmation${ }</ID>
+    <ID>EmptyClassBlock:NewPremises.kt$NewPremises${ }</ID>
+    <ID>EmptyClassBlock:NewReallocation.kt$NewReallocation${ }</ID>
+    <ID>EmptyClassBlock:NewReferralHistoryUserNote.kt$NewReferralHistoryUserNote${ }</ID>
+    <ID>EmptyClassBlock:NewRoom.kt$NewRoom${ }</ID>
+    <ID>EmptyClassBlock:NewTurnaround.kt$NewTurnaround${ }</ID>
+    <ID>EmptyClassBlock:NewWithdrawal.kt$NewWithdrawal${ }</ID>
+    <ID>EmptyClassBlock:NomisUser.kt$NomisUser${ }</ID>
+    <ID>EmptyClassBlock:NonArrivalReason.kt$NonArrivalReason${ }</ID>
+    <ID>EmptyClassBlock:Nonarrival.kt$Nonarrival${ }</ID>
+    <ID>EmptyClassBlock:OASysQuestion.kt$OASysQuestion${ }</ID>
+    <ID>EmptyClassBlock:OASysRiskOfSeriousHarm.kt$OASysRiskOfSeriousHarm${ }</ID>
+    <ID>EmptyClassBlock:OASysRiskToSelf.kt$OASysRiskToSelf${ }</ID>
+    <ID>EmptyClassBlock:OASysSection.kt$OASysSection${ }</ID>
+    <ID>EmptyClassBlock:OASysSections.kt$OASysSections${ }</ID>
+    <ID>EmptyClassBlock:OASysSupportingInformationQuestion.kt$OASysSupportingInformationQuestion${ }</ID>
+    <ID>EmptyClassBlock:OfflineApplication.kt$OfflineApplication${ }</ID>
+    <ID>EmptyClassBlock:OfflineApplicationSummary.kt$OfflineApplicationSummary${ }</ID>
+    <ID>EmptyClassBlock:PersonAcctAlert.kt$PersonAcctAlert${ }</ID>
+    <ID>EmptyClassBlock:PersonArrived.kt$PersonArrived${ }</ID>
+    <ID>EmptyClassBlock:PersonArrivedEnvelope.kt$PersonArrivedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:PersonDeparted.kt$PersonDeparted${ }</ID>
+    <ID>EmptyClassBlock:PersonDepartedDestination.kt$PersonDepartedDestination${ }</ID>
+    <ID>EmptyClassBlock:PersonDepartedEnvelope.kt$PersonDepartedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:PersonNotArrived.kt$PersonNotArrived${ }</ID>
+    <ID>EmptyClassBlock:PersonNotArrivedEnvelope.kt$PersonNotArrivedEnvelope${ }</ID>
+    <ID>EmptyClassBlock:PersonReference.kt$PersonReference${ }</ID>
+    <ID>EmptyClassBlock:PersonRisks.kt$PersonRisks${ }</ID>
+    <ID>EmptyClassBlock:PlacementApplication.kt$PlacementApplication${ }</ID>
+    <ID>EmptyClassBlock:PlacementApplicationAllOf.kt$PlacementApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:PlacementApplicationDecisionEnvelope.kt$PlacementApplicationDecisionEnvelope${ }</ID>
+    <ID>EmptyClassBlock:PlacementApplicationTask.kt$PlacementApplicationTask${ }</ID>
+    <ID>EmptyClassBlock:PlacementApplicationTaskAllOf.kt$PlacementApplicationTaskAllOf${ }</ID>
+    <ID>EmptyClassBlock:PlacementDates.kt$PlacementDates${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequest.kt$PlacementRequest${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequestAllOf.kt$PlacementRequestAllOf${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequestDetail.kt$PlacementRequestDetail${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequestDetailAllOf.kt$PlacementRequestDetailAllOf${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequestTask.kt$PlacementRequestTask${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequestTaskAllOf.kt$PlacementRequestTaskAllOf${ }</ID>
+    <ID>EmptyClassBlock:PlacementRequirements.kt$PlacementRequirements${ }</ID>
+    <ID>EmptyClassBlock:Premises.kt$Premises${ }</ID>
+    <ID>EmptyClassBlock:PremisesBooking.kt$PremisesBooking${ }</ID>
+    <ID>EmptyClassBlock:PrisonCaseNote.kt$PrisonCaseNote${ }</ID>
+    <ID>EmptyClassBlock:ProbationArea.kt$ProbationArea${ }</ID>
+    <ID>EmptyClassBlock:ProbationDeliveryUnit.kt$ProbationDeliveryUnit${ }</ID>
+    <ID>EmptyClassBlock:ProbationRegion.kt$ProbationRegion${ }</ID>
+    <ID>EmptyClassBlock:Problem.kt$Problem${ }</ID>
+    <ID>EmptyClassBlock:Reallocation.kt$Reallocation${ }</ID>
+    <ID>EmptyClassBlock:ReferralHistoryUserNote.kt$ReferralHistoryUserNote${ }</ID>
+    <ID>EmptyClassBlock:Region.kt$Region${ }</ID>
+    <ID>EmptyClassBlock:RestrictedPerson.kt$RestrictedPerson${ }</ID>
+    <ID>EmptyClassBlock:RiskTier.kt$RiskTier${ }</ID>
+    <ID>EmptyClassBlock:RiskTierEnvelope.kt$RiskTierEnvelope${ }</ID>
+    <ID>EmptyClassBlock:Room.kt$Room${ }</ID>
+    <ID>EmptyClassBlock:RoshRisks.kt$RoshRisks${ }</ID>
+    <ID>EmptyClassBlock:RoshRisksEnvelope.kt$RoshRisksEnvelope${ }</ID>
+    <ID>EmptyClassBlock:SeedRequest.kt$SeedRequest${ }</ID>
+    <ID>EmptyClassBlock:StaffMember.kt$StaffMember${ }</ID>
+    <ID>EmptyClassBlock:SubmitApprovedPremisesApplication.kt$SubmitApprovedPremisesApplication${ }</ID>
+    <ID>EmptyClassBlock:SubmitApprovedPremisesApplicationAllOf.kt$SubmitApprovedPremisesApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:SubmitCas2Application.kt$SubmitCas2Application${ }</ID>
+    <ID>EmptyClassBlock:SubmitPlacementApplication.kt$SubmitPlacementApplication${ }</ID>
+    <ID>EmptyClassBlock:SubmitTemporaryAccommodationApplication.kt$SubmitTemporaryAccommodationApplication${ }</ID>
+    <ID>EmptyClassBlock:SubmitTemporaryAccommodationApplicationAllOf.kt$SubmitTemporaryAccommodationApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:SupervisingOfficer.kt$SupervisingOfficer${ }</ID>
+    <ID>EmptyClassBlock:SupervisingProvider.kt$SupervisingProvider${ }</ID>
+    <ID>EmptyClassBlock:SupervisingTeam.kt$SupervisingTeam${ }</ID>
+    <ID>EmptyClassBlock:TaskWrapper.kt$TaskWrapper${ }</ID>
+    <ID>EmptyClassBlock:Team.kt$Team${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationApplication.kt$TemporaryAccommodationApplication${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationApplicationAllOf.kt$TemporaryAccommodationApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationApplicationSummary.kt$TemporaryAccommodationApplicationSummary${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationApplicationSummaryAllOf.kt$TemporaryAccommodationApplicationSummaryAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationAssessment.kt$TemporaryAccommodationAssessment${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationAssessmentAllOf.kt$TemporaryAccommodationAssessmentAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationAssessmentSummary.kt$TemporaryAccommodationAssessmentSummary${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationAssessmentSummaryAllOf.kt$TemporaryAccommodationAssessmentSummaryAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationBedSearchParameters.kt$TemporaryAccommodationBedSearchParameters${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationBedSearchParametersAllOf.kt$TemporaryAccommodationBedSearchParametersAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationBedSearchResult.kt$TemporaryAccommodationBedSearchResult${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationBedSearchResultAllOf.kt$TemporaryAccommodationBedSearchResultAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationBedSearchResultOverlap.kt$TemporaryAccommodationBedSearchResultOverlap${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationPremises.kt$TemporaryAccommodationPremises${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationPremisesAllOf.kt$TemporaryAccommodationPremisesAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationPremisesSummary.kt$TemporaryAccommodationPremisesSummary${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationPremisesSummaryAllOf.kt$TemporaryAccommodationPremisesSummaryAllOf${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationUser.kt$TemporaryAccommodationUser${ }</ID>
+    <ID>EmptyClassBlock:TemporaryAccommodationUserAllOf.kt$TemporaryAccommodationUserAllOf${ }</ID>
+    <ID>EmptyClassBlock:TimelineEvent.kt$TimelineEvent${ }</ID>
+    <ID>EmptyClassBlock:TimelineEventAssociatedUrl.kt$TimelineEventAssociatedUrl${ }</ID>
+    <ID>EmptyClassBlock:Turnaround.kt$Turnaround${ }</ID>
+    <ID>EmptyClassBlock:UnknownPerson.kt$UnknownPerson${ }</ID>
+    <ID>EmptyClassBlock:UpdateApprovedPremisesApplication.kt$UpdateApprovedPremisesApplication${ }</ID>
+    <ID>EmptyClassBlock:UpdateApprovedPremisesApplicationAllOf.kt$UpdateApprovedPremisesApplicationAllOf${ }</ID>
+    <ID>EmptyClassBlock:UpdateAssessment.kt$UpdateAssessment${ }</ID>
+    <ID>EmptyClassBlock:UpdateCas2Application.kt$UpdateCas2Application${ }</ID>
+    <ID>EmptyClassBlock:UpdateLostBed.kt$UpdateLostBed${ }</ID>
+    <ID>EmptyClassBlock:UpdatePlacementApplication.kt$UpdatePlacementApplication${ }</ID>
+    <ID>EmptyClassBlock:UpdatePremises.kt$UpdatePremises${ }</ID>
+    <ID>EmptyClassBlock:UpdateRoom.kt$UpdateRoom${ }</ID>
+    <ID>EmptyClassBlock:UpdateTemporaryAccommodationApplication.kt$UpdateTemporaryAccommodationApplication${ }</ID>
+    <ID>EmptyClassBlock:UpdatedClarificationNote.kt$UpdatedClarificationNote${ }</ID>
+    <ID>EmptyClassBlock:UserRolesAndQualifications.kt$UserRolesAndQualifications${ }</ID>
+    <ID>EmptyClassBlock:UserWithWorkload.kt$UserWithWorkload${ }</ID>
+    <ID>EmptyClassBlock:UserWithWorkloadAllOf.kt$UserWithWorkloadAllOf${ }</ID>
+    <ID>EmptyClassBlock:ValidationError.kt$ValidationError${ }</ID>
+    <ID>EmptyClassBlock:ValidationErrorAllOf.kt$ValidationErrorAllOf${ }</ID>
+    <ID>EmptyClassBlock:WithdrawPlacementApplication.kt$WithdrawPlacementApplication${ }</ID>
+    <ID>EmptyClassBlock:WithdrawPlacementRequest.kt$WithdrawPlacementRequest${ }</ID>
+    <ID>EmptyClassBlock:Withdrawable.kt$Withdrawable${ }</ID>
+    <ID>EmptyDefaultConstructor:ArrivalTransformer.kt$ArrivalTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:CancellationReasonTransformer.kt$CancellationReasonTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:DateChangeTransformer.kt$DateChangeTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:DepartureReasonTransformer.kt$DepartureReasonTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:DestinationProviderTransformer.kt$DestinationProviderTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:ExtensionTransformer.kt$ExtensionTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:ForbiddenProblem.kt$ForbiddenProblem$()</ID>
+    <ID>EmptyDefaultConstructor:LostBedReasonTransformer.kt$LostBedReasonTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:MoveOnCategoryTransformer.kt$MoveOnCategoryTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:NonArrivalReasonTransformer.kt$NonArrivalReasonTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:OAuth2ResourceServerSecurityConfiguration.kt$AuthAwareTokenConverter$()</ID>
+    <ID>EmptyDefaultConstructor:PremisesSummaryTransformer.kt$PremisesSummaryTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:StaffMemberTransformer.kt$StaffMemberTransformer$()</ID>
+    <ID>EmptyDefaultConstructor:TracesSamplerCallback.kt$TracesSamplerCallback$()</ID>
+    <ID>EmptyDefaultConstructor:UserAccessService.kt$UserAccessService$()</ID>
+    <ID>EnumNaming:AllocatedFilter.kt$AllocatedFilter$allocated : AllocatedFilter</ID>
+    <ID>EnumNaming:AllocatedFilter.kt$AllocatedFilter$unallocated : AllocatedFilter</ID>
+    <ID>EnumNaming:ApType.kt$ApType$esap : ApType</ID>
+    <ID>EnumNaming:ApType.kt$ApType$normal : ApType</ID>
+    <ID>EnumNaming:ApType.kt$ApType$pipe : ApType</ID>
+    <ID>EnumNaming:ApType.kt$ApType$rfap : ApType</ID>
+    <ID>EnumNaming:ApplicationSortField.kt$ApplicationSortField$arrivalDate : ApplicationSortField</ID>
+    <ID>EnumNaming:ApplicationSortField.kt$ApplicationSortField$createdAt : ApplicationSortField</ID>
+    <ID>EnumNaming:ApplicationSortField.kt$ApplicationSortField$tier : ApplicationSortField</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$awaitingPlacement : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$inProgress : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$inapplicable : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$pending : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$placed : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$rejected : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$requestedFurtherInformation : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$submitted : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationStatus.kt$ApplicationStatus$withdrawn : ApplicationStatus</ID>
+    <ID>EnumNaming:ApplicationSubmitted.kt$ApplicationSubmitted.Gender$female : Gender</ID>
+    <ID>EnumNaming:ApplicationSubmitted.kt$ApplicationSubmitted.Gender$male : Gender</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$assesmentInProgress : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$awaitingAssesment : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$awaitingPlacement : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$inapplicable : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$pendingPlacementRequest : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$placementAllocated : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$rejected : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$requestedFurtherInformation : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$started : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$submitted : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$unallocatedAssesment : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$withdrawn : ApprovedPremisesApplicationStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesAssessmentStatus.kt$ApprovedPremisesAssessmentStatus$awaitingResponse : ApprovedPremisesAssessmentStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesAssessmentStatus.kt$ApprovedPremisesAssessmentStatus$completed : ApprovedPremisesAssessmentStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesAssessmentStatus.kt$ApprovedPremisesAssessmentStatus$inProgress : ApprovedPremisesAssessmentStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesAssessmentStatus.kt$ApprovedPremisesAssessmentStatus$notStarted : ApprovedPremisesAssessmentStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesAssessmentStatus.kt$ApprovedPremisesAssessmentStatus$reallocated : ApprovedPremisesAssessmentStatus</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$applicant : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$assessor : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$excludedFromAssessAllocation : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$excludedFromMatchAllocation : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$excludedFromPlacementApplicationAllocation : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$manager : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$matcher : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$reportViewer : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$roleAdmin : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:ApprovedPremisesUserRole.kt$ApprovedPremisesUserRole$workflowManager : ApprovedPremisesUserRole</ID>
+    <ID>EnumNaming:AssessmentDecision.kt$AssessmentDecision$accepted : AssessmentDecision</ID>
+    <ID>EnumNaming:AssessmentDecision.kt$AssessmentDecision$rejected : AssessmentDecision</ID>
+    <ID>EnumNaming:AssessmentSortField.kt$AssessmentSortField$assessmentArrivalDate : AssessmentSortField</ID>
+    <ID>EnumNaming:AssessmentSortField.kt$AssessmentSortField$assessmentCreatedAt : AssessmentSortField</ID>
+    <ID>EnumNaming:AssessmentSortField.kt$AssessmentSortField$assessmentStatus : AssessmentSortField</ID>
+    <ID>EnumNaming:AssessmentSortField.kt$AssessmentSortField$personCrn : AssessmentSortField</ID>
+    <ID>EnumNaming:AssessmentSortField.kt$AssessmentSortField$personName : AssessmentSortField</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas1AwaitingResponse : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas1Completed : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas1InProgress : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas1NotStarted : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas1Reallocated : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas3Closed : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas3InReview : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas3ReadyToPlace : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas3Rejected : AssessmentStatus</ID>
+    <ID>EnumNaming:AssessmentStatus.kt$AssessmentStatus$cas3Unallocated : AssessmentStatus</ID>
+    <ID>EnumNaming:BedOccupancyEntryType.kt$BedOccupancyEntryType$booking : BedOccupancyEntryType</ID>
+    <ID>EnumNaming:BedOccupancyEntryType.kt$BedOccupancyEntryType$lostBed : BedOccupancyEntryType</ID>
+    <ID>EnumNaming:BedOccupancyEntryType.kt$BedOccupancyEntryType$open : BedOccupancyEntryType</ID>
+    <ID>EnumNaming:BedStatus.kt$BedStatus$available : BedStatus</ID>
+    <ID>EnumNaming:BedStatus.kt$BedStatus$occupied : BedStatus</ID>
+    <ID>EnumNaming:BedStatus.kt$BedStatus$outOfService : BedStatus</ID>
+    <ID>EnumNaming:BookingSearchSortField.kt$BookingSearchSortField$bookingCreatedAt : BookingSearchSortField</ID>
+    <ID>EnumNaming:BookingSearchSortField.kt$BookingSearchSortField$bookingEndDate : BookingSearchSortField</ID>
+    <ID>EnumNaming:BookingSearchSortField.kt$BookingSearchSortField$bookingStartDate : BookingSearchSortField</ID>
+    <ID>EnumNaming:BookingSearchSortField.kt$BookingSearchSortField$personCrn : BookingSearchSortField</ID>
+    <ID>EnumNaming:BookingSearchSortField.kt$BookingSearchSortField$personName : BookingSearchSortField</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$arrived : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$awaitingMinusArrival : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$cancelled : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$closed : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$confirmed : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$departed : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$notMinusArrived : BookingStatus</ID>
+    <ID>EnumNaming:BookingStatus.kt$BookingStatus$provisional : BookingStatus</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$inmateDetails : CacheType</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$offenderDetails : CacheType</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$qCodeStaffMembers : CacheType</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$staffDetails : CacheType</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$teamsManagingCase : CacheType</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$ukBankHolidays : CacheType</ID>
+    <ID>EnumNaming:CacheType.kt$CacheType$userAccess : CacheType</ID>
+    <ID>EnumNaming:Characteristic.kt$Characteristic.ModelScope$premises : ModelScope</ID>
+    <ID>EnumNaming:Characteristic.kt$Characteristic.ModelScope$room : ModelScope</ID>
+    <ID>EnumNaming:Characteristic.kt$Characteristic.ModelScope$star : ModelScope</ID>
+    <ID>EnumNaming:Characteristic.kt$Characteristic.ServiceScope$approvedMinusPremises : ServiceScope</ID>
+    <ID>EnumNaming:Characteristic.kt$Characteristic.ServiceScope$star : ServiceScope</ID>
+    <ID>EnumNaming:Characteristic.kt$Characteristic.ServiceScope$temporaryMinusAccommodation : ServiceScope</ID>
+    <ID>EnumNaming:DocumentLevel.kt$DocumentLevel$conviction : DocumentLevel</ID>
+    <ID>EnumNaming:DocumentLevel.kt$DocumentLevel$offender : DocumentLevel</ID>
+    <ID>EnumNaming:EventType.kt$EventType$applicationStatusUpdated : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$applicationSubmitted : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$bookingCancelled : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$bookingCancelledUpdated : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$bookingConfirmed : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$bookingProvisionallyMade : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$personArrived : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$personArrivedUpdated : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$personDeparted : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$personDepartureUpdated : EventType</ID>
+    <ID>EnumNaming:EventType.kt$EventType$referralSubmitted : EventType</ID>
+    <ID>EnumNaming:Gender.kt$Gender$female : Gender</ID>
+    <ID>EnumNaming:Gender.kt$Gender$male : Gender</ID>
+    <ID>EnumNaming:LostBedStatus.kt$LostBedStatus$active : LostBedStatus</ID>
+    <ID>EnumNaming:LostBedStatus.kt$LostBedStatus$cancelled : LostBedStatus</ID>
+    <ID>EnumNaming:MigrationJobType.kt$MigrationJobType$allUsersFromCommunityApi : MigrationJobType</ID>
+    <ID>EnumNaming:MigrationJobType.kt$MigrationJobType$applicationApAreas : MigrationJobType</ID>
+    <ID>EnumNaming:MigrationJobType.kt$MigrationJobType$bookingStatus : MigrationJobType</ID>
+    <ID>EnumNaming:MigrationJobType.kt$MigrationJobType$inmateStatusOnSubmission : MigrationJobType</ID>
+    <ID>EnumNaming:MigrationJobType.kt$MigrationJobType$sentenceTypeAndSituation : MigrationJobType</ID>
+    <ID>EnumNaming:OASysAssessmentState.kt$OASysAssessmentState$completed : OASysAssessmentState</ID>
+    <ID>EnumNaming:OASysAssessmentState.kt$OASysAssessmentState$incomplete : OASysAssessmentState</ID>
+    <ID>EnumNaming:PersonStatus.kt$PersonStatus$inCommunity : PersonStatus</ID>
+    <ID>EnumNaming:PersonStatus.kt$PersonStatus$inCustody : PersonStatus</ID>
+    <ID>EnumNaming:PersonStatus.kt$PersonStatus$unknown : PersonStatus</ID>
+    <ID>EnumNaming:PersonType.kt$PersonType$fullPerson : PersonType</ID>
+    <ID>EnumNaming:PersonType.kt$PersonType$fullPersonInfo : PersonType</ID>
+    <ID>EnumNaming:PersonType.kt$PersonType$restrictedPerson : PersonType</ID>
+    <ID>EnumNaming:PersonType.kt$PersonType$restrictedPersonInfo : PersonType</ID>
+    <ID>EnumNaming:PersonType.kt$PersonType$unknownPerson : PersonType</ID>
+    <ID>EnumNaming:PlacementApplicationDecision.kt$PlacementApplicationDecision$accepted : PlacementApplicationDecision</ID>
+    <ID>EnumNaming:PlacementApplicationDecision.kt$PlacementApplicationDecision$rejected : PlacementApplicationDecision</ID>
+    <ID>EnumNaming:PlacementApplicationDecision.kt$PlacementApplicationDecision$withdraw : PlacementApplicationDecision</ID>
+    <ID>EnumNaming:PlacementApplicationDecision.kt$PlacementApplicationDecision$withdrawnByPp : PlacementApplicationDecision</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$acceptsChildSexOffenders : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$acceptsHateCrimeOffenders : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$acceptsNonSexualChildOffenders : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$acceptsSexOffenders : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$hasBrailleSignage : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$hasEnSuite : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$hasHearingLoop : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$hasTactileFlooring : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isArsonDesignated : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isArsonSuitable : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isCatered : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isESAP : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isGroundFloor : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isPIPE : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isRecoveryFocussed : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isSemiSpecialistMentalHealth : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isSingle : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isStepFreeDesignated : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isSuitableForVulnerable : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isSuitedForSexOffenders : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementCriteria.kt$PlacementCriteria$isWheelchairDesignated : PlacementCriteria</ID>
+    <ID>EnumNaming:PlacementRequestRequestType.kt$PlacementRequestRequestType$parole : PlacementRequestRequestType</ID>
+    <ID>EnumNaming:PlacementRequestRequestType.kt$PlacementRequestRequestType$standardRelease : PlacementRequestRequestType</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$applicationSubmittedAt : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$createdAt : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$duration : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$expectedArrival : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$personName : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$personRisksTier : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestSortField.kt$PlacementRequestSortField$requestType : PlacementRequestSortField</ID>
+    <ID>EnumNaming:PlacementRequestStatus.kt$PlacementRequestStatus$matched : PlacementRequestStatus</ID>
+    <ID>EnumNaming:PlacementRequestStatus.kt$PlacementRequestStatus$notMatched : PlacementRequestStatus</ID>
+    <ID>EnumNaming:PlacementRequestStatus.kt$PlacementRequestStatus$unableToMatch : PlacementRequestStatus</ID>
+    <ID>EnumNaming:PlacementType.kt$PlacementType$additionalPlacement : PlacementType</ID>
+    <ID>EnumNaming:PlacementType.kt$PlacementType$releaseFollowingDecision : PlacementType</ID>
+    <ID>EnumNaming:PlacementType.kt$PlacementType$rotl : PlacementType</ID>
+    <ID>EnumNaming:PropertyStatus.kt$PropertyStatus$active : PropertyStatus</ID>
+    <ID>EnumNaming:PropertyStatus.kt$PropertyStatus$archived : PropertyStatus</ID>
+    <ID>EnumNaming:PropertyStatus.kt$PropertyStatus$pending : PropertyStatus</ID>
+    <ID>EnumNaming:ReferralHistorySystemNote.kt$ReferralHistorySystemNote.Category$completed : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNote.kt$ReferralHistorySystemNote.Category$inReview : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNote.kt$ReferralHistorySystemNote.Category$readyToPlace : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNote.kt$ReferralHistorySystemNote.Category$rejected : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNote.kt$ReferralHistorySystemNote.Category$submitted : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNote.kt$ReferralHistorySystemNote.Category$unallocated : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNoteAllOf.kt$ReferralHistorySystemNoteAllOf.Category$completed : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNoteAllOf.kt$ReferralHistorySystemNoteAllOf.Category$inReview : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNoteAllOf.kt$ReferralHistorySystemNoteAllOf.Category$readyToPlace : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNoteAllOf.kt$ReferralHistorySystemNoteAllOf.Category$rejected : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNoteAllOf.kt$ReferralHistorySystemNoteAllOf.Category$submitted : Category</ID>
+    <ID>EnumNaming:ReferralHistorySystemNoteAllOf.kt$ReferralHistorySystemNoteAllOf.Category$unallocated : Category</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$extendedDeterminateLicence : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$hdc : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$inCommunity : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$licence : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$notApplicable : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$paroleDirectedLicence : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$pss : ReleaseTypeOption</ID>
+    <ID>EnumNaming:ReleaseTypeOption.kt$ReleaseTypeOption$rotl : ReleaseTypeOption</ID>
+    <ID>EnumNaming:RiskEnvelopeStatus.kt$RiskEnvelopeStatus$error : RiskEnvelopeStatus</ID>
+    <ID>EnumNaming:RiskEnvelopeStatus.kt$RiskEnvelopeStatus$notFound : RiskEnvelopeStatus</ID>
+    <ID>EnumNaming:RiskEnvelopeStatus.kt$RiskEnvelopeStatus$retrieved : RiskEnvelopeStatus</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$a0 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$a1 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$a2 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$a3 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$b0 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$b1 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$b2 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$b3 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$c0 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$c1 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$c2 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$c3 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$d0 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$d1 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$d2 : RiskTierLevel</ID>
+    <ID>EnumNaming:RiskTierLevel.kt$RiskTierLevel$d3 : RiskTierLevel</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$approvedPremises : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$approvedPremisesBookings : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$approvedPremisesCancelBookings : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$approvedPremisesOfflineApplications : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$approvedPremisesRooms : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$approvedPremisesUsers : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$cas2Applications : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$characteristics : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$externalUsers : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$nomisUsers : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$temporaryAccommodationBedspace : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$temporaryAccommodationPremises : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$temporaryAccommodationUsers : SeedFileType</ID>
+    <ID>EnumNaming:SeedFileType.kt$SeedFileType$user : SeedFileType</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$bailPlacement : SentenceTypeOption</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$communityOrder : SentenceTypeOption</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$extendedDeterminate : SentenceTypeOption</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$ipp : SentenceTypeOption</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$life : SentenceTypeOption</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$nonStatutory : SentenceTypeOption</ID>
+    <ID>EnumNaming:SentenceTypeOption.kt$SentenceTypeOption$standardDeterminate : SentenceTypeOption</ID>
+    <ID>EnumNaming:ServiceName.kt$ServiceName$approvedPremises : ServiceName</ID>
+    <ID>EnumNaming:ServiceName.kt$ServiceName$cas2 : ServiceName</ID>
+    <ID>EnumNaming:ServiceName.kt$ServiceName$temporaryAccommodation : ServiceName</ID>
+    <ID>EnumNaming:SituationOption.kt$SituationOption$bailAssessment : SituationOption</ID>
+    <ID>EnumNaming:SituationOption.kt$SituationOption$bailSentence : SituationOption</ID>
+    <ID>EnumNaming:SituationOption.kt$SituationOption$residencyManagement : SituationOption</ID>
+    <ID>EnumNaming:SituationOption.kt$SituationOption$riskManagement : SituationOption</ID>
+    <ID>EnumNaming:SortDirection.kt$SortDirection$asc : SortDirection</ID>
+    <ID>EnumNaming:SortDirection.kt$SortDirection$desc : SortDirection</ID>
+    <ID>EnumNaming:SortOrder.kt$SortOrder$ascending : SortOrder</ID>
+    <ID>EnumNaming:SortOrder.kt$SortOrder$descending : SortOrder</ID>
+    <ID>EnumNaming:TaskSortField.kt$TaskSortField$createdAt : TaskSortField</ID>
+    <ID>EnumNaming:TaskStatus.kt$TaskStatus$complete : TaskStatus</ID>
+    <ID>EnumNaming:TaskStatus.kt$TaskStatus$inProgress : TaskStatus</ID>
+    <ID>EnumNaming:TaskStatus.kt$TaskStatus$notStarted : TaskStatus</ID>
+    <ID>EnumNaming:TaskType.kt$TaskType$assessment : TaskType</ID>
+    <ID>EnumNaming:TaskType.kt$TaskType$bookingAppeal : TaskType</ID>
+    <ID>EnumNaming:TaskType.kt$TaskType$placementApplication : TaskType</ID>
+    <ID>EnumNaming:TaskType.kt$TaskType$placementRequest : TaskType</ID>
+    <ID>EnumNaming:TemporaryAccommodationAssessmentStatus.kt$TemporaryAccommodationAssessmentStatus$closed : TemporaryAccommodationAssessmentStatus</ID>
+    <ID>EnumNaming:TemporaryAccommodationAssessmentStatus.kt$TemporaryAccommodationAssessmentStatus$inReview : TemporaryAccommodationAssessmentStatus</ID>
+    <ID>EnumNaming:TemporaryAccommodationAssessmentStatus.kt$TemporaryAccommodationAssessmentStatus$readyToPlace : TemporaryAccommodationAssessmentStatus</ID>
+    <ID>EnumNaming:TemporaryAccommodationAssessmentStatus.kt$TemporaryAccommodationAssessmentStatus$rejected : TemporaryAccommodationAssessmentStatus</ID>
+    <ID>EnumNaming:TemporaryAccommodationAssessmentStatus.kt$TemporaryAccommodationAssessmentStatus$unallocated : TemporaryAccommodationAssessmentStatus</ID>
+    <ID>EnumNaming:TemporaryAccommodationUserRole.kt$TemporaryAccommodationUserRole$assessor : TemporaryAccommodationUserRole</ID>
+    <ID>EnumNaming:TemporaryAccommodationUserRole.kt$TemporaryAccommodationUserRole$referrer : TemporaryAccommodationUserRole</ID>
+    <ID>EnumNaming:TemporaryAccommodationUserRole.kt$TemporaryAccommodationUserRole$reporter : TemporaryAccommodationUserRole</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$applicationTimelineNote : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesApplicationAssessed : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesApplicationSubmitted : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesApplicationWithdrawn : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesBookingCancelled : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesBookingChanged : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesBookingMade : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesBookingNotMade : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesInformationRequest : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesPersonArrived : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesPersonDeparted : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$approvedPremisesPersonNotArrived : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$cas3PersonArrived : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventType.kt$TimelineEventType$cas3PersonDeparted : TimelineEventType</ID>
+    <ID>EnumNaming:TimelineEventUrlType.kt$TimelineEventUrlType$application : TimelineEventUrlType</ID>
+    <ID>EnumNaming:TimelineEventUrlType.kt$TimelineEventUrlType$assessment : TimelineEventUrlType</ID>
+    <ID>EnumNaming:TimelineEventUrlType.kt$TimelineEventUrlType$booking : TimelineEventUrlType</ID>
+    <ID>EnumNaming:UserQualification.kt$UserQualification$emergency : UserQualification</ID>
+    <ID>EnumNaming:UserQualification.kt$UserQualification$esap : UserQualification</ID>
+    <ID>EnumNaming:UserQualification.kt$UserQualification$lao : UserQualification</ID>
+    <ID>EnumNaming:UserQualification.kt$UserQualification$pipe : UserQualification</ID>
+    <ID>EnumNaming:UserQualification.kt$UserQualification$womens : UserQualification</ID>
+    <ID>EnumNaming:UserSortField.kt$UserSortField$personName : UserSortField</ID>
+    <ID>EnumNaming:WithdrawPlacementRequestReason.kt$WithdrawPlacementRequestReason$alternativeProvisionIdentified : WithdrawPlacementRequestReason</ID>
+    <ID>EnumNaming:WithdrawPlacementRequestReason.kt$WithdrawPlacementRequestReason$duplicatePlacementRequest : WithdrawPlacementRequestReason</ID>
+    <ID>EnumNaming:WithdrawableType.kt$WithdrawableType$booking : WithdrawableType</ID>
+    <ID>EnumNaming:WithdrawableType.kt$WithdrawableType$placementApplication : WithdrawableType</ID>
+    <ID>EnumNaming:WithdrawableType.kt$WithdrawableType$placementRequest : WithdrawableType</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$alternativeIdentifiedPlacementNoLongerRequired : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$changeInCircumstancesNewApplicationToBeSubmitted : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$changeInCircumstancesPlacementNoLongerRequired : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$changeInReleaseDatePlacementNoLongerRequired : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$changeInReleaseDecisionPlacementNoLongerRequired : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$duplicateApplication : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$errorInApplication : WithdrawalReason</ID>
+    <ID>EnumNaming:WithdrawalReason.kt$WithdrawalReason$other : WithdrawalReason</ID>
+    <ID>ForbiddenComment:BookingService.kt$BookingService$// TODO: Bookings will need to be specialised in a similar way to Premises so that TA Bookings do not have a keyWorkerStaffCode field</ID>
+    <ID>ForbiddenComment:PremisesEntity.kt$ApprovedPremisesEntity$// TODO: Make not-null once Premises have had point added in all environments</ID>
+    <ID>ForbiddenComment:UserAccessService.kt$UserAccessService$// TODO: Revisit if Approved Premises introduces region-limited access</ID>
+    <ID>ForbiddenComment:UserAccessService.kt$UserAccessService$// TODO: Revisit once Temporary Accommodation introduces user roles</ID>
+    <ID>FunctionNaming:ApplicationEntity.kt$ApplicationRepository$@Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id") fun &lt;T : ApplicationEntity&gt; findAllByCreatedByUser_Id(id: UUID, type: Class&lt;T&gt;): List&lt;ApplicationEntity&gt;</ID>
+    <ID>FunctionNaming:AssessmentEntity.kt$AssessmentRepository$fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?</ID>
+    <ID>FunctionNaming:BedMoveEntity.kt$BedMoveRepository$@Query("SELECT b FROM BedMoveEntity b WHERE b.booking.id = :bookingId") fun findByBooking_IdOrNull(bookingId: UUID): BedMoveEntity?</ID>
+    <ID>FunctionNaming:Cas2ApplicationEntity.kt$Cas2ApplicationRepository$@Query("SELECT a FROM Cas2ApplicationEntity a WHERE a.createdByUser.id = :id") fun findAllByCreatedByUser_Id(id: UUID): List&lt;Cas2ApplicationEntity&gt;</ID>
+    <ID>FunctionNaming:ProbationDeliveryUnitEntity.kt$ProbationDeliveryUnitRepository$fun findAllByProbationRegion_Id(probationRegionId: UUID): List&lt;ProbationDeliveryUnitEntity&gt;</ID>
+    <ID>FunctionNaming:ProbationDeliveryUnitEntity.kt$ProbationDeliveryUnitRepository$fun findByIdAndProbationRegion_Id(id: UUID, probationRegionId: UUID): ProbationDeliveryUnitEntity?</ID>
+    <ID>FunctionNaming:ProbationDeliveryUnitEntity.kt$ProbationDeliveryUnitRepository$fun findByNameAndProbationRegion_Id(name: String, probationRegionId: UUID): ProbationDeliveryUnitEntity?</ID>
+    <ID>HasPlatformType:ApplicationService.kt$ApplicationService$fun createOfflineApplication(offlineApplication: OfflineApplicationEntity)</ID>
+    <ID>HasPlatformType:Dates.kt$fun LocalDate.toLocalDateTime(zoneOffset: ZoneOffset = ZoneOffset.UTC)</ID>
+    <ID>HasPlatformType:PreemptiveCacheRefresher.kt$CacheRefreshWorker$protected val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>HasPlatformType:PreemptiveCacheRefresher.kt$PreemptiveCacheRefresher$protected val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>ImplicitDefaultLocale:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$String.format("%.1f days", averagePlacementMatchingTimeliness)</ID>
+    <ID>ImplicitDefaultLocale:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$String.format("%.1f days", averageTimeliness)</ID>
+    <ID>ImplicitDefaultLocale:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$String.format("%.1f%%", percentage)</ID>
+    <ID>ImplicitDefaultLocale:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$String.format("%.1f%%", percentage)</ID>
+    <ID>InjectDispatcher:PeopleController.kt$PeopleController$IO</ID>
+    <ID>InvalidPackageDeclaration:UserSpecifications.kt$package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.specification</ID>
+    <ID>LargeClass:BookingService.kt$BookingService</ID>
+    <ID>LongMethod:SeedUtils.kt$@Suppress("CyclomaticComplexMethod") fun getCanonicalLocalAuthorityName(localAuthorityName: String): String</ID>
+    <ID>LongParameterList:ApplicationStatusUpdatesReportRow.kt$ApplicationStatusUpdatesReportRow$( val eventId: String, val applicationId: String, val personCrn: String, val personNoms: String, val newStatus: String, val updatedAt: String, val updatedBy: String, )</ID>
+    <ID>LongParameterList:ApplicationsApi.kt$ApplicationsApi$( @RequestHeader(value="X-Service-Name", required=true) xServiceName: ServiceName , @RequestParam(value = "page", required = false) page: kotlin.Int? , @RequestParam(value = "crnOrName", required = false) crnOrName: kotlin.String? , @RequestParam(value = "sortDirection", required = false) sortDirection: SortDirection? , @RequestParam(value = "status", required = false) status: ApprovedPremisesApplicationStatus? , @RequestParam(value = "sortBy", required = false) sortBy: ApplicationSortField? )</ID>
+    <ID>LongParameterList:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$(xServiceName: ServiceName, page: kotlin.Int?, crnOrName: kotlin.String?, sortDirection: SortDirection?, status: ApprovedPremisesApplicationStatus?, sortBy: ApplicationSortField?)</ID>
+    <ID>LongParameterList:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$( fileName: String, private val bookingRepository: BookingRepository, private val bookingService: BookingService, private val communityApiClient: CommunityApiClient, private val bedRepository: BedRepository, private val departureReasonRepository: DepartureReasonRepository, private val moveOnCategoryRepository: MoveOnCategoryRepository, private val destinationProviderRepository: DestinationProviderRepository, private val nonArrivalReasonRepository: NonArrivalReasonRepository, private val cancellationReasonRepository: CancellationReasonRepository, )</ID>
+    <ID>LongParameterList:AssessmentInfo.kt$AssessmentInfo$( val assessmentId: Long, val assessmentType: String, val dateCompleted: OffsetDateTime?, val assessorSignedDate: OffsetDateTime?, val initiationDate: OffsetDateTime, val assessmentStatus: String, val superStatus: String?, val limitedAccessOffender: Boolean, )</ID>
+    <ID>LongParameterList:AssessmentTask.kt$AssessmentTask$( @field:JsonProperty("taskType", required = true) override val taskType: TaskType, @field:JsonProperty("id", required = true) override val id: java.util.UUID, @field:JsonProperty("applicationId", required = true) override val applicationId: java.util.UUID, @field:JsonProperty("personName", required = true) override val personName: kotlin.String, @field:JsonProperty("crn", required = true) override val crn: kotlin.String, @field:JsonProperty("dueDate", required = true) override val dueDate: java.time.LocalDate, @field:JsonProperty("status", required = true) override val status: TaskStatus, @field:JsonProperty("allocatedToStaffMember") override val allocatedToStaffMember: ApprovedPremisesUser? = null )</ID>
+    <ID>LongParameterList:AssessmentsApi.kt$AssessmentsApi$( @RequestHeader(value="X-Service-Name", required=true) xServiceName: ServiceName , @RequestParam(value = "sortDirection", required = false) sortDirection: SortDirection? , @RequestParam(value = "sortBy", required = false) sortBy: AssessmentSortField? , @RequestParam(value = "statuses", required = false) statuses: kotlin.collections.List&lt;AssessmentStatus&gt;? , @RequestParam(value = "crn", required = false) crn: kotlin.String? , @RequestParam(value = "page", required = false) page: kotlin.Int? , @RequestParam(value = "perPage", required = false) perPage: kotlin.Int? )</ID>
+    <ID>LongParameterList:AssessmentsApiDelegate.kt$AssessmentsApiDelegate$(xServiceName: ServiceName, sortDirection: SortDirection?, sortBy: AssessmentSortField?, statuses: kotlin.collections.List&lt;AssessmentStatus&gt;?, crn: kotlin.String?, page: kotlin.Int?, perPage: kotlin.Int?)</ID>
+    <ID>LongParameterList:BedSearchRepository.kt$ApprovedPremisesBedSearchResult$( premisesId: UUID, premisesName: String, premisesAddressLine1: String, premisesAddressLine2: String?, premisesTown: String?, premisesPostcode: String, premisesCharacteristics: MutableList&lt;CharacteristicNames&gt;, premisesBedCount: Int, roomId: UUID, roomName: String, bedId: UUID, bedName: String, roomCharacteristics: MutableList&lt;CharacteristicNames&gt;, val distance: Double, )</ID>
+    <ID>LongParameterList:BedSearchRepository.kt$BedSearchResult$( val premisesId: UUID, val premisesName: String, val premisesAddressLine1: String, val premisesAddressLine2: String?, val premisesTown: String?, val premisesPostcode: String, val premisesCharacteristics: MutableList&lt;CharacteristicNames&gt;, val premisesBedCount: Int, val roomId: UUID, val roomName: String, val bedId: UUID, val bedName: String, val roomCharacteristics: MutableList&lt;CharacteristicNames&gt;, )</ID>
+    <ID>LongParameterList:BedSearchRepository.kt$TemporaryAccommodationBedSearchResult$( premisesId: UUID, premisesName: String, premisesAddressLine1: String, premisesAddressLine2: String?, premisesTown: String?, premisesPostcode: String, premisesCharacteristics: MutableList&lt;CharacteristicNames&gt;, premisesBedCount: Int, roomId: UUID, roomName: String, bedId: UUID, bedName: String, roomCharacteristics: MutableList&lt;CharacteristicNames&gt;, val overlaps: MutableList&lt;TemporaryAccommodationBedSearchResultOverlap&gt;, )</ID>
+    <ID>LongParameterList:BookingAppealTask.kt$BookingAppealTask$( @field:JsonProperty("taskType", required = true) override val taskType: TaskType, @field:JsonProperty("id", required = true) override val id: java.util.UUID, @field:JsonProperty("applicationId", required = true) override val applicationId: java.util.UUID, @field:JsonProperty("personName", required = true) override val personName: kotlin.String, @field:JsonProperty("crn", required = true) override val crn: kotlin.String, @field:JsonProperty("dueDate", required = true) override val dueDate: java.time.LocalDate, @field:JsonProperty("status", required = true) override val status: TaskStatus, @field:JsonProperty("allocatedToStaffMember") override val allocatedToStaffMember: ApprovedPremisesUser? = null )</ID>
+    <ID>LongParameterList:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$( fileName: String, private val repository: Cas2ApplicationRepository, private val userRepository: NomisUserRepository, private val externalUserRepository: ExternalUserRepository, private val statusUpdateRepository: Cas2StatusUpdateRepository, private val jsonSchemaService: JsonSchemaService, private val statusFinder: Cas2PersistedApplicationStatusFinder, )</ID>
+    <ID>LongParameterList:HealthDetails.kt$HealthDetails$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val health: HealthDetailsInner, )</ID>
+    <ID>LongParameterList:InmateDetailsCacheRefreshWorker.kt$InmateDetailsCacheRefreshWorker$( private val applicationRepository: ApplicationRepository, private val bookingRepository: BookingRepository, private val prisonsApiClient: PrisonsApiClient, private val loggingEnabled: Boolean, private val delayMs: Long, redLock: RedLock, lockDurationMs: Int, )</ID>
+    <ID>LongParameterList:NeedsDetails.kt$NeedsDetails$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val needs: NeedsDetailsInner?, val linksToHarm: LinksToHarm?, val linksToReOffending: LinksToReOffending?, )</ID>
+    <ID>LongParameterList:OffenceDetails.kt$OffenceDetails$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val offence: OffenceDetailsInner?, )</ID>
+    <ID>LongParameterList:OffenderDetailsCacheRefreshWorker.kt$OffenderDetailsCacheRefreshWorker$( private val applicationRepository: ApplicationRepository, private val bookingRepository: BookingRepository, private val communityApiClient: CommunityApiClient, private val loggingEnabled: Boolean, private val delayMs: Long, redLock: RedLock, lockDurationMs: Int, )</ID>
+    <ID>LongParameterList:PlacementRequestsApi.kt$PlacementRequestsApi$( @RequestParam(value = "status", required = false) status: PlacementRequestStatus? , @RequestParam(value = "crn", required = false) crn: kotlin.String? , @RequestParam(value = "crnOrName", required = false) crnOrName: kotlin.String? , @RequestParam(value = "tier", required = false) tier: RiskTierLevel? , @RequestParam(value = "arrivalDateStart", required = false) @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE) arrivalDateStart: java.time.LocalDate? , @RequestParam(value = "arrivalDateEnd", required = false) @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE) arrivalDateEnd: java.time.LocalDate? , @RequestParam(value = "requestType", required = false) requestType: PlacementRequestRequestType? , @RequestParam(value = "apAreaId", required = false) apAreaId: java.util.UUID? , @RequestParam(value = "page", required = false) page: kotlin.Int? , @RequestParam(value = "sortBy", required = false) sortBy: PlacementRequestSortField? , @RequestParam(value = "sortDirection", required = false) sortDirection: SortDirection? )</ID>
+    <ID>LongParameterList:PlacementRequestsApiDelegate.kt$PlacementRequestsApiDelegate$(status: PlacementRequestStatus?, crn: kotlin.String?, crnOrName: kotlin.String?, tier: RiskTierLevel?, arrivalDateStart: java.time.LocalDate?, arrivalDateEnd: java.time.LocalDate?, requestType: PlacementRequestRequestType?, apAreaId: java.util.UUID?, page: kotlin.Int?, sortBy: PlacementRequestSortField?, sortDirection: SortDirection?)</ID>
+    <ID>LongParameterList:RedisConfiguration.kt$RedisConfiguration$( buildProperties: BuildProperties, objectMapper: ObjectMapper, @Value("\${caches.staffMembers.expiry-seconds}") staffMembersExpirySeconds: Long, @Value("\${caches.staffMember.expiry-seconds}") staffMemberExpirySeconds: Long, @Value("\${caches.userAccess.expiry-seconds}") userAccessExpirySeconds: Long, @Value("\${caches.staffDetails.expiry-seconds}") staffDetailsExpirySeconds: Long, @Value("\${caches.teamManagingCases.expiry-seconds}") teamManagingCasesExpirySeconds: Long, @Value("\${caches.ukBankHolidays.expiry-seconds}") ukBankHolidaysExpirySeconds: Long, @Value("21600") crnGetCaseDetailExpirySeconds: Long, )</ID>
+    <ID>LongParameterList:RiskManagementPlan.kt$RiskManagementPlan$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val riskManagementPlan: RiskManagementPlanInner?, )</ID>
+    <ID>LongParameterList:RiskToTheIndividual.kt$RisksToTheIndividual$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val riskToTheIndividual: RiskToTheIndividualInner?, )</ID>
+    <ID>LongParameterList:RoshRatings.kt$RoshRatings$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val rosh: RoshRatingsInner, )</ID>
+    <ID>LongParameterList:RoshSummary.kt$RoshSummary$( assessmentId: Long, assessmentType: String, dateCompleted: OffsetDateTime?, assessorSignedDate: OffsetDateTime?, initiationDate: OffsetDateTime, assessmentStatus: String, superStatus: String?, limitedAccessOffender: Boolean, val roshSummary: RoshSummaryInner?, )</ID>
+    <ID>LongParameterList:TasksApi.kt$TasksApi$( @RequestParam(value = "type", required = false) type: kotlin.String? , @RequestParam(value = "page", required = false) page: kotlin.Int? , @RequestParam(value = "sortBy", required = false) sortBy: TaskSortField? , @RequestParam(value = "sortDirection", required = false) sortDirection: SortDirection? , @RequestParam(value = "allocatedFilter", required = false) allocatedFilter: AllocatedFilter? , @RequestParam(value = "apAreaId", required = false) apAreaId: java.util.UUID? )</ID>
+    <ID>LongParameterList:TasksApiDelegate.kt$TasksApiDelegate$(type: kotlin.String?, page: kotlin.Int?, sortBy: TaskSortField?, sortDirection: SortDirection?, allocatedFilter: AllocatedFilter?, apAreaId: java.util.UUID?)</ID>
+    <ID>LongParameterList:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$( row: TemporaryAccommodationPremisesSeedCsvRow, existingPremises: TemporaryAccommodationPremisesEntity, probationRegion: ProbationRegionEntity, localAuthorityArea: LocalAuthorityAreaEntity, probationDeliveryUnit: ProbationDeliveryUnitEntity, characteristics: List&lt;CharacteristicEntity&gt;, )</ID>
+    <ID>LongParameterList:UsersApi.kt$UsersApi$( @RequestHeader(value="X-Service-Name", required=true) xServiceName: ServiceName , @RequestParam(value = "roles", required = false) roles: kotlin.collections.List&lt;ApprovedPremisesUserRole&gt;? , @RequestParam(value = "qualifications", required = false) qualifications: kotlin.collections.List&lt;UserQualification&gt;? , @RequestParam(value = "probationRegionId", required = false) probationRegionId: java.util.UUID? , @RequestParam(value = "apAreaId", required = false) apAreaId: java.util.UUID? , @RequestParam(value = "page", required = false) page: kotlin.Int? , @RequestParam(value = "sortBy", required = false) sortBy: UserSortField? , @RequestParam(value = "sortDirection", required = false) sortDirection: SortDirection? )</ID>
+    <ID>LongParameterList:UsersApiDelegate.kt$UsersApiDelegate$(xServiceName: ServiceName, roles: kotlin.collections.List&lt;ApprovedPremisesUserRole&gt;?, qualifications: kotlin.collections.List&lt;UserQualification&gt;?, probationRegionId: java.util.UUID?, apAreaId: java.util.UUID?, page: kotlin.Int?, sortBy: UserSortField?, sortDirection: SortDirection?)</ID>
+    <ID>MagicNumber:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$1_000</ID>
+    <ID>MagicNumber:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$4326</ID>
+    <ID>MagicNumber:BaseHMPPSClient.kt$BaseHMPPSClient.HMPPSRequestConfiguration$10000</ID>
+    <ID>MagicNumber:BookingService.kt$BookingService$7</ID>
+    <ID>MagicNumber:CommunityApiClient.kt$CommunityApiClient$10</ID>
+    <ID>MagicNumber:CommunityApiClient.kt$CommunityApiClient$12</ID>
+    <ID>MagicNumber:CommunityApiClient.kt$CommunityApiClient$30</ID>
+    <ID>MagicNumber:CommunityApiClient.kt$CommunityApiClient$5</ID>
+    <ID>MagicNumber:CommunityApiClient.kt$CommunityApiClient$6</ID>
+    <ID>MagicNumber:InmateDetailsCacheRefreshWorker.kt$InmateDetailsCacheRefreshWorker$50</ID>
+    <ID>MagicNumber:MigrationJobService.kt$MigrationJobService$50</ID>
+    <ID>MagicNumber:NomisUsersSeedJob.kt$NomisUsersSeedJob$100000</ID>
+    <ID>MagicNumber:NomisUsersSeedJob.kt$NomisUsersSeedJob$900000</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$10</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$11</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$12</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$3</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$4</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$5</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$6</ID>
+    <ID>MagicNumber:OASysSectionsTransformer.kt$OASysSectionsTransformer$7</ID>
+    <ID>MagicNumber:OAuth2ResourceServerSecurityConfiguration.kt$OAuth2ResourceServerSecurityConfiguration$401</ID>
+    <ID>MagicNumber:OAuth2ResourceServerSecurityConfiguration.kt$OAuth2ResourceServerSecurityConfiguration.&lt;no name provided&gt;$401</ID>
+    <ID>MagicNumber:OffenderDetailsCacheRefreshWorker.kt$OffenderDetailsCacheRefreshWorker$50</ID>
+    <ID>MagicNumber:PaginationUtils.kt$10</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$120</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$121</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$15</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$150</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$151</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$16</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$180</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$181</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$275</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$276</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$3</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$30</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$31</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$365</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$366</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$4</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$60</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$61</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$8</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$90</ID>
+    <ID>MagicNumber:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator$91</ID>
+    <ID>MagicNumber:PreemptiveCacheRefresher.kt$CacheRefreshWorker$1000</ID>
+    <ID>MagicNumber:PreemptiveCacheRefresher.kt$CacheRefreshWorker$10000</ID>
+    <ID>MagicNumber:PreemptiveCacheRefresher.kt$PreemptiveCacheRefresher$100</ID>
+    <ID>MagicNumber:PrisonsApiClient.kt$PrisonsApiClient$10</ID>
+    <ID>MagicNumber:PrisonsApiClient.kt$PrisonsApiClient$12</ID>
+    <ID>MagicNumber:PrisonsApiClient.kt$PrisonsApiClient$30</ID>
+    <ID>MagicNumber:PrisonsApiClient.kt$PrisonsApiClient$5</ID>
+    <ID>MagicNumber:PrisonsApiClient.kt$PrisonsApiClient$6</ID>
+    <ID>MagicNumber:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$10</ID>
+    <ID>MagicNumber:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$100</ID>
+    <ID>MagicNumber:ReportsController.kt$ReportsController$12</ID>
+    <ID>MagicNumber:TaskTransformer.kt$TaskTransformer$10</ID>
+    <ID>MagicNumber:UpdateAllUsersFromCommunityApiJob.kt$UpdateAllUsersFromCommunityApiJob$500</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$columns["id"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$columns["bedCode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$columns["crn"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesOfflineApplicationsSeedJob.kt$ApprovedPremisesOfflineApplicationsSeedJob$columns["crn"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["apCode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["bedCode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["bedCount"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasArsonInsuranceConditions"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasCallForAssistance"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasCrib7Bedding"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasEnSuite"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasFixedMobilityAids"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasNearbySprinkler"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasSmokeDetector"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasStepFreeAccess"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasTurningSpace"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasWideDoor"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isArsonDesignated"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isArsonSuitable"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isFullyFm"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isGroundFloor"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isGroundFloorNrOffice"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isSingle"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isStepFreeDesignated"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isSuitedForSexOffenders"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isTopFloorVulnerable"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isWheelchairAccessible"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isWheelchairDesignated"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["notes"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["roomNumber"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsChildSexOffenders"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsHateCrimeOffenders"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsNonSexualChildOffenders"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsSexOffenders"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["addressLine1"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["addressLine2"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["apCode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["characteristics"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["emailAddress"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasBrailleSignage"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasHearingLoop"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasLift"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasStepFreeAccessToCommunalAreas"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasTactileFlooring"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasWheelChairAccessibleBathrooms"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasWideAccessToCommunalAreas"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasWideStepFreeAccess"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isCatered"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isESAP"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isIAP"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isPIPE"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isRecoveryFocussed"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isSemiSpecialistMentalHealth"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isSuitableForVulnerable"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["latitude"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["localAuthorityArea"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["longitude"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["name"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["notes"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["postcode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["probationRegion"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["qCode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["status"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["town"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["createdBy"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["crn"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["id"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["location"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["nomsNumber"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["state"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["statusUpdates"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["characteristic_name"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["characteristic_property_name"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["model_scope"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["service_scope"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$columns["email"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$columns["name"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$columns["username"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:NomisUsersSeedJob.kt$NomisUsersSeedJob$columns["email"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:NomisUsersSeedJob.kt$NomisUsersSeedJob$columns["name"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:NomisUsersSeedJob.kt$NomisUsersSeedJob$columns["nomisUsername"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TasksController.kt$TasksController$workload[it.id]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$columns["Bedspace reference"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$columns["Property reference"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Address Line 1"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Local authority / Borough"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Postcode"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Probation delivery unit (PDU)"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Property reference"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Region"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:UsersSeedJob.kt$UsersSeedJob$columns["deliusUsername"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:UsersSeedJob.kt$UsersSeedJob$columns["qualifications"]!!</ID>
+    <ID>MapGetWithNotNullAssertionOperator:UsersSeedJob.kt$UsersSeedJob$columns["roles"]!!</ID>
+    <ID>MaxLineLength:Application.kt$Application$@ComponentScan(basePackages = ["uk.gov.justice.digital.hmpps.approvedpremisesapi", "uk.gov.justice.digital.hmpps.approvedpremisesapi.api", "uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model"])</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"fileName\" : \"fileName\", \"description\" : \"description\", \"typeDescription\" : \"typeDescription\", \"id\" : \"id\", \"typeCode\" : \"typeCode\"}")</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"type\" : \"type\", \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"type\" : \"type\"}")</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"schemaVersion\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"data\" : \"\", \"referralHistoryNotes\" : [ { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdByUserName\" : \"createdByUserName\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"message\" : \"message\", \"type\" : \"type\" }, { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdByUserName\" : \"createdByUserName\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"message\" : \"message\", \"type\" : \"type\" } ], \"service\" : \"service\", \"rejectionRationale\" : \"rejectionRationale\", \"outdatedSchema\" : true, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"allocatedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"clarificationNotes\" : [ { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"response\" : \"response\", \"query\" : \"query\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"responseReceivedOn\" : \"2000-01-23\", \"createdByStaffMemberId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"response\" : \"response\", \"query\" : \"query\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"responseReceivedOn\" : \"2000-01-23\", \"createdByStaffMemberId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } ]}")</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dates\" : [ { \"endDate\" : \"2000-01-23\", \"startDate\" : \"2000-01-23\" }, { \"endDate\" : \"2000-01-23\", \"startDate\" : \"2000-01-23\" } ], \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"note\" : \"note\", \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdByUser\" : { \"telephoneNumber\" : \"telephoneNumber\", \"service\" : \"service\", \"deliusUsername\" : \"deliusUsername\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true, \"region\" : { \"name\" : \"NPS North East Central Referrals\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\" }, \"email\" : \"email\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:ApplicationsApiDelegate.kt$ApplicationsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"occurredAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdBy\" : { \"telephoneNumber\" : \"telephoneNumber\", \"service\" : \"service\", \"deliusUsername\" : \"deliusUsername\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true, \"region\" : { \"name\" : \"NPS North East Central Referrals\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\" }, \"email\" : \"email\" }, \"associatedUrls\" : [ { \"url\" : \"url\" }, { \"url\" : \"url\" } ], \"id\" : \"id\", \"content\" : \"content\"}")</ID>
+    <ID>MaxLineLength:ApplicationsCas2Delegate.kt$ApplicationsCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"type\" : \"type\", \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:ApplicationsCas2Delegate.kt$ApplicationsCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"type\" : \"type\"}")</ID>
+    <ID>MaxLineLength:ApprovedPremisesApplicationStatus.kt$ApprovedPremisesApplicationStatus$*</ID>
+    <ID>MaxLineLength:AssessmentsApiDelegate.kt$AssessmentsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdByUserName\" : \"createdByUserName\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"message\" : \"message\", \"type\" : \"type\"}")</ID>
+    <ID>MaxLineLength:AssessmentsApiDelegate.kt$AssessmentsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"response\" : \"response\", \"query\" : \"query\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"responseReceivedOn\" : \"2000-01-23\", \"createdByStaffMemberId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:AssessmentsApiDelegate.kt$AssessmentsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"risks\" : { \"mappa\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"level\" : \"level\" } }, \"tier\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"level\" : \"level\" } }, \"roshRisks\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"overallRisk\" : \"overallRisk\", \"riskToChildren\" : \"riskToChildren\", \"riskToPublic\" : \"riskToPublic\", \"riskToKnownAdult\" : \"riskToKnownAdult\", \"riskToStaff\" : \"riskToStaff\" } }, \"flags\" : { \"value\" : [ \"value\", \"value\" ] }, \"crn\" : \"crn\" }, \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"dateOfInfoRequest\" : \"2000-01-23T04:56:07.000+00:00\", \"type\" : \"type\", \"applicationId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"arrivalDate\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:AssessmentsApiDelegate.kt$AssessmentsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"schemaVersion\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"data\" : \"\", \"referralHistoryNotes\" : [ { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdByUserName\" : \"createdByUserName\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"message\" : \"message\", \"type\" : \"type\" }, { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"createdByUserName\" : \"createdByUserName\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"message\" : \"message\", \"type\" : \"type\" } ], \"service\" : \"service\", \"rejectionRationale\" : \"rejectionRationale\", \"outdatedSchema\" : true, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"allocatedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"clarificationNotes\" : [ { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"response\" : \"response\", \"query\" : \"query\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"responseReceivedOn\" : \"2000-01-23\", \"createdByStaffMemberId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"response\" : \"response\", \"query\" : \"query\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"responseReceivedOn\" : \"2000-01-23\", \"createdByStaffMemberId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } ]}")</ID>
+    <ID>MaxLineLength:BedsApiDelegate.kt$BedsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"resultsBedCount\" : 1, \"results\" : [ { \"bed\" : { \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"premises\" : { \"characteristics\" : [ { \"propertyName\" : \"propertyName\", \"name\" : \"name\" }, { \"propertyName\" : \"propertyName\", \"name\" : \"name\" } ], \"town\" : \"town\", \"name\" : \"name\", \"postcode\" : \"postcode\", \"addressLine1\" : \"addressLine1\", \"addressLine2\" : \"addressLine2\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bedCount\" : 5 }, \"room\" : { \"characteristics\" : [ { \"propertyName\" : \"propertyName\", \"name\" : \"name\" }, { \"propertyName\" : \"propertyName\", \"name\" : \"name\" } ], \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } }, { \"bed\" : { \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"premises\" : { \"characteristics\" : [ { \"propertyName\" : \"propertyName\", \"name\" : \"name\" }, { \"propertyName\" : \"propertyName\", \"name\" : \"name\" } ], \"town\" : \"town\", \"name\" : \"name\", \"postcode\" : \"postcode\", \"addressLine1\" : \"addressLine1\", \"addressLine2\" : \"addressLine2\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bedCount\" : 5 }, \"room\" : { \"characteristics\" : [ { \"propertyName\" : \"propertyName\", \"name\" : \"name\" }, { \"propertyName\" : \"propertyName\", \"name\" : \"name\" } ], \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } } ], \"resultsRoomCount\" : 0, \"resultsPremisesCount\" : 6}")</ID>
+    <ID>MaxLineLength:BookingEntity.kt$BookingRepository$@Query("SELECT b FROM BookingEntity b WHERE b.bed.id = :bedId AND b.arrivalDate &lt;= :endDate AND b.departureDate &gt;= :startDate AND SIZE(b.cancellations) = 0 AND (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR b.id != :thisEntityId)")</ID>
+    <ID>MaxLineLength:BookingsApiDelegate.kt$BookingsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"resultsCount\" : 0, \"results\" : [ { \"bed\" : { \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"booking\" : { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"endDate\" : \"2000-01-23\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"startDate\" : \"2000-01-23\" }, \"person\" : { \"name\" : \"name\", \"crn\" : \"crn\" }, \"premises\" : { \"town\" : \"town\", \"name\" : \"name\", \"postcode\" : \"postcode\", \"addressLine1\" : \"addressLine1\", \"addressLine2\" : \"addressLine2\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"room\" : { \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } }, { \"bed\" : { \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"booking\" : { \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"endDate\" : \"2000-01-23\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"startDate\" : \"2000-01-23\" }, \"person\" : { \"name\" : \"name\", \"crn\" : \"crn\" }, \"premises\" : { \"town\" : \"town\", \"name\" : \"name\", \"postcode\" : \"postcode\", \"addressLine1\" : \"addressLine1\", \"addressLine2\" : \"addressLine2\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"room\" : { \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } } ]}")</ID>
+    <ID>MaxLineLength:DailyMetricReportRow.kt$// Date	Applications Started	Unique Users starting applications	Applications Submitted	Unique Users submitting applications	Assessments completed	Unique Users completing assessments	Bookings made	Unique Users making bookings</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"attemptedBy\" : { \"staffMember\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"cru\" : { \"name\" : \"NPS North East\" } }, \"deliusEventNumber\" : \"7\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"attemptedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"failureDescription\" : \"No availability\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.booking.not-made\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"cancellationReason\" : \"cancellationReason\", \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"cancelledAt\" : \"2000-01-23T04:56:07.000+00:00\", \"deliusEventNumber\" : \"7\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"cancelledBy\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.booking.cancelled\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"decision\" : \"Rejected\", \"assessedBy\" : { \"staffMember\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"cru\" : { \"name\" : \"NPS North East\" }, \"probationArea\" : { \"code\" : \"N02\", \"name\" : \"NPS North East\" } }, \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"deliusEventNumber\" : \"7\", \"assessedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"decisionRationale\" : \"Risk too low\", \"arrivalDate\" : \"2000-01-23T04:56:07.000+00:00\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.application.assessed\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"departureOn\" : \"2023-04-30T00:00:00.000+00:00\", \"changedBy\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"deliusEventNumber\" : \"7\", \"changedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"arrivalOn\" : \"2023-01-30T00:00:00.000+00:00\", \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.booking.changed\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"departureOn\" : \"2023-04-30T00:00:00.000+00:00\", \"deliusEventNumber\" : \"7\", \"arrivalOn\" : \"2023-01-30T00:00:00.000+00:00\", \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\", \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"releaseType\" : \"releaseType\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"bookedBy\" : { \"staffMember\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"cru\" : { \"name\" : \"NPS North East\" } }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationSubmittedOn\" : \"2000-01-23T04:56:07.000+00:00\", \"sentenceType\" : \"sentenceType\", \"situation\" : \"situation\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.booking.made\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"extendedBy\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"deliusEventNumber\" : \"7\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"extensionReason\" : \"There has been a flood at the housing association to which Mr Smith is moving\", \"previousDepartureOn\" : \"2023-01-30T00:00:00.000+00:00\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"extendedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\", \"newDepartureOn\" : \"2023-02-12T00:00:00.000+00:00\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.booking.extended\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"mappa\" : \"CAT C3/LEVEL L2\", \"offenceId\" : \"AB43782\", \"submittedBy\" : { \"staffMember\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"team\" : { \"code\" : \"N54NGH\", \"name\" : \"Gateshead 1\" }, \"probationArea\" : { \"code\" : \"N02\", \"name\" : \"NPS North East\" }, \"ldu\" : { \"code\" : \"N54PPU\", \"name\" : \"Public Protection NE\" }, \"region\" : { \"code\" : \"NE\", \"name\" : \"North East\" } }, \"gender\" : \"Male\", \"deliusEventNumber\" : \"7\", \"targetLocation\" : \"LS2\", \"releaseType\" : \"rotl\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"age\" : 43, \"sentenceLengthInMonths\" : 57 }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.application.submitted\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"notes\" : \"Arrived a day late due to rail strike. Informed in advance by COM.\", \"arrivedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"keyWorker\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"deliusEventNumber\" : \"7\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"expectedDepartureOn\" : \"2023-02-28T00:00:00.000+00:00\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"applicationSubmittedOn\" : \"2022-08-21T00:00:00.000+00:00\", \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.person.arrived\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"otherWithdrawalReason\" : \"otherWithdrawalReason\", \"withdrawnAt\" : \"2000-01-23T04:56:07.000+00:00\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"deliusEventNumber\" : \"7\", \"withdrawnBy\" : { \"staffMember\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"probationArea\" : { \"code\" : \"N02\", \"name\" : \"NPS North East\" } }, \"withdrawalReason\" : \"withdrawalReason\", \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" } }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.application.withdrawn\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"reason\" : \"Arrested, remanded in custody, or sentenced\", \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"keyWorker\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"deliusEventNumber\" : \"7\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"destination\" : { \"destinationProvider\" : { \"description\" : \"Ext - North East Region\", \"id\" : \"f0703382-3e8f-49ff-82bc-b970c9fe1b35\" }, \"moveOnCategory\" : { \"description\" : \"B&amp;B / Temp / Short-Term Housing\", \"id\" : \"a3c3d3df-1e27-4ee5-aef6-8a0f0471075f\", \"legacyMoveOnCategoryCode\" : \"MC05\" }, \"premises\" : { \"legacyApCode\" : \"Q061\", \"name\" : \"New Place\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NENEW1\", \"probationArea\" : { \"code\" : \"N02\", \"name\" : \"NPS North East\" } } }, \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"departedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\", \"legacyReasonCode\" : \"Q\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.person.departed\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:EventsApiDelegate.kt$EventsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"eventDetails\" : { \"reason\" : \"Arrested, remanded in custody, or sentenced\", \"recordedBy\" : { \"staffCode\" : \"N54A999\", \"surname\" : \"Smith\", \"staffIdentifier\" : 1501234567, \"forenames\" : \"John\", \"username\" : \"JohnSmithNPS\" }, \"notes\" : \"We learnt that Mr Smith is in hospital.\", \"premises\" : { \"legacyApCode\" : \"Q057\", \"name\" : \"Hope House\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"NEHOPE1\", \"localAuthorityAreaName\" : \"localAuthorityAreaName\" }, \"deliusEventNumber\" : \"7\", \"applicationUrl\" : \"https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713\", \"personReference\" : { \"noms\" : \"A1234ZX\", \"crn\" : \"C123456\" }, \"applicationId\" : \"484b8b5e-6c3b-4400-b200-425bbe410713\", \"bookingId\" : \"14c80733-4b6d-4f35-b724-66955aac320c\", \"expectedArrivalOn\" : \"2022-11-29T00:00:00.000+00:00\", \"legacyReasonCode\" : \"Q\" }, \"id\" : \"364145f9-0af8-488e-9901-b4c46cd9ba37\", \"eventType\" : \"approved-premises.person.not-arrived\", \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:ExceptionHandling.kt$ExceptionHandling$private fun logBadRequestProblem(problem: BadRequestProblem)</ID>
+    <ID>MaxLineLength:NotFoundProblem.kt$NotFoundProblem$class</ID>
+    <ID>MaxLineLength:OAuth2ResourceServerSecurityConfiguration.kt$LoggingInMemoryOAuth2AuthorizedClientService$log.info("Retrieved a client_credentials JWT for service-&gt;service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"note\" : \"note\", \"occurredAt\" : \"2000-01-23T04:56:07.000+00:00\", \"authorName\" : \"authorName\", \"subType\" : \"subType\", \"id\" : \"id\", \"sensitive\" : true, \"type\" : \"type\"}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dateCreated\" : \"2000-01-23\", \"expired\" : true, \"dateExpires\" : \"2000-01-23\", \"active\" : true, \"comment\" : \"comment\", \"alertId\" : 0}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dateStarted\" : \"2000-01-23T04:56:07.000+00:00\", \"dateCompleted\" : \"2000-01-23T04:56:07.000+00:00\", \"rosh\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"assessmentId\" : 138985987}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"mappa\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"level\" : \"level\" } }, \"tier\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"level\" : \"level\" } }, \"roshRisks\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"overallRisk\" : \"overallRisk\", \"riskToChildren\" : \"riskToChildren\", \"riskToPublic\" : \"riskToPublic\", \"riskToKnownAdult\" : \"riskToKnownAdult\", \"riskToStaff\" : \"riskToStaff\" } }, \"flags\" : { \"value\" : [ \"value\", \"value\" ] }, \"crn\" : \"crn\"}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"offenceId\" : \"M1502750438\", \"convictionId\" : 1502724704, \"deliusEventNumber\" : \"7\", \"offenceDate\" : \"2000-01-23\", \"offenceDescription\" : \"offenceDescription\"}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"reportedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"establishment\" : \"establishment\", \"id\" : 0, \"finding\" : \"finding\", \"offenceDescription\" : \"Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801\", \"hearingHeld\" : true}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"riskToSelf\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"dateStarted\" : \"2000-01-23T04:56:07.000+00:00\", \"dateCompleted\" : \"2000-01-23T04:56:07.000+00:00\", \"assessmentId\" : 138985987}")</ID>
+    <ID>MaxLineLength:PeopleApiDelegate.kt$PeopleApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"roshSummary\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"riskToSelf\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"dateStarted\" : \"2000-01-23T04:56:07.000+00:00\", \"dateCompleted\" : \"2000-01-23T04:56:07.000+00:00\", \"offenceDetails\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"supportingInformation\" : [ { \"answer\" : \"answer\", \"sectionNumber\" : 0, \"linkedToReOffending\" : true, \"label\" : \"label\", \"linkedToHarm\" : true, \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"sectionNumber\" : 0, \"linkedToReOffending\" : true, \"label\" : \"label\", \"linkedToHarm\" : true, \"questionNumber\" : \"questionNumber\" } ], \"assessmentId\" : 138985987, \"riskManagementPlan\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ]}")</ID>
+    <ID>MaxLineLength:PeopleCas2Delegate.kt$PeopleCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dateStarted\" : \"2000-01-23T04:56:07.000+00:00\", \"dateCompleted\" : \"2000-01-23T04:56:07.000+00:00\", \"rosh\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"assessmentId\" : 138985987}")</ID>
+    <ID>MaxLineLength:PeopleCas2Delegate.kt$PeopleCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"mappa\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"level\" : \"level\" } }, \"tier\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"level\" : \"level\" } }, \"roshRisks\" : { \"value\" : { \"lastUpdated\" : \"2000-01-23\", \"overallRisk\" : \"overallRisk\", \"riskToChildren\" : \"riskToChildren\", \"riskToPublic\" : \"riskToPublic\", \"riskToKnownAdult\" : \"riskToKnownAdult\", \"riskToStaff\" : \"riskToStaff\" } }, \"flags\" : { \"value\" : [ \"value\", \"value\" ] }, \"crn\" : \"crn\"}")</ID>
+    <ID>MaxLineLength:PeopleCas2Delegate.kt$PeopleCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"riskToSelf\" : [ { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" }, { \"answer\" : \"answer\", \"label\" : \"label\", \"questionNumber\" : \"questionNumber\" } ], \"dateStarted\" : \"2000-01-23T04:56:07.000+00:00\", \"dateCompleted\" : \"2000-01-23T04:56:07.000+00:00\", \"assessmentId\" : 138985987}")</ID>
+    <ID>MaxLineLength:PlacementCriteria.kt$PlacementCriteria$*</ID>
+    <ID>MaxLineLength:PlacementRequestsApi.kt$PlacementRequestsApi$,</ID>
+    <ID>MaxLineLength:PlacementRequestsApiDelegate.kt$PlacementRequestsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"placementRequestId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"notes\" : \"notes\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PlacementRequestsApiDelegate.kt$PlacementRequestsApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"premisesName\" : \"premisesName\", \"departureDate\" : \"2022-09-30T00:00:00.000+00:00\", \"arrivalDate\" : \"2022-07-28T00:00:00.000+00:00\"}")</ID>
+    <ID>MaxLineLength:PremisesApi.kt$PremisesApi$,</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"characteristics\" : [ { \"propertyName\" : \"isCatered\", \"name\" : \"Is this premises catered (rather than self-catered)?\", \"serviceScope\" : \"approved-premises\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\", \"modelScope\" : \"premises\" }, { \"propertyName\" : \"isCatered\", \"name\" : \"Is this premises catered (rather than self-catered)?\", \"serviceScope\" : \"approved-premises\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\", \"modelScope\" : \"premises\" } ], \"code\" : \"NEABC-4\", \"notes\" : \"notes\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"beds\" : [ { \"code\" : \"NEABC04\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, { \"code\" : \"NEABC04\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" } ]}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"characteristics\" : [ { \"propertyName\" : \"isCatered\", \"name\" : \"Is this premises catered (rather than self-catered)?\", \"serviceScope\" : \"approved-premises\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\", \"modelScope\" : \"premises\" }, { \"propertyName\" : \"isCatered\", \"name\" : \"Is this premises catered (rather than self-catered)?\", \"serviceScope\" : \"approved-premises\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\", \"modelScope\" : \"premises\" } ], \"notes\" : \"some notes about this property\", \"town\" : \"Braintree\", \"probationRegion\" : { \"name\" : \"NPS North East Central Referrals\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\" }, \"postcode\" : \"LS1 3AD\", \"availableBedsForToday\" : 20, \"apArea\" : { \"identifier\" : \"LON\", \"name\" : \"Yorkshire &amp; The Humber\", \"id\" : \"cd1c2d43-0b0b-4438-b0e3-d4424e61fb6a\" }, \"localAuthorityArea\" : { \"identifier\" : \"LEEDS\", \"name\" : \"Leeds City Council\", \"id\" : \"6abb5fa3-e93f-4445-887b-30d081688f44\" }, \"service\" : \"service\", \"name\" : \"Hope House\", \"addressLine1\" : \"one something street\", \"addressLine2\" : \"Blackmore End\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bedCount\" : 22}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"newArrivalDate\" : \"2000-01-23\", \"previousDepartureDate\" : \"2000-01-23\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"previousArrivalDate\" : \"2000-01-23\", \"newDepartureDate\" : \"2000-01-23\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"keyWorkerStaffCode\" : \"keyWorkerStaffCode\", \"arrivalTime\" : \"arrivalTime\", \"expectedDepartureDate\" : \"2000-01-23\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"arrivalDate\" : \"2000-01-23\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"previousDepartureDate\" : \"2000-01-23\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"newDepartureDate\" : \"2000-01-23\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"workingDays\" : 0, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dateCapacities\" : [ { \"date\" : \"2000-01-23\", \"availableBeds\" : 10 }, { \"date\" : \"2000-01-23\", \"availableBeds\" : 10 } ], \"name\" : \"name\", \"postcode\" : \"postcode\", \"availableBedsForToday\" : 6, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"apCode\" : \"apCode\", \"bookings\" : [ { \"bed\" : { \"code\" : \"NEABC04\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"departureDate\" : \"2000-01-23\", \"arrivalDate\" : \"2000-01-23\" }, { \"bed\" : { \"code\" : \"NEABC04\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\" }, \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"departureDate\" : \"2000-01-23\", \"arrivalDate\" : \"2000-01-23\" } ], \"bedCount\" : 0}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dateTime\" : \"2000-01-23T04:56:07.000+00:00\", \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"dateTime\" : \"2000-01-23T04:56:07.000+00:00\", \"reason\" : { \"name\" : \"Admitted to Hospital\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true }, \"destinationProvider\" : { \"name\" : \"Ext - North East Region\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true }, \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"moveOnCategory\" : { \"name\" : \"Housing Association - Rented\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"date\" : \"2000-01-23\", \"reason\" : { \"name\" : \"Recall\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true }, \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"date\" : \"2000-01-23\", \"reason\" : { \"name\" : \"Recall\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true }, \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"notes\" : \"notes\", \"premisesName\" : \"premisesName\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bookingId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"reason\" : { \"name\" : \"Double Room with Single Occupancy - Other (Non-FM)\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true }, \"notes\" : \"notes\", \"cancellation\" : \"\", \"endDate\" : \"2000-01-23\", \"referenceNumber\" : \"referenceNumber\", \"bedId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"startDate\" : \"2000-01-23\", \"bedName\" : \"bedName\", \"roomName\" : \"roomName\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"schedule\" : [ { \"endDate\" : \"2000-01-23\", \"length\" : 0, \"startDate\" : \"2000-01-23\" }, { \"endDate\" : \"2000-01-23\", \"length\" : 0, \"startDate\" : \"2000-01-23\" } ], \"bedId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bedName\" : \"bedName\"}")</ID>
+    <ID>MaxLineLength:PremisesApiDelegate.kt$PremisesApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"service\" : \"service\", \"name\" : \"Hope House\", \"postcode\" : \"LS1 3AD\", \"addressLine1\" : \"one something street\", \"addressLine2\" : \"Blackmore End\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"bedCount\" : 22}")</ID>
+    <ID>MaxLineLength:ProfileApiDelegate.kt$ProfileApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"telephoneNumber\" : \"telephoneNumber\", \"service\" : \"service\", \"deliusUsername\" : \"deliusUsername\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true, \"region\" : { \"name\" : \"NPS North East Central Referrals\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\" }, \"email\" : \"email\"}")</ID>
+    <ID>MaxLineLength:ReferenceDataApiDelegate.kt$ReferenceDataApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"name\" : \"Admitted to Hospital\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true}")</ID>
+    <ID>MaxLineLength:ReferenceDataApiDelegate.kt$ReferenceDataApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"name\" : \"Double Room with Single Occupancy - Other (Non-FM)\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true}")</ID>
+    <ID>MaxLineLength:ReferenceDataApiDelegate.kt$ReferenceDataApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"name\" : \"Housing Association - Rented\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true}")</ID>
+    <ID>MaxLineLength:ReferenceDataApiDelegate.kt$ReferenceDataApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"name\" : \"Recall\", \"serviceScope\" : \"serviceScope\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true}")</ID>
+    <ID>MaxLineLength:ReferenceDataApiDelegate.kt$ReferenceDataApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"propertyName\" : \"isCatered\", \"name\" : \"Is this premises catered (rather than self-catered)?\", \"serviceScope\" : \"approved-premises\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\", \"modelScope\" : \"premises\"}")</ID>
+    <ID>MaxLineLength:ReferenceDataCas2Delegate.kt$ReferenceDataCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"name\" : \"moreInfoRequested\", \"description\" : \"More information about the application has been requested from the POM (Prison Offender Manager).\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"label\" : \"More information requested\"}")</ID>
+    <ID>MaxLineLength:SeedFileType.kt$SeedFileType$*</ID>
+    <ID>MaxLineLength:SubmissionsCas2Delegate.kt$SubmissionsCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"createdByUserId\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"person\" : { \"crn\" : \"crn\" }, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\"}")</ID>
+    <ID>MaxLineLength:SubmissionsCas2Delegate.kt$SubmissionsCas2Delegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"submittedBy\" : { \"name\" : \"Roger Smith\", \"nomisUsername\" : \"SMITHR_GEN\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true, \"email\" : \"Roger.Smith@justice.gov.uk\" }, \"createdAt\" : \"2000-01-23T04:56:07.000+00:00\", \"schemaVersion\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"telephoneNumber\" : \"telephoneNumber\", \"person\" : { \"crn\" : \"crn\" }, \"document\" : \"\", \"outdatedSchema\" : true, \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"submittedAt\" : \"2000-01-23T04:56:07.000+00:00\", \"statusUpdates\" : [ { \"updatedBy\" : { \"origin\" : \"NACRO\", \"name\" : \"Roger Smith\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"email\" : \"roger@external.example.com\", \"username\" : \"CAS2_ASSESSOR_USER\" }, \"name\" : \"moreInfoRequested\", \"description\" : \"More information about the application has been requested from the POM (Prison Offender Manager).\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"label\" : \"More information requested\", \"updatedAt\" : \"2000-01-23T04:56:07.000+00:00\" }, { \"updatedBy\" : { \"origin\" : \"NACRO\", \"name\" : \"Roger Smith\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"email\" : \"roger@external.example.com\", \"username\" : \"CAS2_ASSESSOR_USER\" }, \"name\" : \"moreInfoRequested\", \"description\" : \"More information about the application has been requested from the POM (Prison Offender Manager).\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"label\" : \"More information requested\", \"updatedAt\" : \"2000-01-23T04:56:07.000+00:00\" } ]}")</ID>
+    <ID>MaxLineLength:TasksApiDelegate.kt$TasksApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"personName\" : \"personName\", \"dueDate\" : \"2000-01-23\", \"id\" : \"6abb5fa3-e93f-4445-887b-30d081688f44\", \"applicationId\" : \"6abb5fa3-e93f-4445-887b-30d081688f44\", \"crn\" : \"crn\"}")</ID>
+    <ID>MaxLineLength:TasksApiDelegate.kt$TasksApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"task\" : { \"personName\" : \"personName\", \"dueDate\" : \"2000-01-23\", \"id\" : \"6abb5fa3-e93f-4445-887b-30d081688f44\", \"applicationId\" : \"6abb5fa3-e93f-4445-887b-30d081688f44\", \"crn\" : \"crn\" }, \"users\" : [ null, null ]}")</ID>
+    <ID>MaxLineLength:TimelineEventType.kt$TimelineEventType$*</ID>
+    <ID>MaxLineLength:UnauthenticatedProblem.kt$UnauthenticatedProblem$class</ID>
+    <ID>MaxLineLength:UserService.kt$UserService$return (deliusUser.email !== user.email) || (deliusUser.telephoneNumber !== user.telephoneNumber) || (deliusUser.staff.fullName != user.name) || (deliusUser.staffCode != user.deliusStaffCode) || (deliusUser.probationArea.code != user.probationRegion.deliusCode)</ID>
+    <ID>MaxLineLength:UsersApiDelegate.kt$UsersApiDelegate$ApiUtil.setExampleResponse(request, "application/json", "{ \"telephoneNumber\" : \"telephoneNumber\", \"service\" : \"service\", \"deliusUsername\" : \"deliusUsername\", \"name\" : \"name\", \"id\" : \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"isActive\" : true, \"region\" : { \"name\" : \"NPS North East Central Referrals\", \"id\" : \"952790c0-21d7-4fd6-a7e1-9018f08d8bb0\" }, \"email\" : \"email\"}")</ID>
+    <ID>MaxLineLength:UsersController.kt$UsersController$private</ID>
+    <ID>MaxLineLength:WithdrawalReason.kt$WithdrawalReason$*</ID>
+    <ID>NestedBlockDepth:DeserializationValidationService.kt$DeserializationValidationService$fun validateObject(path: String = "$", targetType: KClass&lt;*&gt;, jsonObject: ObjectNode): Map&lt;String, String&gt;</ID>
+    <ID>NestedBlockDepth:OffenderService.kt$OffenderService$fun getInfoForPerson(crn: String, deliusUsername: String, ignoreLao: Boolean): PersonInfoResult</ID>
+    <ID>NestedBlockDepth:SeedService.kt$SeedService$@PostConstruct fun autoSeed()</ID>
+    <ID>NoNameShadowing:BookingSearchController.kt$BookingSearchController$sortField</ID>
+    <ID>NoNameShadowing:BookingSearchController.kt$BookingSearchController$sortOrder</ID>
+    <ID>NoNameShadowing:BookingService.kt$BookingService$user</ID>
+    <ID>NoNameShadowing:BookingService.kt$BookingService${ return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates" }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ ChronoUnit.DAYS.between(LocalDateTime.of(booking.startDate, LocalTime.MAX), it.toLocalDateTime()).toInt() }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ ChronoUnit.DAYS.between(it, LocalDate.now()).toInt() }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ it.dateOfBirth }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ it.gender }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ it.pnc }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ it.profile?.ethnicity }</ID>
+    <ID>NoNameShadowing:BookingsReportGenerator.kt$BookingsReportGenerator${ val nameParts = listOf(it.name.forename) + it.name.middleNames + it.name.surname nameParts.joinToString(" ") }</ID>
+    <ID>NoNameShadowing:CalendarService.kt$CalendarService${ it.crn }</ID>
+    <ID>NoNameShadowing:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator${ it.toDomainEvent&lt;ApplicationAssessedEnvelope&gt;(objectMapper) }</ID>
+    <ID>NoNameShadowing:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator${ it.toDomainEvent&lt;ApplicationSubmittedEnvelope&gt;(objectMapper) }</ID>
+    <ID>NoNameShadowing:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator${ it.toDomainEvent&lt;BookingMadeEnvelope&gt;(objectMapper) }</ID>
+    <ID>NoNameShadowing:DepartureTransformer.kt$DepartureTransformer${ destinationProviderTransformer.transformJpaToApi(it) }</ID>
+    <ID>NoNameShadowing:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator${ it.overallTimeliness != null &amp;&amp; it.overallTimeliness &gt;= 366 }</ID>
+    <ID>NoNameShadowing:PlacementMetricsReportGenerator.kt$PlacementMetricsReportGenerator${ it.overallTimeliness == 0 }</ID>
+    <ID>NoNameShadowing:PremisesService.kt$PremisesService${ it!! }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.clarificationNoteCount &gt; 0 }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.decision == AssessmentDecision.ACCEPTED.toString() }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.isEsapApplication == false &amp;&amp; it.isPipeApplication == false }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.isEsapApplication == true }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.isPipeApplication == true }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.tier == null }</ID>
+    <ID>NoNameShadowing:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator${ it.tier == this.toString() }</ID>
+    <ID>NoNameShadowing:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob${ it.serviceScope == "temporary-accommodation" }</ID>
+    <ID>NoNameShadowing:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob${ it.serviceScope == "temporary-accommodation" }</ID>
+    <ID>NoNameShadowing:UsersController.kt$UsersController$qualifications</ID>
+    <ID>NoNameShadowing:UsersController.kt$UsersController$roles</ID>
+    <ID>ProtectedMemberInFinalClass:PreemptiveCacheRefresher.kt$PreemptiveCacheRefresher$protected val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>RedundantSuspendModifier:TasksController.kt$TasksController$suspend</ID>
+    <ID>ReturnCount:ApplicationService.kt$ApplicationService$@Transactional fun submitApplication( submitApplication: SubmitCas2Application, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;Cas2ApplicationEntity&gt;&gt;</ID>
+    <ID>ReturnCount:ApplicationService.kt$ApplicationService$fun updateApplication(applicationId: UUID, data: String?, username: String?): AuthorisableActionResult&lt;ValidatableActionResult&lt;Cas2ApplicationEntity&gt;&gt;</ID>
+    <ID>ReturnCount:ExceptionHandling.kt$ExceptionHandling$override fun toProblem(throwable: Throwable, status: StatusType): ThrowableProblem?</ID>
+    <ID>ReturnCount:OffenderService.kt$OffenderService$fun getInfoForPerson(crn: String, deliusUsername: String, ignoreLao: Boolean): PersonInfoResult</ID>
+    <ID>ReturnCount:TaskService.kt$TaskService$fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, id: UUID): AuthorisableActionResult&lt;ValidatableActionResult&lt;Reallocation&gt;&gt;</ID>
+    <ID>SpreadOperator:Application.kt$(*args)</ID>
+    <ID>SpreadOperator:ReportGenerator.kt$ReportGenerator$(*sorted.toTypedArray())</ID>
+    <ID>SpreadOperator:UserAllocationsEngine.kt$UserAllocationsEngine$(*predicates.toTypedArray())</ID>
+    <ID>SpreadOperator:UserService.kt$UserService$(*UserRole.getAllRolesForService(ServiceName.temporaryAccommodation).toTypedArray())</ID>
+    <ID>SpreadOperator:UserSpecifications.kt$(*predicates.toTypedArray())</ID>
+    <ID>SwallowedException:DeserializationValidationService.kt$e: Exception</ID>
+    <ID>SwallowedException:OffenderService.kt$OffenderService$exception: Exception</ID>
+    <ID>SwallowedException:PlacementRequestTransformer.kt$PlacementRequestTransformer$exception: Exception</ID>
+    <ID>SwallowedException:SeedService.kt$SeedService$exception: Exception</ID>
+    <ID>ThrowsCount:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$private fun createBooking( row: ApprovedPremisesBookingSeedCsvRow, )</ID>
+    <ID>ThrowsCount:DeletePremisesController.kt$DeletePremisesController$@RequestMapping(method = [RequestMethod.DELETE], value = ["/internal/premises/{premisesId}"]) fun internalDeletePremises(@PathVariable("premisesId") premisesId: UUID): ResponseEntity&lt;Unit&gt;</ID>
+    <ID>ThrowsCount:DeleteRoomController.kt$DeleteRoomController$@RequestMapping(method = [RequestMethod.DELETE], value = ["/internal/room/{roomId}"]) fun internalDeletePremises(@PathVariable("roomId") roomId: UUID): ResponseEntity&lt;Unit&gt;</ID>
+    <ID>ThrowsCount:DocumentsController.kt$DocumentsController$@RequestMapping(method = [RequestMethod.GET], value = ["/documents/{crn}/{documentId}"], produces = ["application/octet-stream"]) fun documentsCrnDocumentIdGet(@PathVariable("crn") crn: String, @PathVariable("documentId") documentId: String): ResponseEntity&lt;StreamingResponseBody&gt;</ID>
+    <ID>ThrowsCount:ReportsController.kt$ReportsController$private fun validateParameters(probationRegionId: UUID?, month: Int)</ID>
+    <ID>TooGenericExceptionCaught:BaseHMPPSClient.kt$BaseHMPPSClient$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:CommunityApiClient.kt$CommunityApiClient$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:DeserializationValidationService.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:MigrationJobService.kt$MigrationJobService$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:NomisUsersSeedJob.kt$NomisUsersSeedJob$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:OAuth2ResourceServerSecurityConfiguration.kt$LoggingInMemoryOAuth2AuthorizedClientService$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:OffenderService.kt$OffenderService$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:PersonRisks.kt$PersonRisksConverter$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:PlacementRequestTransformer.kt$PlacementRequestTransformer$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:PreemptiveCacheRefresher.kt$CacheRefreshWorker$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:SeedService.kt$SeedService$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:SeedService.kt$SeedService$exception: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:UpdateAllUsersFromCommunityApiJob.kt$UpdateAllUsersFromCommunityApiJob$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:UsersSeedJob.kt$UsersSeedJob$exception: Exception</ID>
+    <ID>TooGenericExceptionThrown:AdjudicationTransformer.kt$AdjudicationTransformer$throw RuntimeException("Agency ${result.agencyId} not found")</ID>
+    <ID>TooGenericExceptionThrown:ApAreaMigrationJob.kt$ApAreaMigrationJob$throw RuntimeException("Cannot find probation region - Midlands")</ID>
+    <ID>TooGenericExceptionThrown:ApAreaMigrationJob.kt$ApAreaMigrationJob$throw RuntimeException("Cannot find probation region - North East")</ID>
+    <ID>TooGenericExceptionThrown:ApAreaMigrationJob.kt$ApAreaMigrationJob$throw RuntimeException("Cannot find probation region - South East &amp; Eastern")</ID>
+    <ID>TooGenericExceptionThrown:ApiUtil.kt$ApiUtil$throw RuntimeException(e)</ID>
+    <ID>TooGenericExceptionThrown:ApplicationService.kt$ApplicationService$throw RuntimeException("Cannot create an Application for an Offender without a NOMS number")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationService.kt$ApplicationService$throw RuntimeException("Could not get user")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationService.kt$ApplicationService$throw RuntimeException("Incorrect type of JSON schema referenced by CAS2 Application")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException( "CAS2 now has its own " + "Cas2ApplicationsController", )</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException("Unsupported Application type: ${application::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException("Unsupported SubmitApplication type: ${submitApplication::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsController.kt$ApplicationsController$throw RuntimeException("Unsupported UpdateApplication type: ${body::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsTransformer.kt$ApplicationsTransformer$throw RuntimeException("Application ${entity.getId()} has no status")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsTransformer.kt$ApplicationsTransformer$throw RuntimeException("Unrecognised application type when transforming: ${domain::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationsTransformer.kt$ApplicationsTransformer$throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$throw RuntimeException("Booking ${row.id} is not an Approved Premises Booking")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$throw RuntimeException("Conflict trying to create Cancellation: ${validationResult.message}")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$throw RuntimeException("Field error trying to create Cancellation: ${validationResult.validationMessages}")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$throw RuntimeException("General error trying to create Cancellation: ${validationResult.message}")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$throw RuntimeException("No Booking with Id of ${row.id} exists")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Bed with code ${row.bedCode} does not exist")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Could not find Cancellation Reason with name '${row.cancellationReason}'")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Could not find Departure Reason with name '${row.departureReason}'")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Could not find Destination Provider with name '${row.departureDestinationProvider}'")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Could not find Move on Category with name '${row.departureMoveOnCategory}'")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Could not find Non Arrival Reason with name '${row.nonArrivalReason}'")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If arrivalDate is provided, keyWorkerDeliusUsername must also be provided.")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If cancellationDate is provided, cancellationReason must also be provided")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If departureDateTime is provided, arrivalDate must also be provided.")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If departureDateTime is provided, departureReason must also be provided")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If departureDateTime is provided, destinationProvider must also be provided")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If departureDateTime is provided, moveOnCategory must also be provided")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("If nonArrivalDate is provided, nonArrivalReason must also be provided")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$throw RuntimeException("Offender does not have a NOMS number")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$throw RuntimeException( "Error: no premises with apCode '${row.apCode}' found. " + "Please seed premises before rooms/beds.", )</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$throw RuntimeException("'$value' is not a recognised boolean for '$fieldName' (use yes | no)")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$throw RuntimeException("Characteristic '${it.propertyName}' does not exist for AP room")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$throw RuntimeException("'$value' is not a recognised boolean for '$fieldName' (use yes | no)")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$throw RuntimeException("Characteristic '${it.propertyName}' does not exist for AP premises")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$throw RuntimeException("Local Authority Area ${row.localAuthorityArea} does not exist")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$throw RuntimeException("Premises ${row.apCode} is of type ${existingPremises::class.qualifiedName}, cannot be updated with Approved Premises Seed Job")</ID>
+    <ID>TooGenericExceptionThrown:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$throw RuntimeException("Probation Region ${row.probationRegion} does not exist")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentReferralHistoryNoteTransformer.kt$AssessmentReferralHistoryNoteTransformer$throw RuntimeException("Unsupported ReferralHistoryNote type: ${jpa::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Assessment type '${assessment::class.qualifiedName}' is not currently supported")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Only CAS3 Assessments are currently supported")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Only CAS3 assessments are currently supported")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Only CAS3 is currently supported")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Reallocating an assessment of type '${currentAssessment::class.qualifiedName}' has not been implemented.")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Unable to get Offender Details when creating Application Assessed Domain Event: Not Found")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentService.kt$AssessmentService$throw RuntimeException("Unable to get Offender Details when creating Application Assessed Domain Event: Unauthorised")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentTransformer.kt$AssessmentTransformer$throw RuntimeException("Unsupported Application type when transforming Assessment: ${jpa.application::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentTransformer.kt$AssessmentTransformer$throw RuntimeException("Unsupported type: ${ase.type}")</ID>
+    <ID>TooGenericExceptionThrown:AssessmentUtils.kt$throw RuntimeException("Cannot compare values of types ${a::class.qualifiedName} and ${b::class.qualifiedName} due to incomparable status types.")</ID>
+    <ID>TooGenericExceptionThrown:BedSearchController.kt$BedSearchController$throw RuntimeException("Unsupported BedSearchParameters type: ${bedSearchParameters::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:BookingSearchResultTransformer.kt$BookingSearchResultTransformer$throw RuntimeException("Unknown booking status ${result.bookingStatus}")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Booking has a Key Worker specified but Premises is not an ApprovedPremises")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Only CAS1 bookings are supported")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Only CAS3 bookings are supported")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Unable to get Offender Details when creating Booking Cancelled Domain Event: Not Found")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Unable to get Offender Details when creating Booking Cancelled Domain Event: Unauthorised")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Unable to get Offender Details when creating Booking Made Domain Event: Not Found")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Unable to get Offender Details when creating Booking Made Domain Event: Unauthorised")</ID>
+    <ID>TooGenericExceptionThrown:BookingService.kt$BookingService$throw RuntimeException("Unknown premises type ${booking.premises::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:BookingTransformer.kt$BookingTransformer$throw RuntimeException("Could not determine service for Booking ${jpa.id}")</ID>
+    <ID>TooGenericExceptionThrown:BookingTransformer.kt$BookingTransformer$throw RuntimeException("Could not determine status for Booking ${jpa.id}")</ID>
+    <ID>TooGenericExceptionThrown:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$throw RuntimeException("Could not create application ${row.id}", exception)</ID>
+    <ID>TooGenericExceptionThrown:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$throw RuntimeException("Could not find applicant with nomisUsername ${row.createdBy}")</ID>
+    <ID>TooGenericExceptionThrown:CharacteristicTransformer.kt$CharacteristicTransformer$throw RuntimeException("Unsupported service scope: ${jpa.modelScope}")</ID>
+    <ID>TooGenericExceptionThrown:CharacteristicTransformer.kt$CharacteristicTransformer$throw RuntimeException("Unsupported service scope: ${jpa.serviceScope}")</ID>
+    <ID>TooGenericExceptionThrown:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$throw RuntimeException("The field: '$requiredField' is required")</ID>
+    <ID>TooGenericExceptionThrown:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$throw RuntimeException("Your '$requiredField' value: '$value' is not recognised")</ID>
+    <ID>TooGenericExceptionThrown:DomainEventEntity.kt$DomainEventEntity$throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${this.type.name}")</ID>
+    <ID>TooGenericExceptionThrown:DomainEventService.kt$DomainEventService$throw RuntimeException("Unrecognised domain event type: ${type.name}")</ID>
+    <ID>TooGenericExceptionThrown:DomainEventService.kt$DomainEventService$throw RuntimeException("Unrecognised domain event type: ${type.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:DomainEventService.kt$DomainEventService$throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${domainEventEntity.type.name}")</ID>
+    <ID>TooGenericExceptionThrown:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$throw RuntimeException("Could not create external user ${row.username}", exception)</ID>
+    <ID>TooGenericExceptionThrown:NomisUsersSeedJob.kt$NomisUsersSeedJob$throw RuntimeException("Could not create user ${row.nomisUsername}", exception)</ID>
+    <ID>TooGenericExceptionThrown:OAuth2ResourceServerSecurityConfiguration.kt$AuthAwareTokenConverter$throw RuntimeException("Unable to find a claim to identify Subject by")</ID>
+    <ID>TooGenericExceptionThrown:OffenderService.kt$OffenderService$throw RuntimeException("No category provided for prison-case-notes.excluded-categories at index $index")</ID>
+    <ID>TooGenericExceptionThrown:OffenderService.kt$OffenderService$throw RuntimeException("No prison-adjudications.adjudications-api-page-size configuration provided")</ID>
+    <ID>TooGenericExceptionThrown:OffenderService.kt$OffenderService$throw RuntimeException("No prison-api-page-size configuration provided")</ID>
+    <ID>TooGenericExceptionThrown:OffenderService.kt$OffenderService$throw RuntimeException("No prison-case-notes.excluded-categories provided")</ID>
+    <ID>TooGenericExceptionThrown:OffenderService.kt$OffenderService$throw RuntimeException("No prison-case-notes.lookback-days configuration provided")</ID>
+    <ID>TooGenericExceptionThrown:PersonRisks.kt$PersonRisksConverter$throw RuntimeException("Unable to deserialize PersonRisks from JSON string", exception)</ID>
+    <ID>TooGenericExceptionThrown:PersonRisks.kt$PersonRisksConverter$throw RuntimeException("Unable to serialize PersonRisks to JSON string for database", exception)</ID>
+    <ID>TooGenericExceptionThrown:PlacementApplicationsController.kt$PlacementApplicationsController$throw RuntimeException("Only CAS1 Applications are currently supported")</ID>
+    <ID>TooGenericExceptionThrown:PlacementRequestTransformer.kt$PlacementRequestTransformer$throw RuntimeException("Unrecognised releaseType: $releaseType")</ID>
+    <ID>TooGenericExceptionThrown:PlacementRequirementsService.kt$PlacementRequirementsService$throw RuntimeException("Only Approved Premises Assessments are currently supported for Placement Requests")</ID>
+    <ID>TooGenericExceptionThrown:PremisesController.kt$PremisesController$throw RuntimeException("Booking ${it.id} has a Key Worker specified but Premises ${premises.id} is not an ApprovedPremises")</ID>
+    <ID>TooGenericExceptionThrown:PremisesController.kt$PremisesController$throw RuntimeException("CAS2 not supported")</ID>
+    <ID>TooGenericExceptionThrown:PremisesController.kt$PremisesController$throw RuntimeException("Unsupported New Booking type: ${body::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:PremisesController.kt$PremisesController$throw RuntimeException("Unsupported NewArrival type: ${body::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:PremisesService.kt$PremisesService$throw RuntimeException("startDate must be before endDate when calculating availability for range")</ID>
+    <ID>TooGenericExceptionThrown:PremisesTransformer.kt$PremisesTransformer$throw RuntimeException("Unsupported PremisesEntity type: ${jpa::class.qualifiedName}")</ID>
+    <ID>TooGenericExceptionThrown:RedisConfiguration.kt$ClientResultRedisSerializer$throw RuntimeException("Preemptively cached requests should not be annotated with @Cacheable")</ID>
+    <ID>TooGenericExceptionThrown:RedisConfiguration.kt$ClientResultRedisSerializer$throw RuntimeException("Unhandled discriminator type: ${deserializedWrapper.discriminator}")</ID>
+    <ID>TooGenericExceptionThrown:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$throw RuntimeException("Unknown Metric type - ${this::class.java}")</ID>
+    <ID>TooGenericExceptionThrown:ReportGenerator.kt$ReportGenerator$throw RuntimeException("CAS2 not supported")</ID>
+    <ID>TooGenericExceptionThrown:RoshRatings.kt$RoshRatingsInner$throw RuntimeException("No RiskLevels found")</ID>
+    <ID>TooGenericExceptionThrown:SeedJob.kt$SeedJob$throw RuntimeException("Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied")</ID>
+    <ID>TooGenericExceptionThrown:SeedJob.kt$SeedJob$throw RuntimeException("required headers: $missingHeaders")</ID>
+    <ID>TooGenericExceptionThrown:SeedService.kt$SeedService$throw RuntimeException("The headers provided: $headerRow did not include ${exception.message}")</ID>
+    <ID>TooGenericExceptionThrown:SeedService.kt$SeedService$throw RuntimeException("There was an issue opening the CSV file", exception)</ID>
+    <ID>TooGenericExceptionThrown:SeedService.kt$SeedService$throw RuntimeException("There were issues deserializing the CSV:\n${errors.joinToString(", \n")}")</ID>
+    <ID>TooGenericExceptionThrown:SeedService.kt$SeedService$throw RuntimeException("Unable to process CSV at row $rowNumber", exception)</ID>
+    <ID>TooGenericExceptionThrown:TaskService.kt$TaskService$throw RuntimeException("Unexpected type")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$throw RuntimeException("Characteristic $it does not exist")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$throw RuntimeException("Premises with reference '${row.premisesName}' does not exist")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$throw RuntimeException("Characteristic $it does not exist")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$throw RuntimeException("Local Authority Area ${row.localAuthorityArea} does not exist")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$throw RuntimeException("Model scope does not match for Characteristic $it")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$throw RuntimeException("Probation Delivery Unit ${row.pdu} does not exist")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$throw RuntimeException("Probation Region $canonicalRegionName does not exist")</ID>
+    <ID>TooGenericExceptionThrown:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$throw RuntimeException("Service scope does not match for Characteristic $it")</ID>
+    <ID>TooGenericExceptionThrown:UserTransformer.kt$UserTransformer$throw RuntimeException("CAS2 not supported")</ID>
+    <ID>TooGenericExceptionThrown:UsersSeedJob.kt$UsersSeedJob$throw RuntimeException("Could not get user ${row.deliusUsername}", exception)</ID>
+    <ID>TooGenericExceptionThrown:UsersSeedJob.kt$UsersSeedJob$throw RuntimeException("Unrecognised User Qualifications(s): $unknownQualifications")</ID>
+    <ID>TooGenericExceptionThrown:UsersSeedJob.kt$UsersSeedJob$throw RuntimeException("Unrecognised User Role(s): $unknownRoles")</ID>
+    <ID>TooGenericExceptionThrown:ValidatableActionResult.kt$ValidatableActionResult$throw RuntimeException("Cannot translate Success")</ID>
+    <ID>TooGenericExceptionThrown:WebClientCache.kt$WebClientCache$throw RuntimeException("Must provide a preemptiveCacheKey")</ID>
+    <ID>TooManyFunctions:ApplicationEntity.kt$ApplicationRepository : JpaRepository</ID>
+    <ID>TooManyFunctions:ApplicationEntityReportRow.kt$ApplicationEntityReportRow</ID>
+    <ID>TooManyFunctions:ApplicationsApi.kt$ApplicationsApi</ID>
+    <ID>TooManyFunctions:ApplicationsApiDelegate.kt$ApplicationsApiDelegate</ID>
+    <ID>TooManyFunctions:AssessmentService.kt$AssessmentService</ID>
+    <ID>TooManyFunctions:BookingEntity.kt$BookingRepository : JpaRepository</ID>
+    <ID>TooManyFunctions:BookingService.kt$BookingService</ID>
+    <ID>TooManyFunctions:DomainEventService.kt$DomainEventService</ID>
+    <ID>TooManyFunctions:EventsApi.kt$EventsApi</ID>
+    <ID>TooManyFunctions:EventsApiDelegate.kt$EventsApiDelegate</ID>
+    <ID>TooManyFunctions:OffenderService.kt$OffenderService</ID>
+    <ID>TooManyFunctions:PeopleApi.kt$PeopleApi</ID>
+    <ID>TooManyFunctions:PeopleApiDelegate.kt$PeopleApiDelegate</ID>
+    <ID>TooManyFunctions:PremisesApi.kt$PremisesApi</ID>
+    <ID>TooManyFunctions:PremisesApiDelegate.kt$PremisesApiDelegate</ID>
+    <ID>TooManyFunctions:PremisesController.kt$PremisesController : PremisesApiDelegate</ID>
+    <ID>TooManyFunctions:PremisesEntity.kt$PremisesRepository : JpaRepository</ID>
+    <ID>TooManyFunctions:PremisesService.kt$PremisesService</ID>
+    <ID>TooManyFunctions:ReferenceDataApi.kt$ReferenceDataApi</ID>
+    <ID>TooManyFunctions:ReferenceDataApiDelegate.kt$ReferenceDataApiDelegate</ID>
+    <ID>TooManyFunctions:ReportsApi.kt$ReportsApi</ID>
+    <ID>TooManyFunctions:ReportsApiDelegate.kt$ReportsApiDelegate</ID>
+    <ID>TooManyFunctions:UserAccessService.kt$UserAccessService</ID>
+    <ID>TopLevelPropertyNaming:BedEntity.kt$const val bedSummaryQuery = """ select cast(b.id as text) as id, cast(b.name as text) as name, cast(r.name as text) as roomName, r.id as roomId, ( select count(booking.id) from bookings booking left join cancellations cancellation on booking.id = cancellation.booking_id left join non_arrivals non_arrival on non_arrival.booking_id = booking.id where booking.bed_id = b.id and booking.arrival_date &lt;= CURRENT_DATE and booking.departure_date &gt;= CURRENT_DATE and cancellation IS NULL and non_arrival IS NULL ) &gt; 0 as bedBooked, ( select count(lost_bed.id) from lost_beds lost_bed left join lost_bed_cancellations cancellation on lost_bed.id = cancellation.lost_bed_id where lost_bed.bed_id = b.id and lost_bed.start_date &lt;= CURRENT_DATE and lost_bed.end_date &gt;= CURRENT_DATE and cancellation IS NULL ) &gt; 0 as bedOutOfService from beds b join rooms r on b.room_id = r.id """</ID>
+    <ID>UnnecessaryAbstractClass:AssessmentEntity.kt$AssessmentEntity$AssessmentEntity</ID>
+    <ID>UnnecessaryAbstractClass:AssessmentEntity.kt$AssessmentReferralHistoryNoteEntity$AssessmentReferralHistoryNoteEntity</ID>
+    <ID>UnnecessaryAbstractClass:AssessmentInfo.kt$AssessmentInfo$AssessmentInfo</ID>
+    <ID>UnnecessaryAbstractClass:BaseHMPPSClient.kt$BaseHMPPSClient$BaseHMPPSClient</ID>
+    <ID>UnnecessaryAbstractClass:JsonSchemaEntity.kt$JsonSchemaEntity$JsonSchemaEntity</ID>
+    <ID>UnnecessaryAbstractClass:OASysTransformer.kt$OASysTransformer$OASysTransformer</ID>
+    <ID>UnnecessaryAbstractClass:PremisesEntity.kt$PremisesEntity$PremisesEntity</ID>
+    <ID>UnnecessaryApply:ApplicationService.kt$ApplicationService$apply { this.data = data }</ID>
+    <ID>UnnecessaryApply:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$apply { name = "${row.roomNumber} - ${row.bedCount}" }</ID>
+    <ID>UnnecessaryApply:Cas2AutoScript.kt$Cas2AutoScript$apply { this.createdAt = application.submittedAt!!.plusDays(idx + 1.toLong()) }</ID>
+    <ID>UnnecessaryApply:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$apply { this.name = row.name }</ID>
+    <ID>UnnecessaryFilter:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$filter { it.clarificationNoteCount &gt; 0 }</ID>
+    <ID>UnnecessaryFilter:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$filter { it.decision == AssessmentDecision.ACCEPTED.toString() }</ID>
+    <ID>UnnecessaryFilter:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$filter { it.rejectionRationale == rejectionReason }</ID>
+    <ID>UnnecessaryFilter:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$filter { it.releaseType == releaseType }</ID>
+    <ID>UnnecessaryFilter:ReferralsMetricsReportGenerator.kt$ReferralsMetricsReportGenerator$filter { val startDate = it.applicationSubmittedAt val endDate = it.assessmentSubmittedAt (startDate !== null &amp;&amp; endDate !== null &amp;&amp; workingDayCountService.getWorkingDaysCount(startDate, endDate) &lt;= 10) }</ID>
+    <ID>UnnecessaryFilter:WorkingDayCountService.kt$WorkingDayCountService$filter { it.isWorkingDay(bankHolidays) }</ID>
+    <ID>UnnecessaryNotNullOperator:ApplicationStatusMigrationJob.kt$ApplicationStatusMigrationJob$application.status!!</ID>
+    <ID>UnnecessaryNotNullOperator:ApplicationsTransformer.kt$ApplicationsTransformer$jpa.riskRatings!!</ID>
+    <ID>UnnecessaryNotNullOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$room!!</ID>
+    <ID>UnnecessaryNotNullOperator:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$this!!</ID>
+    <ID>UnnecessaryNotNullOperator:BookingService.kt$BookingService$keyWorkerStaffCode!!</ID>
+    <ID>UnnecessaryNotNullOperator:PlacementRequirementsService.kt$PlacementRequirementsService$postcodeDistrict!!</ID>
+    <ID>UnnecessaryNotNullOperator:PremisesService.kt$PremisesService$turnaroundWorkingDayCount!!</ID>
+    <ID>UnnecessarySafeCall:UserService.kt$UserService$deliusUser.probationArea?.let { probationArea -&gt; findProbationRegionFromArea(probationArea)?.let { probationRegion -&gt; user.probationRegion = probationRegion } }</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationService.kt$ApplicationService$application.withdrawalReason!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationService.kt$ApplicationService$convictionId!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationService.kt$ApplicationService$deliusEventNumber!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationService.kt$ApplicationService$offenceId!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationService.kt$ApplicationService$user.email!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationsController.kt$ApplicationsController$actionResult.entityType!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationsController.kt$ApplicationsController$actionResult.id!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationsTransformer.kt$ApplicationsTransformer$domain.getRiskRatings()!!</ID>
+    <ID>UnsafeCallOnNullableType:ApplicationsTransformer.kt$ApplicationsTransformer$jpa.riskRatings!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesBookingCancelSeedJob.kt$ApprovedPremisesBookingCancelSeedJob$columns["id"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$columns["bedCode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesBookingSeedJob.kt$ApprovedPremisesBookingSeedJob$columns["crn"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesOfflineApplicationsSeedJob.kt$ApprovedPremisesOfflineApplicationsSeedJob$columns["crn"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["apCode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["bedCode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["bedCount"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasArsonInsuranceConditions"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasCallForAssistance"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasCrib7Bedding"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasEnSuite"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasFixedMobilityAids"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasNearbySprinkler"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasSmokeDetector"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasStepFreeAccess"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasTurningSpace"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["hasWideDoor"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isArsonDesignated"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isArsonSuitable"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isFullyFm"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isGroundFloor"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isGroundFloorNrOffice"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isSingle"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isStepFreeDesignated"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isSuitedForSexOffenders"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isTopFloorVulnerable"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isWheelchairAccessible"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["isWheelchairDesignated"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["notes"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$columns["roomNumber"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesRoomsSeedJob.kt$ApprovedPremisesRoomsSeedJob$room!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsChildSexOffenders"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsHateCrimeOffenders"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsNonSexualChildOffenders"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["acceptsSexOffenders"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["addressLine1"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["addressLine2"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["apCode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["characteristics"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["emailAddress"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasBrailleSignage"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasHearingLoop"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasLift"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasStepFreeAccessToCommunalAreas"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasTactileFlooring"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasWheelChairAccessibleBathrooms"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasWideAccessToCommunalAreas"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["hasWideStepFreeAccess"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isCatered"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isESAP"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isIAP"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isPIPE"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isRecoveryFocussed"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isSemiSpecialistMentalHealth"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["isSuitableForVulnerable"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["latitude"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["localAuthorityArea"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["longitude"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["name"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["notes"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["postcode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["probationRegion"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["qCode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["status"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ApprovedPremisesSeedJob.kt$ApprovedPremisesSeedJob$columns["town"]!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$allocatedToUser.email!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$allocatedUser.email!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$application.createdByUser.email!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$assessment.submittedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$assigneeUser.email!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$currentAssessment.allocatedToUser!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$placementDates!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentService.kt$AssessmentService$placementRequirements!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentTransformer.kt$AssessmentTransformer$jpa.allocatedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:AssessmentTransformer.kt$AssessmentTransformer$jpa.allocatedToUser!!</ID>
+    <ID>UnsafeCallOnNullableType:BaseHMPPSClient.kt$BaseHMPPSClient$requestBuilder.body!!</ID>
+    <ID>UnsafeCallOnNullableType:BedSearchRepository.kt$BedSearchRepository$beds[bedId]!!</ID>
+    <ID>UnsafeCallOnNullableType:BedSearchRepository.kt$BedSearchRepository$roomId!!</ID>
+    <ID>UnsafeCallOnNullableType:BedSearchService.kt$BedSearchService$booking.bed?.room!!</ID>
+    <ID>UnsafeCallOnNullableType:BedSearchService.kt$BedSearchService$it.bed!!</ID>
+    <ID>UnsafeCallOnNullableType:BedUtilisationReportGenerator.kt$BedUtilisationReportGenerator$booking.turnaround!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$applicationId!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$applicationSubmittedByUser.email!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$approvedPremises.localAuthorityArea!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$bed!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$booking.bed!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$booking.keyWorkerStaffCode!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$booking.offlineApplication!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$booking.placementRequest!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$booking.premises.emailAddress!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$destinationProvider!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$eventNumberForDomainEvent!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$it.submittedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$keyWorkerStaffCode!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$moveOnCategory!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$moveOnCategory.legacyDeliusCategoryCode!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$newestOfflineApplication!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$placementRequest.booking!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$premises!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$reason!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$reason.legacyDeliusReasonCode!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingService.kt$BookingService$user!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingStatusMigrationJob.kt$BookingStatusMigrationJob$booking.status!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingTransformer.kt$BookingTransformer$cancellationTransformer.transformJpaToApi(it)!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingTransformer.kt$BookingTransformer$departureTransformer.transformJpaToApi(it)!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingTransformer.kt$BookingTransformer$jpa.getBedId()!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingTransformer.kt$BookingTransformer$jpa.getBedName()!!</ID>
+    <ID>UnsafeCallOnNullableType:BookingTransformer.kt$BookingTransformer$jpa.turnaround!!</ID>
+    <ID>UnsafeCallOnNullableType:CalendarRepository.kt$CalendarRepository$resultsMap[bedKey]!!</ID>
+    <ID>UnsafeCallOnNullableType:CalendarTransformer.kt$CalendarTransformer$endOfOpenPeriod!!</ID>
+    <ID>UnsafeCallOnNullableType:CalendarTransformer.kt$CalendarTransformer$it.personName!!</ID>
+    <ID>UnsafeCallOnNullableType:CalendarTransformer.kt$CalendarTransformer$startOfOpenPeriod!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["createdBy"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["crn"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["id"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["location"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["nomsNumber"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["state"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$columns["statusUpdates"]!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2ApplicationsSeedJob.kt$Cas2ApplicationsSeedJob$e.message!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2AutoScript.kt$Cas2AutoScript$application.submittedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:Cas2AutoScript.kt$Cas2AutoScript$e.message!!</ID>
+    <ID>UnsafeCallOnNullableType:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["characteristic_name"]!!</ID>
+    <ID>UnsafeCallOnNullableType:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["characteristic_property_name"]!!</ID>
+    <ID>UnsafeCallOnNullableType:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["model_scope"]!!</ID>
+    <ID>UnsafeCallOnNullableType:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$columns["service_scope"]!!</ID>
+    <ID>UnsafeCallOnNullableType:DailyMetricsReportGenerator.kt$DailyMetricsReportGenerator$domainEvent.data.eventDetails.assessedBy.staffMember!!</ID>
+    <ID>UnsafeCallOnNullableType:DeserializationValidationService.kt$DeserializationValidationService$expectedJsonPrimitiveType!!</ID>
+    <ID>UnsafeCallOnNullableType:DeserializationValidationService.kt$DeserializationValidationService$it.returnType.arguments.first().type!!</ID>
+    <ID>UnsafeCallOnNullableType:DocumentTransformer.kt$DocumentTransformer$it.id!!</ID>
+    <ID>UnsafeCallOnNullableType:DomainEventBuilder.kt$DomainEventBuilder$application.toUrl()!!</ID>
+    <ID>UnsafeCallOnNullableType:DomainEventBuilder.kt$DomainEventBuilder$booking.arrival!!</ID>
+    <ID>UnsafeCallOnNullableType:DomainEventBuilder.kt$DomainEventBuilder$booking.cancellation!!</ID>
+    <ID>UnsafeCallOnNullableType:DomainEventBuilder.kt$DomainEventBuilder$booking.departure!!</ID>
+    <ID>UnsafeCallOnNullableType:DomainEventService.kt$DomainEventService$domainEvent.data!!</ID>
+    <ID>UnsafeCallOnNullableType:EmailNotificationService.kt$EmailNotificationService$guestListNotificationClient!!</ID>
+    <ID>UnsafeCallOnNullableType:EmailNotificationService.kt$EmailNotificationService$normalNotificationClient!!</ID>
+    <ID>UnsafeCallOnNullableType:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$columns["email"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$columns["name"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ExternalUsersSeedJob.kt$ExternalUsersSeedJob$columns["username"]!!</ID>
+    <ID>UnsafeCallOnNullableType:InmateStatusOnSubmissionMigrationJob.kt$InmateStatusOnSubmissionMigrationJob$application.nomsNumber!!</ID>
+    <ID>UnsafeCallOnNullableType:InmateStatusOnSubmissionMigrationJob.kt$InmateStatusOnSubmissionMigrationJob$application.submittedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:InmateStatusOnSubmissionMigrationJob.kt$movement.dateInToPrison!!</ID>
+    <ID>UnsafeCallOnNullableType:JsonSchemaService.kt$JsonSchemaService$schemas[schema.id]!!</ID>
+    <ID>UnsafeCallOnNullableType:NomisUsersSeedJob.kt$NomisUsersSeedJob$columns["email"]!!</ID>
+    <ID>UnsafeCallOnNullableType:NomisUsersSeedJob.kt$NomisUsersSeedJob$columns["name"]!!</ID>
+    <ID>UnsafeCallOnNullableType:NomisUsersSeedJob.kt$NomisUsersSeedJob$columns["nomisUsername"]!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$ApDeliusContextApiOffenderRisksDataSource$summary.riskChildrenCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$ApDeliusContextApiOffenderRisksDataSource$summary.riskKnownAdultCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$ApDeliusContextApiOffenderRisksDataSource$summary.riskPublicCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$ApDeliusContextApiOffenderRisksDataSource$summary.riskStaffCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$ApDeliusContextApiOffenderRisksDataSource$this.mappaDetail.categoryDescription!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$ApDeliusContextApiOffenderRisksDataSource$this.mappaDetail.levelDescription!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$CommunityApiOffenderRisksDataSource$registration.registerCategory!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$CommunityApiOffenderRisksDataSource$registration.registerLevel!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$CommunityApiOffenderRisksDataSource$summary.riskChildrenCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$CommunityApiOffenderRisksDataSource$summary.riskKnownAdultCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$CommunityApiOffenderRisksDataSource$summary.riskPublicCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderRisksDataSource.kt$CommunityApiOffenderRisksDataSource$summary.riskStaffCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderService.kt$OffenderService$currentPageIndex!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderService.kt$OffenderService$summary.riskChildrenCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderService.kt$OffenderService$summary.riskKnownAdultCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderService.kt$OffenderService$summary.riskPublicCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:OffenderService.kt$OffenderService$summary.riskStaffCommunity!!</ID>
+    <ID>UnsafeCallOnNullableType:PersonTransformer.kt$PersonTransformer$probationOffenderResult.probationOffenderDetail.dateOfBirth!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementApplicationTransformer.kt$PlacementApplicationTransformer$jpa.application.getLatestAssessment()!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementApplicationTransformer.kt$PlacementApplicationTransformer$jpa.application.submittedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementApplicationTransformer.kt$PlacementApplicationTransformer$latestAssessment.submittedAt!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestDetailTransformer.kt$PlacementRequestDetailTransformer$jpa.booking!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$assessmentTransformer.transformJpaDecisionToApi(jpa.assessment.decision)!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$characteristic.propertyName!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$jpa.application.riskRatings!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$jpa.application.submittedAt?.toInstant()!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$jpa.assessment.allocatedToUser!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$jpa.assessment.submittedAt?.toInstant()!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestTransformer.kt$PlacementRequestTransformer$jpa.booking!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestsController.kt$PlacementRequestsController$authorisableResult.entityType!!</ID>
+    <ID>UnsafeCallOnNullableType:PlacementRequestsController.kt$PlacementRequestsController$authorisableResult.id!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesController.kt$PremisesController$bookingResult.entityType!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesController.kt$PremisesController$bookingResult.id!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesController.kt$PremisesController$xUserRegion!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesService.kt$PremisesService$bed!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesService.kt$PremisesService$it!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesService.kt$PremisesService$probationDeliveryUnit!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesService.kt$PremisesService$probationRegion!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesService.kt$PremisesService$reason!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesService.kt$PremisesService$turnaroundWorkingDayCount!!</ID>
+    <ID>UnsafeCallOnNullableType:PremisesTransformer.kt$PremisesTransformer$jpa.localAuthorityArea!!</ID>
+    <ID>UnsafeCallOnNullableType:RedisConfiguration.kt$ClientResultRedisSerializer$clientResult.body!!</ID>
+    <ID>UnsafeCallOnNullableType:RedisConfiguration.kt$ClientResultRedisSerializer$deserializedWrapper.method!!</ID>
+    <ID>UnsafeCallOnNullableType:RedisConfiguration.kt$ClientResultRedisSerializer$deserializedWrapper.path!!</ID>
+    <ID>UnsafeCallOnNullableType:RedisConfiguration.kt$ClientResultRedisSerializer$deserializedWrapper.status!!</ID>
+    <ID>UnsafeCallOnNullableType:RoomService.kt$RoomService$it!!</ID>
+    <ID>UnsafeCallOnNullableType:SeedService.kt$SeedService$e.message!!</ID>
+    <ID>UnsafeCallOnNullableType:TaskService.kt$TaskService$allocatedToUser!!</ID>
+    <ID>UnsafeCallOnNullableType:TaskService.kt$TaskService$entity.allocatedToUser!!</ID>
+    <ID>UnsafeCallOnNullableType:TaskTransformer.kt$TaskTransformer$placementApplication.application.riskRatings!!</ID>
+    <ID>UnsafeCallOnNullableType:TaskTransformer.kt$TaskTransformer$placementApplication.placementType!!</ID>
+    <ID>UnsafeCallOnNullableType:TaskTransformer.kt$TaskTransformer$placementRequest.application.riskRatings!!</ID>
+    <ID>UnsafeCallOnNullableType:TasksController.kt$TasksController$workload[it.id]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$columns["Bedspace reference"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationBedspaceSeedJob.kt$TemporaryAccommodationBedspaceSeedJob$columns["Property reference"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Address Line 1"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Local authority / Borough"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Postcode"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Probation delivery unit (PDU)"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Property reference"]!!</ID>
+    <ID>UnsafeCallOnNullableType:TemporaryAccommodationPremisesSeedJob.kt$TemporaryAccommodationPremisesSeedJob$columns["Region"]!!</ID>
+    <ID>UnsafeCallOnNullableType:ThrowableUtils.kt$throwable.cause!!</ID>
+    <ID>UnsafeCallOnNullableType:UserService.kt$UserService$probationRegionRepository.findByName("North West")!!</ID>
+    <ID>UnsafeCallOnNullableType:UsersSeedJob.kt$UsersSeedJob$columns["deliusUsername"]!!</ID>
+    <ID>UnsafeCallOnNullableType:UsersSeedJob.kt$UsersSeedJob$columns["qualifications"]!!</ID>
+    <ID>UnsafeCallOnNullableType:UsersSeedJob.kt$UsersSeedJob$columns["roles"]!!</ID>
+    <ID>UnsafeCallOnNullableType:WebClientCache.kt$WebClientCache$cacheEntry.method!!</ID>
+    <ID>UnsafeCallOnNullableType:WebClientCache.kt$WebClientCache$cacheEntry.path!!</ID>
+    <ID>UnsafeCallOnNullableType:WebClientCache.kt$WebClientCache$cachedBody!!</ID>
+    <ID>UnusedParameter:ApplicationService.kt$ApplicationService$jwt: String</ID>
+    <ID>UnusedParameter:ApplicationService.kt$ApplicationService$username: String?</ID>
+    <ID>UnusedParameter:ApplicationsController.kt$ApplicationsController$user: NomisUserEntity</ID>
+    <ID>UnusedParameter:BookingService.kt$BookingService$keyWorkerStaffCode: String?</ID>
+    <ID>UnusedParameter:BookingService.kt$BookingService$user: UserEntity</ID>
+    <ID>UnusedParameter:BookingService.kt$BookingService$user: UserEntity? = null</ID>
+    <ID>UnusedParameter:OAuth2ResourceServerSecurityConfiguration.kt$JwksCacheConfig$applicationContext: ApplicationContext</ID>
+    <ID>UnusedParameter:OffenderService.kt$OffenderService$jwt: String</ID>
+    <ID>UnusedParameter:PremisesService.kt$PremisesService$latitude: Double?</ID>
+    <ID>UnusedParameter:PremisesService.kt$PremisesService$longitude: Double?</ID>
+    <ID>UnusedParameter:PrisonsApiClient.kt$PrisonsApiClient$alertCode: String</ID>
+    <ID>UnusedParameter:RedisConfiguration.kt$RedisConfiguration$@Value("\${caches.staffMember.expiry-seconds}") staffMemberExpirySeconds: Long</ID>
+    <ID>UnusedParameter:WebClientConfiguration.kt$WebClientConfiguration$authorizedClients: OAuth2AuthorizedClientRepository</ID>
+    <ID>UnusedParameter:WebClientConfiguration.kt$WebClientConfiguration$clientRegistrations: ClientRegistrationRepository</ID>
+    <ID>UnusedPrivateMember:ApplicationsTransformer.kt$ApplicationsTransformer$private fun getStatusFromSummary(entity: DomainCas2ApplicationSummary): ApplicationStatus</ID>
+    <ID>UnusedPrivateMember:OAuth2ResourceServerSecurityConfiguration.kt$AuthAwareTokenConverter$private fun extractAuthSource(claims: Map&lt;String, Any?&gt;): String</ID>
+    <ID>UnusedPrivateMember:UserService.kt$UserService$private fun updateUserFromCommunityApi(user: UserEntity): UserEntity</ID>
+    <ID>UnusedPrivateProperty:ApplicationService.kt$ApplicationService$val schema = application.schemaVersion as? Cas2ApplicationJsonSchemaEntity ?: throw RuntimeException("Incorrect type of JSON schema referenced by CAS2 Application")</ID>
+    <ID>UnusedPrivateProperty:ApprovedPremisesOfflineApplicationsSeedJob.kt$ApprovedPremisesOfflineApplicationsSeedJob$private val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>UnusedPrivateProperty:ExternalUserService.kt$ExternalUserService$private val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>UnusedPrivateProperty:JsonSchemaService.kt$JsonSchemaService$private val applicationRepository: ApplicationRepository</ID>
+    <ID>UnusedPrivateProperty:JsonSchemaService.kt$JsonSchemaService$private val applicationRepository: Cas2ApplicationRepository</ID>
+    <ID>UnusedPrivateProperty:NomisUserService.kt$NomisUserService$private val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>UnusedPrivateProperty:PeopleController.kt$PeopleController$private val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>UnusedPrivateProperty:PeopleController.kt$PeopleController$val user = userService.getUserForRequest()</ID>
+    <ID>UnusedPrivateProperty:PremisesController.kt$PremisesController$private val log = LoggerFactory.getLogger(this::class.java)</ID>
+    <ID>UnusedPrivateProperty:UserAccessService.kt$UserAccessService$private val communityApiClient: CommunityApiClient</ID>
+    <ID>UnusedPrivateProperty:WorkingDayCountService.kt$WorkingDayCountService$i</ID>
+    <ID>UseAnyOrNoneInsteadOfFind:OffenderService.kt$OffenderService$find { caseAccess -&gt; caseAccess.crn == crn &amp;&amp; (caseAccess.userExcluded || caseAccess.userRestricted) }</ID>
+    <ID>UseOrEmpty:AssessmentController.kt$AssessmentController$statuses?.map { assessmentTransformer.transformApiStatusToDomainSummaryState(it) } ?: emptyList()</ID>
+    <ID>UseOrEmpty:BadRequestProblem.kt$BadRequestProblem$invalidParams?.map { ParamError( propertyName = it.key, errorType = it.value, ) } ?: emptyList()</ID>
+    <ID>UseOrEmpty:BaseHMPPSClient.kt$BaseHMPPSClient$requestBuilder.path ?: ""</ID>
+    <ID>UseOrEmpty:BedSearchRepository.kt$BedSearchRepository$result ?: emptyList()</ID>
+    <ID>UseOrEmpty:BedSearchService.kt$BedSearchService$groupedOverlappedBookings[it.premisesId]?.toList() ?: listOf()</ID>
+    <ID>UseOrEmpty:ConvictionTransformer.kt$ConvictionTransformer$conviction.offences?.map { ActiveOffence( deliusEventNumber = conviction.index, offenceDescription = nonRedundantDescription(it.detail), offenceId = it.offenceId, convictionId = conviction.convictionId, offenceDate = it.offenceDate?.toLocalDate(), ) } ?: emptyList()</ID>
+    <ID>UseOrEmpty:DomainEventBuilder.kt$DomainEventBuilder$application?.eventNumber ?: ""</ID>
+    <ID>UseOrEmpty:DomainEventBuilder.kt$DomainEventBuilder$arrival.notes ?: ""</ID>
+    <ID>UseOrEmpty:DomainEventBuilder.kt$DomainEventBuilder$departure.moveOnCategory.legacyDeliusCategoryCode ?: ""</ID>
+    <ID>UseOrEmpty:DomainEventBuilder.kt$DomainEventBuilder$departure.notes ?: ""</ID>
+    <ID>UseOrEmpty:OffenderDetailsUtils.kt$this.middleNames ?: emptyList()</ID>
+    <ID>UseOrEmpty:PeopleController.kt$PeopleController$selectedSections ?: emptyList()</ID>
+    <ID>UseOrEmpty:PremisesService.kt$PremisesService$serviceNameToEntityType[service]?.let { premisesRepository.findAllByProbationRegionAndType(probationRegionId, it) } ?: listOf()</ID>
+    <ID>UseOrEmpty:PremisesService.kt$PremisesService$serviceNameToEntityType[service]?.let { premisesRepository.findAllByType(it) } ?: listOf()</ID>
+    <ID>UseOrEmpty:RoomTransformer.kt$RoomTransformer$jpa.notes ?: ""</ID>
+    <ID>UseOrEmpty:SeedUtils.kt$this.trimToNull() ?: ""</ID>
+    <ID>UseOrEmpty:WebClientCache.kt$WebClientCache$requestBuilder.path ?: ""</ID>
+    <ID>UselessCallOnNotNull:BookingService.kt$BookingService$booking.arrivals.isNullOrEmpty()</ID>
+    <ID>UselessCallOnNotNull:BookingService.kt$BookingService$booking.cancellations.isNullOrEmpty()</ID>
+    <ID>UselessCallOnNotNull:BookingService.kt$BookingService$booking.departures.isNullOrEmpty()</ID>
+    <ID>UselessCallOnNotNull:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$row.name.isNullOrEmpty()</ID>
+    <ID>UselessCallOnNotNull:CharacteristicsSeedJob.kt$CharacteristicsSeedJob$value.isNullOrBlank()</ID>
+    <ID>VarCouldBeVal:AssessmentService.kt$AssessmentService$var allocatedToUser = currentAssessment.allocatedToUser</ID>
+    <ID>VarCouldBeVal:BedDetailTransformer.kt$BedDetailTransformer$var bedSummary = bedSummaryTransformer.transformToApi(summary)</ID>
+    <ID>VarCouldBeVal:BedDetailTransformer.kt$BedDetailTransformer$var characteristicPairs = characteristics.map { CharacteristicPair( name = it.name, propertyName = it.propertyName, ) }</ID>
+    <ID>VarCouldBeVal:CsvBuilder.kt$CsvBuilder$private var csv = StringBuilder()</ID>
+    <ID>VarCouldBeVal:OffenderService.kt$OffenderService$var offenderResponse = offenderDetailsDataSource.getOffenderDetailSummary(crn)</ID>
+    <ID>VarCouldBeVal:PlacementApplicationTransformer.kt$PlacementApplicationTransformer$var latestAssessment = jpa.application.getLatestAssessment()!!</ID>
+    <ID>VarCouldBeVal:UsersController.kt$UsersController$var qualifications = qualifications?.map(::transformApiQualification)</ID>
+    <ID>VarCouldBeVal:UsersController.kt$UsersController$var roles = roles?.map(::transformApiRole)</ID>
+    <ID>VariableNaming:Assessment.kt$Assessment$val `data`: kotlin.Any?</ID>
+    <ID>VariableNaming:UpdateApplication.kt$UpdateApplication$val `data`: kotlin.collections.Map&lt;kotlin.String, kotlin.Any&gt;</ID>
+    <ID>WildcardImport:ApplicationsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:ApplicationsCas2.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:AssessmentsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:BedsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:BookingsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:CAS2EventsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:CAS3EventsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:CacheApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:EventsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:MigrationJobApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:PeopleApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:PeopleCas2.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:PlacementApplicationsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:PlacementRequestsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:PremisesApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:ProfileApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:ReferenceDataApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:ReferenceDataCas2.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:ReportsApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:ReportsCas2.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:SeedApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:SubmissionsCas2.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:TasksApi.kt$import org.springframework.web.bind.annotation.*</ID>
+    <ID>WildcardImport:UsersApi.kt$import org.springframework.web.bind.annotation.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
 import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import java.time.LocalDate
@@ -10,6 +12,7 @@ import java.util.UUID
 class ApprovedPremisesBookingCancelSeedJob(
   fileName: String,
   private val bookingService: BookingService,
+  private val bookingRepository: BookingRepository,
 ) : SeedJob<CancelBookingSeedCsvRow>(
   fileName = fileName,
   requiredHeaders = setOf(
@@ -25,7 +28,7 @@ class ApprovedPremisesBookingCancelSeedJob(
   override fun processRow(row: CancelBookingSeedCsvRow) {
     val errorInBookingDetailsCancellationReason = UUID.fromString("7c310cfd-3952-456d-b0ee-0f7817afe64a")
 
-    val booking = bookingService.getBooking(row.id)
+    val booking = bookingRepository.findByIdOrNull(row.id)
       ?: throw RuntimeException("No Booking with Id of ${row.id} exists")
 
     if (booking.service != ServiceName.approvedPremises.value) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -129,7 +129,6 @@ class BookingService(
   private val log = LoggerFactory.getLogger(this::class.java)
 
   fun updateBooking(bookingEntity: BookingEntity): BookingEntity = bookingRepository.save(bookingEntity)
-  fun getBooking(id: UUID) = bookingRepository.findByIdOrNull(id)
 
   @Transactional
   fun createApprovedPremisesBookingFromPlacementRequest(
@@ -1697,7 +1696,7 @@ class BookingService(
     val premises = premisesService.getPremises(premisesId)
       ?: return GetBookingForPremisesResult.PremisesNotFound
 
-    val booking = getBooking(bookingId)
+    val booking = bookingRepository.findByIdOrNull(bookingId)
       ?: return GetBookingForPremisesResult.BookingNotFound
 
     if (booking.premises.id != premises.id) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -210,6 +210,7 @@ class SeedService(
         SeedFileType.approvedPremisesCancelBookings -> ApprovedPremisesBookingCancelSeedJob(
           filename,
           applicationContext.getBean(BookingService::class.java),
+          applicationContext.getBean(BookingRepository::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Bed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PremisesBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -48,6 +49,7 @@ class BookingTransformer(
       status = jpa.getStatus(),
     )
   }
+
   fun transformJpaToApi(jpa: BookingEntity, personInfo: PersonInfoResult, staffMember: StaffMember?): Booking {
     val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
 
@@ -77,6 +79,7 @@ class BookingTransformer(
       effectiveEndDate = if (hasNonZeroDayTurnaround) workingDayCountService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount) else jpa.departureDate,
       applicationId = jpa.application?.id,
       assessmentId = jpa.application?.getLatestAssessment()?.id,
+      premises = jpa.premises.let { BookingPremisesSummary(it.id, it.name) },
     )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -582,11 +582,25 @@ components:
             assessmentId:
               type: string
               format: uuid
+            premises:
+              $ref: '#/components/schemas/BookingPremisesSummary'
           required:
             - status
             - extensions
             - departures
             - cancellations
+            - premises
+    BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     ExtendedPremisesSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4967,11 +4967,25 @@ components:
             assessmentId:
               type: string
               format: uuid
+            premises:
+              $ref: '#/components/schemas/BookingPremisesSummary'
           required:
             - status
             - extensions
             - departures
             - cancellations
+            - premises
+    BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     ExtendedPremisesSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1010,11 +1010,25 @@ components:
             assessmentId:
               type: string
               format: uuid
+            premises:
+              $ref: '#/components/schemas/BookingPremisesSummary'
           required:
             - status
             - extensions
             - departures
             - cancellations
+            - premises
+    BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     ExtendedPremisesSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -312,7 +312,6 @@ class BookingTest : IntegrationTestBase() {
         }
       }
     }
-
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -120,7 +120,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
 import java.time.Instant
 import java.time.LocalDate
@@ -160,82 +163,53 @@ class BookingServiceTest {
   private val mockBedMoveRepository = mockk<BedMoveRepository>()
   private val mockPremisesRepository = mockk<PremisesRepository>()
   private val mockAssessmentRepository = mockk<AssessmentRepository>()
+  private val mockUserService = mockk<UserService>()
+  private val mockUserAccessService = mockk<UserAccessService>()
 
-  private val bookingService = BookingService(
-    premisesService = mockPremisesService,
-    staffMemberService = mockStaffMemberService,
-    offenderService = mockOffenderService,
-    domainEventService = mockDomainEventService,
-    cas3DomainEventService = mockCas3DomainEventService,
-    cruService = mockCruService,
-    applicationService = mockApplicationService,
-    workingDayCountService = mockWorkingDayCountService,
-    emailNotificationService = mockEmailNotificationService,
-    placementRequestService = mockPlacementRequestService,
-    communityApiClient = mockCommunityApiClient,
-    bookingRepository = mockBookingRepository,
-    arrivalRepository = mockArrivalRepository,
-    cancellationRepository = mockCancellationRepository,
-    confirmationRepository = mockConfirmationRepository,
-    extensionRepository = mockExtensionRepository,
-    dateChangeRepository = mockDateChangeRepository,
-    departureRepository = mockDepartureRepository,
-    nonArrivalRepository = mockNonArrivalRepository,
-    departureReasonRepository = mockDepartureReasonRepository,
-    moveOnCategoryRepository = mockMoveOnCategoryRepository,
-    destinationProviderRepository = mockDestinationProviderRepository,
-    nonArrivalReasonRepository = mockNonArrivalReasonRepository,
-    cancellationReasonRepository = mockCancellationReasonRepository,
-    bedRepository = mockBedRepository,
-    placementRequestRepository = mockPlacementRequestRepository,
-    lostBedsRepository = mockLostBedsRepository,
-    turnaroundRepository = mockTurnaroundRepository,
-    bedMoveRepository = mockBedMoveRepository,
-    premisesRepository = mockPremisesRepository,
-    assessmentRepository = mockAssessmentRepository,
-    notifyConfig = NotifyConfig(),
-    applicationUrlTemplate = "http://frontend/applications/#id",
-    bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
-    arrivedAndDepartedDomainEventsDisabled = false,
-  )
+  fun createBookingService(arrivedAndDepartedDomainEventsDisabled: Boolean): BookingService {
+    return BookingService(
+      premisesService = mockPremisesService,
+      staffMemberService = mockStaffMemberService,
+      offenderService = mockOffenderService,
+      domainEventService = mockDomainEventService,
+      cas3DomainEventService = mockCas3DomainEventService,
+      cruService = mockCruService,
+      applicationService = mockApplicationService,
+      workingDayCountService = mockWorkingDayCountService,
+      emailNotificationService = mockEmailNotificationService,
+      placementRequestService = mockPlacementRequestService,
+      communityApiClient = mockCommunityApiClient,
+      bookingRepository = mockBookingRepository,
+      arrivalRepository = mockArrivalRepository,
+      cancellationRepository = mockCancellationRepository,
+      confirmationRepository = mockConfirmationRepository,
+      extensionRepository = mockExtensionRepository,
+      dateChangeRepository = mockDateChangeRepository,
+      departureRepository = mockDepartureRepository,
+      nonArrivalRepository = mockNonArrivalRepository,
+      departureReasonRepository = mockDepartureReasonRepository,
+      moveOnCategoryRepository = mockMoveOnCategoryRepository,
+      destinationProviderRepository = mockDestinationProviderRepository,
+      nonArrivalReasonRepository = mockNonArrivalReasonRepository,
+      cancellationReasonRepository = mockCancellationReasonRepository,
+      bedRepository = mockBedRepository,
+      placementRequestRepository = mockPlacementRequestRepository,
+      lostBedsRepository = mockLostBedsRepository,
+      turnaroundRepository = mockTurnaroundRepository,
+      bedMoveRepository = mockBedMoveRepository,
+      premisesRepository = mockPremisesRepository,
+      assessmentRepository = mockAssessmentRepository,
+      notifyConfig = NotifyConfig(),
+      applicationUrlTemplate = "http://frontend/applications/#id",
+      bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
+      arrivedAndDepartedDomainEventsDisabled = arrivedAndDepartedDomainEventsDisabled,
+      userService = mockUserService,
+      userAccessService = mockUserAccessService,
+    )
+  }
 
-  private val bookingServiceWithArrivedAndDepartedDomainEventsDisabled = BookingService(
-    premisesService = mockPremisesService,
-    staffMemberService = mockStaffMemberService,
-    offenderService = mockOffenderService,
-    domainEventService = mockDomainEventService,
-    cas3DomainEventService = mockCas3DomainEventService,
-    cruService = mockCruService,
-    applicationService = mockApplicationService,
-    workingDayCountService = mockWorkingDayCountService,
-    emailNotificationService = mockEmailNotificationService,
-    placementRequestService = mockPlacementRequestService,
-    communityApiClient = mockCommunityApiClient,
-    bookingRepository = mockBookingRepository,
-    arrivalRepository = mockArrivalRepository,
-    cancellationRepository = mockCancellationRepository,
-    confirmationRepository = mockConfirmationRepository,
-    extensionRepository = mockExtensionRepository,
-    dateChangeRepository = mockDateChangeRepository,
-    departureRepository = mockDepartureRepository,
-    nonArrivalRepository = mockNonArrivalRepository,
-    departureReasonRepository = mockDepartureReasonRepository,
-    moveOnCategoryRepository = mockMoveOnCategoryRepository,
-    destinationProviderRepository = mockDestinationProviderRepository,
-    nonArrivalReasonRepository = mockNonArrivalReasonRepository,
-    cancellationReasonRepository = mockCancellationReasonRepository,
-    bedRepository = mockBedRepository,
-    placementRequestRepository = mockPlacementRequestRepository,
-    lostBedsRepository = mockLostBedsRepository,
-    turnaroundRepository = mockTurnaroundRepository,
-    bedMoveRepository = mockBedMoveRepository,
-    premisesRepository = mockPremisesRepository,
-    assessmentRepository = mockAssessmentRepository,
-    notifyConfig = NotifyConfig(),
-    applicationUrlTemplate = "http://frontend/applications/#id",
-    bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
-    arrivedAndDepartedDomainEventsDisabled = true,
-  )
+  private val bookingService = createBookingService(arrivedAndDepartedDomainEventsDisabled = false)
+  private val bookingServiceWithArrivedAndDepartedDomainEventsDisabled = createBookingService(arrivedAndDepartedDomainEventsDisabled = true)
 
   private val user = UserEntityFactory()
     .withUnitTestControlProbationRegion()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
@@ -255,6 +256,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -335,6 +337,7 @@ class BookingTransformerTest {
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         applicationId = application.id,
         assessmentId = latestAssessment.id,
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -380,6 +383,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -449,6 +453,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -523,6 +528,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -603,6 +609,7 @@ class BookingTransformerTest {
         ),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -715,6 +722,7 @@ class BookingTransformerTest {
         ),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -892,6 +900,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -1096,6 +1105,7 @@ class BookingTransformerTest {
           ),
         ),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -1314,6 +1324,7 @@ class BookingTransformerTest {
         ),
         turnaroundStartDate = departedAt.toLocalDate().plusDays(1),
         effectiveEndDate = expectedEffectiveEndDate,
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -1532,6 +1543,7 @@ class BookingTransformerTest {
         ),
         turnaroundStartDate = departedAt.toLocalDate().plusDays(1),
         effectiveEndDate = expectedEffectiveEndDate,
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -1792,6 +1804,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -1862,6 +1875,7 @@ class BookingTransformerTest {
         cancellations = listOf(),
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }
@@ -1979,6 +1993,7 @@ class BookingTransformerTest {
         ),
         turnaroundStartDate = LocalDate.parse("2022-08-31"),
         effectiveEndDate = LocalDate.parse("2022-09-05"),
+        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
       ),
     )
   }


### PR DESCRIPTION
Previously the logic to get a booking for a given premises was fully defined in the premises controller. Whilst some of this logic is specific to premises (e.g. checking if the booking belongs to the given premises), the majority of the logic is generic when retreiving booking.

Because we’re going to add an endpoint to retrieve a booking by its ID only (i.e. no premise ID) to support new withdrawal logic, the common ‘get booking’ logic needs moving into the BookingService

This commit also adds a small premises summary to the Booking API response. This allows the controller to validate that the premises id is as expected, and the premises name will be of use to the UI in subsequent changes

There are no functional changes on this PR, just refactoring