### PR TITLE
Placement Requests withdrawals should cascade to Bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -10,6 +10,10 @@ import javax.persistence.Table
 
 @Repository
 interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity, UUID> {
+  companion object Constants {
+    val CAS1_WITHDRAWN_BY_PP_ID: UUID = UUID.fromString("d39572ea-9e42-460c-ae88-b6b30fca0b09")
+  }
+
   @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*'")
   fun findAllByServiceScope(serviceName: String): List<CancellationReasonEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
@@ -17,3 +17,10 @@ sealed interface ValidatableActionResult<EntityType> {
   data class GeneralValidationError<EntityType>(val message: String) : ValidatableActionResult<EntityType>
   data class ConflictError<EntityType>(val conflictingEntityId: UUID, val message: String) : ValidatableActionResult<EntityType>
 }
+
+fun extractMessage(validatableActionResult: ValidatableActionResult<*>): String? = when (validatableActionResult) {
+  is ValidatableActionResult.Success -> null
+  is ValidatableActionResult.FieldValidationError -> validatableActionResult.validationMessages.toString()
+  is ValidatableActionResult.GeneralValidationError -> validatableActionResult.message
+  is ValidatableActionResult.ConflictError -> validatableActionResult.message
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1194,8 +1194,9 @@ class BookingService(
     reasonId: UUID,
     notes: String?,
   ) = validated<CancellationEntity> {
-    if (booking.premises is ApprovedPremisesEntity && booking.cancellation != null) {
-      return generalError("This Booking already has a Cancellation set")
+    val existingCancellation = booking.cancellation
+    if (booking.premises is ApprovedPremisesEntity && existingCancellation != null) {
+      return success(existingCancellation)
     }
 
     val reason = cancellationReasonRepository.findByIdOrNull(reasonId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -287,6 +287,10 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
 
+    if(placementRequest.isWithdrawn) {
+      return AuthorisableActionResult.Success(Unit)
+    }
+
     if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.application.createdByUser != user) {
       return AuthorisableActionResult.Unauthorised()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Lazy
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocator
@@ -21,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository.Constants.CAS1_WITHDRAWN_BY_PP_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
@@ -38,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.extractMessage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
@@ -59,8 +64,11 @@ class PlacementRequestService(
   private val placementDateRepository: PlacementDateRepository,
   private val cancellationRepository: CancellationRepository,
   private val userAllocator: UserAllocator,
+  @Lazy private val bookingService: BookingService,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
 ) {
+
+  var log: Logger = LoggerFactory.getLogger(this::class.java)
 
   fun getVisiblePlacementRequestsForUser(
     user: UserEntity,
@@ -287,7 +295,7 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
 
-    if(placementRequest.isWithdrawn) {
+    if (placementRequest.isWithdrawn) {
       return AuthorisableActionResult.Success(Unit)
     }
 
@@ -299,6 +307,25 @@ class PlacementRequestService(
     placementRequest.withdrawalReason = reason
 
     placementRequestRepository.save(placementRequest)
+
+    placementRequest.booking?.let { booking ->
+      val bookingCancellationResult = bookingService.createCancellation(
+        user,
+        booking,
+        LocalDate.now(),
+        CAS1_WITHDRAWN_BY_PP_ID,
+        "Automatically withdrawn as placement request was withdrawn",
+      )
+
+      when (bookingCancellationResult) {
+        is ValidatableActionResult.Success -> Unit
+        else -> log.error(
+          "Failed to automatically withdraw booking ${booking.id} " +
+            "when withdrawing placement request ${placementRequest.id} " +
+            "with message ${extractMessage(bookingCancellationResult)}",
+        )
+      }
+    }
 
     return AuthorisableActionResult.Success(Unit)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -4,12 +4,12 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository.Constants.CAS1_WITHDRAWN_BY_PP_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Withdrawables
 import java.time.LocalDate
-import java.util.UUID
 
 @Service
 class WithdrawableService(
@@ -20,8 +20,6 @@ class WithdrawableService(
   @Lazy private val userAccessService: UserAccessService,
   @Lazy private val applicationService: ApplicationService,
 ) {
-  val approvedPremisesWithdrawnByPPBookingWithdrawnReasonId: UUID =
-    UUID.fromString("d39572ea-9e42-460c-ae88-b6b30fca0b09")
 
   fun allWithdrawables(
     application: ApprovedPremisesApplicationEntity,
@@ -71,7 +69,7 @@ class WithdrawableService(
         user,
         it,
         now,
-        approvedPremisesWithdrawnByPPBookingWithdrawnReasonId,
+        CAS1_WITHDRAWN_BY_PP_ID,
         "Automatically withdrawn as application was withdrawn",
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -89,12 +89,22 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.probationRegion = probationRegion
   }
 
+  fun withDefaultProbationRegion() = withYieldedProbationRegion {
+    ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+  }
+
   fun withLocalAuthorityArea(localAuthorityAreaEntity: LocalAuthorityAreaEntity) = apply {
     this.localAuthorityArea = { localAuthorityAreaEntity }
   }
 
   fun withYieldedLocalAuthorityArea(localAuthorityAreaEntity: Yielded<LocalAuthorityAreaEntity>) = apply {
     this.localAuthorityArea = localAuthorityAreaEntity
+  }
+
+  fun withDefaultLocalAuthorityArea() = withYieldedLocalAuthorityArea {
+    LocalAuthorityEntityFactory().produce()
   }
 
   fun withQCode(qCode: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -141,6 +141,13 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.premises = { premises }
   }
 
+  fun withDefaultPremises() = withPremises(
+    ApprovedPremisesEntityFactory()
+      .withDefaultProbationRegion()
+      .withDefaultLocalAuthorityArea()
+      .produce(),
+  )
+
   fun withServiceName(serviceName: ServiceName) = apply {
     this.serviceName = { serviceName }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2066,7 +2066,7 @@ class BookingServiceTest {
   }
 
   @Nested
-  inner class CreateCancellation {
+  inner class CreateCas1Cancellation {
     val premises = ApprovedPremisesEntityFactory()
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -2510,6 +2510,10 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
     }
+  }
+
+  @Nested
+  inner class CreateCas3Cancellation {
 
     @Test
     fun `createCancellation returns Success with correct result and emits a domain event for CAS3`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.Called
 import io.mockk.Runs
+import io.mockk.called
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -2077,7 +2078,7 @@ class BookingServiceTest {
       .produce()
 
     @Test
-    fun `createCancellation returns GeneralValidationError with correct message when Booking already has a Cancellation`() {
+    fun `createCancellation is idempotent if the booking is already cancelled`() {
       val bookingEntity = BookingEntityFactory()
         .withPremises(premises)
         .produce()
@@ -2097,8 +2098,11 @@ class BookingServiceTest {
         user = user,
       )
 
-      assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
-      assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("This Booking already has a Cancellation set")
+      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+      result as ValidatableActionResult.Success
+
+      assertThat(result.entity).isEqualTo(cancellationEntity)
+      verify { mockBookingRepository.save(any()) wasNot called }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequire
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
@@ -184,7 +185,7 @@ class WithdrawableServiceTest {
         user,
         any(),
         any(),
-        withdrawableService.approvedPremisesWithdrawnByPPBookingWithdrawnReasonId,
+        CancellationReasonRepository.CAS1_WITHDRAWN_BY_PP_ID,
         "Automatically withdrawn as application was withdrawn",
       )
     } returns mockk<ValidatableActionResult<CancellationEntity>>()
@@ -205,7 +206,7 @@ class WithdrawableServiceTest {
           user,
           it,
           LocalDate.now(),
-          withdrawableService.approvedPremisesWithdrawnByPPBookingWithdrawnReasonId,
+          CancellationReasonRepository.CAS1_WITHDRAWN_BY_PP_ID,
           "Automatically withdrawn as application was withdrawn",
         )
       }


### PR DESCRIPTION
This relates to the second bullet point on https://dsdmoj.atlassian.net/browse/APS-292

Most of the work on this PR is changing the placement request and booking withdrawal/cancellation endpoints to be idempotent to ensure that when withdrawals are cascaded (particularly via the Withdrawal service), we don't end up withdrawing the same entity multiple times (which would lead to multiple notifications)

