### PR TITLE
[APS-239] Introduce domain event for created appeals

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -46,6 +46,7 @@ generic-service:
     HMPPS_SQS_USE_WEB_TOKEN: true
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -60,6 +60,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -52,6 +52,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -38,6 +38,7 @@ generic-service:
     NOTIFY_MODE: TEST_AND_GUEST_LIST
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -61,6 +61,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -47,6 +47,7 @@ generic-service:
     HMPPS_SQS_USE_WEB_TOKEN: true
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -40,6 +40,7 @@ generic-service:
     SEED_AUTO-SCRIPT_NOMS: G9542VP
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -54,6 +54,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-test.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.EventsApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
@@ -86,6 +87,13 @@ class DomainEventsController(
 
   override fun eventsApplicationWithdrawnEventIdGet(eventId: UUID): ResponseEntity<ApplicationWithdrawnEnvelope> {
     val event = domainEventService.getApplicationWithdrawnEvent(eventId)
+      ?: throw NotFoundProblem(eventId, "DomainEvent")
+
+    return ResponseEntity.ok(event.data)
+  }
+
+  override fun eventsAssessmentAppealedEventIdGet(eventId: UUID): ResponseEntity<AssessmentAppealedEnvelope> {
+    val event = domainEventService.getAssessmentAppealedEvent(eventId)
       ?: throw NotFoundProblem(eventId, "DomainEvent")
 
     return ResponseEntity.ok(event.data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -25,6 +25,7 @@ class DomainEventDescriber(
       DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> buildBookingCancelledDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> "The booking had its arrival or departure date changed"
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> "The application was withdrawn"
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> buildAssessmentAppealedDescription(domainEventSummary)
       else -> throw IllegalArgumentException("Only CAS1 is currently supported")
     }
   }
@@ -62,6 +63,11 @@ class DomainEventDescriber(
   private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
     return event.describe { "The booking was cancelled. The reason was: ${it.eventDetails.cancellationReason}" }
+  }
+
+  private fun buildAssessmentAppealedDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getAssessmentAppealedEvent(domainEventSummary.id())
+    return event.describe { "The assessment was appealed and ${it.eventDetails.decision.value}. The reason was: ${it.eventDetails.decisionDetail}" }
   }
 
   private fun DomainEventSummary.id(): UUID = UUID.fromString(this.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -5,6 +5,7 @@ import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
@@ -94,6 +95,8 @@ data class DomainEventEntity(
         objectMapper.readValue(this.data, T::class.java)
       T::class == ApplicationWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN ->
         objectMapper.readValue(this.data, T::class.java)
+      T::class == AssessmentAppealedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED ->
+        objectMapper.readValue(this.data, T::class.java)
       else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${this.type.name}")
     }
 
@@ -120,6 +123,7 @@ enum class DomainEventType {
   APPROVED_PREMISES_BOOKING_CANCELLED,
   APPROVED_PREMISES_BOOKING_CHANGED,
   APPROVED_PREMISES_APPLICATION_WITHDRAWN,
+  APPROVED_PREMISES_ASSESSMENT_APPEALED,
   CAS2_APPLICATION_SUBMITTED,
   CAS2_APPLICATION_STATUS_UPDATED,
   CAS3_BOOKING_CANCELLED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -1,24 +1,39 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealDecision as DomainEventApiAppealDecision
 
 @Service
 class AppealService(
   private val appealRepository: AppealRepository,
+  private val domainEventService: DomainEventService,
+  private val communityApiClient: CommunityApiClient,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.application-appeal}") private val applicationAppealUrlTemplate: UrlTemplate,
 ) {
   fun getAppeal(appealId: UUID, application: ApplicationEntity, user: UserEntity): AuthorisableActionResult<AppealEntity> {
     if (!user.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return AuthorisableActionResult.Unauthorised()
@@ -80,8 +95,65 @@ class AppealService(
           ),
         )
 
+        saveEvent(appeal)
+
         success(appeal)
       },
     )
   }
+
+  private fun saveEvent(appeal: AppealEntity) {
+    val id = UUID.randomUUID()
+    val timestamp = appeal.createdAt.toInstant()
+
+    val staffDetails = when (val result = communityApiClient.getStaffUserDetails(appeal.createdBy.deliusUsername)) {
+      is ClientResult.Success -> result.body
+      is ClientResult.Failure -> result.throwException()
+    }
+
+    domainEventService.saveAssessmentAppealedEvent(
+      DomainEvent(
+        id = id,
+        applicationId = appeal.application.id,
+        assessmentId = null,
+        bookingId = null,
+        crn = appeal.application.crn,
+        occurredAt = timestamp,
+        data = AssessmentAppealedEnvelope(
+          id = id,
+          timestamp = timestamp,
+          eventType = "approved-premises.assessment.appealed",
+          eventDetails = AssessmentAppealed(
+            applicationId = appeal.application.id,
+            applicationUrl = applicationUrlTemplate.resolve("id", appeal.application.id.toString()),
+            appealId = appeal.id,
+            appealUrl = applicationAppealUrlTemplate.resolve(
+              mapOf("applicationId" to appeal.application.id.toString(), "appealId" to appeal.id.toString()),
+            ),
+            personReference = PersonReference(
+              crn = appeal.application.crn,
+              noms = appeal.application.nomsNumber!!,
+            ),
+            deliusEventNumber = (appeal.application as ApprovedPremisesApplicationEntity).eventNumber,
+            createdAt = timestamp,
+            createdBy = StaffMember(
+              staffCode = staffDetails.staffCode,
+              staffIdentifier = staffDetails.staffIdentifier,
+              forenames = staffDetails.staff.forenames,
+              surname = staffDetails.staff.surname,
+              username = staffDetails.username,
+            ),
+            reviewer = appeal.reviewer,
+            appealDetail = appeal.appealDetail,
+            decision = parseDecision(appeal.decision),
+            decisionDetail = appeal.decisionDetail,
+          ),
+        ),
+      ),
+    )
+  }
+
+  private fun parseDecision(value: String): DomainEventApiAppealDecision =
+    DomainEventApiAppealDecision.entries.firstOrNull { it.value == value }
+      ?: throw IllegalArgumentException("Unknown appeal decision type '$value'")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -75,6 +75,7 @@ class ApplicationTimelineTransformer(
       DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> TimelineEventType.approvedPremisesBookingCancelled
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> TimelineEventType.approvedPremisesBookingChanged
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> TimelineEventType.approvedPremisesApplicationWithdrawn
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> TimelineEventType.approvedPremisesAssessmentAppealed
       else -> throw IllegalArgumentException("Only CAS1 is currently supported")
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -218,6 +218,7 @@ url-templates:
       booking-cancelled-event-detail: http://localhost:3000/events/booking-cancelled/#eventId
       booking-changed-event-detail: http://localhost:3000/events/booking-changed/#eventId
       application-withdrawn-event-detail: http://localhost:3000/events/application-withdrawn/#eventId
+      assessment-appealed-event-detail: http://localhost:3000/events/assessment-appealed/#eventId
     cas2:
       application-submitted-event-detail: http://localhost:3000/events/cas2/application-submitted/#eventId
       application-status-updated-event-detail: http://localhost:3000/events/cas2/application-status-updated/#eventId

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -236,6 +236,7 @@ url-templates:
       person-departure-updated-event-detail: http://localhost:3000/events/cas3/person-departure-updated/#eventId
   frontend:
     application: http://localhost:3000/applications/#id
+    application-appeal: http://localhost:3000/applications/#applicationId/appeals/#appealId
     assessment: http://localhost:3000/assessments/#id
     booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
     cas2:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3318,6 +3318,7 @@ components:
         - approved_premises_booking_changed
         - approved_premises_application_withdrawn
         - approved_premises_information_request
+        - approved_premises_assessment_appealed
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7866,6 +7866,7 @@ components:
         - approved_premises_booking_changed
         - approved_premises_application_withdrawn
         - approved_premises_information_request
+        - approved_premises_assessment_appealed
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3801,6 +3801,7 @@ components:
         - approved_premises_booking_changed
         - approved_premises_application_withdrawn
         - approved_premises_information_request
+        - approved_premises_assessment_appealed
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3366,6 +3366,7 @@ components:
         - approved_premises_booking_changed
         - approved_premises_application_withdrawn
         - approved_premises_information_request
+        - approved_premises_assessment_appealed
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -85,6 +85,33 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /events/assessment-appealed/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Apply' events"
+      summary: An 'assessment-appealed' event
+      responses:
+        '200':
+          description: The 'assessment-appealed' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentAppealedEnvelope'
+        404:
+          description: No assessment-appealed event found for the provided `eventId`
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /events/booking-made/{eventId}:
     parameters:
       - name: eventId
@@ -328,6 +355,15 @@ components:
       description: The URL on the Approved Premises service at which a user can view a representation of an AP application and related resources, including bookings
       type: string
       example: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713
+    AppealId:
+      description: The UUID of an appeal for an application
+      type: string
+      format: uuid
+      example: dd450bbc-162d-4380-a103-9f261943b98f
+    AppealUrl:
+      description: The URL on the Approved Premises service at which a user can view a representation of an appeal and related resources
+      type: string
+      example: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713/appeals/dd450bbc-162d-4380-a103-9f261943b98f
     BookingId:
       description: The UUID of booking for an AP place
       type: string
@@ -1127,6 +1163,72 @@ components:
         - reason
         - legacyReasonCode
         - destination
+    AssessmentAppealedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.assessment.appealed
+        eventDetails:
+          $ref: '#/components/schemas/AssessmentAppealed'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
+    AssessmentAppealed:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
+        appealId:
+          $ref: '#/components/schemas/AppealId'
+        appealUrl:
+          $ref: '#/components/schemas/AppealUrl'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        deliusEventNumber:
+          $ref: '#/components/schemas/DeliusEventNumber'
+        createdAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+        createdBy:
+          $ref: '#/components/schemas/StaffMember'
+        reviewer:
+          type: string
+        appealDetail:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+      required:
+        - applicationId
+        - applicationUrl
+        - appealId
+        - appealUrl
+        - personReference
+        - deliusEventNumber
+        - createdAt
+        - createdBy
+        - reviewer
+        - appealDetail
+        - decision
+        - decisionDetail
+    AppealDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
     Premises:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAppealedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAppealedFactory.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.util.UUID
+
+class AssessmentAppealedFactory : Factory<AssessmentAppealed> {
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var appealId: Yielded<UUID> = { UUID.randomUUID() }
+  private var appealUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
+  private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var createdAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
+  private var createdBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var reviewer: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var appealDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var decision: Yielded<AppealDecision> = { randomOf(AppealDecision.entries) }
+  private var decisionDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withApplicationUrl(applicationUrl: String) = apply {
+    this.applicationUrl = { applicationUrl }
+  }
+
+  fun withAppealId(appealId: UUID) = apply {
+    this.appealId = { appealId }
+  }
+
+  fun withAppealUrl(appealUrl: String) = apply {
+    this.appealUrl = { appealUrl }
+  }
+
+  fun withPersonReference(personReference: PersonReference) = apply {
+    this.personReference = { personReference }
+  }
+
+  fun withDeliusEventNumber(deliusEventNumber: String) = apply {
+    this.deliusEventNumber = { deliusEventNumber }
+  }
+
+  fun withCreatedAt(createdAt: Instant) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withCreatedBy(createdBy: StaffMember) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  fun withCreatedBy(configuration: StaffMemberFactory.() -> Unit) = apply {
+    this.createdBy = { StaffMemberFactory().apply(configuration).produce() }
+  }
+
+  fun withReviewer(reviewer: String) = apply {
+    this.reviewer = { reviewer }
+  }
+
+  fun withAppealDetail(appealDetail: String) = apply {
+    this.appealDetail = { appealDetail }
+  }
+
+  fun withDecision(decision: AppealDecision) = apply {
+    this.decision = { decision }
+  }
+
+  fun withDecisionDetail(decisionDetail: String) = apply {
+    this.decisionDetail = { decisionDetail }
+  }
+
+  override fun produce() = AssessmentAppealed(
+    applicationId = this.applicationId(),
+    applicationUrl = this.applicationUrl(),
+    appealId = this.appealId(),
+    appealUrl = this.appealUrl(),
+    personReference = this.personReference(),
+    deliusEventNumber = this.deliusEventNumber(),
+    createdAt = this.createdAt(),
+    createdBy = this.createdBy(),
+    reviewer = this.reviewer(),
+    appealDetail = this.appealDetail(),
+    decision = this.decision(),
+    decisionDetail = this.decisionDetail(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationSubmittedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationWithdrawnFactory
@@ -607,6 +609,63 @@ class DomainEventTest : IntegrationTestBase() {
       .expectStatus()
       .isOk
       .expectBody(ApplicationWithdrawnEnvelope::class.java)
+      .returnResult()
+
+    assertThat(response.responseBody).isEqualTo(envelopedData)
+  }
+
+  @Test
+  fun `Get Assessment Appealed Event without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/events/assessment-appealed/e4b004f8-bdb2-4bf6-9958-db602be71ed3")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get Assessment Appealed Event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+    )
+
+    webTestClient.get()
+      .uri("/events/assessment-appealed/e4b004f8-bdb2-4bf6-9958-db602be71ed3")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Get Assessment Appealed Event returns 200 with correct body`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
+    )
+
+    val eventId = UUID.randomUUID()
+
+    val envelopedData = AssessmentAppealedEnvelope(
+      id = eventId,
+      timestamp = Instant.now(),
+      eventType = "approved-premises.assessment.appealed",
+      eventDetails = AssessmentAppealedFactory().produce(),
+    )
+
+    val event = domainEventFactory.produceAndPersist {
+      withId(eventId)
+      withType(DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED)
+      withData(objectMapper.writeValueAsString(envelopedData))
+    }
+
+    val response = webTestClient.get()
+      .uri("/events/assessment-appealed/${event.id}")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(AssessmentAppealedEnvelope::class.java)
       .returnResult()
 
     assertThat(response.responseBody).isEqualTo(envelopedData)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -209,6 +209,7 @@ class ApplicationTimelineTransformerTest {
       DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED to TimelineEventType.approvedPremisesBookingCancelled,
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED to TimelineEventType.approvedPremisesBookingChanged,
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN to TimelineEventType.approvedPremisesApplicationWithdrawn,
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED to TimelineEventType.approvedPremisesAssessmentAppealed,
     )
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -134,6 +134,7 @@ url-templates:
       booking-cancelled-event-detail: http://api/events/booking-cancelled/#eventId
       booking-changed-event-detail: http://api/events/booking-changed/#eventId
       application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
+      assessment-appealed-event-detail: http://api/events/assessment-appealed/#eventId
     cas2:
       application-submitted-event-detail: http://api/events/cas2/application-submitted/#eventId
     cas3:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -151,6 +151,7 @@ url-templates:
       referral-submitted-event-detail: http://api/events/cas3/referral-submitted/#eventId
   frontend:
     application: http://frontend/applications/#id
+    application-appeal: http://frontend/applications/#applicationId/appeals/#appealId
     assessment: http://frontend/assessments/#id
     booking: http://frontend/premises/#premisesId/bookings/#bookingId
     cas2:


### PR DESCRIPTION
> See [APS-239 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-239).

This PR introduces the `approved-premises.assessment.appealed` domain event type and amends the logic for creating appeals to include this event.

The new domain event looks like this:
```json
{
  "id": "00000000-0000-0000-0000-000000000000",
  "applicationId": "00000000-0000-0000-0000-000000000000",
  "assessmentId": null,
  "bookingId": null,
  "crn": "X123456",
  "occurredAt": "2024-02-07T12:34:56.789Z",
  "data": {
    "id": "00000000-0000-0000-0000-000000000000",
    "timestamp": "2024-02-07T12:34:56.789Z",
    "eventType": "approved-premises.assessment.appealed",
    "eventDetails": {
      "applicationId": "00000000-0000-0000-0000-000000000000",
      "applicationUrl": "https://approved-premises-frontend/applications/00000000-0000-0000-0000-000000000000",
      "appealId": "00000000-0000-0000-0000-000000000000",
      "appealUrl": "https://approved-premises-frontend/applications/00000000-0000-0000-0000-000000000000/appeals/00000000-0000-0000-0000-000000000000",
      "personReference": {
        "crn": "X123456",
        "noms": "A9876BC"
      },
      "deliusEventNumber": "123",
      "createdAt": "2024-02-07T12:34:56.789Z",
      "createdBy": "Some User",
      "reviewer": "Someone Else",
      "appealDetail": "Some information about why the appeal was made",
      "decision": "accepted",
      "decisionDetail": "Some information about the decision made"
    }
  }
}
```

This event is saved to the database and emitted whenever a successful call to the `POST /applications/{applicationId}/appeals` endpoint is made (see #1426).
