### PR TITLE
Add an optional list of `StatusDetails` to CAS2 Application `StatusUpdates` 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateDetailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateDetailEntity.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface Cas2StatusUpdateDetailRepository : JpaRepository<Cas2StatusUpdateDetailEntity, UUID> {
+  fun findFirstByStatusUpdateIdOrderByCreatedAtDesc(statusUpdateId: UUID): Cas2StatusUpdateDetailEntity?
+}
+
+@Entity
+@Table(name = "cas_2_status_update_details")
+data class Cas2StatusUpdateDetailEntity(
+  @Id
+  val id: UUID,
+  val statusDetailId: UUID,
+
+  val label: String,
+
+  @ManyToOne
+  @JoinColumn(name = "status_update_id")
+  val statusUpdate: Cas2StatusUpdateEntity,
+
+  @CreationTimestamp
+  var createdAt: OffsetDateTime? = null,
+) {
+  override fun toString() = "Cas2StatusDetailEntity: $id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateDetailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateDetailEntity.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
@@ -33,4 +35,9 @@ data class Cas2StatusUpdateDetailEntity(
   var createdAt: OffsetDateTime? = null,
 ) {
   override fun toString() = "Cas2StatusDetailEntity: $id"
+
+  fun statusDetail(statusId: UUID, detailId: UUID): Cas2PersistedApplicationStatusDetail {
+    return Cas2PersistedApplicationStatusFinder().getById(statusId).statusDetails?.find { detail -> detail.id == detailId }
+      ?: error("Status detail with id $detailId not found")
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -11,6 +11,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
@@ -36,6 +37,9 @@ data class Cas2StatusUpdateEntity(
   @ManyToOne
   @JoinColumn(name = "application_id")
   val application: Cas2ApplicationEntity,
+
+  @OneToMany(mappedBy = "statusUpdate")
+  val statusUpdateDetails: List<Cas2StatusUpdateDetailEntity>? = null,
 
   @CreationTimestamp
   var createdAt: OffsetDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -55,18 +55,99 @@ object Cas2ApplicationStatusSeeding {
         name = "offerDeclined",
         label = "Offer declined or withdrawn",
         description = "The accommodation offered has been declined or withdrawn.",
+        statusDetails = listOf(
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("62645779-242d-4601-a8f8-d2cbf1d41dfa"),
+            name = "areaUnsuitable",
+            label = "Area unsuitable",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("fc38f750-e9d2-4270-b542-d38286b9855c"),
+            name = "changeOfCircumstances",
+            label = "Change of circumstances",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("31122b89-e087-4b5f-b59a-f7ffa0dd3e0c"),
+            name = "noResponse",
+            label = "No response",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("32e62af3-6ea5-4496-a82c-b7bad67080a5"),
+            name = "offerWithdrawnByNacro",
+            label = "Offer withdrawn by Nacro",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("b5bfbff4-aaa6-4fb0-ba36-5bca58927dc5"),
+            name = "propertyUnsuitable",
+            label = "Property unsuitable for needs",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("f58267b8-f91b-4a4f-9aa2-80089ba111e4"),
+            name = "withdrawnByReferrer",
+            label = "Withdrawn by referrer",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("ed5d529c-d7d1-4f29-a0c0-89fd104cc320"),
+            name = "rehousedByAnotherLandlord",
+            label = "Rehoused by another landlord",
+          ),
+        ),
       ),
       Cas2PersistedApplicationStatus(
         id = UUID.fromString("004e2419-9614-4c1e-a207-a8418009f23d"),
         name = "withdrawn",
         label = "Referral withdrawn",
         description = "The prison offender manager (POM) withdrew the application.",
+        statusDetails = listOf(
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("e4a2391e-e847-427a-a913-51e0b0ad9f52"),
+            name = "hdcNoLongerEligible",
+            label = "HDC - No longer eligible",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("c5dce0d2-fc05-4a07-8157-25b8821cdb06"),
+            name = "governorDecidedUnsuitable",
+            label = "Governor - Decided unsuitable",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("3fb37f85-be88-4eee-812d-af122e268eef"),
+            name = "governorChosenAlternative",
+            label = "Governor - Chosen alternative accommodation",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("8a857a7d-94f9-43ec-963c-2a2528e88a6e"),
+            name = "governorOther",
+            label = "Governor - Other",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("d3c789b8-947d-4e24-9cef-335545d85abe"),
+            name = "withdrewOrDeclinedOffer",
+            label = "Withdrew or declined offer",
+          ),
+        ),
       ),
       Cas2PersistedApplicationStatus(
         id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
         name = "cancelled",
         label = "Referral cancelled",
         description = "The application has been cancelled.",
+        statusDetails = listOf(
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            name = "assessedAsHighRisk",
+            label = "Assessed as High Risk",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            name = "notEligible",
+            label = "Not Eligible",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            name = "noRecourseToPublicFunds",
+            label = "No Recourse to Public Funds",
+          ),
+        ),
       ),
       Cas2PersistedApplicationStatus(
         id = UUID.fromString("89458555-3219-44a2-9584-c4f715d6b565"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -4,6 +4,7 @@ import java.util.UUID
 
 object Cas2ApplicationStatusSeeding {
 
+  @SuppressWarnings("LongMethod")
   fun statusList(): List<Cas2PersistedApplicationStatus> {
     return listOf(
       Cas2PersistedApplicationStatus(
@@ -11,6 +12,53 @@ object Cas2ApplicationStatusSeeding {
         name = "moreInfoRequested",
         label = "More information requested",
         description = "The prison offender manager (POM) must provide information requested for the application to progress.",
+        statusDetails = listOf(
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("fabbb8c0-344e-4a9d-a964-7987b22d09c6"),
+            name = "personalInformation",
+            label = "Personal information",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("05669c8a-d65c-48d2-a5e4-0c3f6fc8977b"),
+            name = "exclusionZonesAndAreas",
+            label = "Exclusion zones and preferred areas",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("831c241d-63f3-4d17-b969-b8154d7e4902"),
+            name = "healthNeeds",
+            label = "Health needs",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("7ba5cd7d-8ae3-4fe5-bb27-9367197ea160"),
+            name = "riskToSelf",
+            label = "Risk to self",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("8641d719-7356-42d3-8363-e323bf76caec"),
+            name = "riskOfSeriousHarm",
+            label = "Risk of serious harm",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("90f075ae-0b9f-445b-a9b5-1095abca87dc"),
+            name = "currentOffences",
+            label = "Current offences",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("8ce77ea1-324e-4ac8-be8c-33d6d4d927f8"),
+            name = "offendingHistory",
+            label = "Offending history",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("d2c44705-2795-4610-9879-dcf26940e121"),
+            name = "hdcAndCpp",
+            label = "HDC licence and CPP details",
+          ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("94631a70-6c51-43d6-9112-2b6d042b5aa0"),
+            name = "other",
+            label = "Other",
+          ),
+        ),
       ),
       Cas2PersistedApplicationStatus(
         id = UUID.fromString("ba4d8432-250b-4ab9-81ec-7eb4b16e5dd1"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatus.kt
@@ -9,4 +9,7 @@ data class Cas2PersistedApplicationStatus(
   val description: String,
   val statusDetails: List<Cas2PersistedApplicationStatusDetail>? = emptyList(),
   val isActive: Boolean = true,
-)
+) {
+  fun findStatusDetailOnStatus(detailName: String) =
+    statusDetails?.find { detail -> detail.name == detailName }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatusDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatusDetail.kt
@@ -2,11 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference
 
 import java.util.UUID
 
-data class Cas2PersistedApplicationStatus(
+data class Cas2PersistedApplicationStatusDetail(
   val id: UUID,
   val name: String,
   val label: String,
-  val description: String,
-  val statusDetails: List<Cas2PersistedApplicationStatusDetail>? = emptyList(),
   val isActive: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationStatusTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationStatusTransformer.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusDetail
 
 @Component("Cas2ApplicationStatusTransformer")
 class ApplicationStatusTransformer {
@@ -12,6 +14,16 @@ class ApplicationStatusTransformer {
       name = status.name,
       label = status.label,
       description = status.description,
+      statusDetails = status.statusDetails?.map { statusDetail -> transformStatusDetailModelToApi(statusDetail) }
+        ?: emptyList(),
+    )
+  }
+
+  fun transformStatusDetailModelToApi(statusDetail: Cas2PersistedApplicationStatusDetail): Cas2ApplicationStatusDetail {
+    return Cas2ApplicationStatusDetail(
+      id = statusDetail.id,
+      name = statusDetail.name,
+      label = statusDetail.label,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
 
@@ -21,6 +23,16 @@ class StatusUpdateTransformer(
       description = jpa.description,
       updatedBy = externalUserTransformer.transformJpaToApi(jpa.assessor),
       updatedAt = jpa.createdAt?.toInstant(),
+      statusUpdateDetails = jpa.statusUpdateDetails?.map { detail -> transformStatusUpdateDetailsJpaToApi(detail) },
+    )
+  }
+
+  fun transformStatusUpdateDetailsJpaToApi(jpa: Cas2StatusUpdateDetailEntity):
+    Cas2StatusUpdateDetail {
+    return Cas2StatusUpdateDetail(
+      id = jpa.id,
+      name = jpa.statusDetail(jpa.statusUpdate.statusId, jpa.statusDetailId).name,
+      label = jpa.label,
     )
   }
 }

--- a/src/main/resources/db/migration/all/20240206092803__add_cas2_status_update_detail_table.sql
+++ b/src/main/resources/db/migration/all/20240206092803__add_cas2_status_update_detail_table.sql
@@ -1,0 +1,18 @@
+-- create new table for CAS2 status updates
+CREATE TABLE cas_2_status_update_details (
+    id               UUID                        NOT NULL,
+    status_update_id UUID                        NOT NULL,
+    status_detail_id UUID                        NOT NULL,
+    label            TEXT                        NOT NULL,
+    created_at       TIMESTAMP WITH TIME ZONE    NOT NULL,
+
+    PRIMARY KEY (id),
+
+    CONSTRAINT fk_status_update_id
+        FOREIGN KEY(status_update_id)
+    	    REFERENCES cas_2_status_updates(id)
+
+);
+-- index for status updates to cas_2_status_updates table
+CREATE INDEX ON cas_2_status_update_details(status_update_id);
+

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1909,11 +1909,31 @@ components:
         updatedAt:
           type: string
           format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdateDetail'
       required:
         - id
         - name
         - label
         - description
+    Cas2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
     ApplicationStatus:
       type: string
       enum:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1825,11 +1825,32 @@ components:
         description:
           type: string
           example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2ApplicationStatusDetail'
       required:
         - id
         - name
         - label
         - description
+        - statusDetails
+    Cas2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label
     Cas2ApplicationStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1858,6 +1858,12 @@ components:
           type: string
           example: 'moreInfoRequired'
           description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
       required:
         - newStatus
     Cas2SubmittedApplicationSummary:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6400,6 +6400,12 @@ components:
           type: string
           example: 'moreInfoRequired'
           description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
       required:
         - newStatus
     Cas2SubmittedApplicationSummary:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6367,11 +6367,32 @@ components:
         description:
           type: string
           example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2ApplicationStatusDetail'
       required:
         - id
         - name
         - label
         - description
+        - statusDetails
+    Cas2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label
     Cas2ApplicationStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6451,11 +6451,31 @@ components:
         updatedAt:
           type: string
           format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdateDetail'
       required:
         - id
         - name
         - label
         - description
+    Cas2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
     ApplicationStatus:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2301,6 +2301,12 @@ components:
           type: string
           example: 'moreInfoRequired'
           description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
       required:
         - newStatus
     Cas2SubmittedApplicationSummary:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2352,11 +2352,31 @@ components:
         updatedAt:
           type: string
           format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdateDetail'
       required:
         - id
         - name
         - label
         - description
+    Cas2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
     ApplicationStatus:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2268,11 +2268,32 @@ components:
         description:
           type: string
           example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2ApplicationStatusDetail'
       required:
         - id
         - name
         - label
         - description
+        - statusDetails
+    Cas2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label
     Cas2ApplicationStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1957,11 +1957,31 @@ components:
         updatedAt:
           type: string
           format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdateDetail'
       required:
         - id
         - name
         - label
         - description
+    Cas2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
     ApplicationStatus:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1906,6 +1906,12 @@ components:
           type: string
           example: 'moreInfoRequired'
           description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
       required:
         - newStatus
     Cas2SubmittedApplicationSummary:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1873,11 +1873,32 @@ components:
         description:
           type: string
           example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2ApplicationStatusDetail'
       required:
         - id
         - name
         - label
         - description
+        - statusDetails
+    Cas2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label
     Cas2ApplicationStatusUpdate:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationStatusTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationStatusTransformerTest.kt
@@ -4,7 +4,9 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationStatusTransformer
 import java.util.UUID
 
@@ -15,26 +17,69 @@ class ApplicationStatusTransformerTest {
   @Nested
   inner class TransformModelToApi {
 
-    @Test
-    fun `returns the expected properties from the internal _model_`() {
-      val internalModel = Cas2PersistedApplicationStatus(
-        id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
-        name = "cancelled",
-        label = "Referral cancelled",
-        description = "The application has been cancelled.",
-        isActive = true,
-      )
-
-      val apiRepresentation = transformer.transformModelToApi(internalModel)
-
-      Assertions.assertThat(apiRepresentation).isEqualTo(
-        Cas2ApplicationStatus(
+    @Nested
+    inner class WhenThereAreStatusDetails {
+      @Test
+      fun `returns the expected properties from the internal _model_`() {
+        val internalModel = Cas2PersistedApplicationStatus(
           id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
           name = "cancelled",
           label = "Referral cancelled",
           description = "The application has been cancelled.",
-        ),
-      )
+          statusDetails = listOf(
+            Cas2PersistedApplicationStatusDetail(
+              id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+              name = "changeOfCircumstances",
+              label = "Change of circumstances",
+            ),
+          ),
+          isActive = true,
+        )
+
+        val apiRepresentation = transformer.transformModelToApi(internalModel)
+
+        Assertions.assertThat(apiRepresentation).isEqualTo(
+          Cas2ApplicationStatus(
+            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            name = "cancelled",
+            label = "Referral cancelled",
+            statusDetails = listOf(
+              Cas2ApplicationStatusDetail(
+                id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+                name = "changeOfCircumstances",
+                label = "Change of circumstances",
+              ),
+            ),
+            description = "The application has been cancelled.",
+          ),
+        )
+      }
+    }
+
+    @Nested
+    inner class WhenThereAreNotStatusDetails {
+      @Test
+      fun `returns the expected properties from the internal _model_`() {
+        val internalModel = Cas2PersistedApplicationStatus(
+          id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+          name = "cancelled",
+          label = "Referral cancelled",
+          description = "The application has been cancelled.",
+          isActive = true,
+        )
+
+        val apiRepresentation = transformer.transformModelToApi(internalModel)
+
+        Assertions.assertThat(apiRepresentation).isEqualTo(
+          Cas2ApplicationStatus(
+            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            name = "cancelled",
+            label = "Referral cancelled",
+            description = "The application has been cancelled.",
+            statusDetails = emptyList(),
+          ),
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
* I'm not a Kotlin/SQL expert, would appreciate any feedback about better way of doing this.
* This is quite a big PR because we are in a rush to have work un-blocked for Frontend. 
* DOES NOT INCLUDE: 
  * updating Domain Events or MI reports - this can come in near future.
  * the Details for Further Information - this not confirmed yet

We [previously introduced ](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1113)a set of CAS2 specific Application Statuses, that are applied by Assessors.

![Screenshot 2024-02-02 at 17 01 25](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/bfd05a33-afe5-446e-a68c-1e9a730df1e8)


We now need to introduce an optional sub-level of category on those statuses, which we are calling 'Status Details'.
A Status (e.g. 'Offer declined') could have none or several Details on it (e.g. 'Change of circumstances', 'No Reply/No Response'). 

This is proposing

1. Display the new details to the UI
![Screenshot 2024-02-02 at 17 07 00](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/dbfe5222-3291-407f-950f-807cb8bab669)

* We add the concept of a `Cas2PersistedApplicationStatusDetail` as a field on the `Cas2PersistedApplicationStatus` models seeded in `Cas2PersistedApplicationStatusSeeding.kt` file. So that the Details are returned when the UI calls `/reference-data/application-status`.

2. Add Details to the saved Status Updates on an Application

![Screenshot 2024-02-02 at 17 14 19](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/961841f9-e9a1-42cc-9b07-787aa5912728)

* The endpoint `/submissions/{applicationId}/status-updates` takes an optional param `newStatusDetails`.
* We create a new table `cas_2_status_update_details` , which has a ManyToOne bi-directional relationship with the existing `cas2_status_updates`
* When a Status Update is posted with a list of Details, the `StatusUpdateService` iterates through the list of Details and saves them in the db.

3. Return the Details on Status Updates on an Application

![Screenshot 2024-02-02 at 17 18 20](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/f881c4d9-9dc3-4661-877b-fd672c713214)

* So that we can render these Details on the UI, we update the StatusUpdateTransformer to return Details, which are then returned on a SubmittedApplication when making a GET request to `/submissions/{applicationId}` 


