### PR TITLE
Added missing release types to PR transformer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -84,6 +84,8 @@ class PlacementRequestTransformer(
     "pss" -> ReleaseTypeOption.pss
     "inCommunity" -> ReleaseTypeOption.inCommunity
     "notApplicable" -> ReleaseTypeOption.notApplicable
+    "extendedDeterminateLicence" -> ReleaseTypeOption.extendedDeterminateLicence
+    "paroleDirectedLicence" -> ReleaseTypeOption.paroleDirectedLicence
     else -> throw RuntimeException("Unrecognised releaseType: $releaseType")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -189,7 +189,7 @@ class TaskTransformerTest {
   }
 
   @Nested
-  inner class TransformPlacementApplicationsTest {
+  inner class TransformPlacementApplicationToTaskTest {
     private val placementApplication = placementApplicationFactory
       .withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
       .withData(null)
@@ -295,7 +295,7 @@ class TaskTransformerTest {
   }
 
   @Nested
-  inner class TransformPlacementRequestsTest {
+  inner class TransformPlacementRequestToTaskTest {
 
     val placementRequest = placementRequestFactory.produce()
     val application = placementRequest.application


### PR DESCRIPTION
New application release types were added to the open api in commit 54c6fdb, but the placement request transformer was not updated to include these new types. These leads to RuntimeExceptions when attempting to view a placement request task for an application for one of these new release types.

This commit adds those missing mappings and improves regression testing to ensure all release types are mapped going forward