### PR TITLE
[APS-238] Add endpoint to view an appeal on an application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
@@ -18,6 +19,17 @@ import java.util.UUID
 class AppealService(
   private val appealRepository: AppealRepository,
 ) {
+  fun getAppeal(appealId: UUID, application: ApplicationEntity, user: UserEntity): AuthorisableActionResult<AppealEntity> {
+    if (!user.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return AuthorisableActionResult.Unauthorised()
+
+    val appeal = appealRepository.findByIdOrNull(appealId)
+      ?: return AuthorisableActionResult.NotFound("Appeal", appealId.toString())
+
+    if (appeal.application.id != application.id) return AuthorisableActionResult.NotFound("Appeal", appealId.toString())
+
+    return AuthorisableActionResult.Success(appeal)
+  }
+
   fun createAppeal(
     appealDate: LocalDate,
     appealDetail: String,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2133,6 +2133,45 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /applications/{applicationId}/appeals/{appealId}:
+    get:
+      tags:
+        - Application data
+      summary: Get an appeal on an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: appealId
+          in: path
+          description: ID of the appeal
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Appeal'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid applicationId or appealId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /documents/{crn}/{documentId}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2135,6 +2135,45 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /applications/{applicationId}/appeals/{appealId}:
+    get:
+      tags:
+        - Application data
+      summary: Get an appeal on an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: appealId
+          in: path
+          description: ID of the appeal
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Appeal'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid applicationId or appealId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /documents/{crn}/{documentId}:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -7,12 +7,118 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class AppealsTest : IntegrationTestBase() {
+  @Test
+  fun `Get appeal without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/applications/${UUID.randomUUID()}/appeals/${UUID.randomUUID()}")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get appeal returns 404 when application could not be found`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { _, jwt ->
+      webTestClient.get()
+        .uri("/applications/${UUID.randomUUID()}/appeals/${UUID.randomUUID()}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Get appeal returns 403 when application is not accessible to user`() {
+    `Given a User` { createdByUser, _ ->
+      `Given an Application`(createdByUser) { application ->
+        `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { _, jwt ->
+          webTestClient.get()
+            .uri("/applications/${application.id}/appeals/${UUID.randomUUID()}")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isForbidden
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `Get appeal returns 403 when user does not have CAS1_APPEALS_MANAGER role`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Application`(userEntity) { application ->
+        val appeal = appealEntityFactory.produceAndPersist {
+          withApplication(application as ApprovedPremisesApplicationEntity)
+          withCreatedBy(userEntity)
+        }
+
+        webTestClient.get()
+          .uri("/applications/${application.id}/appeals/${appeal.id}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+  }
+
+  @Test
+  fun `Get appeal returns 404 when appeal could not be found`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { userEntity, jwt ->
+      `Given an Application`(userEntity) { application ->
+        webTestClient.get()
+          .uri("/applications/${application.id}/appeals/${UUID.randomUUID()}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
+
+  @Test
+  fun `Get appeal returns 200 with correct body`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { userEntity, jwt ->
+      `Given an Application`(userEntity) { application ->
+        val appeal = appealEntityFactory.produceAndPersist {
+          withApplication(application as ApprovedPremisesApplicationEntity)
+          withCreatedBy(userEntity)
+          withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+        }
+
+        val result = webTestClient.get()
+          .uri("/applications/${application.id}/appeals/${appeal.id}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .returnResult(Appeal::class.java)
+
+        assertThat(result.responseBody.blockFirst()).matches {
+          it.appealDate == appeal.appealDate &&
+            it.appealDetail == appeal.appealDetail &&
+            it.reviewer == appeal.reviewer &&
+            it.createdAt == appeal.createdAt.toInstant() &&
+            it.applicationId == application.id &&
+            it.createdByUserId == userEntity.id &&
+            it.decision.value == appeal.decision &&
+            it.decisionDetail == appeal.decisionDetail &&
+            it.assessmentId == null
+        }
+      }
+    }
+  }
+
   @Test
   fun `Create new appeal without JWT returns 401`() {
     webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -25,6 +25,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTeamCodeEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTimelineNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
@@ -83,6 +84,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
@@ -157,6 +159,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Staf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.AppealTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApplicationTeamCodeTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesApplicationTestRepository
@@ -482,6 +485,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var placementRequestTestRepository: PlacementRequestTestRepository
 
+  @Autowired
+  lateinit var appealTestRepository: AppealTestRepository
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
@@ -539,6 +545,7 @@ abstract class IntegrationTestBase {
   lateinit var placementDateFactory: PersistedFactory<PlacementDateEntity, UUID, PlacementDateEntityFactory>
   lateinit var probationAreaProbationRegionMappingFactory: PersistedFactory<ProbationAreaProbationRegionMappingEntity, UUID, ProbationAreaProbationRegionMappingEntityFactory>
   lateinit var applicationTimelineNoteEntityFactory: PersistedFactory<ApplicationTimelineNoteEntity, UUID, ApplicationTimelineNoteEntityFactory>
+  lateinit var appealEntityFactory: PersistedFactory<AppealEntity, UUID, AppealEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -624,6 +631,7 @@ abstract class IntegrationTestBase {
     placementDateFactory = PersistedFactory({ PlacementDateEntityFactory() }, placementDateRepository)
     probationAreaProbationRegionMappingFactory = PersistedFactory({ ProbationAreaProbationRegionMappingEntityFactory() }, probationAreaProbationRegionMappingRepository)
     applicationTimelineNoteEntityFactory = PersistedFactory({ ApplicationTimelineNoteEntityFactory() }, applicationTimelineNoteRepository)
+    appealEntityFactory = PersistedFactory({ AppealEntityFactory() }, appealTestRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AppealTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AppealTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+import java.util.UUID
+
+@Repository
+interface AppealTestRepository : JpaRepository<AppealEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.EmptySource
 import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -21,6 +22,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AppealService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
 import java.time.LocalDate
+import java.util.Optional
+import java.util.UUID
 
 class AppealServiceTest {
   private val appealRepository = mockk<AppealRepository>()
@@ -41,6 +44,77 @@ class AppealServiceTest {
   private val application = ApprovedPremisesApplicationEntityFactory()
     .withCreatedByUser(createdByUser)
     .produce()
+
+  @Nested
+  inner class GetAppeal {
+    @Test
+    fun `Returns Unauthorised if the user does not have the CAS1_APPEALS_MANAGER role`() {
+      val user = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+
+      val appeal = AppealEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      every { appealRepository.findById(appeal.id) } returns Optional.of(appeal)
+
+      val result = appealService.getAppeal(appeal.id, application, user)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Unauthorised::class.java)
+    }
+
+    @Test
+    fun `Returns NotFound if the appeal does not exist`() {
+      val user = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+        .addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      every { appealRepository.findById(any()) } returns Optional.empty()
+
+      val result = appealService.getAppeal(UUID.randomUUID(), application, user)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+    }
+
+    @Test
+    fun `Returns NotFound if the appeal is not for the given application`() {
+      val user = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+        .addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val appeal = AppealEntityFactory()
+        .produce()
+
+      every { appealRepository.findById(appeal.id) } returns Optional.of(appeal)
+
+      val result = appealService.getAppeal(appeal.id, application, user)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+    }
+
+    @Test
+    fun `Returns Success containing expected appeal`() {
+      val user = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+        .addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      val appeal = AppealEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      every { appealRepository.findById(appeal.id) } returns Optional.of(appeal)
+
+      val result = appealService.getAppeal(appeal.id, application, user)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).isEqualTo(appeal)
+    }
+  }
 
   @Nested
   inner class CreateAppeal {


### PR DESCRIPTION
> See [APS-238 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-238).

This PR introduces the `GET /applications/{applicationId}/appeals/{appealId}` endpoint to get information about a particular appeal. It extends the work in #1426 to introduce appeals.