### PR TITLE
CAS2 E2E tests are now run from the frontend repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,15 +264,17 @@ jobs:
       - run:
           name: Clone E2E repo
           command: |
-            git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e.git .
+            git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui.git .
       - run:
           name: Update npm
           command: 'npm install -g npm@latest'
       - node/install-packages
       - run:
-          name: E2E Check
-          command: |
-            npm run test
+          name: Install Playwright
+          command: npx playwright install
+      - run:
+          name: Run E2E tests
+          command: npm run test:e2e
       - store_artifacts:
           path: playwright-report
           destination: playwright-report


### PR DESCRIPTION
CAS2 have decided to move our e2e tests from a dedicated repo, into the same repo similarly to CAS3.

https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/482
https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/495

Once this work is complete we'll archive our old [e2e repo](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e).
