### PR TITLE
Allow CAS1 Workflow Manager to withdraw apps

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -350,6 +350,7 @@ class ApprovedPremisesApplicationEntity(
 
   fun getLatestPlacementRequest(): PlacementRequestEntity? = this.placementRequests.maxByOrNull { it.createdAt }
   fun getLatestBooking(): BookingEntity? = getLatestPlacementRequest()?.booking
+  fun isSubmitted() = submittedAt != null
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -604,8 +604,8 @@ class ApplicationService(
     )
   }
 
-  fun isWithdrawable(application: ApplicationEntity, user: UserEntity) =
-    application.createdByUser == user
+  fun isWithdrawable(application: ApplicationEntity, user: UserEntity)
+    = userAccessService.userCanWithdrawApplication(user, application)
 
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {
     if (user.email != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -191,6 +191,11 @@ class UserAccessService(
 
     else -> false
   }
+
+  fun userCanWithdrawApplication(user: UserEntity, application: ApplicationEntity): Boolean = when (application) {
+    is ApprovedPremisesApplicationEntity -> application.createdByUser == user
+    else -> false
+  }
 }
 
 enum class ApprovedPremisesApplicationAccessLevel {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -193,7 +193,9 @@ class UserAccessService(
   }
 
   fun userCanWithdrawApplication(user: UserEntity, application: ApplicationEntity): Boolean = when (application) {
-    is ApprovedPremisesApplicationEntity -> application.createdByUser == user
+    is ApprovedPremisesApplicationEntity ->
+      application.createdByUser == user || (
+      application.isSubmitted() && user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER))
     else -> false
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3360,7 +3360,12 @@ class ApplicationTest : IntegrationTestBase() {
               withBooking(bookingWithArrival)
             }
 
-            val expected = listOf(
+            val expected = listOfNotNull(
+              if (role == UserRole.CAS1_WORKFLOW_MANAGER) Withdrawable(
+                application.id,
+                WithdrawableType.application,
+                emptyList(),
+              ) else null,
               Withdrawable(
                 booking1.id,
                 WithdrawableType.booking,
@@ -3414,6 +3419,11 @@ class ApplicationTest : IntegrationTestBase() {
             val placementRequest = produceAndPersistPlacementRequest(application)
 
             val expected = listOf(
+              Withdrawable(
+                application.id,
+                WithdrawableType.application,
+                emptyList(),
+              ),
               Withdrawable(
                 booking1.id,
                 WithdrawableType.booking,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1876,7 +1876,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `withdrawApprovedPremisesApplication returns Unauthorised if Application not created by user`() {
+  fun `withdrawApprovedPremisesApplication returns Unauthorised if user access service denies withdrawal`() {
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()
       .produce()
@@ -1890,6 +1890,7 @@ class ApplicationServiceTest {
       .produce()
 
     every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
+    every { mockUserAccessService.userCanWithdrawApplication(user, application) } returns false
 
     val result = applicationService.withdrawApprovedPremisesApplication(
       application.id,
@@ -1913,6 +1914,7 @@ class ApplicationServiceTest {
       .produce()
 
     every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
+    every { mockUserAccessService.userCanWithdrawApplication(user, application) } returns true
 
     val authorisableActionResult = applicationService.withdrawApprovedPremisesApplication(
       application.id,
@@ -1943,6 +1945,7 @@ class ApplicationServiceTest {
       .produce()
 
     every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
+    every { mockUserAccessService.userCanWithdrawApplication(user, application) } returns true
 
     val authorisableActionResult =
       applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", null)
@@ -1970,6 +1973,7 @@ class ApplicationServiceTest {
       .produce()
 
     every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
+    every { mockUserAccessService.userCanWithdrawApplication(user, application) } returns true
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
@@ -2045,6 +2049,7 @@ class ApplicationServiceTest {
       .produce()
 
     every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
+    every { mockUserAccessService.userCanWithdrawApplication(user, application) } returns true
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
@@ -2118,6 +2123,7 @@ class ApplicationServiceTest {
       .produce()
 
     every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
+    every { mockUserAccessService.userCanWithdrawApplication(user, application) } returns true
     every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -30,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REFERRER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
@@ -1513,6 +1515,47 @@ class UserAccessServiceTest {
         .produce()
 
       assertThat(userAccessService.userCanWithdrawApplication(user, application)).isFalse()
+    }
+
+    @Test
+    fun `userCanWithdrawApplication returns true if submitted and has CAS1_WORKFLOW_MANAGER role`() {
+      val workflowManager = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+
+      workflowManager.roles.add(
+        UserRoleAssignmentEntityFactory()
+          .withUser(user)
+          .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
+          .produce()
+      )
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
+        .produce()
+
+      assertThat(userAccessService.userCanWithdrawApplication(workflowManager, application)).isTrue()
+    }
+
+    @Test
+    fun `userCanWithdrawApplication returns false if not submitted and has CAS1_WORKFLOW_MANAGER role`() {
+      val workflowManager = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+
+      workflowManager.roles.add(
+        UserRoleAssignmentEntityFactory()
+          .withUser(user)
+          .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
+          .produce()
+      )
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      assertThat(userAccessService.userCanWithdrawApplication(workflowManager, application)).isFalse()
     }
 
     @Test


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-290

If an application is submitted, a workflow manager should be able to withdraw it. This commit updates the application withdrawal logic which will be automatically used when returning a list of withdrawables to the UI