### PR TITLE
Return region with `ApprovedPremisesApplication`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -32,6 +32,7 @@ class ApplicationsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
+  private val apAreaTransformer: ApAreaTransformer,
 ) {
 
   final val applicationStatuses = mapOf(
@@ -89,6 +90,7 @@ class ApplicationsTransformer(
           InOutStatus.entries.firstOrNull { it.name == jpa.inmateInOutStatusOnSubmission },
         ),
         type = "CAS1",
+        apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) },
       )
 
       is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1602,6 +1602,8 @@ components:
               format: date-time
             personStatusOnSubmission:
               $ref: '#/components/schemas/PersonStatus'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6017,6 +6017,8 @@ components:
               format: date-time
             personStatusOnSubmission:
               $ref: '#/components/schemas/PersonStatus'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2030,6 +2030,8 @@ components:
               format: date-time
             personStatusOnSubmission:
               $ref: '#/components/schemas/PersonStatus'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
           required:
             - createdByUserId
             - schemaVersion


### PR DESCRIPTION
In some cases it's going to be useful to show an application's region when listing (for example) tasks.