### PR TITLE
[APS-236] Introduce appeals for CAS1 applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface AppealRepository : JpaRepository<AppealEntity, UUID>
+
+@Entity
+@Table(name = "appeals")
+data class AppealEntity(
+  @Id
+  val id: UUID,
+  val appealDate: LocalDate,
+  val appealDetail: String,
+  val reviewer: String,
+  var decision: String,
+  var decisionDetail: String,
+  val createdAt: OffsetDateTime,
+  @ManyToOne
+  @JoinColumn(name = "application_id")
+  val application: ApplicationEntity,
+  @ManyToOne
+  @JoinColumn(name = "assessment_id")
+  var assessment: AssessmentEntity?,
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdBy: UserEntity,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class AppealService(
+  private val appealRepository: AppealRepository,
+) {
+  fun createAppeal(
+    appealDate: LocalDate,
+    appealDetail: String,
+    reviewer: String,
+    decision: AppealDecision,
+    decisionDetail: String,
+    application: ApplicationEntity,
+    createdBy: UserEntity,
+  ): AuthorisableActionResult<ValidatableActionResult<AppealEntity>> {
+    if (!createdBy.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return AuthorisableActionResult.Unauthorised()
+
+    return AuthorisableActionResult.Success(
+      validated {
+        if (appealDate.isAfter(LocalDate.now())) {
+          "$.appealDate" hasValidationError "mustNotBeFuture"
+        }
+
+        if (appealDetail.isBlank()) {
+          "$.appealDetail" hasValidationError "empty"
+        }
+
+        if (reviewer.isBlank()) {
+          "$.reviewer" hasValidationError "empty"
+        }
+
+        if (decisionDetail.isBlank()) {
+          "$.decisionDetail" hasValidationError "empty"
+        }
+
+        if (validationErrors.any()) {
+          return@validated fieldValidationError
+        }
+
+        val appeal = appealRepository.save(
+          AppealEntity(
+            id = UUID.randomUUID(),
+            appealDate = appealDate,
+            appealDetail = appealDetail,
+            reviewer = reviewer,
+            decision = decision.value,
+            decisionDetail = decisionDetail,
+            createdAt = OffsetDateTime.now(),
+            application = application,
+            assessment = null,
+            createdBy = createdBy,
+          ),
+        )
+
+        success(appeal)
+      },
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AppealTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AppealTransformer.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Appeal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+
+@Component
+class AppealTransformer {
+  fun transformJpaToApi(jpa: AppealEntity): Appeal = Appeal(
+    id = jpa.id,
+    appealDate = jpa.appealDate,
+    appealDetail = jpa.appealDetail,
+    reviewer = jpa.reviewer,
+    createdAt = jpa.createdAt.toInstant(),
+    applicationId = jpa.application.id,
+    createdByUserId = jpa.createdBy.id,
+    decision = AppealDecision.entries.first { it.value == jpa.decision },
+    decisionDetail = jpa.decisionDetail,
+    assessmentId = jpa.assessment?.id,
+  )
+}

--- a/src/main/resources/db/migration/all/20240130114858__create_table_for_appeals.sql
+++ b/src/main/resources/db/migration/all/20240130114858__create_table_for_appeals.sql
@@ -1,0 +1,16 @@
+CREATE TABLE appeals (
+    id UUID NOT NULL,
+    appeal_date DATE NOT NULL,
+    appeal_detail TEXT NOT NULL,
+    reviewer TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    decision_detail TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    application_id UUID NOT NULL,
+    assessment_id UUID,
+    created_by_user_id UUID NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (application_id) REFERENCES applications(id),
+    FOREIGN KEY (assessment_id) REFERENCES assessments(id),
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4124,3 +4124,67 @@ components:
         - A1
         - A2
         - A3
+    NewAppeal:
+      type: object
+      properties:
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        reviewer:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+      required:
+        - appealDate
+        - appealDetail
+        - reviewer
+        - decision
+        - decisionDetail
+    Appeal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        reviewer:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        applicationId:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+      required:
+        - id
+        - appealDate
+        - appealDetail
+        - reviewer
+        - decision
+        - decisionDetail
+        - createdAt
+        - applicationId
+        - createdByUserId
+    AppealDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2093,6 +2093,46 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /applications/{applicationId}/appeals:
+    post:
+      tags:
+        - Application data
+      summary: Add an appeal to an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the appeal to add
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewAppeal'
+        required: true
+      responses:
+        201:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Appeal'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /documents/{crn}/{documentId}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2095,6 +2095,46 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/appeals:
+    post:
+      tags:
+        - Application data
+      summary: Add an appeal to an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the appeal to add
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewAppeal'
+        required: true
+      responses:
+        201:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Appeal'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /documents/{crn}/{documentId}:
     get:
       tags:
@@ -8545,3 +8585,67 @@ components:
         - A1
         - A2
         - A3
+    NewAppeal:
+      type: object
+      properties:
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        reviewer:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+      required:
+        - appealDate
+        - appealDetail
+        - reviewer
+        - decision
+        - decisionDetail
+    Appeal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        reviewer:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        applicationId:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+      required:
+        - id
+        - appealDate
+        - appealDetail
+        - reviewer
+        - decision
+        - decisionDetail
+        - createdAt
+        - applicationId
+        - createdByUserId
+    AppealDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4552,3 +4552,67 @@ components:
         - A1
         - A2
         - A3
+    NewAppeal:
+      type: object
+      properties:
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        reviewer:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+      required:
+        - appealDate
+        - appealDetail
+        - reviewer
+        - decision
+        - decisionDetail
+    Appeal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        reviewer:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        applicationId:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+      required:
+        - id
+        - appealDate
+        - appealDetail
+        - reviewer
+        - decision
+        - decisionDetail
+        - createdAt
+        - applicationId
+        - createdByUserId
+    AppealDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AppealEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AppealEntityFactory.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class AppealEntityFactory : Factory<AppealEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var appealDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var appealDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var reviewer: Yielded<String> = { randomEmailAddress() }
+  private var decision: Yielded<String> = { randomOf(AppealDecision.entries).value }
+  private var decisionDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var application: Yielded<ApprovedPremisesApplicationEntity> = {
+    ApprovedPremisesApplicationEntityFactory()
+      .withYieldedCreatedByUser(createdBy)
+      .produce()
+  }
+  private var assessment: Yielded<ApprovedPremisesAssessmentEntity?> = { null }
+  private var createdBy: Yielded<UserEntity> = {
+    UserEntityFactory()
+      .withProbationRegion(
+        ProbationRegionEntityFactory()
+          .withApArea(
+            ApAreaEntityFactory().produce(),
+          )
+          .produce(),
+      )
+      .produce()
+  }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withAppealDate(appealDate: LocalDate) = apply {
+    this.appealDate = { appealDate }
+  }
+
+  fun withAppealDetail(appealDetail: String) = apply {
+    this.appealDetail = { appealDetail }
+  }
+
+  fun withReviewer(reviewer: String) = apply {
+    this.reviewer = { reviewer }
+  }
+
+  fun withDecision(decision: AppealDecision) = apply {
+    this.decision = { decision.value }
+  }
+
+  fun withDecisionDetail(decisionDetail: String) = apply {
+    this.decisionDetail = { decisionDetail }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withApplication(configuration: ApprovedPremisesApplicationEntityFactory.() -> Unit) = apply {
+    this.application = { ApprovedPremisesApplicationEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withApplication(application: ApprovedPremisesApplicationEntity) = apply {
+    this.application = { application }
+  }
+
+  fun withAssessment(configuration: ApprovedPremisesAssessmentEntityFactory.() -> Unit) = apply {
+    this.assessment = { ApprovedPremisesAssessmentEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withAssessment(assessment: ApprovedPremisesAssessmentEntity?) = apply {
+    this.assessment = { assessment }
+  }
+
+  fun withCreatedBy(configuration: UserEntityFactory.() -> Unit) = apply {
+    this.createdBy = { UserEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  override fun produce() = AppealEntity(
+    id = this.id(),
+    appealDate = this.appealDate(),
+    appealDetail = this.appealDetail(),
+    reviewer = this.reviewer(),
+    decision = this.decision(),
+    decisionDetail = this.decisionDetail(),
+    createdAt = this.createdAt(),
+    application = this.application(),
+    assessment = this.assessment(),
+    createdBy = this.createdBy(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -1,0 +1,165 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Appeal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
+import java.time.LocalDate
+import java.util.UUID
+
+class AppealsTest : IntegrationTestBase() {
+  @Test
+  fun `Create new appeal without JWT returns 401`() {
+    webTestClient.post()
+      .uri("/applications/${UUID.randomUUID()}/appeals")
+      .bodyValue(
+        NewAppeal(
+          appealDate = LocalDate.parse("2024-01-01"),
+          appealDetail = "Some details about the appeal.",
+          reviewer = "Someone Else",
+          decision = AppealDecision.accepted,
+          decisionDetail = "Some details about the decision.",
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Create new appeal returns 404 when application could not be found`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { _, jwt ->
+      webTestClient.post()
+        .uri("/applications/${UUID.randomUUID()}/appeals")
+        .bodyValue(
+          NewAppeal(
+            appealDate = LocalDate.parse("2024-01-01"),
+            appealDetail = "Some details about the appeal.",
+            reviewer = "Someone Else",
+            decision = AppealDecision.accepted,
+            decisionDetail = "Some details about the decision.",
+          ),
+        )
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Create new appeal returns 403 when application is not accessible to user`() {
+    `Given a User` { createdByUser, _ ->
+      `Given an Application`(createdByUser) { application ->
+        `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { _, jwt ->
+          webTestClient.post()
+            .uri("/applications/${application.id}/appeals")
+            .bodyValue(
+              NewAppeal(
+                appealDate = LocalDate.parse("2024-01-01"),
+                appealDetail = "Some details about the appeal.",
+                reviewer = "Someone Else",
+                decision = AppealDecision.accepted,
+                decisionDetail = "Some details about the decision.",
+              ),
+            )
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isForbidden
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `Create new appeal returns 403 when user does not have CAS1_APPEALS_MANAGER role`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Application`(userEntity) { application ->
+        webTestClient.post()
+          .uri("/applications/${application.id}/appeals")
+          .bodyValue(
+            NewAppeal(
+              appealDate = LocalDate.parse("2024-01-01"),
+              appealDetail = "Some details about the appeal.",
+              reviewer = "Someone Else",
+              decision = AppealDecision.accepted,
+              decisionDetail = "Some details about the decision.",
+            ),
+          )
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+  }
+
+  @Test
+  fun `Create new appeal returns 400 when invalid data is provided`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { userEntity, jwt ->
+      `Given an Application`(userEntity) { application ->
+        webTestClient.post()
+          .uri("/applications/${application.id}/appeals")
+          .bodyValue(
+            NewAppeal(
+              appealDate = LocalDate.now().plusDays(1),
+              appealDetail = "  ",
+              reviewer = "\t",
+              decision = AppealDecision.rejected,
+              decisionDetail = "\n",
+            ),
+          )
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+      }
+    }
+  }
+
+  @Test
+  fun `Create new appeal returns 201 with correct body and Location header`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { userEntity, jwt ->
+      `Given an Application`(userEntity) { application ->
+        val result = webTestClient.post()
+          .uri("/applications/${application.id}/appeals")
+          .bodyValue(
+            NewAppeal(
+              appealDate = LocalDate.parse("2024-01-01"),
+              appealDetail = "Some details about the appeal.",
+              reviewer = "Someone Else",
+              decision = AppealDecision.accepted,
+              decisionDetail = "Some details about the decision.",
+            ),
+          )
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .returnResult(Appeal::class.java)
+
+        assertThat(result.responseHeaders["Location"]).anyMatch {
+          it.matches(Regex("/applications/${application.id}/appeals/[0-9a-f-]+"))
+        }
+
+        assertThat(result.responseBody.blockFirst()).matches {
+          it.appealDate == LocalDate.parse("2024-01-01") &&
+            it.appealDetail == "Some details about the appeal." &&
+            it.reviewer == "Someone Else" &&
+            withinSeconds(5L).matches(it.createdAt.toString()) &&
+            it.applicationId == application.id &&
+            it.createdByUserId == userEntity.id &&
+            it.decision == AppealDecision.accepted &&
+            it.decisionDetail == "Some details about the decision." &&
+            it.assessmentId == null
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -1,0 +1,198 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EmptySource
+import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AppealService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import java.time.LocalDate
+
+class AppealServiceTest {
+  private val appealRepository = mockk<AppealRepository>()
+
+  private val appealService = AppealService(appealRepository)
+
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withApArea(
+      ApAreaEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  private val createdByUser = UserEntityFactory()
+    .withProbationRegion(probationRegion)
+    .produce()
+
+  private val application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(createdByUser)
+    .produce()
+
+  @Nested
+  inner class CreateAppeal {
+    @Test
+    fun `Returns Unauthorised if the creating user does not have the CAS1_APPEALS_MANAGER role`() {
+      val result = appealService.createAppeal(
+        LocalDate.now(),
+        "Some information about why the appeal is being made",
+        "ReviewBot 9000",
+        AppealDecision.accepted,
+        "Some information about the decision made",
+        application,
+        createdByUser,
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Unauthorised::class.java)
+    }
+
+    @Test
+    fun `Returns FieldValidationError if the appeal date is in the future`() {
+      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val result = appealService.createAppeal(
+        LocalDate.now().plusDays(1),
+        "Some information about why the appeal is being made",
+        "ReviewBot 9000",
+        AppealDecision.accepted,
+        "Some information about the decision made",
+        application,
+        createdByUser,
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
+      assertThat(resultEntity.validationMessages).containsEntry("$.appealDate", "mustNotBeFuture")
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = ["  ", "\t", "\n"])
+    fun `Returns FieldValidationError if the appeal detail is blank`(appealDetail: String) {
+      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val result = appealService.createAppeal(
+        LocalDate.now(),
+        appealDetail,
+        "ReviewBot 9000",
+        AppealDecision.accepted,
+        "Some information about the decision made",
+        application,
+        createdByUser,
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
+      assertThat(resultEntity.validationMessages).containsEntry("$.appealDetail", "empty")
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = ["  ", "\t", "\n"])
+    fun `Returns FieldValidationError if the reviewer is blank`(reviewer: String) {
+      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val result = appealService.createAppeal(
+        LocalDate.now(),
+        "Some information about why the appeal is being made",
+        reviewer,
+        AppealDecision.accepted,
+        "Some information about the decision made",
+        application,
+        createdByUser,
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
+      assertThat(resultEntity.validationMessages).containsEntry("$.reviewer", "empty")
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = ["  ", "\t", "\n"])
+    fun `Returns FieldValidationError if the decision detail is blank`(decisionDetail: String) {
+      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val result = appealService.createAppeal(
+        LocalDate.now(),
+        "Some information about why the appeal is being made",
+        "ReviewBot 9000",
+        AppealDecision.accepted,
+        decisionDetail,
+        application,
+        createdByUser,
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
+      assertThat(resultEntity.validationMessages).containsEntry("$.decisionDetail", "empty")
+    }
+
+    @Test
+    fun `Stores appeal in repository and returns the stored appeal`() {
+      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val now = LocalDate.now()
+
+      every { appealRepository.save(any()) } returnsArgument 0
+
+      val result = appealService.createAppeal(
+        now,
+        "Some information about why the appeal is being made",
+        "ReviewBot 9000",
+        AppealDecision.accepted,
+        "Some information about the decision made",
+        application,
+        createdByUser,
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
+      val resultEntity = result.entity as ValidatableActionResult.Success
+      assertThat(resultEntity.entity).matches {
+        it.appealDate == now &&
+          it.appealDetail == "Some information about why the appeal is being made" &&
+          it.reviewer == "ReviewBot 9000" &&
+          it.decision == AppealDecision.accepted.value &&
+          it.decisionDetail == "Some information about the decision made" &&
+          it.application == application &&
+          it.createdBy == createdByUser
+      }
+      verify(exactly = 1) {
+        appealRepository.save(
+          match {
+            it.appealDate == now &&
+              it.appealDetail == "Some information about why the appeal is being made" &&
+              it.reviewer == "ReviewBot 9000" &&
+              it.decision == AppealDecision.accepted.value &&
+              it.decisionDetail == "Some information about the decision made" &&
+              it.application == application &&
+              it.createdBy == createdByUser
+          },
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AppealTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AppealTransformerTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AppealTransformer
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class AppealTransformerTest {
+  private val appealTransformer = AppealTransformer()
+
+  @Test
+  fun `A newly created appeal is transformed correctly`() {
+    val appealEntity = AppealEntityFactory()
+      .produce()
+
+    val transformedAppeal = appealTransformer.transformJpaToApi(appealEntity)
+
+    assertThat(transformedAppeal.id).isEqualTo(appealEntity.id)
+    assertThat(transformedAppeal.appealDate).isEqualTo(appealEntity.appealDate)
+    assertThat(transformedAppeal.appealDetail).isEqualTo(appealEntity.appealDetail)
+    assertThat(transformedAppeal.reviewer).isEqualTo(appealEntity.reviewer)
+    assertThat(transformedAppeal.createdAt).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS))
+    assertThat(transformedAppeal.applicationId).isEqualTo(appealEntity.application.id)
+    assertThat(transformedAppeal.createdByUserId).isEqualTo(appealEntity.createdBy.id)
+    assertThat(transformedAppeal.decision.value).isEqualTo(appealEntity.decision)
+    assertThat(transformedAppeal.decisionDetail).isEqualTo(appealEntity.decisionDetail)
+    assertThat(transformedAppeal.assessmentId).isNull()
+  }
+
+  @Test
+  fun `An appeal with an assessment linked is transformed correctly`() {
+    val appealEntity = AppealEntityFactory()
+      .produce()
+
+    appealEntity.assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withApplication(appealEntity.application)
+      .produce()
+
+    val transformedAppeal = appealTransformer.transformJpaToApi(appealEntity)
+
+    assertThat(transformedAppeal.id).isEqualTo(appealEntity.id)
+    assertThat(transformedAppeal.appealDate).isEqualTo(appealEntity.appealDate)
+    assertThat(transformedAppeal.appealDetail).isEqualTo(appealEntity.appealDetail)
+    assertThat(transformedAppeal.reviewer).isEqualTo(appealEntity.reviewer)
+    assertThat(transformedAppeal.createdAt).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS))
+    assertThat(transformedAppeal.applicationId).isEqualTo(appealEntity.application.id)
+    assertThat(transformedAppeal.createdByUserId).isEqualTo(appealEntity.createdBy.id)
+    assertThat(transformedAppeal.decision.value).isEqualTo(appealEntity.decision)
+    assertThat(transformedAppeal.decisionDetail).isEqualTo(appealEntity.decisionDetail)
+    assertThat(transformedAppeal.assessmentId).isEqualTo(appealEntity.assessment!!.id)
+  }
+}


### PR DESCRIPTION
> See [APS-236 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-236).

This PR introduces appeals for when an application is rejected. An appeal can be created for an application using the `POST /applications/{applicationId}/appeals` endpoint. The body of a request to this endpoint looks like:

```json
{
    "appealDate": "2024-01-01",
    "appealDetail": "Some information about the appeal",
    "reviewer": "A Name",
    "decision": "accepted",
    "decisionDetail": "Some information about the decision"
}
```

An appeal can only be created by a user if they have the `CAS1_APPEALS_MANAGER` role (see #1411) and can access the application.

This PR does not include an endpoint for viewing an appeal, as this is part of APS-238.