### PR TITLE
Refactor GetReallocatedTasks Functions to reduce duplication and provide generic functionality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -85,7 +85,7 @@ class TasksController(
     }
 
     if (type == null) {
-      return responseForAllTypes(user, pageCriteria, allocatedFilter, apAreaId)
+      return reallocatableResponseForAllTypes(user, pageCriteria, allocatedFilter, apAreaId)
     }
 
     val taskType = enumConverterFactory.getConverter(TaskType::class.java).convert(
@@ -93,9 +93,9 @@ class TasksController(
     ) ?: throw NotFoundProblem(type, "TaskType")
 
     return when (taskType) {
-      TaskType.assessment -> assessmentTasksResponse(user, pageCriteria, allocatedFilter, apAreaId)
-      TaskType.placementRequest -> placementRequestTasks(user, pageCriteria, allocatedFilter, apAreaId)
-      TaskType.placementApplication -> placementApplicationTasks(user, pageCriteria, allocatedFilter, apAreaId)
+      TaskType.assessment -> reallocatableResponseForAssessments(user, pageCriteria, allocatedFilter, apAreaId)
+      TaskType.placementRequest -> reallocatableResponseForPlacementRequests(user, pageCriteria, allocatedFilter, apAreaId)
+      TaskType.placementApplication -> reallocatbleResponseForPlacementApplications(user, pageCriteria, allocatedFilter, apAreaId)
       else -> throw BadRequestProblem()
     }
   }
@@ -430,7 +430,7 @@ class TasksController(
       }
     }
 
-  private fun responseForAllTypes(
+  private fun reallocatableResponseForAllTypes(
     user: UserEntity,
     pageCriteria: PageCriteria<TaskSortField>,
     allocatedFilter: AllocatedFilter?,
@@ -469,7 +469,7 @@ class TasksController(
     )
   }
 
-  private fun assessmentTasksResponse(
+  private fun reallocatableResponseForAssessments(
     user: UserEntity,
     pageCriteria: PageCriteria<TaskSortField>,
     allocatedFilter: AllocatedFilter?,
@@ -490,7 +490,7 @@ class TasksController(
     )
   }
 
-  private fun placementRequestTasks(
+  private fun reallocatableResponseForPlacementRequests(
     user: UserEntity,
     pageCriteria: PageCriteria<TaskSortField>,
     allocatedFilter: AllocatedFilter?,
@@ -514,7 +514,7 @@ class TasksController(
     )
   }
 
-  private fun placementApplicationTasks(
+  private fun reallocatbleResponseForPlacementApplications(
     user: UserEntity,
     pageCriteria: PageCriteria<TaskSortField>,
     allocatedFilter: AllocatedFilter?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -436,9 +436,11 @@ class TasksController(
     allocatedFilter: AllocatedFilter?,
     apAreaId: UUID?,
   ): ResponseEntity<List<Task>> = runBlocking {
-    val (allocatedTasks, metadata) = taskService.getAllReallocatable(
-      allocatedFilter,
-      apAreaId,
+    val (allocatedTasks, metadata) = taskService.getAll(
+      TaskService.TaskFilterCriteria(
+        allocatedFilter,
+        apAreaId,
+      ),
       pageCriteria,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -170,36 +170,6 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
     page: Pageable? = null,
   ): Page<DomainAssessmentSummary>
 
-  @Query(
-    """
-      SELECT a FROM ApprovedPremisesAssessmentEntity a 
-      JOIN a.application app
-      LEFT OUTER JOIN app.apArea area
-      WHERE a.reallocatedAt IS NULL AND
-            a.isWithdrawn != true AND 
-            a.submittedAt IS NULL AND 
-            (
-              (:#{#allocationStatus?.toString()} = 'ALLOCATED' AND a.allocatedToUser IS NOT NULL) OR
-              (:#{#allocationStatus?.toString()} = 'UNALLOCATED' AND a.allocatedToUser IS NULL) OR
-              (:#{#allocationStatus?.toString()} = 'EITHER')
-            ) AND (
-              (cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR 
-              (area.id = :apAreaId)
-            )
-    """,
-  )
-  fun findByAllocationStatus(
-    allocationStatus: AllocationStatus,
-    apAreaId: UUID?,
-    pageable: Pageable?,
-  ): Page<ApprovedPremisesAssessmentEntity>
-
-  enum class AllocationStatus {
-    ALLOCATED,
-    UNALLOCATED,
-    EITHER,
-  }
-
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -24,36 +24,6 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   @Query(
     """
-    SELECT
-      pa
-    FROM
-      PlacementApplicationEntity pa
-      JOIN pa.application app
-      LEFT OUTER JOIN app.apArea area
-    where
-      pa.submittedAt IS NOT NULL AND
-      pa.reallocatedAt IS NULL AND
-      pa.decision IS NULL AND 
-      (
-        (:#{#allocationStatus?.toString()} = 'ALLOCATED' AND pa.allocatedToUser IS NOT NULL) OR
-        (:#{#allocationStatus?.toString()} = 'UNALLOCATED' AND pa.allocatedToUser IS NULL) OR
-        (:#{#allocationStatus?.toString()} = 'EITHER')
-      ) AND (
-        (cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR 
-        (area.id = :apAreaId)
-      )
-    """,
-  )
-  fun findByAllocationStatus(allocationStatus: AllocationStatus, apAreaId: UUID?, pageable: Pageable?): Page<PlacementApplicationEntity>
-
-  enum class AllocationStatus {
-    ALLOCATED,
-    UNALLOCATED,
-    EITHER,
-  }
-
-  @Query(
-    """
       SELECT pa FROM PlacementApplicationEntity pa
       JOIN pa.application a
       LEFT OUTER JOIN a.apArea apArea

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -48,40 +48,6 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
   @Query(
     """
     SELECT
-      placement_request.*
-    FROM
-      placement_requests placement_request
-      LEFT JOIN booking_not_mades booking_not_made ON booking_not_made.placement_request_id = placement_request.id
-      INNER JOIN approved_premises_applications app ON app.id = placement_request.application_id 
-      LEFT OUTER JOIN ap_areas area ON area.id = app.ap_area_id
-    WHERE
-      placement_request.booking_id IS NULL
-      AND placement_request.reallocated_at IS NULL
-      AND placement_request.is_withdrawn IS FALSE
-      AND booking_not_made.id IS NULL
-      AND (
-        (:#{#allocationStatus?.toString()} = 'ALLOCATED' AND placement_request.allocated_to_user_id IS NOT NULL) OR
-        (:#{#allocationStatus?.toString()} = 'UNALLOCATED' AND placement_request.allocated_to_user_id IS NULL) OR
-        (:#{#allocationStatus?.toString()} = 'EITHER')
-      ) AND (
-        (cast(:apAreaId as uuid) IS NULL) OR
-        (area.id = :apAreaId)
-      )
-
-    """,
-    nativeQuery = true,
-  )
-  fun findByAllocationStatus(allocationStatus: AllocationStatus, apAreaId: UUID?, pageable: Pageable?): Page<PlacementRequestEntity>
-
-  enum class AllocationStatus {
-    ALLOCATED,
-    UNALLOCATED,
-    EITHER,
-  }
-
-  @Query(
-    """
-    SELECT
       pq.*,
       application.created_at as application_date,
       CASE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -25,6 +25,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         inner join approved_premises_applications application on assessment.application_id = application.id
         left join ap_areas area on area.id = application.ap_area_id
       where
+        'ASSESSMENT' in :taskTypes AND
         assessment.is_withdrawn is not true
         and assessment.reallocated_at is null
         and assessment.submitted_at is null
@@ -48,6 +49,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         inner join approved_premises_applications application on placement_application.application_id = application.id
         left join ap_areas area on area.id = application.ap_area_id
       where
+        'PLACEMENT_APPLICATION' in :taskTypes AND
         placement_application.submitted_at is not null
         and placement_application.reallocated_at is null
         and placement_application.decision is null
@@ -72,6 +74,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         left join booking_not_mades booking_not_made on booking_not_made.placement_request_id = placement_request.id
         left join ap_areas area on area.id = application.ap_area_id
       where
+        'PLACEMENT_REQUEST' in :taskTypes AND
         placement_request.booking_id IS NULL
         AND placement_request.reallocated_at IS NULL
         AND placement_request.is_withdrawn is false
@@ -94,7 +97,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     countQuery = "SELECT COUNT(1) FROM ($ALLOCATABLE_QUERY) as count",
     nativeQuery = true,
   )
-  fun getAllReallocatable(isAllocated: Boolean?, apAreaId: UUID?, pageable: Pageable?): Page<Task>
+  fun getAllReallocatable(isAllocated: Boolean?, apAreaId: UUID?, taskTypes: List<String>, pageable: Pageable?): Page<Task>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -8,16 +8,18 @@ import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.Id
 
 @Repository
-interface TaskRespository : JpaRepository<Task, UUID> {
+interface TaskRepository : JpaRepository<Task, UUID> {
   companion object {
     private const val ALLOCATABLE_QUERY = """
       SELECT
         cast(assessment.id as TEXT) as id,
         assessment.created_at as created_at,
-        'assessment' as type
+        'ASSESSMENT' as type
       from
         assessments assessment
         inner join approved_premises_applications application on assessment.application_id = application.id
@@ -40,7 +42,7 @@ interface TaskRespository : JpaRepository<Task, UUID> {
       SELECT
         cast(placement_application.id as TEXT) as id,
         placement_application.created_at as created_at,
-        'placement_application' as type
+        'PLACEMENT_APPLICATION' as type
       from
         placement_applications placement_application
         inner join approved_premises_applications application on placement_application.application_id = application.id
@@ -63,7 +65,7 @@ interface TaskRespository : JpaRepository<Task, UUID> {
       SELECT
         cast(placement_request.id as TEXT) as id,
         placement_request.created_at as created_at,
-        'placement_request' as type
+        'PLACEMENT_REQUEST' as type
       from
         placement_requests placement_request
         inner join approved_premises_applications application on placement_request.application_id = application.id
@@ -100,5 +102,12 @@ data class Task(
   @Id
   val id: UUID,
   val createdAt: LocalDateTime,
-  val type: String,
+  @Enumerated(EnumType.STRING)
+  val type: TaskEntityType,
 )
+
+enum class TaskEntityType {
+  ASSESSMENT,
+  PLACEMENT_APPLICATION,
+  PLACEMENT_REQUEST,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
@@ -4,12 +4,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import java.time.OffsetDateTime
+import java.util.UUID
 
 sealed class TypedTask(
+  val id: UUID,
   val createdAt: OffsetDateTime,
   val crn: String,
 ) {
-  data class Assessment(val entity: ApprovedPremisesAssessmentEntity) : TypedTask(entity.createdAt, entity.application.crn)
-  data class PlacementRequest(val entity: PlacementRequestEntity) : TypedTask(entity.createdAt, entity.application.crn)
-  data class PlacementApplication(val entity: PlacementApplicationEntity) : TypedTask(entity.createdAt, entity.application.crn)
+  data class Assessment(val entity: ApprovedPremisesAssessmentEntity) : TypedTask(entity.id, entity.createdAt, entity.application.crn)
+  data class PlacementRequest(val entity: PlacementRequestEntity) : TypedTask(entity.id, entity.createdAt, entity.application.crn)
+  data class PlacementApplication(val entity: PlacementApplicationEntity) : TypedTask(entity.id, entity.createdAt, entity.application.crn)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -13,12 +13,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AllocatedFilter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
@@ -52,10 +50,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.wrapWithMetadata
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -141,37 +141,6 @@ class AssessmentService(
     }
   }
 
-  fun getAllReallocatable(
-    pageCriteria: PageCriteria<TaskSortField>,
-    allocatedFilter: AllocatedFilter?,
-    apAreaId: UUID?,
-  ): Pair<List<ApprovedPremisesAssessmentEntity>, PaginationMetadata?> {
-    val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)
-    val pageable = getPageable(
-      pageCriteria.withSortBy(
-        when (pageCriteria.sortBy) {
-          TaskSortField.createdAt -> "createdAt"
-        },
-      ),
-    )
-
-    val assessments = assessmentRepository.findByAllocationStatus(
-      when (allocatedFilter) {
-        AllocatedFilter.allocated -> AssessmentRepository.AllocationStatus.ALLOCATED
-        AllocatedFilter.unallocated -> AssessmentRepository.AllocationStatus.UNALLOCATED
-        null -> AssessmentRepository.AllocationStatus.EITHER
-      },
-      apAreaId,
-      pageable,
-    )
-
-    assessments.forEach {
-      it.schemaUpToDate = it.schemaVersion.id == latestSchema.id
-    }
-
-    return wrapWithMetadata(assessments, pageCriteria)
-  }
-
   fun getAssessmentForUser(user: UserEntity, assessmentId: UUID): AuthorisableActionResult<AssessmentEntity> {
     val assessment = assessmentRepository.findByIdOrNull(assessmentId)
       ?: return AuthorisableActionResult.NotFound()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -4,10 +4,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AllocatedFilter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -27,10 +25,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.wrapWithMetadata
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -402,32 +402,6 @@ class PlacementApplicationService(
     }
   }
 
-  fun getAllReallocatable(
-    pageCriteria: PageCriteria<TaskSortField>,
-    allocatedFilter: AllocatedFilter?,
-    apAreaId: UUID?,
-  ): Pair<List<PlacementApplicationEntity>, PaginationMetadata?> {
-    val pageable = getPageable(
-      pageCriteria.withSortBy(
-        when (pageCriteria.sortBy) {
-          TaskSortField.createdAt -> "createdAt"
-        },
-      ),
-    )
-
-    val allReallocatable = placementApplicationRepository.findByAllocationStatus(
-      when (allocatedFilter) {
-        AllocatedFilter.allocated -> PlacementApplicationRepository.AllocationStatus.ALLOCATED
-        AllocatedFilter.unallocated -> PlacementApplicationRepository.AllocationStatus.UNALLOCATED
-        null -> PlacementApplicationRepository.AllocationStatus.EITHER
-      },
-      apAreaId,
-      pageable,
-    )
-
-    return wrapWithMetadata(allReallocatable, pageCriteria)
-  }
-
   fun getWithdrawablePlacementApplications(application: ApprovedPremisesApplicationEntity) =
     placementApplicationRepository.findByApplication(application).filter { it.canBeWithdrawn() }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -82,30 +82,6 @@ class PlacementRequestService(
     return Pair(response.content, getMetadata(response, page))
   }
 
-  fun getAllReallocatable(
-    pageCriteria: PageCriteria<TaskSortField>,
-    allocatedFilter: AllocatedFilter?,
-    apAreaId: UUID?,
-  ): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
-    val pageable = getPageable(
-      pageCriteria.withSortBy(
-        when (pageCriteria.sortBy) {
-          TaskSortField.createdAt -> "created_at"
-        },
-      ),
-    )
-
-    val allocationStatus = when (allocatedFilter) {
-      AllocatedFilter.allocated -> PlacementRequestRepository.AllocationStatus.ALLOCATED
-      AllocatedFilter.unallocated -> PlacementRequestRepository.AllocationStatus.UNALLOCATED
-      null -> PlacementRequestRepository.AllocationStatus.EITHER
-    }
-
-    val allReallocatable = placementRequestRepository.findByAllocationStatus(allocationStatus, apAreaId, pageable)
-
-    return wrapWithMetadata(allReallocatable, pageCriteria)
-  }
-
   fun getAllActive(
     searchCriteria: AllActiveSearchCriteria,
     pageCriteria: PageCriteria<PlacementRequestSortField>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -10,13 +10,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AllocatedFilter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
@@ -44,7 +42,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.wrapWithMetadata
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -41,9 +41,14 @@ class TaskService(
   private val placementApplicationRepository: PlacementApplicationRepository,
   private val placementRequestRepository: PlacementRequestRepository,
 ) {
-  fun getAllReallocatable(
-    allocatedFilter: AllocatedFilter?,
-    apAreaId: UUID?,
+
+  data class TaskFilterCriteria(
+    val allocatedFilter: AllocatedFilter?,
+    val apAreaId: UUID?,
+  )
+
+  fun getAll(
+    filterCriteria: TaskFilterCriteria,
     pageCriteria: PageCriteria<TaskSortField>,
   ): Pair<List<TypedTask>, PaginationMetadata?> {
     val pageable = getPageable(
@@ -53,6 +58,9 @@ class TaskService(
         },
       ),
     )
+
+    val allocatedFilter = filterCriteria.allocatedFilter
+    val apAreaId = filterCriteria.apAreaId
 
     val isAllocated = if (allocatedFilter == null) { null } else { allocatedFilter == AllocatedFilter.allocated }
     val tasksResult = taskRepository.getAllReallocatable(isAllocated, apAreaId, pageable)
@@ -69,7 +77,7 @@ class TaskService(
 
     val typedTasks = tasks
       .map { task ->
-        val candidateList = when(task.type) {
+        val candidateList = when (task.type) {
           TaskEntityType.ASSESSMENT -> assessments
           TaskEntityType.PLACEMENT_APPLICATION -> placementApplications
           TaskEntityType.PLACEMENT_REQUEST -> placementRequests

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransfor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.wrapWithMetadata
 import java.util.UUID
 
 @Service
@@ -71,7 +70,7 @@ class TaskService(
       isAllocated,
       apAreaId,
       taskTypes.map { it.name },
-      pageable
+      pageable,
     )
 
     val tasks = tasksResult.content
@@ -79,17 +78,23 @@ class TaskService(
     val assessments = if (taskTypes.contains(TaskEntityType.ASSESSMENT)) {
       val assessmentIds = tasks.idsForType(TaskEntityType.ASSESSMENT)
       assessmentRepository.findAllById(assessmentIds).map { TypedTask.Assessment(it as ApprovedPremisesAssessmentEntity) }
-    } else emptyList()
+    } else {
+      emptyList()
+    }
 
     val placementApplications = if (taskTypes.contains(TaskEntityType.PLACEMENT_APPLICATION)) {
       val placementApplicationIds = tasks.idsForType(TaskEntityType.PLACEMENT_APPLICATION)
       placementApplicationRepository.findAllById(placementApplicationIds).map { TypedTask.PlacementApplication(it) }
-    } else emptyList()
+    } else {
+      emptyList()
+    }
 
     val placementRequests = if (taskTypes.contains(TaskEntityType.PLACEMENT_REQUEST)) {
       val placementRequestIds = tasks.idsForType(TaskEntityType.PLACEMENT_REQUEST)
       placementRequestRepository.findAllById(placementRequestIds).map { TypedTask.PlacementRequest(it) }
-    } else emptyList()
+    } else {
+      emptyList()
+    }
 
     val typedTasks = tasks
       .map { task ->
@@ -107,7 +112,6 @@ class TaskService(
   }
 
   private fun List<Task>.idsForType(type: TaskEntityType) = this.filter { it.type == type }.map { it.id }
-
 
   fun reallocateTask(requestUser: UserEntity, taskType: TaskType, userToAllocateToId: UUID, id: UUID): AuthorisableActionResult<ValidatableActionResult<Reallocation>> {
     if (!userAccessService.userCanReallocateTask(requestUser)) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -33,7 +33,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Task
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskRespository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskEntityType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
@@ -59,7 +60,7 @@ class TaskServiceTest {
   private val placementRequestServiceMock = mockk<PlacementRequestService>()
   private val userTransformerMock = mockk<UserTransformer>()
   private val placementApplicationServiceMock = mockk<PlacementApplicationService>()
-  private val taskRepositoryMock = mockk<TaskRespository>()
+  private val taskRepositoryMock = mockk<TaskRepository>()
   private val assessmentRepositoryMock = mockk<AssessmentRepository>()
   private val placementApplicationRepositoryMock = mockk<PlacementApplicationRepository>()
   private val placementRequestRepositoryMock = mockk<PlacementRequestRepository>()
@@ -310,9 +311,9 @@ class TaskServiceTest {
     val placementApplications = List(4) { generatePlacementApplication() }
     val placementRequests = List(4) { generatePlacementRequest() }
 
-    val assessmentTasks = assessments.map { Task(it.id, it.createdAt.toLocalDateTime(), "assessment") }
-    val placementApplicationTasks = placementApplications.map { Task(it.id, it.createdAt.toLocalDateTime(), "placement_application") }
-    val placementRequestTasks = placementRequests.map { Task(it.id, it.createdAt.toLocalDateTime(), "placement_request") }
+    val assessmentTasks = assessments.map { Task(it.id, it.createdAt.toLocalDateTime(), TaskEntityType.ASSESSMENT) }
+    val placementApplicationTasks = placementApplications.map { Task(it.id, it.createdAt.toLocalDateTime(), TaskEntityType.PLACEMENT_APPLICATION) }
+    val placementRequestTasks = placementRequests.map { Task(it.id, it.createdAt.toLocalDateTime(), TaskEntityType.PLACEMENT_REQUEST) }
 
     val tasks = listOf(
       assessmentTasks,
@@ -339,7 +340,7 @@ class TaskServiceTest {
       assessments.map { TypedTask.Assessment(it) },
       placementApplications.map { TypedTask.PlacementApplication(it) },
       placementRequests.map { TypedTask.PlacementRequest(it) },
-    ).flatten().sortedBy { it.createdAt }
+    ).flatten()
 
     Assertions.assertThat(result.first).isEqualTo(expectedTasks)
     Assertions.assertThat(result.second).isEqualTo(metadata)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -299,7 +299,7 @@ class TaskServiceTest {
   }
 
   @Test
-  fun `getAllReallocatable returns all tasks for a particular page`() {
+  fun `getAll returns all tasks for a particular page`() {
     mockkStatic("uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationUtilsKt")
 
     PaginationConfig(defaultPageSize = 10).postInit()
@@ -334,7 +334,7 @@ class TaskServiceTest {
 
     every { getMetadata(page, pageCriteria) } returns metadata
 
-    val result = taskService.getAllReallocatable(AllocatedFilter.allocated, apAreaId, pageCriteria)
+    val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId), pageCriteria)
 
     val expectedTasks = listOf(
       assessments.map { TypedTask.Assessment(it) },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -323,9 +323,17 @@ class TaskServiceTest {
 
     val page = mockk<Page<Task>>()
     val metadata = mockk<PaginationMetadata>()
+    val taskEntityTypes = TaskEntityType.entries
 
     every { page.content } returns tasks
-    every { taskRepositoryMock.getAllReallocatable(isAllocated, apAreaId, PageRequest.of(0, 10, Sort.by("created_at").ascending())) } returns page
+    every {
+      taskRepositoryMock.getAllReallocatable(
+        isAllocated,
+        apAreaId,
+        taskEntityTypes.map { it.name },
+        PageRequest.of(0, 10, Sort.by("created_at").ascending())
+      )
+    } returns page
     every { assessmentRepositoryMock.findAllById(assessments.map { it.id }) } returns assessments
     every { placementApplicationRepositoryMock.findAllById(placementApplications.map { it.id }) } returns placementApplications
     every { placementRequestRepositoryMock.findAllById(placementRequests.map { it.id }) } returns placementRequests
@@ -334,7 +342,8 @@ class TaskServiceTest {
 
     every { getMetadata(page, pageCriteria) } returns metadata
 
-    val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId), pageCriteria)
+
+    val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId, taskEntityTypes), pageCriteria)
 
     val expectedTasks = listOf(
       assessments.map { TypedTask.Assessment(it) },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -331,7 +331,7 @@ class TaskServiceTest {
         isAllocated,
         apAreaId,
         taskEntityTypes.map { it.name },
-        PageRequest.of(0, 10, Sort.by("created_at").ascending())
+        PageRequest.of(0, 10, Sort.by("created_at").ascending()),
       )
     } returns page
     every { assessmentRepositoryMock.findAllById(assessments.map { it.id }) } returns assessments
@@ -341,7 +341,6 @@ class TaskServiceTest {
     val pageCriteria = PageCriteria(TaskSortField.createdAt, SortDirection.asc, 1)
 
     every { getMetadata(page, pageCriteria) } returns metadata
-
 
     val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId, taskEntityTypes), pageCriteria)
 


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-223

This PR is in preparation for sharing the functionality with the /tasks endpoint, reducing duplication. At which point we can then add additional functionality required by APS-223. There is no functional change

The changes significantly reduce duplication when retreiving tasks for reallocation. Previously this request could be redirected to one of four different services (one for each specific type and one for all types). Now all requests go to a single service and a single SQL query.

This may be slightly less performant than the previous approach when requesting a specific task type. If we find there are performance problems it's an easy fix because all requests now go through a single function. In this case we'd add a specific repository function on the TaskRepository for task types, but do in such a way that we use the same SQL through constants.