### PR TITLE
Use /tasks/reallocatable code to service /tasks requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -73,6 +73,7 @@ class TasksController(
     sortDirection: SortDirection?,
     allocatedFilter: AllocatedFilter?,
     apAreaId: UUID?,
+    allocatedToUserId: UUID?
   ): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
@@ -82,9 +83,10 @@ class TasksController(
 
     val (typedTasks, metadata) = taskService.getAll(
       TaskService.TaskFilterCriteria(
-        allocatedFilter,
-        apAreaId,
-        determineTaskEntityTypes(type),
+        allocatedFilter = allocatedFilter,
+        apAreaId = apAreaId,
+        types = determineTaskEntityTypes(type),
+        allocatedToUserId = allocatedToUserId
       ),
       PageCriteria(
         sortBy = sortBy ?: TaskSortField.createdAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -116,11 +116,7 @@ class TasksController(
       return TaskEntityType.entries
     }
 
-    val taskType = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      type.kebabCaseToPascalCase(),
-    ) ?: throw NotFoundProblem(type, "TaskType")
-
-    return when (taskType) {
+    return when (toTaskType(type)) {
       TaskType.assessment -> listOf(TaskEntityType.ASSESSMENT)
       TaskType.placementRequest -> listOf(TaskEntityType.PLACEMENT_REQUEST)
       TaskType.placementApplication -> listOf(TaskEntityType.PLACEMENT_APPLICATION)
@@ -175,9 +171,7 @@ class TasksController(
   ): ResponseEntity<List<Task>> = runBlocking {
     val user = userService.getUserForRequest()
     val tasks = mutableListOf<Task>()
-    val type = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      taskType.kebabCaseToPascalCase(),
-    ) ?: throw NotFoundProblem(taskType, "TaskType")
+    val type = toTaskType(taskType)
 
     var paginationMetaData: PaginationMetadata? = null
 
@@ -238,9 +232,7 @@ class TasksController(
 
   override fun tasksTaskTypeIdGet(id: UUID, taskType: String): ResponseEntity<TaskWrapper> {
     val user = userService.getUserForRequest()
-    val type = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      taskType.kebabCaseToPascalCase(),
-    ) ?: throw NotFoundProblem(taskType, "TaskType")
+    val type = toTaskType(taskType)
 
     val transformedTask: Task
 
@@ -321,9 +313,7 @@ class TasksController(
   ): ResponseEntity<Reallocation> {
     val user = userService.getUserForRequest()
 
-    val type = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      taskType.kebabCaseToPascalCase(),
-    ) ?: throw NotFoundProblem(taskType, "TaskType")
+    val type = toTaskType(taskType)
 
     val userId = when {
       xServiceName == ServiceName.temporaryAccommodation -> user.id
@@ -364,9 +354,7 @@ class TasksController(
   override fun tasksTaskTypeIdAllocationsDelete(id: UUID, taskType: String): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
 
-    val type = enumConverterFactory.getConverter(TaskType::class.java).convert(
-      taskType.kebabCaseToPascalCase(),
-    ) ?: throw NotFoundProblem(taskType, "TaskType")
+    val type = toTaskType(taskType)
 
     val validationResult = when (val authorisationResult = taskService.deallocateTask(user, type, id)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, taskType.toString())
@@ -451,4 +439,9 @@ class TasksController(
       false,
     )
   }
+
+  private fun toTaskType(type: String) = enumConverterFactory.getConverter(TaskType::class.java).convert(
+    type.kebabCaseToPascalCase(),
+  ) ?: throw NotFoundProblem(type, "TaskType")
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -77,7 +77,7 @@ class TasksController(
   ): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
-    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)) {
+    if (!user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_MATCHER)) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -119,11 +119,13 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     countQuery = "SELECT COUNT(1) FROM ($ALLOCATABLE_QUERY) as count",
     nativeQuery = true,
   )
-  fun getAllReallocatable(isAllocated: Boolean?,
-                          apAreaId: UUID?,
-                          taskTypes: List<String>,
-                          allocatedToUserId: UUID?,
-                          pageable: Pageable?): Page<Task>
+  fun getAll(
+    isAllocated: Boolean?,
+    apAreaId: UUID?,
+    taskTypes: List<String>,
+    allocatedToUserId: UUID?,
+    pageable: Pageable?,
+  ): Page<Task>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -39,6 +39,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         ) AND (
           (cast(:apAreaId as uuid) IS NULL) OR
           (area.id = :apAreaId)
+        ) AND (
+          (cast(:allocatedToUserId as uuid) IS NULL) OR
+          assessment.allocated_to_user_id = :allocatedToUserId
         )
     """
 
@@ -65,6 +68,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         ) AND (
           (cast(:apAreaId as uuid) IS NULL) OR
           (area.id = :apAreaId)
+        ) AND (
+          (cast(:allocatedToUserId as uuid) IS NULL) OR
+          placement_application.allocated_to_user_id = :allocatedToUserId
         )
     """
 
@@ -93,7 +99,11 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         ) AND (
           (cast(:apAreaId as uuid) IS NULL) OR
           (area.id = :apAreaId)
-        )"""
+        ) AND (
+          (cast(:allocatedToUserId as uuid) IS NULL) OR
+          placement_request.allocated_to_user_id = :allocatedToUserId
+        )
+        """
 
     private const val ALLOCATABLE_QUERY = """
       $ASSESSMENT_QUERY
@@ -109,7 +119,11 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     countQuery = "SELECT COUNT(1) FROM ($ALLOCATABLE_QUERY) as count",
     nativeQuery = true,
   )
-  fun getAllReallocatable(isAllocated: Boolean?, apAreaId: UUID?, taskTypes: List<String>, pageable: Pageable?): Page<Task>
+  fun getAllReallocatable(isAllocated: Boolean?,
+                          apAreaId: UUID?,
+                          taskTypes: List<String>,
+                          allocatedToUserId: UUID?,
+                          pageable: Pageable?): Page<Task>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -47,6 +47,7 @@ class TaskService(
     val allocatedFilter: AllocatedFilter?,
     val apAreaId: UUID?,
     val types: List<TaskEntityType>,
+    val allocatedToUserId: UUID?,
   )
 
   fun getAll(
@@ -62,15 +63,15 @@ class TaskService(
     )
 
     val allocatedFilter = filterCriteria.allocatedFilter
-    val apAreaId = filterCriteria.apAreaId
     val taskTypes = filterCriteria.types
+    val isAllocated = allocatedFilter?.let { allocatedFilter == AllocatedFilter.allocated }
 
-    val isAllocated = if (allocatedFilter == null) { null } else { allocatedFilter == AllocatedFilter.allocated }
     val tasksResult = taskRepository.getAllReallocatable(
-      isAllocated,
-      apAreaId,
-      taskTypes.map { it.name },
-      pageable,
+      isAllocated = isAllocated,
+      apAreaId = filterCriteria.apAreaId,
+      taskTypes = taskTypes.map { it.name },
+      allocatedToUserId = filterCriteria.allocatedToUserId,
+      pageable = pageable,
     )
 
     val tasks = tasksResult.content

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -66,7 +66,7 @@ class TaskService(
     val taskTypes = filterCriteria.types
     val isAllocated = allocatedFilter?.let { allocatedFilter == AllocatedFilter.allocated }
 
-    val tasksResult = taskRepository.getAllReallocatable(
+    val tasksResult = taskRepository.getAll(
       isAllocated = isAllocated,
       apAreaId = filterCriteria.apAreaId,
       taskTypes = taskTypes.map { it.name },

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2800,6 +2800,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: allocatedToUserId
+          in: query
+          description: Only show tasks allocated to this user id
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2802,6 +2802,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: allocatedToUserId
+          in: query
+          description: Only show tasks allocated to this user id
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -756,20 +756,20 @@ class TasksTest : IntegrationTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
-            val (task1,_) = `Given a Placement Request`(
+            val (task1, _) = `Given a Placement Request`(
               placementRequestAllocatedTo = otherUser,
               assessmentAllocatedTo = otherUser,
               createdByUser = user,
               crn = offenderDetails.otherIds.crn,
             )
 
-            val (task2,_) = `Given an Assessment for Approved Premises`(
+            val (task2, _) = `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
             )
 
-            val (task3,_) = `Given a Placement Request`(
+            val (task3, _) = `Given a Placement Request`(
               placementRequestAllocatedTo = otherUser,
               assessmentAllocatedTo = otherUser,
               createdByUser = user,
@@ -851,7 +851,7 @@ class TasksTest : IntegrationTestBase() {
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
 
-            val (task1,_) = `Given a Placement Request`(
+            val (task1, _) = `Given a Placement Request`(
               placementRequestAllocatedTo = otherUser,
               assessmentAllocatedTo = callingUser,
               createdByUser = callingUser,
@@ -865,7 +865,7 @@ class TasksTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
             )
 
-            val (task2,_) = `Given an Assessment for Approved Premises`(
+            val (task2, _) = `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
               createdByUser = callingUser,
               crn = offenderDetails.otherIds.crn,
@@ -938,7 +938,7 @@ class TasksTest : IntegrationTestBase() {
             val apArea1 = `Given an AP Area`()
             val apArea2 = `Given an AP Area`()
 
-            val (task1,_) = `Given a Placement Request`(
+            val (task1, _) = `Given a Placement Request`(
               placementRequestAllocatedTo = otherUser,
               assessmentAllocatedTo = otherUser,
               createdByUser = user,
@@ -954,7 +954,7 @@ class TasksTest : IntegrationTestBase() {
               apArea = apArea2,
             )
 
-            val (task2,_) = `Given an Assessment for Approved Premises`(
+            val (task2, _) = `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
@@ -1510,6 +1510,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Request`(
@@ -1534,6 +1535,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Application`(
@@ -1544,6 +1546,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               reallocated = true,
+              submittedAt = OffsetDateTime.now(),
             )
 
             webTestClient.get()
@@ -1597,6 +1600,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               apArea = apArea2,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Request`(
@@ -1615,6 +1619,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               apArea = apArea1,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Request`(
@@ -1633,6 +1638,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               apArea = apArea2,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Application`(
@@ -1643,6 +1649,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               reallocated = true,
+              submittedAt = OffsetDateTime.now(),
             )
 
             webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -69,7 +69,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body, only returns Assessments from CAS1`() {
+    fun `Get all reallocatable tasks returns 200 when no type with only CAS1 assessments`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, inmateDetails ->
@@ -196,7 +196,7 @@ class TasksTest : IntegrationTestBase() {
 
     @Test
     fun `Get all reallocatable tasks with taskType that doesn't exist returns 404`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
         webTestClient.get()
           .uri("/tasks/reallocatable?type=RANDOMWORD")
           .header("Authorization", "Bearer $jwt")
@@ -207,19 +207,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks with taskType of bookingAppeal returns 400`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
-        webTestClient.get()
-          .uri("/tasks/reallocatable?type=bookingAppeal")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isBadRequest
-      }
-    }
-
-    @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type assessment`() {
+    fun `Get all reallocatable tasks returns 200 when type assessment`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -252,7 +240,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type assessment and ap area defined`() {
+    fun `Get all reallocatable tasks returns 200 when type assessment and ap area defined`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -297,7 +285,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement request`() {
+    fun `Get all reallocatable tasks returns 200 when type placement request`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -332,7 +320,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement application`() {
+    fun `Get all reallocatable tasks returns 200 when type placement application`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -370,7 +358,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement application and ap area defined`() {
+    fun `Get all reallocatable tasks returns 200 when type placement application and ap area defined`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -423,7 +411,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type assessment and page is two and no allocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when type assessment and page is two and no allocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -464,7 +452,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type assessment and page is two and allocated filter allocated`() {
+    fun `Get all reallocatable tasks returns 200 when type assessment and page is two and allocated filter allocated`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -504,7 +492,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type assessment and page is two and allocated filter unallocated`() {
+    fun `Get all reallocatable tasks returns 200 when type assessment and page is two and allocated filter unallocated`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -544,7 +532,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement requests and page two no allocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when type placement requests and page two no allocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -588,7 +576,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement requests and ap area defined`() {
+    fun `Get all reallocatable tasks returns 200 when type placement requests and ap area defined`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -635,7 +623,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement requests and page two and allocated filter allocated`() {
+    fun `Get all reallocatable tasks returns 200 when type placement requests and page two and allocated filter allocated`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -678,7 +666,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement requests and page two and allocated filter unallocated`() {
+    fun `Get all reallocatable tasks returns 200 when type placement requests and page two and allocated filter unallocated`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -721,7 +709,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and no type retains original sort order`() {
+    fun `Get all reallocatable tasks returns 200 when no type retains original sort order`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -815,7 +803,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and no type and ap area defined`() {
+    fun `Get all reallocatable tasks returns 200 when no type and ap area defined`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -908,7 +896,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement application and page two`() {
+    fun `Get all reallocatable tasks returns 200 when type placement application and page two`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -944,7 +932,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement application and page two and no allocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when type placement application and page two and no allocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -993,7 +981,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement application and page two and unallocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when type placement application and page two and unallocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -1041,7 +1029,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and type placement application and page two and allocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when type placement application and page two and allocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -1089,7 +1077,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and no type and page two and no allocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when no type and page two and no allocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -1182,7 +1170,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and no type and page two and allocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when no type and page two and allocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -1272,7 +1260,7 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all reallocatable tasks returns 200 with correct body and no type and page two and unallocated filter`() {
+    fun `Get all reallocatable tasks returns 200 when no type and page two and unallocated filter`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -324,6 +324,7 @@ class TaskServiceTest {
     val page = mockk<Page<Task>>()
     val metadata = mockk<PaginationMetadata>()
     val taskEntityTypes = TaskEntityType.entries
+    val allocatedToUserId = UUID.randomUUID()
 
     every { page.content } returns tasks
     every {
@@ -331,6 +332,7 @@ class TaskServiceTest {
         isAllocated,
         apAreaId,
         taskEntityTypes.map { it.name },
+        allocatedToUserId,
         PageRequest.of(0, 10, Sort.by("created_at").ascending()),
       )
     } returns page
@@ -342,7 +344,7 @@ class TaskServiceTest {
 
     every { getMetadata(page, pageCriteria) } returns metadata
 
-    val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId, taskEntityTypes), pageCriteria)
+    val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId, taskEntityTypes, allocatedToUserId), pageCriteria)
 
     val expectedTasks = listOf(
       assessments.map { TypedTask.Assessment(it) },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -328,7 +328,7 @@ class TaskServiceTest {
 
     every { page.content } returns tasks
     every {
-      taskRepositoryMock.getAllReallocatable(
+      taskRepositoryMock.getAll(
         isAllocated,
         apAreaId,
         taskEntityTypes.map { it.name },


### PR DESCRIPTION
This PR makes several enhancements to the /tasks/reallocatable endpoint such that it can support requests sent to the /tasks endpoint. These are

1. Allow requests from users with the role CAS1_MATCHER
2. Add the option to filter on the allocated user

Subsequently, requests for /tasks endpoint is now forwarded to the reallocatable logic

The end goal is to have a single one-size-fits-all tasks endpoint