### PR TITLE
(APS-250) Remove withdrawal reasons

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4052,11 +4052,7 @@ components:
     WithdrawalReason:
       type: string
       enum:
-        - alternative_identified_placement_no_longer_required
-        - change_in_circumstances_placement_no_longer_required
         - change_in_circumstances_new_application_to_be_submitted
-        - change_in_release_date_placement_no_longer_required
-        - change_in_release_decision_placement_no_longer_required
         - error_in_application
         - duplicate_application
         - other

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8467,11 +8467,7 @@ components:
     WithdrawalReason:
       type: string
       enum:
-        - alternative_identified_placement_no_longer_required
-        - change_in_circumstances_placement_no_longer_required
         - change_in_circumstances_new_application_to_be_submitted
-        - change_in_release_date_placement_no_longer_required
-        - change_in_release_decision_placement_no_longer_required
         - error_in_application
         - duplicate_application
         - other

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4480,11 +4480,7 @@ components:
     WithdrawalReason:
       type: string
       enum:
-        - alternative_identified_placement_no_longer_required
-        - change_in_circumstances_placement_no_longer_required
         - change_in_circumstances_new_application_to_be_submitted
-        - change_in_release_date_placement_no_longer_required
-        - change_in_release_decision_placement_no_longer_required
         - error_in_application
         - duplicate_application
         - other

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3000,7 +3000,7 @@ class ApplicationTest : IntegrationTestBase() {
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             NewWithdrawal(
-              reason = WithdrawalReason.alternativeIdentifiedPlacementNoLongerRequired,
+              reason = WithdrawalReason.duplicateApplication,
             ),
           )
           .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -950,7 +950,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
       .header("X-Service-Name", ServiceName.approvedPremises.value)
       .bodyValue(
         NewWithdrawal(
-          reason = WithdrawalReason.alternativeIdentifiedPlacementNoLongerRequired,
+          reason = WithdrawalReason.duplicateApplication,
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -355,7 +355,7 @@ class ApplicationStateTest : IntegrationTestBase() {
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewWithdrawal(
-          reason = WithdrawalReason.alternativeIdentifiedPlacementNoLongerRequired,
+          reason = WithdrawalReason.duplicateApplication,
         ),
       )
       .exchange()


### PR DESCRIPTION
These are no longer needed. We'll need to make sure the corresponding UI changes are deployed before / as soon as these changes are live, as this will be a breaking change