### PR TITLE
More verbose error logging for notify

### DIFF
--- a/doc/how-to/verify_email_sending.md
+++ b/doc/how-to/verify_email_sending.md
@@ -1,0 +1,25 @@
+# How to verify email sending in non-prod environments
+
+We can verify emails would have been sent in two ways, depending on how the environment is configured:
+
+## If the `NotifyMode` is `DISABLED`
+
+We can query Application Insights with the following query:
+
+```
+traces
+| where customDimensions["Logger Message"] contains "Email sending is disabled"
+| order by timestamp desc
+| project timestamp, operation_Name, customDimensions["Logger Message"]
+```
+
+## If the `NotifyMode` is `TEST_AND_GUEST_LIST` or `ENABLED`
+
+We can query Application Insights with the following query:
+
+```
+exceptions
+| where customDimensions["Logger Message"] contains "Unable to send email"
+| order by timestamp desc
+| project timestamp, operation_Name, customDimensions["Logger Message"]
+```

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
@@ -14,7 +15,7 @@ class EmailNotificationService(
   @Qualifier("normalNotificationClient") private val normalNotificationClient: NotificationClient?,
   @Qualifier("guestListNotificationClient") private val guestListNotificationClient: NotificationClient?,
 ) {
-  private val log = LoggerFactory.getLogger(this::class.java)
+  var log: Logger = LoggerFactory.getLogger(this::class.java)
 
   fun sendEmail(email: String, templateId: String, personalisation: Map<String, *>) {
     try {
@@ -29,7 +30,7 @@ class EmailNotificationService(
         normalNotificationClient!!.sendEmail(templateId, email, personalisation, null)
       }
     } catch (notificationClientException: NotificationClientException) {
-      log.error("Unable to send email", notificationClientException)
+      log.error("Unable to send template $templateId to user $email", notificationClientException)
     }
   }
 }


### PR DESCRIPTION
This adds some more verbose error logging for Notify, so we can confirm email sending will work as expected in production.