### PR TITLE
Paginate CAS2 submissions end point

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.OrderBy
 import org.hibernate.annotations.Type
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -48,9 +50,15 @@ SELECT
 FROM cas_2_applications a
 WHERE a.submitted_at IS NOT NULL
 """,
+    countQuery =
+    """
+    SELECT COUNT(*)
+      FROM cas_2_applications a
+      WHERE a.submitted_at IS NOT NULL
+    """,
     nativeQuery = true,
   )
-  fun findAllSubmittedCas2ApplicationSummaries(): List<Cas2ApplicationSummary>
+  fun findAllSubmittedCas2ApplicationSummaries(pageable: Pageable?): Page<Cas2ApplicationSummary>
 
   @Query(
     "SELECT a FROM Cas2ApplicationEntity a WHERE a.id = :id AND " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -26,6 +27,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UpstreamApiException
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -51,8 +55,14 @@ class ApplicationService(
     return applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id)
   }
 
-  fun getAllSubmittedApplicationsForAssessor(): List<Cas2ApplicationSummary> {
-    return applicationRepository.findAllSubmittedCas2ApplicationSummaries()
+  fun getAllSubmittedApplicationsForAssessor(pageCriteria: PageCriteria<String>): Pair<List<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val pageable = getPageable(pageCriteria)
+
+    val response = applicationRepository.findAllSubmittedCas2ApplicationSummaries(pageable)
+
+    val metadata = getMetadata(response, pageCriteria)
+
+    return Pair(response.content, metadata)
   }
 
   fun getSubmittedApplicationForAssessor(applicationId: UUID):

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -133,6 +133,12 @@ paths:
       tags:
         - Operations on submitted CAS2 applications (Assessors)
       summary: List summaries of all submitted CAS2 applications
+      parameters:
+        - name: page
+          in: query
+          description: Page number of results to return. If blank, returns all results
+          schema:
+            type: integer
       responses:
         200:
           description: successful operation
@@ -142,6 +148,15 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Cas2SubmittedApplicationSummary'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -135,6 +135,12 @@ paths:
       tags:
         - Operations on submitted CAS2 applications (Assessors)
       summary: List summaries of all submitted CAS2 applications
+      parameters:
+        - name: page
+          in: query
+          description: Page number of results to return. If blank, returns all results
+          schema:
+            type: integer
       responses:
         200:
           description: successful operation
@@ -144,6 +150,15 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas2SubmittedApplicationSummary'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '#/components/responses/401Response'
         403:


### PR DESCRIPTION
UI PR is here https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/498

This adds pagination to `/submissions`, which lists all submitted CAS2
applications.

We are using the existing utility functions and `Page` response already
in the API, and utilised by CAS1/3's `getAllApprovedPremisesApplications` method. 

* The sorting is hardcoded as ascending "submitted_at" because we do not yet have UI/need
to set the sort order from the frontend. 
* We're using the default page size for now, but may need to customise that in the near future.
* We have set the page`param` to be optional in order not to break the existing frontend - if
no page param is given, then all the results are returned, which means
we will not break the existing UX on the frontend.

