### PR TITLE
(APS-282) Add APArea to `UserWithWorkload`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -36,6 +36,7 @@ class UserTransformer(
       numTasksCompleted30Days = userWorkload.numTasksCompleted30Days,
       qualifications = jpa.qualifications.distinctBy { it.qualification }.map(::transformQualificationToApi),
       roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToApi),
+      apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
     )
   }
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2670,6 +2670,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
     ApprovedPremisesUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7091,6 +7091,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
     ApprovedPremisesUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3098,6 +3098,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
     ApprovedPremisesUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -39,10 +39,12 @@ class UserTransformerTest {
 
   private val userTransformer = UserTransformer(probationRegionTransformer, apAreaTransformer)
 
+  private val apArea = ApArea(randomUUID(), "someIdentifier", "someName")
+
   @BeforeEach
   fun setup() {
     every { probationRegionTransformer.transformJpaToApi(any()) } returns ProbationRegion(randomUUID(), "someName")
-    every { apAreaTransformer.transformJpaToApi(any()) } returns ApArea(randomUUID(), "someIdentifier", "someName")
+    every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
   }
 
   @Test
@@ -142,6 +144,26 @@ class UserTransformerTest {
         workflowManager,
       ),
     )
+  }
+
+  @Test
+  fun `transformJpaToAPIUserWithWorkload should return AP area`() {
+    val user = buildUserEntity(UserRole.CAS1_MATCHER)
+
+    val workload = UserWorkload(
+      0,
+      0,
+      0,
+    )
+
+    val result =
+      userTransformer.transformJpaToAPIUserWithWorkload(user, workload) as UserWithWorkload
+
+    assertThat(result.apArea).isEqualTo(apArea)
+
+    verify {
+      apAreaTransformer.transformJpaToApi(user.probationRegion.apArea)
+    }
   }
 
   private fun buildUserEntity(


### PR DESCRIPTION
This is needed to filter by AP Area. Ordinarily, we’d extend the `ApprovedPremisesUser` here, but the code generator doesn’t like extensions of an already extended type.