### PR TITLE
[CAS-191]-Get latest departure,arrival for CAS3 booking report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
@@ -48,9 +48,9 @@ interface BookingsReportRepository : JpaRepository<BookingEntity, UUID> {
     LEFT JOIN
       confirmations confirmation ON confirmation.booking_id = booking.id
     LEFT JOIN
-      departures departure ON departure.booking_id = booking.id
+      departures departure ON departure.booking_id = booking.id AND departure.created_at = (SELECT max(d.created_at) FROM departures d WHERE d.booking_id=booking.id)
     LEFT JOIN
-      arrivals arr ON arr.booking_id = booking.id
+      arrivals arr ON arr.booking_id = booking.id AND arr.created_at = (SELECT max(a.created_at) FROM arrivals a WHERE a.booking_id=booking.id)
     LEFT JOIN
       cancellations cancellation ON cancellation.booking_id = booking.id
     LEFT JOIN


### PR DESCRIPTION
# Changes in this PR
Refer [CAS-191](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-191) for more information.

This PR is to fix a bug in CAS3-booking report where booking appears in the report more than once due to multiple updates in departure date, Hence getting the latest departure date should gives correct information in the report.
Same applies to arrival date as well. Both are fixed in this PR.

Need to monitor the performance of this report in pre-prod due to the change in the sql, but it should be minimum due to fact its for a specific booking and chance of multiple updates in departure/arrival are minimal. 

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.