### PR TITLE
Return Status Updates on CAS2 Submitted Applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -15,6 +15,7 @@ class ApplicationsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
   private val nomisUserTransformer: NomisUserTransformer,
+  private val statusUpdateTransformer: StatusUpdateTransformer,
 ) {
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult):
@@ -32,6 +33,7 @@ class ApplicationsTransformer(
       status = getStatus(jpa),
       type = "CAS2",
       telephoneNumber = jpa.telephoneNumber,
+      statusUpdates = jpa.statusUpdates?.map { statusUpdate -> statusUpdateTransformer.transformJpaToApi(statusUpdate) },
     )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1640,6 +1640,10 @@ components:
               format: date-time
             telephoneNumber:
               type: string
+            statusUpdates:
+              type: array
+              items:
+                $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6182,6 +6182,10 @@ components:
               format: date-time
             telephoneNumber:
               type: string
+            statusUpdates:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2StatusUpdate'
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2083,6 +2083,10 @@ components:
               format: date-time
             telephoneNumber:
               type: string
+            statusUpdates:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2StatusUpdate'
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1688,6 +1688,10 @@ components:
               format: date-time
             telephoneNumber:
               type: string
+            statusUpdates:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2StatusUpdate'
           required:
             - createdBy
             - schemaVersion


### PR DESCRIPTION
We'd like referrers to see status updates on an
application. These are only applied to
applications after they've been submitted.

This adds the `statusUpdates` via the ApplicationsTransformer.