### PR TITLE
(APS-265) Loosen permissions when viewing assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -183,7 +183,7 @@ class UserAccessService(
 
   fun userCanViewAssessment(user: UserEntity, assessment: AssessmentEntity): Boolean = when (assessment) {
     is ApprovedPremisesAssessmentEntity ->
-      user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_MANAGER) || assessment.allocatedToUser == user
+      true
 
     is TemporaryAccommodationAssessmentEntity ->
       user.hasRole(UserRole.CAS3_ASSESSOR) &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1399,8 +1399,8 @@ class AssessmentTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_MANAGER"])
-  fun `Get assessment by ID returns 200 with correct body for CAS1_WORKFLOW_MANAGER and CAS1_MANAGER`(role: UserRole) {
+  @EnumSource(value = UserRole::class)
+  fun `Get assessment by ID returns 200 with correct body for all roles`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { _, jwt ->
       `Given a User` { userEntity, _ ->
         `Given an Offender` { offenderDetails, inmateDetails ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1357,9 +1357,11 @@ class UserAccessServiceTest {
     assertThat(userAccessService.userCanViewAssessment(user, assessment)).isTrue
   }
 
-  @Test
-  fun `userCanViewAssessment returns true for an Approved Premises assessment if the assessment is assigned to the user`() {
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class)
+  fun `userCanViewAssessment returns true for an Approved Premises assessment for any role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
+    user.addRoleForUnitTest(role)
 
     val application = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(anotherUserInRegion)
@@ -1371,22 +1373,6 @@ class UserAccessServiceTest {
       .produce()
 
     assertThat(userAccessService.userCanViewAssessment(user, assessment)).isTrue
-  }
-
-  @Test
-  fun `userCanViewAssessment returns false for an Approved Premises assessment if the user does not have the CAS1_WORKFLOW_MANAGER and the assessment is not assigned to the user`() {
-    currentRequestIsFor(ServiceName.approvedPremises)
-
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(anotherUserInRegion)
-      .produce()
-
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(anotherUserInRegion)
-      .produce()
-
-    assertThat(userAccessService.userCanViewAssessment(user, assessment)).isFalse
   }
 
   @Test
@@ -1473,22 +1459,6 @@ class UserAccessServiceTest {
       .produce()
 
     assertThat(userAccessService.currentUserCanViewAssessment(assessment)).isTrue
-  }
-
-  @Test
-  fun `currentUserCanViewAssessment returns false for an Approved Premises assessment if the user does not have the CAS1_WORKFLOW_MANAGER and the assessment is not assigned to the user`() {
-    currentRequestIsFor(ServiceName.approvedPremises)
-
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(anotherUserInRegion)
-      .produce()
-
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(anotherUserInRegion)
-      .produce()
-
-    assertThat(userAccessService.currentUserCanViewAssessment(assessment)).isFalse
   }
 
   @Test


### PR DESCRIPTION
All users will need to view an assessment (except when the offender is a limited access offender and they don’t have permissions to view), so we’ll open up permissions to all logged in users.