### PR TITLE
CAS1 Allow applicant to view & withdraw booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -139,7 +139,7 @@ class BookingService(
 
     val user = userService.getUserForRequest()
 
-    if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
+    if (!userAccessService.userCanViewBooking(user, booking)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -64,9 +65,21 @@ class UserAccessService(
   fun currentUserCanManagePremisesBookings(premises: PremisesEntity) =
     userCanManagePremisesBookings(userService.getUserForRequest(), premises)
 
+  fun userCanViewBooking(user: UserEntity, booking: BookingEntity) = when(booking.premises) {
+    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+    is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+    else -> false
+  }
+
   fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
     is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
+    else -> false
+  }
+
+  fun userCanCancelBooking(user: UserEntity, booking: BookingEntity) = when(booking.premises) {
+    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+    is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
     else -> false
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -65,8 +65,8 @@ class UserAccessService(
   fun currentUserCanManagePremisesBookings(premises: PremisesEntity) =
     userCanManagePremisesBookings(userService.getUserForRequest(), premises)
 
-  fun userCanViewBooking(user: UserEntity, booking: BookingEntity) = when(booking.premises) {
-    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+  fun userCanViewBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
+    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises) || booking.application?.createdByUser == user
     is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
     else -> false
   }
@@ -77,8 +77,8 @@ class UserAccessService(
     else -> false
   }
 
-  fun userCanCancelBooking(user: UserEntity, booking: BookingEntity) = when(booking.premises) {
-    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+  fun userCanCancelBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
+    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises) || booking.application?.createdByUser == user
     is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
     else -> false
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -77,33 +77,35 @@ class BookingTest : IntegrationTestBase() {
 
     @Test
     fun `Get a booking returns 401 if user doesnt have correct roles`() {
-      `Given a User` { userEntity, jwt ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
-          }
+      `Given a User` { applicant, _ ->
+        `Given a User` { userEntity, jwt ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            val premises = approvedPremisesEntityFactory.produceAndPersist {
+              withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+              withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+            }
 
-          val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
-            withCreatedByUser(userEntity)
-            withCrn(offenderDetails.otherIds.crn)
-            withProbationRegion(userEntity.probationRegion)
-            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-          }
+            val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+              withCreatedByUser(applicant)
+              withCrn(offenderDetails.otherIds.crn)
+              withProbationRegion(userEntity.probationRegion)
+              withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+            }
 
-          val booking = bookingEntityFactory.produceAndPersist {
-            withPremises(premises)
-            withCrn(offenderDetails.otherIds.crn)
-            withServiceName(ServiceName.approvedPremises)
-            withApplication(application)
-          }
+            val booking = bookingEntityFactory.produceAndPersist {
+              withPremises(premises)
+              withCrn(offenderDetails.otherIds.crn)
+              withServiceName(ServiceName.approvedPremises)
+              withApplication(application)
+            }
 
-          webTestClient.get()
-            .uri("/bookings/${booking.id}")
-            .header("Authorization", "Bearer $jwt")
-            .exchange()
-            .expectStatus()
-            .isForbidden
+            webTestClient.get()
+              .uri("/bookings/${booking.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isForbidden
+          }
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -369,8 +369,8 @@ class UserAccessServiceTest {
 
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
-    fun `userCanViewBooking returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(
-      role: UserRole
+    fun `userCanViewBooking returns true if the given premises is a CAS1 premises and the user has either the MANAGER or MATCHER user role`(
+      role: UserRole,
     ) {
       currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -380,23 +380,32 @@ class UserAccessServiceTest {
     }
 
     @Test
-    fun `userCanViewBooking returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    fun `userCanViewBooking returns true if the given premises is a CAS1 premises and the user created the application`() {
+      currentRequestIsFor(ServiceName.approvedPremises)
+
+      val application = ApprovedPremisesApplicationEntityFactory().withCreatedByUser(user).produce()
+
+      assertThat(userAccessService.userCanViewBooking(user, cas1Booking.copy(application = application))).isTrue
+    }
+
+    @Test
+    fun `userCanViewBooking returns false if the given premises is a CAS1 premises and the user has no suitable role`() {
       currentRequestIsFor(ServiceName.approvedPremises)
 
       assertThat(userAccessService.userCanViewBooking(user, cas1Booking)).isFalse
     }
 
     @Test
-    fun `userCanViewBooking returns true if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+    fun `userCanViewBooking returns true if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-      assertThat(userAccessService.userCanViewBooking(user,cas3BookingInUserRegion)).isTrue
+      assertThat(userAccessService.userCanViewBooking(user, cas3BookingInUserRegion)).isTrue
     }
 
     @Test
-    fun `userCanViewBooking returns false if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+    fun `userCanViewBooking returns false if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
@@ -404,19 +413,18 @@ class UserAccessServiceTest {
       assertThat(
         userAccessService.userCanViewBooking(
           user,
-          cas3BookingNotInUserRegion
-        )
+          cas3BookingNotInUserRegion,
+        ),
       ).isFalse
     }
 
     @Test
-    fun `userCanViewBooking returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+    fun `userCanViewBooking returns false if the given premises is a CAS3 premises and the user does not have a suitable role`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
-      assertThat(userAccessService.userCanViewBooking(user,cas3BookingInUserRegion)).isFalse
-      assertThat(userAccessService.userCanViewBooking(user,cas3BookingNotInUserRegion)).isFalse
+      assertThat(userAccessService.userCanViewBooking(user, cas3BookingInUserRegion)).isFalse
+      assertThat(userAccessService.userCanViewBooking(user, cas3BookingNotInUserRegion)).isFalse
     }
-
   }
 
   @Nested
@@ -424,8 +432,8 @@ class UserAccessServiceTest {
 
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
-    fun `userCanManagePremisesBookings returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(
-      role: UserRole
+    fun `userCanManagePremisesBookings returns true if the given premises is a CAS1 premises and the user has either the MANAGER or MATCHER user role`(
+      role: UserRole,
     ) {
       currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -435,14 +443,14 @@ class UserAccessServiceTest {
     }
 
     @Test
-    fun `userCanManagePremisesBookings returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    fun `userCanManagePremisesBookings returns false if the given premises is a CAS1 premises and the user has no suitable role`() {
       currentRequestIsFor(ServiceName.approvedPremises)
 
       assertThat(userAccessService.userCanManagePremisesBookings(user, approvedPremises)).isFalse
     }
 
     @Test
-    fun `userCanManagePremisesBookings returns true if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+    fun `userCanManagePremisesBookings returns true if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
@@ -450,13 +458,13 @@ class UserAccessServiceTest {
       assertThat(
         userAccessService.userCanManagePremisesBookings(
           user,
-          temporaryAccommodationPremisesInUserRegion
-        )
+          temporaryAccommodationPremisesInUserRegion,
+        ),
       ).isTrue
     }
 
     @Test
-    fun `userCanManagePremisesBookings returns false if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+    fun `userCanManagePremisesBookings returns false if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
@@ -464,29 +472,28 @@ class UserAccessServiceTest {
       assertThat(
         userAccessService.userCanManagePremisesBookings(
           user,
-          temporaryAccommodationPremisesNotInUserRegion
-        )
+          temporaryAccommodationPremisesNotInUserRegion,
+        ),
       ).isFalse
     }
 
     @Test
-    fun `userCanManagePremisesBookings returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+    fun `userCanManagePremisesBookings returns false if the given premises is a CAS3 premises and the user does not have a suitable role`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       assertThat(
         userAccessService.userCanManagePremisesBookings(
           user,
-          temporaryAccommodationPremisesInUserRegion
-        )
+          temporaryAccommodationPremisesInUserRegion,
+        ),
       ).isFalse
       assertThat(
         userAccessService.userCanManagePremisesBookings(
           user,
-          temporaryAccommodationPremisesNotInUserRegion
-        )
+          temporaryAccommodationPremisesNotInUserRegion,
+        ),
       ).isFalse
     }
-
   }
 
   @Nested
@@ -509,8 +516,8 @@ class UserAccessServiceTest {
 
       @ParameterizedTest
       @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
-      fun `userCanCancelBooking returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(
-        role: UserRole
+      fun `userCanCancelBooking returns true if the given premises is a CAS1 premises and the user has either the MANAGER or MATCHER user role`(
+        role: UserRole,
       ) {
         currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -520,40 +527,47 @@ class UserAccessServiceTest {
       }
 
       @Test
-      fun `userCanCancelBooking returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+      fun `userCanCancelBooking returns true if the given premises is a CAS1 premises and the user created the application`() {
+        currentRequestIsFor(ServiceName.approvedPremises)
+
+        val application = ApprovedPremisesApplicationEntityFactory().withCreatedByUser(user).produce()
+
+        assertThat(userAccessService.userCanCancelBooking(user, cas1Booking.copy(application = application))).isTrue
+      }
+
+      @Test
+      fun `userCanCancelBooking returns false if the given premises is a CAS1 premises and the user has no suitable role`() {
         currentRequestIsFor(ServiceName.approvedPremises)
 
         assertThat(userAccessService.userCanCancelBooking(user, cas1Booking)).isFalse
       }
 
       @Test
-      fun `userCanCancelBooking returns true if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+      fun `userCanCancelBooking returns true if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
         currentRequestIsFor(ServiceName.temporaryAccommodation)
 
         user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-        assertThat(userAccessService.userCanCancelBooking(user,cas3BookingInUserRegion)).isTrue
+        assertThat(userAccessService.userCanCancelBooking(user, cas3BookingInUserRegion)).isTrue
       }
 
       @Test
-      fun `userCanCancelBooking returns false if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+      fun `userCanCancelBooking returns false if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
         currentRequestIsFor(ServiceName.temporaryAccommodation)
 
         user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-        assertThat(userAccessService.userCanCancelBooking(user,cas3BookingNotInUserRegion)).isFalse
+        assertThat(userAccessService.userCanCancelBooking(user, cas3BookingNotInUserRegion)).isFalse
       }
 
       @Test
-      fun `userCanCancelBooking returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+      fun `userCanCancelBooking returns false if the given premises is a CAS3 premises and the user does not have a suitable role`() {
         currentRequestIsFor(ServiceName.temporaryAccommodation)
 
-        assertThat(userAccessService.userCanCancelBooking(user,cas3BookingInUserRegion)).isFalse
-        assertThat(userAccessService.userCanCancelBooking(user,cas3BookingNotInUserRegion)).isFalse
+        assertThat(userAccessService.userCanCancelBooking(user, cas3BookingInUserRegion)).isFalse
+        assertThat(userAccessService.userCanCancelBooking(user, cas3BookingNotInUserRegion)).isFalse
       }
-
     }
-
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-262

Existing 'manage booking permissions' are retained for viewing and cancelling bookings, with applicant being added to the allowed list for cas1