### PR TITLE
Fix mapping bug when using delius offender api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -101,7 +101,6 @@ abstract class BaseHMPPSClient(
 }
 
 sealed interface ClientResult<ResponseType> {
-  fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>>
   fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType>
 
   data class Success<ResponseType>(
@@ -109,8 +108,7 @@ sealed interface ClientResult<ResponseType> {
     val body: ResponseType,
     val isPreemptivelyCachedResponse: Boolean = false,
   ) : ClientResult<ResponseType> {
-    override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-      transform(this.body).map { Success(this.status, it, this.isPreemptivelyCachedResponse) }
+    fun <TargetType> copyWithBody(body: TargetType) = Success(this.status, body, this.isPreemptivelyCachedResponse)
 
     override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
       Success(this.status, transform(body), this.isPreemptivelyCachedResponse)
@@ -127,9 +125,6 @@ sealed interface ClientResult<ResponseType> {
       val body: String?,
       val isPreemptivelyCachedResponse: Boolean = false,
     ) : Failure<ResponseType> {
-      @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        List(listSize) { this as StatusCode<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -147,9 +142,6 @@ sealed interface ClientResult<ResponseType> {
       val cacheKey: String,
       val timeoutMs: Int,
     ) : Failure<ResponseType> {
-      @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        List(listSize) { this as PreemptiveCacheTimeout<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -159,9 +151,6 @@ sealed interface ClientResult<ResponseType> {
     }
 
     data class CachedValueUnavailable<ResponseType>(val cacheKey: String) : Failure<ResponseType> {
-      @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        List(listSize) { this as CachedValueUnavailable<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -175,9 +164,6 @@ sealed interface ClientResult<ResponseType> {
       val path: String,
       val exception: Exception,
     ) : Failure<ResponseType> {
-      @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        List(listSize) { this as Other<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -101,7 +101,7 @@ abstract class BaseHMPPSClient(
 }
 
 sealed interface ClientResult<ResponseType> {
-  fun <TargetType> flatMap(transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>>
+  fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>>
   fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType>
 
   data class Success<ResponseType>(
@@ -109,7 +109,7 @@ sealed interface ClientResult<ResponseType> {
     val body: ResponseType,
     val isPreemptivelyCachedResponse: Boolean = false,
   ) : ClientResult<ResponseType> {
-    override fun <TargetType> flatMap(transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
+    override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
       transform(this.body).map { Success(this.status, it, this.isPreemptivelyCachedResponse) }
 
     override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -128,8 +128,8 @@ sealed interface ClientResult<ResponseType> {
       val isPreemptivelyCachedResponse: Boolean = false,
     ) : Failure<ResponseType> {
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        listOf(this as StatusCode<TargetType>)
+      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
+        List(listSize) { this as StatusCode<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -148,8 +148,8 @@ sealed interface ClientResult<ResponseType> {
       val timeoutMs: Int,
     ) : Failure<ResponseType> {
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        listOf(this as PreemptiveCacheTimeout<TargetType>)
+      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
+        List(listSize) { this as PreemptiveCacheTimeout<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -160,8 +160,8 @@ sealed interface ClientResult<ResponseType> {
 
     data class CachedValueUnavailable<ResponseType>(val cacheKey: String) : Failure<ResponseType> {
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        listOf(this as CachedValueUnavailable<TargetType>)
+      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
+        List(listSize) { this as CachedValueUnavailable<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =
@@ -176,8 +176,8 @@ sealed interface ClientResult<ResponseType> {
       val exception: Exception,
     ) : Failure<ResponseType> {
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
-      override fun <TargetType> flatMap(transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
-        listOf(this as Other<TargetType>)
+      override fun <TargetType> flatMap(listSize: Int, transform: (ResponseType) -> Iterable<TargetType>): List<ClientResult<TargetType>> =
+        List(listSize) { this as Other<TargetType> }
 
       @Suppress("UNCHECKED_CAST") // Safe as this variant contains nothing of type `ResponseType`.
       override fun <TargetType> map(transform: (ResponseType) -> TargetType): ClientResult<TargetType> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
@@ -16,9 +16,9 @@ interface OffenderDetailsDataSource {
   val name: OffenderDetailsDataSourceName
 
   fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary>
-  fun getOffenderDetailSummaries(crns: List<String>): List<ClientResult<OffenderDetailSummary>>
+  fun getOffenderDetailSummaries(crns: List<String>): Map<String, ClientResult<OffenderDetailSummary>>
   fun getUserAccessForOffenderCrn(deliusUsername: String, crn: String): ClientResult<UserOffenderAccess>
-  fun getUserAccessForOffenderCrns(deliusUsername: String, crns: List<String>): List<ClientResult<UserOffenderAccess>>
+  fun getUserAccessForOffenderCrns(deliusUsername: String, crns: List<String>): Map<String, ClientResult<UserOffenderAccess>>
 }
 
 enum class OffenderDetailsDataSourceName {
@@ -69,8 +69,11 @@ class CommunityApiOffenderDetailsDataSource(
     return offenderResponse
   }
 
-  override fun getOffenderDetailSummaries(crns: List<String>): List<ClientResult<OffenderDetailSummary>> =
-    crns.map(this::getOffenderDetailSummary)
+  override fun getOffenderDetailSummaries(crns: List<String>): Map<String, ClientResult<OffenderDetailSummary>> =
+    crns.associateBy(
+      keySelector = { crn -> crn },
+      valueTransform = { crn -> getOffenderDetailSummary(crn) },
+    )
 
   override fun getUserAccessForOffenderCrn(deliusUsername: String, crn: String): ClientResult<UserOffenderAccess> =
     communityApiClient.getUserAccessForOffenderCrn(deliusUsername, crn)
@@ -78,8 +81,11 @@ class CommunityApiOffenderDetailsDataSource(
   override fun getUserAccessForOffenderCrns(
     deliusUsername: String,
     crns: List<String>,
-  ): List<ClientResult<UserOffenderAccess>> =
-    crns.map { getUserAccessForOffenderCrn(deliusUsername, it) }
+  ): Map<String, ClientResult<UserOffenderAccess>> =
+    crns.associateBy(
+      keySelector = { crn -> crn },
+      valueTransform = { crn -> getUserAccessForOffenderCrn(deliusUsername, crn) },
+    )
 }
 
 @Component
@@ -90,28 +96,44 @@ class ApDeliusContextApiOffenderDetailsDataSource(
     get() = OffenderDetailsDataSourceName.AP_DELIUS_CONTEXT_API
 
   override fun getOffenderDetailSummary(crn: String): ClientResult<OffenderDetailSummary> {
-    return getOffenderDetailSummaries(listOf(crn)).first()
+    return getOffenderDetailSummaries(listOf(crn)).values.first()
   }
 
-  override fun getOffenderDetailSummaries(crns: List<String>): List<ClientResult<OffenderDetailSummary>> {
-    return apDeliusContextApiClient
-      .getSummariesForCrns(crns)
-      .flatMap(crns.size) { caseSummaries -> caseSummaries.cases.map { it.asOffenderDetailSummary() } }
+  @Suppress("UNCHECKED_CAST") // Safe as we only do this for non-success types
+  override fun getOffenderDetailSummaries(crns: List<String>): Map<String, ClientResult<OffenderDetailSummary>> {
+    return when (val clientResult = apDeliusContextApiClient.getSummariesForCrns(crns)) {
+      is ClientResult.Success -> {
+        clientResult.body.cases
+          .associateBy(
+            keySelector = { it.crn },
+            valueTransform = { clientResult.copyWithBody(body = it.asOffenderDetailSummary()) },
+          )
+      }
+      else -> return crns.associateWith { clientResult as ClientResult<OffenderDetailSummary> }
+    }
   }
 
   override fun getUserAccessForOffenderCrn(
     deliusUsername: String,
     crn: String,
   ): ClientResult<UserOffenderAccess> {
-    return getUserAccessForOffenderCrns(deliusUsername, listOf(crn)).first()
+    return getUserAccessForOffenderCrns(deliusUsername, listOf(crn)).values.first()
   }
 
+  @Suppress("UNCHECKED_CAST") // Safe as we only do this for non-success types
   override fun getUserAccessForOffenderCrns(
     deliusUsername: String,
     crns: List<String>,
-  ): List<ClientResult<UserOffenderAccess>> {
-    return apDeliusContextApiClient
-      .getUserAccessForCrns(deliusUsername, crns)
-      .flatMap(crns.size) { userAccess -> userAccess.access.map { it.asUserOffenderAccess() } }
+  ): Map<String, ClientResult<UserOffenderAccess>> {
+    return when (val clientResult = apDeliusContextApiClient.getUserAccessForCrns(deliusUsername, crns)) {
+      is ClientResult.Success -> {
+        clientResult.body.access
+          .associateBy(
+            keySelector = { it.crn },
+            valueTransform = { clientResult.copyWithBody(body = it.asUserOffenderAccess()) },
+          )
+      }
+      else -> crns.associateWith { clientResult as ClientResult<UserOffenderAccess> }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
@@ -96,7 +96,7 @@ class ApDeliusContextApiOffenderDetailsDataSource(
   override fun getOffenderDetailSummaries(crns: List<String>): List<ClientResult<OffenderDetailSummary>> {
     return apDeliusContextApiClient
       .getSummariesForCrns(crns)
-      .flatMap { caseSummaries -> caseSummaries.cases.map { it.asOffenderDetailSummary() } }
+      .flatMap(crns.size) { caseSummaries -> caseSummaries.cases.map { it.asOffenderDetailSummary() } }
   }
 
   override fun getUserAccessForOffenderCrn(
@@ -112,6 +112,6 @@ class ApDeliusContextApiOffenderDetailsDataSource(
   ): List<ClientResult<UserOffenderAccess>> {
     return apDeliusContextApiClient
       .getUserAccessForCrns(deliusUsername, crns)
-      .flatMap { userAccess -> userAccess.access.map { it.asUserOffenderAccess() } }
+      .flatMap(crns.size) { userAccess -> userAccess.access.map { it.asUserOffenderAccess() } }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -93,8 +93,8 @@ class OffenderService(
 
     if (crns.isEmpty()) return emptyList()
 
-    val offenderDetailsList = offenderDetailsDataSource.getOffenderDetailSummaries(crns.toList())
-    val userAccessList = offenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, crns.toList())
+    val offenderDetailsList = offenderDetailsDataSource.getOffenderDetailSummaries(crns.toList()).values
+    val userAccessList = offenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, crns.toList()).values
 
     return crns
       .zip(offenderDetailsList, userAccessList) { crn, offenderResponse, accessResponse ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderDetailsDataSourceTest.kt
@@ -58,7 +58,7 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
         .produce(),
     )
 
-    val expectedResults = caseSummaries.map { ClientResult.Success(HttpStatus.OK, it.asOffenderDetailSummary(), false) }
+    val expectedResults = caseSummaries.map { it.crn to ClientResult.Success(HttpStatus.OK, it.asOffenderDetailSummary(), false) }.toMap()
 
     every { mockApDeliusContextApiClient.getSummariesForCrns(crns) } returns ClientResult.Success(
       HttpStatus.OK,
@@ -80,9 +80,9 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
 
     val results = apDeliusContextApiOffenderDetailsDataSource.getOffenderDetailSummaries(crns)
     assertThat(results).hasSize(3)
-    assertThat(results[0]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results[1]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results[2]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results["CRN-A"]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results["CRN-B"]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results["CRN-C"]).isEqualTo(cacheTimeoutClientResult)
   }
 
   @ParameterizedTest
@@ -112,7 +112,8 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
         .withCrn("CRN-C")
         .produce(),
     )
-    val expectedResults = caseAccesses.map { ClientResult.Success(HttpStatus.OK, it.asUserOffenderAccess(), false) }
+
+    val expectedResults = caseAccesses.map { it.crn to ClientResult.Success(HttpStatus.OK, it.asUserOffenderAccess(), false) }.toMap()
 
     every { mockApDeliusContextApiClient.getUserAccessForCrns("DELIUS-USER", crns) } returns ClientResult.Success(
       HttpStatus.OK,
@@ -134,9 +135,9 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
 
     val results = apDeliusContextApiOffenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
     assertThat(results).hasSize(3)
-    assertThat(results[0]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results[1]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results[2]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results["CRN-A"]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results["CRN-B"]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results["CRN-C"]).isEqualTo(cacheTimeoutClientResult)
   }
 
   private companion object {
@@ -158,11 +159,12 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
 
     @JvmStatic
     fun userOffenderAccessClientResults(): Stream<Arguments> {
-      val successBody = UserOffenderAccess(
-        userRestricted = false,
-        userExcluded = false,
-        restrictionMessage = null,
-      )
+      val successBody =
+        UserOffenderAccess(
+          userRestricted = false,
+          userExcluded = false,
+          restrictionMessage = null,
+        )
 
       return allClientResults(successBody).intoArgumentStream()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ApDeliusContextApiOffenderDetailsDataSourceTest.kt
@@ -71,6 +71,20 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
     assertThat(results).isEqualTo(expectedResults)
   }
 
+  @Test
+  fun `getOffenderDetailSummaries returns an entry per CRN for failures`() {
+    val crns = listOf("CRN-A", "CRN-B", "CRN-C")
+
+    val cacheTimeoutClientResult = cacheTimeoutClientResult<CaseSummaries>()
+    every { mockApDeliusContextApiClient.getSummariesForCrns(crns) } returns cacheTimeoutClientResult
+
+    val results = apDeliusContextApiOffenderDetailsDataSource.getOffenderDetailSummaries(crns)
+    assertThat(results).hasSize(3)
+    assertThat(results[0]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results[1]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results[2]).isEqualTo(cacheTimeoutClientResult)
+  }
+
   @ParameterizedTest
   @MethodSource("userOffenderAccessClientResults")
   fun `getUserAccessForOffenderCrn returns transformed response from AP Delius Context API call`(
@@ -109,6 +123,20 @@ class ApDeliusContextApiOffenderDetailsDataSourceTest {
     val results = apDeliusContextApiOffenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
 
     assertThat(results).isEqualTo(expectedResults)
+  }
+
+  @Test
+  fun `getUserAccessForOffenderCrns returns an entry per CRN for failures`() {
+    val crns = listOf("CRN-A", "CRN-B", "CRN-C")
+
+    val cacheTimeoutClientResult = cacheTimeoutClientResult<UserAccess>()
+    every { mockApDeliusContextApiClient.getUserAccessForCrns("DELIUS-USER", crns) } returns cacheTimeoutClientResult
+
+    val results = apDeliusContextApiOffenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
+    assertThat(results).hasSize(3)
+    assertThat(results[0]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results[1]).isEqualTo(cacheTimeoutClientResult)
+    assertThat(results[2]).isEqualTo(cacheTimeoutClientResult)
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/ConfiguredOffenderDetailsDataSourceTest.kt
@@ -25,9 +25,9 @@ class ConfiguredOffenderDetailsDataSourceTest {
   @Test
   fun `getOffenderDetailSummary delegates to the Community API data source when configured`() {
     every { mockCommunityApiDataSource.getOffenderDetailSummary(any()) } returns mockk<ClientResult<OffenderDetailSummary>>()
-    every { mockCommunityApiDataSource.getOffenderDetailSummaries(any()) } returns mockk<List<ClientResult<OffenderDetailSummary>>>()
+    every { mockCommunityApiDataSource.getOffenderDetailSummaries(any()) } returns mockk<Map<String, ClientResult<OffenderDetailSummary>>>()
     every { mockCommunityApiDataSource.getUserAccessForOffenderCrn(any(), any()) } returns mockk<ClientResult<UserOffenderAccess>>()
-    every { mockCommunityApiDataSource.getUserAccessForOffenderCrns(any(), any()) } returns mockk<List<ClientResult<UserOffenderAccess>>>()
+    every { mockCommunityApiDataSource.getUserAccessForOffenderCrns(any(), any()) } returns mockk<Map<String, ClientResult<UserOffenderAccess>>>()
 
     val source = getConfiguredDataSource(OffenderDetailsDataSourceName.COMMUNITY_API)
 
@@ -53,9 +53,9 @@ class ConfiguredOffenderDetailsDataSourceTest {
   @Test
   fun `getOffenderDetailSummary delegates to the AP-Delius data source when configured`() {
     every { mockApDeliusDataSource.getOffenderDetailSummary(any()) } returns mockk<ClientResult<OffenderDetailSummary>>()
-    every { mockApDeliusDataSource.getOffenderDetailSummaries(any()) } returns mockk<List<ClientResult<OffenderDetailSummary>>>()
+    every { mockApDeliusDataSource.getOffenderDetailSummaries(any()) } returns mockk<Map<String, ClientResult<OffenderDetailSummary>>>()
     every { mockApDeliusDataSource.getUserAccessForOffenderCrn(any(), any()) } returns mockk<ClientResult<UserOffenderAccess>>()
-    every { mockApDeliusDataSource.getUserAccessForOffenderCrns(any(), any()) } returns mockk<List<ClientResult<UserOffenderAccess>>>()
+    every { mockApDeliusDataSource.getUserAccessForOffenderCrns(any(), any()) } returns mockk<Map<String, ClientResult<UserOffenderAccess>>>()
 
     val source = getConfiguredDataSource(OffenderDetailsDataSourceName.AP_DELIUS_CONTEXT_API)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -872,44 +872,48 @@ class OffenderServiceTest {
       "NOTFOUND",
     )
 
-    private val offenderDetailsSummaries = listOf(
-      ClientResult.Success(
-        HttpStatus.OK,
-        OffenderDetailsSummaryFactory()
-          .withCrn(crns[0])
-          .withCurrentExclusion(true)
-          .withCurrentRestriction(false)
-          .produce(),
-        false,
-      ),
-      ClientResult.Success(
-        HttpStatus.OK,
-        OffenderDetailsSummaryFactory()
-          .withCrn(crns[1])
-          .withCurrentExclusion(false)
-          .withCurrentRestriction(true)
-          .produce(),
-        false,
-      ),
-      ClientResult.Success(
-        HttpStatus.OK,
-        OffenderDetailsSummaryFactory()
-          .withCrn(crns[2])
-          .withCurrentExclusion(false)
-          .withCurrentRestriction(false)
-          .produce(),
-        false,
-      ),
-      ClientResult.Failure.StatusCode(
-        HttpMethod.GET,
-        "/",
-        HttpStatus.NOT_FOUND,
-        null,
-        false,
-      ),
+    private val offenderDetailsSummaries = mapOf(
+      crns[0] to
+        ClientResult.Success(
+          HttpStatus.OK,
+          OffenderDetailsSummaryFactory()
+            .withCrn(crns[0])
+            .withCurrentExclusion(true)
+            .withCurrentRestriction(false)
+            .produce(),
+          false,
+        ),
+      crns[1] to
+        ClientResult.Success(
+          HttpStatus.OK,
+          OffenderDetailsSummaryFactory()
+            .withCrn(crns[1])
+            .withCurrentExclusion(false)
+            .withCurrentRestriction(true)
+            .produce(),
+          false,
+        ),
+      crns[2] to
+        ClientResult.Success(
+          HttpStatus.OK,
+          OffenderDetailsSummaryFactory()
+            .withCrn(crns[2])
+            .withCurrentExclusion(false)
+            .withCurrentRestriction(false)
+            .produce(),
+          false,
+        ),
+      crns[3] to
+        ClientResult.Failure.StatusCode(
+          HttpMethod.GET,
+          "/",
+          HttpStatus.NOT_FOUND,
+          null,
+          false,
+        ),
     )
 
-    private val caseSummaries = offenderDetailsSummaries.mapNotNull {
+    private val caseSummaries = offenderDetailsSummaries.values.mapNotNull {
       when (it) {
         is ClientResult.Success -> it.body.asCaseSummary()
         else -> null
@@ -1050,7 +1054,9 @@ class OffenderServiceTest {
     fun `it returns full summaries when the user has the correct access (forceApDeliusContextApi = false)`() {
       every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(crns) } returns offenderDetailsSummaries
 
-      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(user.deliusUsername, crns) } returns crns.map {
+      every {
+        mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(user.deliusUsername, crns)
+      } returns crns.associateWith {
         ClientResult.Success(
           HttpStatus.OK,
           UserOffenderAccess(false, false, null),
@@ -1070,29 +1076,35 @@ class OffenderServiceTest {
     fun `it returns full and restricted summaries when the user has the access for some CRNs, but not others (forceApDeliusContextApi = false)`() {
       every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(crns) } returns offenderDetailsSummaries
 
-      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(user.deliusUsername, crns) } returns listOf(
-        ClientResult.Success(
-          HttpStatus.OK,
-          UserOffenderAccess(false, true, null),
-          false,
-        ),
-        ClientResult.Success(
-          HttpStatus.OK,
-          UserOffenderAccess(true, false, null),
-          false,
-        ),
-        ClientResult.Success(
-          HttpStatus.OK,
-          UserOffenderAccess(false, false, null),
-          false,
-        ),
-        ClientResult.Failure.StatusCode(
-          HttpMethod.GET,
-          "/",
-          HttpStatus.NOT_FOUND,
-          null,
-          false,
-        ),
+      every {
+        mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(user.deliusUsername, crns)
+      } returns mapOf(
+        crns[0] to
+          ClientResult.Success(
+            HttpStatus.OK,
+            UserOffenderAccess(false, true, null),
+            false,
+          ),
+        crns[1] to
+          ClientResult.Success(
+            HttpStatus.OK,
+            UserOffenderAccess(true, false, null),
+            false,
+          ),
+        crns[2] to
+          ClientResult.Success(
+            HttpStatus.OK,
+            UserOffenderAccess(false, false, null),
+            false,
+          ),
+        crns[3] to
+          ClientResult.Failure.StatusCode(
+            HttpMethod.GET,
+            "/",
+            HttpStatus.NOT_FOUND,
+            null,
+            false,
+          ),
       )
 
       val result = offenderService.getOffenderSummariesByCrns(crns.toSet(), user.deliusUsername, false, false)
@@ -1107,29 +1119,35 @@ class OffenderServiceTest {
     fun `it ignores LAO when ignoreLao is set to true (forceApDeliusContextApi = false)`() {
       every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(crns) } returns offenderDetailsSummaries
 
-      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(user.deliusUsername, crns) } returns listOf(
-        ClientResult.Success(
-          HttpStatus.OK,
-          UserOffenderAccess(false, true, null),
-          false,
-        ),
-        ClientResult.Success(
-          HttpStatus.OK,
-          UserOffenderAccess(true, false, null),
-          false,
-        ),
-        ClientResult.Success(
-          HttpStatus.OK,
-          UserOffenderAccess(false, false, null),
-          false,
-        ),
-        ClientResult.Failure.StatusCode(
-          HttpMethod.GET,
-          "/",
-          HttpStatus.NOT_FOUND,
-          null,
-          false,
-        ),
+      every {
+        mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(user.deliusUsername, crns)
+      } returns mapOf(
+        crns[0] to
+          ClientResult.Success(
+            HttpStatus.OK,
+            UserOffenderAccess(false, true, null),
+            false,
+          ),
+        crns[1] to
+          ClientResult.Success(
+            HttpStatus.OK,
+            UserOffenderAccess(true, false, null),
+            false,
+          ),
+        crns[2] to
+          ClientResult.Success(
+            HttpStatus.OK,
+            UserOffenderAccess(false, false, null),
+            false,
+          ),
+        crns[3] to
+          ClientResult.Failure.StatusCode(
+            HttpMethod.GET,
+            "/",
+            HttpStatus.NOT_FOUND,
+            null,
+            false,
+          ),
       )
 
       val result = offenderService.getOffenderSummariesByCrns(crns.toSet(), user.deliusUsername, true, false)


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-263

The code previously implicitly assumed that the results from the delius offender details API were being returned in the same order as the list of the CRNs requested. We’ve changed the code to remove this assumption and link results by matching on CRNs.

This PR also fixes an inconsistency between delius API and community API behaviour in the event of error, ensuring a ClientResult.Failure is returned for each CRN requested.