### PR TITLE
Send notifications to assessor on app withdrawal

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -96,6 +96,7 @@ generic-service:
     USER-ALLOCATIONS_RULES_EMERGENCY-ASSESSMENTS_ALLOCATE-TO-USERS_NAT: # TODO: Determine appropriate user
 
     NOTIFY_SEND-PLACEMENT-REQUEST-NOTIFICATIONS: true
+    NOTIFY_SEND-NEW-WITHDRAWAL-NOTIFICATIONS: true
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -90,6 +90,7 @@ generic-service:
     USER-ALLOCATIONS_RULES_EMERGENCY-ASSESSMENTS_ALLOCATE-TO-USERS_NAT: # TODO: Determine appropriate user
 
     NOTIFY_SEND-PLACEMENT-REQUEST-NOTIFICATIONS: true
+    NOTIFY_SEND-NEW-WITHDRAWAL-NOTIFICATIONS: true
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -99,6 +99,7 @@ generic-service:
     USER-ALLOCATIONS_RULES_EMERGENCY-ASSESSMENTS_ALLOCATE-TO-USERS_NAT: # TODO: Determine appropriate user
 
     NOTIFY_SEND-PLACEMENT-REQUEST-NOTIFICATIONS: false
+    NOTIFY_SEND-NEW-WITHDRAWAL-NOTIFICATIONS: false
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -90,6 +90,7 @@ generic-service:
     USER-ALLOCATIONS_RULES_EMERGENCY-ASSESSMENTS_ALLOCATE-TO-USERS_NAT: # TODO: Determine appropriate user
 
     NOTIFY_SEND-PLACEMENT-REQUEST-NOTIFICATIONS: true
+    NOTIFY_SEND-NEW-WITHDRAWAL-NOTIFICATIONS: true
 
   namespace_secrets:
     hmpps-approved-premises-api:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -28,6 +28,7 @@ class NotifyTemplates {
   var assessmentDeallocated = "331ce452-ea83-4f0c-aec0-5eafe85094f2"
   var assessmentAccepted = "ddf87b15-8866-4bad-a87b-47eba69eb6db"
   var assessmentRejected = "b3a98c60-8fe0-4450-8fd0-6430198ee43b"
+  var assessmentWithdrawn = "44ade006-7ac6-4769-aa40-542da56f21b5"
   var bookingMade = "1e3d2ee2-250e-4755-af38-80d24cdc3480"
   var bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
   var placementRequestAllocated = "375d83be-c973-44ed-939f-48ffc00230f3"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -293,7 +293,9 @@ class ApprovedPremisesAssessmentEntity(
   referralHistoryNotes,
   schemaUpToDate,
   isWithdrawn,
-)
+) {
+  fun isPendingAssessment() = this.submittedAt == null && this.reallocatedAt == null && !this.isWithdrawn
+}
 
 @Entity
 @DiscriminatorValue("temporary-accommodation")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -594,7 +594,7 @@ class ApplicationService(
         sendEmailApplicationWithdrawn(user, application, premisesName)
 
         application.assessments.map {
-          assessmentService.updateAssessmentWithdrawn(it.id)
+          assessmentService.updateCas1AssessmentWithdrawn(it.id)
         }
 
         withdrawableService.withdrawAllForApplication(application, user)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -263,3 +263,4 @@ pagination:
 
 notify:
   send-placement-request-notifications: false
+  send-new-withdrawal-notifications: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
@@ -77,7 +77,7 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
     this.decision = { decision }
   }
 
-  fun withAllocatedToUser(allocatedToUser: UserEntity) = apply {
+  fun withAllocatedToUser(allocatedToUser: UserEntity?) = apply {
     this.allocatedToUser = allocatedToUser
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -104,8 +104,9 @@ class AcceptAssessmentTest {
     userAllocator,
     objectMapperMock,
     UrlTemplate("http://frontend/applications/#id"),
-    "http://frontend/assessments/#id",
+    UrlTemplate("http://frontend/assessments/#id"),
     sendPlacementRequestNotifications = true,
+    sendNewWithdrawalNotifications = true,
   )
 
   lateinit var user: UserEntity


### PR DESCRIPTION
If there is an ‘active’ assessment when an application is withdrawn, a notification will be sent to the person currently allocated to the assessment.

A temporary feature flag has been added to allow us to control when this feature goes live in production. A JIRA ticket https://dsdmoj.atlassian.net/browse/APS-285 has been created to track its removal.