### PR TITLE
Redefine /tasks endpoint to provide generic search 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -310,7 +310,7 @@ class TasksController(
     val type = toTaskType(taskType)
 
     val validationResult = when (val authorisationResult = taskService.deallocateTask(user, type, id)) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, taskType.toString())
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, taskType)
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> authorisationResult.entity
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -24,24 +24,6 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   @Query(
     """
-      SELECT pa FROM PlacementApplicationEntity pa
-      JOIN pa.application a
-      LEFT OUTER JOIN a.apArea apArea
-      WHERE 
-        pa.allocatedToUser.id = :userId AND 
-        ((cast(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL) OR apArea.id = :apAreaId) AND
-        pa.reallocatedAt IS NULL AND 
-        pa.decision IS NULL
-    """,
-  )
-  fun findOpenRequestsAssignedToUser(
-    userId: UUID,
-    apAreaId: UUID?,
-    pageable: Pageable?,
-  ): Page<PlacementApplicationEntity>
-
-  @Query(
-    """
       SELECT a from PlacementApplicationEntity a where a.application.id = :applicationId
       AND a.submittedAt is not null
       AND a.reallocatedAt is null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -105,7 +105,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         )
         """
 
-    private const val ALLOCATABLE_QUERY = """
+    private const val ALL_QUERY = """
       $ASSESSMENT_QUERY
       UNION ALL
       $PLACEMENT_APPLICATION_QUERY
@@ -115,11 +115,50 @@ interface TaskRepository : JpaRepository<Task, UUID> {
   }
 
   @Query(
-    ALLOCATABLE_QUERY,
-    countQuery = "SELECT COUNT(1) FROM ($ALLOCATABLE_QUERY) as count",
+    ALL_QUERY,
+    countQuery = "SELECT COUNT(1) FROM ($ALL_QUERY) as count",
     nativeQuery = true,
   )
   fun getAll(
+    isAllocated: Boolean?,
+    apAreaId: UUID?,
+    taskTypes: List<String>,
+    allocatedToUserId: UUID?,
+    pageable: Pageable?,
+  ): Page<Task>
+
+  @Query(
+    PLACEMENT_REQUEST_QUERY,
+    countQuery = "SELECT COUNT(1) FROM ($PLACEMENT_REQUEST_QUERY) as count",
+    nativeQuery = true,
+  )
+  fun getAllPlacementRequests(
+    isAllocated: Boolean?,
+    apAreaId: UUID?,
+    taskTypes: List<String>,
+    allocatedToUserId: UUID?,
+    pageable: Pageable?,
+  ): Page<Task>
+
+  @Query(
+    PLACEMENT_APPLICATION_QUERY,
+    countQuery = "SELECT COUNT(1) FROM ($PLACEMENT_APPLICATION_QUERY) as count",
+    nativeQuery = true,
+  )
+  fun getAllPlacementApplications(
+    isAllocated: Boolean?,
+    apAreaId: UUID?,
+    taskTypes: List<String>,
+    allocatedToUserId: UUID?,
+    pageable: Pageable?,
+  ): Page<Task>
+
+  @Query(
+    ASSESSMENT_QUERY,
+    countQuery = "SELECT COUNT(1) FROM ($ASSESSMENT_QUERY) as count",
+    nativeQuery = true,
+  )
+  fun getAllAssessments(
     isAllocated: Boolean?,
     apAreaId: UUID?,
     taskTypes: List<String>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -49,23 +49,6 @@ class PlacementApplicationService(
   private val sendPlacementRequestNotifications: Boolean,
 ) {
 
-  fun getVisiblePlacementApplicationsForUser(
-    user: UserEntity,
-    page: Int? = null,
-    sortDirection: SortDirection? = null,
-    apAreaId: UUID?,
-  ): Pair<List<PlacementApplicationEntity>, PaginationMetadata?> {
-    val sortField = "createdAt"
-    val pageable = getPageable(sortField, sortDirection, page)
-    val response =
-      placementApplicationRepository.findOpenRequestsAssignedToUser(
-        user.id,
-        apAreaId,
-        pageable,
-      )
-    return Pair(response.content, getMetadata(response, page))
-  }
-
   fun getAllPlacementApplicationEntitiesForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
     return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(
       applicationId,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2793,7 +2793,7 @@ paths:
     get:
       tags:
         - Task data
-      summary: List all tasks. This endpoint is deprecated, use /tasks instead specifying the allocatedToUserId, noting that the 'type' parameter values are enumerated and capitalised.
+      summary: List all tasks that are not in a state of 'complete'. This endpoint is deprecated, use /tasks instead specifying the allocatedToUserId, noting that the 'type' parameter values are enumerated and capitalised.
       deprecated: true
       parameters:
         - in: path

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2727,10 +2727,41 @@ paths:
         - Task data
       summary: List all tasks
       parameters:
+        - in: query
+          name: type
+          required: false
+          description: Returns tasks that match the given type. If no type given return all. BookingAppeal is not supported
+          schema:
+            $ref: '_shared.yml#/components/schemas/TaskType'
+        - name: page
+          in: query
+          description: Page number of results to return.
+          schema:
+            type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '_shared.yml#/components/schemas/TaskSortField'
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank will sort by descending order
+          schema:
+            $ref: '_shared.yml#/components/schemas/SortDirection'
+        - name: allocatedFilter
+          in: query
+          description: Filter by allocated or not
+          schema:
+            $ref: '_shared.yml#/components/schemas/AllocatedFilter'
         - name: apAreaId
           in: query
-          required: false
-          description: If provided, only tasks for this area will be returned
+          description: Approved Premises Area ID to filter results by
+          schema:
+            type: string
+            format: uuid
+        - name: allocatedToUserId
+          in: query
+          description: Only show tasks allocated to this user id
           schema:
             type: string
             format: uuid
@@ -2743,6 +2774,15 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Task'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:
@@ -2753,7 +2793,8 @@ paths:
     get:
       tags:
         - Task data
-      summary: List all tasks
+      summary: List all tasks. This endpoint is deprecated, use /tasks instead specifying the allocatedToUserId, noting that the 'type' parameter values are enumerated and capitalised.
+      deprecated: true
       parameters:
         - in: path
           name: taskType
@@ -2806,7 +2847,8 @@ paths:
     get:
       tags:
         - Task data
-      summary: List all reallocatable tasks
+      summary: List all reallocatable tasks. This endpoint is deprecated, use /tasks instead, noting that the 'type' parameter values are enumerated and capitalised.
+      deprecated: true
       parameters:
         - in: query
           name: type

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2729,10 +2729,41 @@ paths:
         - Task data
       summary: List all tasks
       parameters:
+        - in: query
+          name: type
+          required: false
+          description: Returns tasks that match the given type. If no type given return all. BookingAppeal is not supported
+          schema:
+            $ref: '#/components/schemas/TaskType'
+        - name: page
+          in: query
+          description: Page number of results to return.
+          schema:
+            type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '#/components/schemas/TaskSortField'
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank will sort by descending order
+          schema:
+            $ref: '#/components/schemas/SortDirection'
+        - name: allocatedFilter
+          in: query
+          description: Filter by allocated or not
+          schema:
+            $ref: '#/components/schemas/AllocatedFilter'
         - name: apAreaId
           in: query
-          required: false
-          description: If provided, only tasks for this area will be returned
+          description: Approved Premises Area ID to filter results by
+          schema:
+            type: string
+            format: uuid
+        - name: allocatedToUserId
+          in: query
+          description: Only show tasks allocated to this user id
           schema:
             type: string
             format: uuid
@@ -2745,6 +2776,15 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Task'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -2755,7 +2795,8 @@ paths:
     get:
       tags:
         - Task data
-      summary: List all tasks
+      summary: List all tasks. This endpoint is deprecated, use /tasks instead, noting that the 'type' parameter values are enumerated and capitalised.
+      deprecated: true
       parameters:
         - in: path
           name: taskType
@@ -2808,7 +2849,8 @@ paths:
     get:
       tags:
         - Task data
-      summary: List all reallocatable tasks
+      summary: List all reallocatable tasks. This endpoint is deprecated, use /tasks instead, noting that the 'type' parameter values are enumerated and capitalised.
+      deprecated: true
       parameters:
         - in: query
           name: type

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -327,6 +327,52 @@ class TasksTest : IntegrationTestBase() {
       }
     }
 
+
+    @Test
+    fun `Get all reallocatable tasks returns 200 when type assessment and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val (allocatableAssessment) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = user,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            webTestClient.get()
+              .uri("/tasks/reallocatable?type=assessment&allocatedToUserId=${user.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformAssessmentToTask(
+                      allocatableAssessment,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
     @Test
     fun `Get all reallocatable tasks returns 200 when type placement request`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
@@ -433,6 +479,59 @@ class TasksTest : IntegrationTestBase() {
 
             webTestClient.get()
               .uri("/tasks/reallocatable?type=PlacementApplication&apAreaId=${apArea1.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementApplicationToTask(
+                      allocatablePlacementApplication,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all reallocatable tasks returns 200 when type placement application and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val allocatablePlacementApplication = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea1,
+            )
+
+            `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = otherUser,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea2,
+            )
+
+            webTestClient.get()
+              .uri("/tasks/reallocatable?type=PlacementApplication&allocatedToUserId=${user.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -645,6 +744,53 @@ class TasksTest : IntegrationTestBase() {
 
             webTestClient.get()
               .uri("/tasks/reallocatable?type=PlacementRequest&apAreaId=${apArea2.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementRequestToTask(
+                      allocatablePlacementRequest,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all reallocatable tasks returns 200 when type placement requests and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            val (allocatablePlacementRequest) = `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            webTestClient.get()
+              .uri("/tasks/reallocatable?type=PlacementRequest&allocatedToUserId=${user.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -2206,6 +2206,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Application`(
@@ -2216,6 +2217,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               reallocated = true,
+              submittedAt = OffsetDateTime.now(),
             )
 
             webTestClient.get()
@@ -2262,6 +2264,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Application`(
@@ -2272,6 +2275,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               reallocated = true,
+              submittedAt = OffsetDateTime.now(),
             )
 
             webTestClient.get()
@@ -2359,6 +2363,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               decision = null,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Application`(
@@ -2369,6 +2374,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               decision = PlacementApplicationDecision.ACCEPTED,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Request`(
@@ -2393,6 +2399,7 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
             )
 
             `Given a Placement Application`(
@@ -2403,6 +2410,7 @@ class TasksTest : IntegrationTestBase() {
               },
               crn = offenderDetails.otherIds.crn,
               reallocated = true,
+              submittedAt = OffsetDateTime.now(),
             )
 
             webTestClient.get()
@@ -2458,6 +2466,7 @@ class TasksTest : IntegrationTestBase() {
                 allocatedToUser = user,
                 schema = approvedPremisesPlacementApplicationJsonSchema,
                 crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
               )
             }
 
@@ -2494,6 +2503,7 @@ class TasksTest : IntegrationTestBase() {
             crn = offenderDetails.otherIds.crn,
             decision = null,
             apArea = apArea1,
+            submittedAt = OffsetDateTime.now(),
           )
 
           `Given a Placement Application`(
@@ -2505,6 +2515,7 @@ class TasksTest : IntegrationTestBase() {
             crn = offenderDetails.otherIds.crn,
             decision = null,
             apArea = apArea2,
+            submittedAt = OffsetDateTime.now(),
           )
 
           `Given a Placement Application`(
@@ -2516,6 +2527,7 @@ class TasksTest : IntegrationTestBase() {
             crn = offenderDetails.otherIds.crn,
             reallocated = true,
             apArea = apArea1,
+            submittedAt = OffsetDateTime.now(),
           )
 
           webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -327,7 +327,6 @@ class TasksTest : IntegrationTestBase() {
       }
     }
 
-
     @Test
     fun `Get all reallocatable tasks returns 200 when type assessment and allocated to user defined`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
@@ -1626,55 +1625,40 @@ class TasksTest : IntegrationTestBase() {
     }
   }
 
+  @SuppressWarnings("LargeClass")
   @Nested
-  inner class GetAllForUserTest {
+  inner class GetTasksTest {
+    private val pageSize = 10
+
     @Test
-    fun `Get all tasks for a user without JWT returns 401`() {
+    fun `Get all tasks without JWT returns 401`() {
       webTestClient.get()
-        .uri("/tasks")
+        .uri("/task")
         .exchange()
         .expectStatus()
         .isUnauthorized
     }
 
     @Test
-    fun `Get all tasks for a user returns the relevant tasks for a user`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { user, jwt ->
+    fun `Get all tasks without workflow manager or matcher permissions returns 403`() {
+      `Given a User` { _, jwt ->
+        webTestClient.get()
+          .uri("/tasks")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
+    fun `Get all tasks returns 200 when have CAS1_WORKFLOW_MANAGER OR CAS1_MATCHER roles`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
         `Given a User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
-            val (placementRequestAllocatedToMe) = `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            )
 
-            val placementApplicationAllocatedToMe = `Given a Placement Application`(
-              createdByUser = user,
-              allocatedToUser = user,
-              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                withPermissiveSchema()
-              },
-              crn = offenderDetails.otherIds.crn,
-              submittedAt = OffsetDateTime.now(),
-            )
-
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = otherUser,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-            )
-
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-              reallocated = true,
-            )
-
-            `Given a Placement Application`(
+            val task = `Given a Placement Application`(
               createdByUser = otherUser,
               allocatedToUser = otherUser,
               schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -1684,6 +1668,75 @@ class TasksTest : IntegrationTestBase() {
               submittedAt = OffsetDateTime.now(),
             )
 
+            val expectedTasks = listOf(
+              taskTransformer.transformPlacementApplicationToTask(
+                task,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+            )
+
+            webTestClient.get()
+              .uri("/tasks?page=1&sortBy=createdAt&sortDirection=asc")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  expectedTasks,
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type with only CAS1 assessments`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, inmateDetails ->
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              reallocated = true,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              isWithdrawn = true,
+            )
+
+            `Given an Assessment for Temporary Accommodation`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              decision = PlacementApplicationDecision.ACCEPTED,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              reallocated = true,
+              crn = offenderDetails.otherIds.crn,
+            )
+
             `Given a Placement Application`(
               createdByUser = user,
               allocatedToUser = user,
@@ -1691,7 +1744,47 @@ class TasksTest : IntegrationTestBase() {
                 withPermissiveSchema()
               },
               crn = offenderDetails.otherIds.crn,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
               reallocated = true,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val (allocatableAssessment) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val (allocatablePlacementRequest) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val (placementRequestMarkedAsUnableToMatch) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            bookingNotMadeFactory.produceAndPersist {
+              withPlacementRequest(placementRequestMarkedAsUnableToMatch)
+            }
+
+            val allocatablePlacementApplication = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
               submittedAt = OffsetDateTime.now(),
             )
 
@@ -1705,12 +1798,16 @@ class TasksTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
+                    taskTransformer.transformAssessmentToTask(
+                      allocatableAssessment,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
                     taskTransformer.transformPlacementRequestToTask(
-                      placementRequestAllocatedToMe,
+                      allocatablePlacementRequest,
                       "${offenderDetails.firstName} ${offenderDetails.surname}",
                     ),
                     taskTransformer.transformPlacementApplicationToTask(
-                      placementApplicationAllocatedToMe,
+                      allocatablePlacementApplication,
                       "${offenderDetails.firstName} ${offenderDetails.surname}",
                     ),
                   ),
@@ -1722,84 +1819,183 @@ class TasksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all tasks for a user returns the relevant tasks for a user and ap area`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { user, jwt ->
+    fun `Get all tasks with taskType BookingAppeal returns 400`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+        webTestClient.get()
+          .uri("/tasks?type=BookingAppeal")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type assessment`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
-
-          val apArea1 = `Given an AP Area`()
-          val apArea2 = `Given an AP Area`()
-
           `Given an Offender` { offenderDetails, _ ->
-            val (placementRequestAllocatedToMe) = `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-              apArea = apArea2,
-            )
-
-            val placementApplicationAllocatedToMe = `Given a Placement Application`(
-              createdByUser = user,
-              allocatedToUser = user,
-              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                withPermissiveSchema()
-              },
-              crn = offenderDetails.otherIds.crn,
-              apArea = apArea2,
-              submittedAt = OffsetDateTime.now(),
-            )
-
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-              apArea = apArea1,
-            )
-
-            `Given a Placement Application`(
-              createdByUser = user,
-              allocatedToUser = user,
-              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                withPermissiveSchema()
-              },
-              crn = offenderDetails.otherIds.crn,
-              apArea = apArea1,
-              submittedAt = OffsetDateTime.now(),
-            )
-
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = otherUser,
-              createdByUser = otherUser,
-              crn = offenderDetails.otherIds.crn,
-              reallocated = true,
-            )
-
-            `Given a Placement Application`(
-              createdByUser = otherUser,
+            val (allocatableAssessment) = `Given an Assessment for Approved Premises`(
               allocatedToUser = otherUser,
-              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                withPermissiveSchema()
-              },
+              createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
-              apArea = apArea2,
-              submittedAt = OffsetDateTime.now(),
             )
 
-            `Given a Placement Application`(
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
               createdByUser = user,
-              allocatedToUser = user,
-              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                withPermissiveSchema()
-              },
               crn = offenderDetails.otherIds.crn,
-              reallocated = true,
-              submittedAt = OffsetDateTime.now(),
             )
 
             webTestClient.get()
-              .uri("/tasks?apAreaId=${apArea2.id}")
+              .uri("/tasks?type=Assessment")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformAssessmentToTask(
+                      allocatableAssessment,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type assessment and ap area defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val (allocatableAssessment) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=Assessment&apAreaId=${apArea1.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformAssessmentToTask(
+                      allocatableAssessment,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type assessment and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val (allocatableAssessment) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = user,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=Assessment&allocatedToUserId=${user.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformAssessmentToTask(
+                      allocatableAssessment,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement request`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val (allocatablePlacementRequest) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementRequest")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -1809,16 +2005,1331 @@ class TasksTest : IntegrationTestBase() {
                 objectMapper.writeValueAsString(
                   listOf(
                     taskTransformer.transformPlacementRequestToTask(
-                      placementRequestAllocatedToMe,
-                      "${offenderDetails.firstName} ${offenderDetails.surname}",
-                    ),
-                    taskTransformer.transformPlacementApplicationToTask(
-                      placementApplicationAllocatedToMe,
+                      allocatablePlacementRequest,
                       "${offenderDetails.firstName} ${offenderDetails.surname}",
                     ),
                   ),
                 ),
               )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val allocatablePlacementApplication = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = null,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementApplicationToTask(
+                      allocatablePlacementApplication,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application and ap area defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val allocatablePlacementApplication = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea1,
+            )
+
+            `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea2,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication&apAreaId=${apArea1.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementApplicationToTask(
+                      allocatablePlacementApplication,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val allocatablePlacementApplication = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea1,
+            )
+
+            `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = otherUser,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea2,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication&allocatedToUserId=${user.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementApplicationToTask(
+                      allocatablePlacementApplication,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type assessment and page is two and no allocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            val numAllocatableAssessment = 7
+            val numUnallocatableAssessment = 5
+            val totalTasks = numAllocatableAssessment + numUnallocatableAssessment
+
+            repeat(numAllocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                allocatedToUser = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = null,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=Assessment&page=2")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", totalTasks.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type assessment and page is two and allocated filter allocated`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            val numAllocatableAssessment = 12
+            val numUnallocatableAssessment = 5
+
+            repeat(numAllocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                allocatedToUser = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=Assessment&page=2&allocatedFilter=allocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numAllocatableAssessment.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type assessment and page is two and allocated filter unallocated`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            val numAllocatableAssessment = 2
+            val numUnallocatableAssessment = 15
+
+            repeat(numAllocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                allocatedToUser = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = null,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=Assessment&page=2&allocatedFilter=unallocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numUnallocatableAssessment.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement requests and page two no allocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedRequests = 8
+            val numUnallocatedPlacementRequests = 6
+            val totalTasks = numAllocatedRequests + numUnallocatedPlacementRequests
+
+            repeat(numAllocatedRequests) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatedPlacementRequests) {
+              `Given a Placement Request`(
+                null,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementRequest&page=2")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", totalTasks.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement requests and ap area defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            val (allocatablePlacementRequest) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementRequest&apAreaId=${apArea2.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementRequestToTask(
+                      allocatablePlacementRequest,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement requests and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            val (allocatablePlacementRequest) = `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = user,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementRequest&allocatedToUserId=${user.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  listOf(
+                    taskTransformer.transformPlacementRequestToTask(
+                      allocatablePlacementRequest,
+                      "${offenderDetails.firstName} ${offenderDetails.surname}",
+                    ),
+                  ),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement requests and page two and allocated filter allocated`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedRequests = 12
+            val numUnallocatedPlacementRequests = 5
+
+            repeat(numAllocatedRequests) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatedPlacementRequests) {
+              `Given a Placement Request`(
+                null,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementRequest&page=2&allocatedFilter=allocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numAllocatedRequests.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement requests and page two and allocated filter unallocated`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedRequests = 2
+            val numUnallocatedPlacementRequests = 15
+
+            repeat(numAllocatedRequests) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatedPlacementRequests) {
+              `Given a Placement Request`(
+                null,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = null,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementRequest&page=2&allocatedFilter=unallocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numUnallocatedPlacementRequests.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type retains original sort order`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            val (task1, _) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val (task2, _) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val (task3, _) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val task4 = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+            )
+
+            val (task5) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val expectedTasks = listOf(
+              taskTransformer.transformPlacementRequestToTask(
+                task1,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformAssessmentToTask(
+                task2,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformPlacementRequestToTask(
+                task3,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformPlacementApplicationToTask(
+                task4,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformAssessmentToTask(
+                task5,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+            )
+
+            webTestClient.get()
+              .uri("/tasks?page=1&sortBy=createdAt&sortDirection=asc")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  expectedTasks,
+                ),
+              )
+
+            webTestClient.get()
+              .uri("/tasks?page=1&sortBy=createdAt&sortDirection=desc")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  expectedTasks.reversed(),
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type and allocated to user defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { callingUser, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val (task1, _) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = callingUser,
+              createdByUser = callingUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = callingUser,
+              assessmentAllocatedTo = callingUser,
+              createdByUser = callingUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val (task2, _) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = callingUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = callingUser,
+              createdByUser = callingUser,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            val task3 = `Given a Placement Application`(
+              createdByUser = otherUser,
+              allocatedToUser = otherUser,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+            )
+
+            `Given a Placement Application`(
+              createdByUser = callingUser,
+              allocatedToUser = callingUser,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+            )
+
+            val expectedTasks = listOf(
+              taskTransformer.transformPlacementRequestToTask(
+                task1,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformAssessmentToTask(
+                task2,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformPlacementApplicationToTask(
+                task3,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+            )
+
+            webTestClient.get()
+              .uri("/tasks?page=1&sortBy=createdAt&sortDirection=asc&allocatedToUserId=${otherUser.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  expectedTasks,
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type and ap area defined`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val apArea1 = `Given an AP Area`()
+            val apArea2 = `Given an AP Area`()
+
+            val (task1, _) = `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = otherUser,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            val (task2, _) = `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea1,
+            )
+
+            `Given an Assessment for Approved Premises`(
+              allocatedToUser = otherUser,
+              createdByUser = otherUser,
+              crn = offenderDetails.otherIds.crn,
+              apArea = apArea2,
+            )
+
+            val task3 = `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea1,
+            )
+
+            `Given a Placement Application`(
+              createdByUser = user,
+              allocatedToUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              crn = offenderDetails.otherIds.crn,
+              submittedAt = OffsetDateTime.now(),
+              apArea = apArea2,
+            )
+
+            val expectedTasks = listOf(
+              taskTransformer.transformPlacementRequestToTask(
+                task1,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformAssessmentToTask(
+                task2,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+              taskTransformer.transformPlacementApplicationToTask(
+                task3,
+                "${offenderDetails.firstName} ${offenderDetails.surname}",
+              ),
+            )
+
+            webTestClient.get()
+              .uri("/tasks?page=1&sortBy=createdAt&sortDirection=asc&apAreaId=${apArea1.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  expectedTasks,
+                ),
+              )
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application and page two`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatablePlacementApplications = 12
+
+            repeat(numAllocatablePlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = null,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication&page=2")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numAllocatablePlacementApplications.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application and page two and no allocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedPlacementApplications = 6
+            val numUnallocatedPlacementApplications = 5
+            val totalTasks = numAllocatedPlacementApplications + numUnallocatedPlacementApplications
+
+            repeat(numAllocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numUnallocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = null,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication&page=2")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", totalTasks.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application and page two and unallocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedPlacementApplications = 12
+            val numUnallocatedPlacementApplications = 15
+
+            repeat(numAllocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numUnallocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = null,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication&page=2&allocatedFilter=unallocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numUnallocatedPlacementApplications.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when type placement application and page two and allocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedPlacementApplications = 12
+            val numUnallocatedPlacementApplications = 15
+
+            repeat(numAllocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numUnallocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            `Given a Placement Request`(
+              placementRequestAllocatedTo = user,
+              assessmentAllocatedTo = otherUser,
+              createdByUser = user,
+              crn = offenderDetails.otherIds.crn,
+            )
+
+            webTestClient.get()
+              .uri("/tasks?type=PlacementApplication&page=2&allocatedFilter=allocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", numAllocatedPlacementApplications.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type and page two and no allocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedPlacementApplications = 2
+            val numUnallocatedPlacementApplications = 3
+            val numAllocatableAssessment = 4
+            val numUnallocatableAssessment = 5
+            val numAllocatedPlacementRequests = 6
+            val numUnallocatedPlacementRequests = 7
+
+            val totalTasks = numAllocatedPlacementApplications +
+              numUnallocatedPlacementApplications +
+              numAllocatableAssessment +
+              numUnallocatableAssessment +
+              numAllocatedPlacementRequests +
+              numUnallocatedPlacementRequests
+
+            repeat(numAllocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numUnallocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numAllocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                allocatedToUser = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numAllocatedPlacementRequests) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatedPlacementRequests) {
+              `Given a Placement Request`(
+                null,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            webTestClient.get()
+              .uri("/tasks?page=2")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 3)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", totalTasks.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type and page two and allocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedPlacementApplications = 12
+            val numUnallocatedPlacementApplications = 1
+            val numAllocatableAssessment = 4
+            val numUnallocatableAssessment = 1
+            val numAllocatedPlacementRequests = 6
+            val numUnallocatedPlacementRequests = 1
+
+            val totalTasks = numAllocatedPlacementApplications +
+              numAllocatableAssessment +
+              numAllocatedPlacementRequests
+
+            repeat(numAllocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numUnallocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numAllocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                allocatedToUser = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatableAssessment) {
+              `Given an Assessment for Approved Premises`(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numAllocatedPlacementRequests) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatedPlacementRequests) {
+              `Given a Placement Request`(
+                null,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            webTestClient.get()
+              .uri("/tasks?page=2&allocatedFilter=allocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 3)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", totalTasks.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all tasks returns 200 when no type and page two and unallocated filter`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        `Given a User` { otherUser, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+
+            val numAllocatedPlacementApplications = 1
+            val numAllocatedAssessments = 1
+            val numAllocatedPlacementRequests = 1
+
+            repeat(numAllocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                allocatedToUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+              )
+            }
+
+            repeat(numAllocatedAssessments) {
+              `Given an Assessment for Approved Premises`(
+                allocatedToUser = otherUser,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numAllocatedPlacementRequests) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = otherUser,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            val numUnallocatedPlacementApplications = 11
+            val numUnallocatedAssessments = 5
+            val numUnallocatedPlacementRequests = 7
+
+            repeat(numUnallocatedPlacementApplications) {
+              `Given a Placement Application`(
+                createdByUser = user,
+                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withPermissiveSchema()
+                },
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+                reallocated = false,
+                decision = null,
+              )
+            }
+
+            repeat(numUnallocatedAssessments) {
+              `Given an Assessment for Approved Premises`(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            repeat(numUnallocatedPlacementRequests) {
+              `Given a Placement Request`(
+                null,
+                assessmentAllocatedTo = otherUser,
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+              )
+            }
+
+            val totalUnallocatedTasks = numUnallocatedPlacementApplications +
+              numUnallocatedAssessments +
+              numUnallocatedPlacementRequests
+
+            webTestClient.get()
+              .uri("/tasks?page=2&allocatedFilter=unallocated")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+              .expectHeader().valueEquals("X-Pagination-TotalPages", 3)
+              .expectHeader().valueEquals("X-Pagination-TotalResults", totalUnallocatedTasks.toLong())
+              .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+              .expectBody()
           }
         }
       }


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-223

Before this PR, the /tasks endpoint would return tasks assigned to the calling user, with some additional limited filtering options. This version of the endpoint is not currently used by the UI and as such we can make breaking changes safely

ThisPR redefines the /tasks endpoint to return tasks for any user, with an optional ‘allocatedUserToId’ to replicate the previous /tasks endpoint behaviour. The end point also provides paging and various other filters.

This allows us to deprecate /tasks/reallocatable and /tasks/{taskType} as the same functionality is now provided by the generic /tasks endpoint

https://dsdmoj.atlassian.net/browse/APS-283 and https://dsdmoj.atlassian.net/browse/APS-284 have been created to subsequently remove usages of the deprecated endpoints on the UI, and then remove the deprecated endpoints themselves