### PR TITLE
Fix placement request withdrawable logic bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.Type
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -171,7 +171,10 @@ data class PlacementRequestEntity(
   @Enumerated(value = EnumType.STRING)
   var withdrawalReason: PlacementRequestWithdrawalReason?,
 ) {
-  fun canBeWithdrawn() = reallocatedAt == null && booking == null && !isWithdrawn
+  fun canBeWithdrawn() =
+    reallocatedAt == null && !hasActiveBooking() && !isWithdrawn
+
+  fun hasActiveBooking() = booking != null && booking?.cancellations.isNullOrEmpty()
 
   fun expectedDeparture() = expectedArrival.plusDays(duration.toLong())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -5,7 +5,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
@@ -19,13 +18,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -301,7 +301,8 @@ class PlacementRequestService(
 
   fun getWithdrawablePlacementRequests(
     application: ApprovedPremisesApplicationEntity,
-  ): List<PlacementRequestEntity> = placementRequestRepository.findByApplication(application).filter { it.canBeWithdrawn() }
+  ): List<PlacementRequestEntity> =
+    placementRequestRepository.findByApplication(application).filter { it.canBeWithdrawn() }
 
   private fun saveBookingNotMadeDomainEvent(
     user: UserEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -52,15 +52,15 @@ class PlacementRequestTransformer(
   }
 
   fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
-    if (placementRequest.booking == null || placementRequest.booking?.cancellations?.any() == true) {
-      if (placementRequest.bookingNotMades.any()) {
-        return PlacementRequestStatus.unableToMatch
-      }
-
-      return PlacementRequestStatus.notMatched
+    if (placementRequest.hasActiveBooking()) {
+      return PlacementRequestStatus.matched
     }
 
-    return PlacementRequestStatus.matched
+    if (placementRequest.bookingNotMades.any()) {
+      return PlacementRequestStatus.unableToMatch
+    }
+
+    return PlacementRequestStatus.notMatched
   }
 
   fun transformToWithdrawable(jpa: PlacementRequestEntity) = Withdrawable(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3135,6 +3135,28 @@ class ApplicationTest : IntegrationTestBase() {
               )
             }
 
+            val cancelledBooking = bookingEntityFactory.produceAndPersist {
+              withPremises(
+                approvedPremisesEntityFactory.produceAndPersist {
+                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+                  withYieldedProbationRegion {
+                    probationRegionEntityFactory.produceAndPersist {
+                      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+                    }
+                  }
+                },
+              )
+              withArrivalDate(LocalDate.parse("2023-03-08"))
+              withDepartureDate(LocalDate.parse("2023-03-10"))
+            }
+            cancellationEntityFactory.produceAndPersist {
+              withBooking(cancelledBooking)
+              withReason(cancellationReasonEntityFactory.produceAndPersist())
+            }
+            val placementRequestWithBookingsAllCancelled = produceAndPersistPlacementRequest(application) {
+              withBooking(cancelledBooking)
+            }
+
             produceAndPersistPlacementRequest(application) {
               withIsWithdrawn(true)
             }
@@ -3149,6 +3171,11 @@ class ApplicationTest : IntegrationTestBase() {
                 placementRequest2.id,
                 WithdrawableType.placementRequest,
                 listOf(datePeriodForDuration(placementRequest2.expectedArrival, placementRequest2.duration)),
+              ),
+              Withdrawable(
+                placementRequestWithBookingsAllCancelled.id,
+                WithdrawableType.placementRequest,
+                listOf(datePeriodForDuration(placementRequestWithBookingsAllCancelled.expectedArrival, placementRequestWithBookingsAllCancelled.duration)),
               ),
             )
 


### PR DESCRIPTION
If a placement request has a booking associated with it, but that booking has been cancelled, as per existing behaviour, it will have a status of ‘not matched’. Therefore, a placement request with this state should also be withdrawable.

As part of this commit some logic defined in the PlacementRequestTransformer has been moved into a common entity function to reduce duplication