### PR TITLE
(APS-267) Ensure all things related to an application are withdrawn when an application is withdrawn

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -10,7 +10,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -109,7 +111,12 @@ class PlacementApplicationsController(
     id: UUID,
     withdrawPlacementApplication: WithdrawPlacementApplication?,
   ): ResponseEntity<PlacementApplication> {
-    val result = placementApplicationService.withdrawPlacementApplication(id, withdrawPlacementApplication?.reason)
+    val withdrawalReason = when (withdrawPlacementApplication?.reason) {
+      WithdrawPlacementRequestReason.duplicatePlacementRequest -> PlacementApplicationWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
+      WithdrawPlacementRequestReason.alternativeProvisionIdentified -> PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED
+      null -> null
+    }
+    val result = placementApplicationService.withdrawPlacementApplication(id, withdrawalReason)
 
     val validationResult = extractEntityFromAuthorisableActionResult(result)
     val placementApplication = extractEntityFromValidatableActionResult(validationResult)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -16,7 +16,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -177,9 +179,14 @@ class PlacementRequestsController(
 
   override fun placementRequestsIdWithdrawalPost(id: UUID, body: WithdrawPlacementRequest?): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
+    val reason = when (body?.reason) {
+      WithdrawPlacementRequestReason.duplicatePlacementRequest -> PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
+      WithdrawPlacementRequestReason.alternativeProvisionIdentified -> PlacementRequestWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED
+      null -> null
+    }
 
     val result = extractEntityFromAuthorisableActionResult(
-      placementRequestService.withdrawPlacementRequest(id, user, body?.reason),
+      placementRequestService.withdrawPlacementRequest(id, user, reason),
     )
 
     return ResponseEntity.ok(result)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -137,4 +137,5 @@ enum class PlacementApplicationDecision {
 enum class PlacementApplicationWithdrawalReason {
   DUPLICATE_PLACEMENT_REQUEST,
   ALTERNATIVE_PROVISION_IDENTIFIED,
+  WITHDRAWN_BY_PP,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -179,4 +179,5 @@ data class PlacementRequestEntity(
 enum class PlacementRequestWithdrawalReason {
   DUPLICATE_PLACEMENT_REQUEST,
   ALTERNATIVE_PROVISION_IDENTIFIED,
+  WITHDRAWN_BY_PP,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/Withdrawables.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/Withdrawables.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+
+data class Withdrawables(
+  val placementRequests: List<PlacementRequestEntity>,
+  val placementApplications: List<PlacementApplicationEntity>,
+  val bookings: List<BookingEntity>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -101,6 +101,7 @@ class ApplicationService(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
   private val apAreaRepository: ApAreaRepository,
   private val applicationTimelineTransformer: ApplicationTimelineTransformer,
+  private val withdrawableService: WithdrawableService,
 ) {
   fun getAllApplicationsForUsername(userDistinguishedName: String, serviceName: ServiceName): List<ApplicationSummary> {
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
@@ -595,6 +596,9 @@ class ApplicationService(
         application.assessments.map {
           assessmentService.updateAssessmentWithdrawn(it.id)
         }
+
+        withdrawableService.withdrawAllForApplication(application, user)
+
         return@validated success(Unit)
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
@@ -183,7 +182,7 @@ class PlacementApplicationService(
   @Transactional
   fun withdrawPlacementApplication(
     id: UUID,
-    reason: WithdrawPlacementRequestReason?,
+    reason: PlacementApplicationWithdrawalReason?,
   ): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
     val placementApplicationAuthorisationResult = getApplicationForUpdateOrSubmit(id)
 
@@ -203,11 +202,7 @@ class PlacementApplicationService(
 
     placementApplicationEntity.decision = PlacementApplicationDecision.WITHDRAWN_BY_PP
     placementApplicationEntity.decisionMadeAt = OffsetDateTime.now()
-    placementApplicationEntity.withdrawalReason = when (reason) {
-      WithdrawPlacementRequestReason.duplicatePlacementRequest -> PlacementApplicationWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
-      WithdrawPlacementRequestReason.alternativeProvisionIdentified -> PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED
-      null -> null
-    }
+    placementApplicationEntity.withdrawalReason = reason
 
     val savedApplication = placementApplicationRepository.save(placementApplicationEntity)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -283,7 +282,7 @@ class PlacementRequestService(
   fun withdrawPlacementRequest(
     placementRequestId: UUID,
     user: UserEntity,
-    reason: WithdrawPlacementRequestReason?,
+    reason: PlacementRequestWithdrawalReason?,
   ): AuthorisableActionResult<Unit> {
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
@@ -293,11 +292,7 @@ class PlacementRequestService(
     }
 
     placementRequest.isWithdrawn = true
-    placementRequest.withdrawalReason = when (reason) {
-      WithdrawPlacementRequestReason.duplicatePlacementRequest -> PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
-      WithdrawPlacementRequestReason.alternativeProvisionIdentified -> PlacementRequestWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED
-      null -> null
-    }
+    placementRequest.withdrawalReason = reason
 
     placementRequestRepository.save(placementRequest)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -3,7 +3,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Withdrawables
+import java.time.LocalDate
+import java.util.UUID
 
 @Service
 class WithdrawableService(
@@ -12,6 +17,9 @@ class WithdrawableService(
   @Lazy private val bookingService: BookingService,
   @Lazy private val placementApplicationService: PlacementApplicationService,
 ) {
+  val approvedPremisesWithdrawnByPPBookingWithdrawnReasonId: UUID =
+    UUID.fromString("d39572ea-9e42-460c-ae88-b6b30fca0b09")
+
   fun allWithdrawables(application: ApprovedPremisesApplicationEntity): Withdrawables {
     val placementRequests = placementRequestService.getWithdrawablePlacementRequests(application)
     val bookings = bookingService.getCancelleableBookings(application)
@@ -22,5 +30,21 @@ class WithdrawableService(
       bookings = bookings,
       placementApplications = placementApplications,
     )
+  }
+
+  fun withdrawAllForApplication(application: ApprovedPremisesApplicationEntity, user: UserEntity) {
+    val withdrawables = allWithdrawables(application)
+
+    withdrawables.placementApplications.forEach {
+      placementApplicationService.withdrawPlacementApplication(it.id, PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP)
+    }
+
+    withdrawables.placementRequests.forEach {
+      placementRequestService.withdrawPlacementRequest(it.id, user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+    }
+
+    withdrawables.bookings.forEach {
+      bookingService.createCancellation(user, it, LocalDate.now(), approvedPremisesWithdrawnByPPBookingWithdrawnReasonId, "Automatically withdrawn as application was withdrawn")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Withdrawables
+
+@Service
+class WithdrawableService(
+  // Added Lazy annotations here to prevent circular dependency issues
+  @Lazy private val placementRequestService: PlacementRequestService,
+  @Lazy private val bookingService: BookingService,
+  @Lazy private val placementApplicationService: PlacementApplicationService,
+) {
+  fun allWithdrawables(application: ApprovedPremisesApplicationEntity): Withdrawables {
+    val placementRequests = placementRequestService.getWithdrawablePlacementRequests(application)
+    val bookings = bookingService.getCancelleableBookings(application)
+    val placementApplications = placementApplicationService.getWithdrawablePlacementApplications(application)
+
+    return Withdrawables(
+      placementRequests = placementRequests,
+      bookings = bookings,
+      placementApplications = placementApplications,
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -86,6 +86,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
@@ -120,6 +121,7 @@ class ApplicationServiceTest {
   private val mockObjectMapper = mockk<ObjectMapper>()
   private val mockApAreaRepository = mockk<ApAreaRepository>()
   private val applicationTimelineTransformerMock = mockk<ApplicationTimelineTransformer>()
+  private val mockWithdrawableService = mockk<WithdrawableService>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
@@ -144,6 +146,7 @@ class ApplicationServiceTest {
     "http://frontend/applications/#id",
     mockApAreaRepository,
     applicationTimelineTransformerMock,
+    mockWithdrawableService,
   )
 
   @Test
@@ -1981,6 +1984,8 @@ class ApplicationServiceTest {
       staffUserDetails,
     )
 
+    every { mockWithdrawableService.withdrawAllForApplication(application, user) } returns Unit
+
     val authorisableActionResult = applicationService.withdrawApprovedPremisesApplication(
       application.id,
       user,
@@ -2023,6 +2028,10 @@ class ApplicationServiceTest {
         },
       )
     }
+
+    verify(exactly = 1) {
+      mockWithdrawableService.withdrawAllForApplication(application, user)
+    }
   }
 
   @Test
@@ -2049,6 +2058,8 @@ class ApplicationServiceTest {
       HttpStatus.OK,
       staffUserDetails,
     )
+
+    every { mockWithdrawableService.withdrawAllForApplication(application, user) } returns Unit
 
     val authorisableActionResult =
       applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", "Some other reason")
@@ -2090,6 +2101,10 @@ class ApplicationServiceTest {
         },
       )
     }
+
+    verify(exactly = 1) {
+      mockWithdrawableService.withdrawAllForApplication(application, user)
+    }
   }
 
   @Test
@@ -2116,6 +2131,8 @@ class ApplicationServiceTest {
       HttpStatus.OK,
       staffUserDetails,
     )
+
+    every { mockWithdrawableService.withdrawAllForApplication(application, user) } returns Unit
 
     applicationService.withdrawApprovedPremisesApplication(
       application.id,
@@ -2154,6 +2171,10 @@ class ApplicationServiceTest {
             data.otherWithdrawalReason == null
         },
       )
+    }
+
+    verify(exactly = 1) {
+      mockWithdrawableService.withdrawAllForApplication(application, user)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -14,7 +14,6 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
@@ -29,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -519,7 +519,7 @@ class PlacementApplicationServiceTest {
 
       val result = placementApplicationService.withdrawPlacementApplication(
         placementApplication.id,
-        WithdrawPlacementRequestReason.duplicatePlacementRequest,
+        PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -554,7 +554,7 @@ class PlacementApplicationServiceTest {
 
       val result = placementApplicationService.withdrawPlacementApplication(
         placementApplication.id,
-        WithdrawPlacementRequestReason.duplicatePlacementRequest,
+        PlacementApplicationWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
       )
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
@@ -573,7 +573,7 @@ class PlacementApplicationServiceTest {
 
       val result = placementApplicationService.withdrawPlacementApplication(
         placementApplication.id,
-        WithdrawPlacementRequestReason.duplicatePlacementRequest,
+        PlacementApplicationWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
@@ -15,10 +17,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
+import java.time.LocalDate
 
 class WithdrawableServiceTest {
   private val mockPlacementRequestService = mockk<PlacementRequestService>()
@@ -31,62 +40,112 @@ class WithdrawableServiceTest {
     mockPlacementApplicationService,
   )
 
-  @Test
-  fun `it returns all withdrawables as a Withdrawables object`() {
-    val probationRegion = ProbationRegionEntityFactory()
-      .withYieldedApArea { ApAreaEntityFactory().produce() }
-      .produce()
+  val probationRegion = ProbationRegionEntityFactory()
+    .withYieldedApArea { ApAreaEntityFactory().produce() }
+    .produce()
 
-    val user = UserEntityFactory().withProbationRegion(probationRegion).produce()
+  val user = UserEntityFactory().withProbationRegion(probationRegion).produce()
 
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(user)
-      .produce()
+  val application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .produce()
 
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withAllocatedToUser(user)
-      .withApplication(application)
-      .produce()
+  val assessment = ApprovedPremisesAssessmentEntityFactory()
+    .withAllocatedToUser(user)
+    .withApplication(application)
+    .produce()
 
-    val placementRequirements = PlacementRequirementsEntityFactory()
-      .withApplication(application)
-      .withAssessment(assessment)
-      .produce()
+  val placementRequirements = PlacementRequirementsEntityFactory()
+    .withApplication(application)
+    .withAssessment(assessment)
+    .produce()
 
-    val premises = ApprovedPremisesEntityFactory()
-      .withProbationRegion(probationRegion)
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
+  val premises = ApprovedPremisesEntityFactory()
+    .withProbationRegion(probationRegion)
+    .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+    .produce()
 
-    val placementRequests = PlacementRequestEntityFactory()
-      .withApplication(application)
-      .withAssessment(assessment)
-      .withPlacementRequirements(placementRequirements)
-      .produceMany()
-      .take(5)
-      .toList()
+  val placementRequests = PlacementRequestEntityFactory()
+    .withApplication(application)
+    .withAssessment(assessment)
+    .withPlacementRequirements(placementRequirements)
+    .produceMany()
+    .take(5)
+    .toList()
 
-    val placementApplications = PlacementApplicationEntityFactory()
-      .withCreatedByUser(user)
-      .withApplication(application)
-      .produceMany()
-      .take(2)
-      .toList()
+  val placementApplications = PlacementApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .withApplication(application)
+    .produceMany()
+    .take(2)
+    .toList()
 
-    val bookings = BookingEntityFactory()
-      .withPremises(premises)
-      .produceMany()
-      .take(3)
-      .toList()
+  val bookings = BookingEntityFactory()
+    .withPremises(premises)
+    .produceMany()
+    .take(3)
+    .toList()
 
+  @BeforeEach
+  fun setup() {
     every { mockPlacementRequestService.getWithdrawablePlacementRequests(application) } returns placementRequests
     every { mockPlacementApplicationService.getWithdrawablePlacementApplications(application) } returns placementApplications
     every { mockBookingService.getCancelleableBookings(application) } returns bookings
+  }
 
+  @Test
+  fun `it returns all withdrawables as a Withdrawables object`() {
     val result = withdrawableService.allWithdrawables(application)
 
     assertThat(result.bookings).isEqualTo(bookings)
     assertThat(result.placementRequests).isEqualTo(placementRequests)
     assertThat(result.placementApplications).isEqualTo(placementApplications)
+  }
+
+  @Test
+  fun `withdrawAllForApplication withdraws all withdrawable entities`() {
+    every {
+      mockBookingService.createCancellation(
+        user,
+        any(),
+        any(),
+        withdrawableService.approvedPremisesWithdrawnByPPBookingWithdrawnReasonId,
+        "Automatically withdrawn as application was withdrawn",
+      )
+    } returns mockk<ValidatableActionResult<CancellationEntity>>()
+
+    every {
+      mockPlacementRequestService.withdrawPlacementRequest(any(), user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+    } returns mockk<AuthorisableActionResult<Unit>>()
+
+    every {
+      mockPlacementApplicationService.withdrawPlacementApplication(any(), PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP)
+    } returns mockk<AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>>>()
+
+    withdrawableService.withdrawAllForApplication(application, user)
+
+    bookings.forEach {
+      verify {
+        mockBookingService.createCancellation(
+          user,
+          it,
+          LocalDate.now(),
+          withdrawableService.approvedPremisesWithdrawnByPPBookingWithdrawnReasonId,
+          "Automatically withdrawn as application was withdrawn",
+        )
+      }
+    }
+
+    placementRequests.forEach {
+      verify {
+        mockPlacementRequestService.withdrawPlacementRequest(it.id, user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+      }
+    }
+
+    placementApplications.forEach {
+      verify {
+        mockPlacementApplicationService.withdrawPlacementApplication(it.id, PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP)
+      }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
+
+class WithdrawableServiceTest {
+  private val mockPlacementRequestService = mockk<PlacementRequestService>()
+  private val mockBookingService = mockk<BookingService>()
+  private val mockPlacementApplicationService = mockk<PlacementApplicationService>()
+
+  private val withdrawableService = WithdrawableService(
+    mockPlacementRequestService,
+    mockBookingService,
+    mockPlacementApplicationService,
+  )
+
+  @Test
+  fun `it returns all withdrawables as a Withdrawables object`() {
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+
+    val user = UserEntityFactory().withProbationRegion(probationRegion).produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .produce()
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withAllocatedToUser(user)
+      .withApplication(application)
+      .produce()
+
+    val placementRequirements = PlacementRequirementsEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .produce()
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withProbationRegion(probationRegion)
+      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+      .produce()
+
+    val placementRequests = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .produceMany()
+      .take(5)
+      .toList()
+
+    val placementApplications = PlacementApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withApplication(application)
+      .produceMany()
+      .take(2)
+      .toList()
+
+    val bookings = BookingEntityFactory()
+      .withPremises(premises)
+      .produceMany()
+      .take(3)
+      .toList()
+
+    every { mockPlacementRequestService.getWithdrawablePlacementRequests(application) } returns placementRequests
+    every { mockPlacementApplicationService.getWithdrawablePlacementApplications(application) } returns placementApplications
+    every { mockBookingService.getCancelleableBookings(application) } returns bookings
+
+    val result = withdrawableService.allWithdrawables(application)
+
+    assertThat(result.bookings).isEqualTo(bookings)
+    assertThat(result.placementRequests).isEqualTo(placementRequests)
+    assertThat(result.placementApplications).isEqualTo(placementApplications)
+  }
+}


### PR DESCRIPTION
This adds a new `WithdrawablesService` that contains the source of truth for all things that are "withdrawable", we then can add a `withdrawAllForApplication` function that withdraws everything that is "withdrawable" for an application in one shot. I've had to add a new internal reason for placement application / requests that shows they were withdrawn as a side effect of the whole application being withdrawn.