### PR TITLE
Placement requests with bookings can be withdrawn

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -172,7 +172,7 @@ data class PlacementRequestEntity(
   var withdrawalReason: PlacementRequestWithdrawalReason?,
 ) {
   fun canBeWithdrawn() =
-    reallocatedAt == null && !hasActiveBooking() && !isWithdrawn
+    reallocatedAt == null && !isWithdrawn
 
   fun hasActiveBooking() = booking != null && booking?.cancellations.isNullOrEmpty()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -604,8 +604,8 @@ class ApplicationService(
     )
   }
 
-  fun isWithdrawable(application: ApplicationEntity, user: UserEntity)
-    = userAccessService.userCanWithdrawApplication(user, application)
+  fun isWithdrawable(application: ApplicationEntity, user: UserEntity) =
+    userAccessService.userCanWithdrawApplication(user, application)
 
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {
     if (user.email != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -195,7 +195,8 @@ class UserAccessService(
   fun userCanWithdrawApplication(user: UserEntity, application: ApplicationEntity): Boolean = when (application) {
     is ApprovedPremisesApplicationEntity ->
       application.createdByUser == user || (
-      application.isSubmitted() && user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER))
+        application.isSubmitted() && user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+        )
     else -> false
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3153,7 +3153,7 @@ class ApplicationTest : IntegrationTestBase() {
               withReallocatedAt(OffsetDateTime.now())
             }
 
-            produceAndPersistPlacementRequest(application) {
+            val placementRequestWithBooking = produceAndPersistPlacementRequest(application) {
               val premises = approvedPremisesEntityFactory.produceAndPersist {
                 withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
                 withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
@@ -3164,28 +3164,6 @@ class ApplicationTest : IntegrationTestBase() {
                   withPremises(premises)
                 },
               )
-            }
-
-            val cancelledBooking = bookingEntityFactory.produceAndPersist {
-              withPremises(
-                approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegionEntityFactory.produceAndPersist {
-                      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-                    }
-                  }
-                },
-              )
-              withArrivalDate(LocalDate.parse("2023-03-08"))
-              withDepartureDate(LocalDate.parse("2023-03-10"))
-            }
-            cancellationEntityFactory.produceAndPersist {
-              withBooking(cancelledBooking)
-              withReason(cancellationReasonEntityFactory.produceAndPersist())
-            }
-            val placementRequestWithBookingsAllCancelled = produceAndPersistPlacementRequest(application) {
-              withBooking(cancelledBooking)
             }
 
             produceAndPersistPlacementRequest(application) {
@@ -3204,9 +3182,9 @@ class ApplicationTest : IntegrationTestBase() {
                 listOf(datePeriodForDuration(placementRequest2.expectedArrival, placementRequest2.duration)),
               ),
               Withdrawable(
-                placementRequestWithBookingsAllCancelled.id,
+                placementRequestWithBooking.id,
                 WithdrawableType.placementRequest,
-                listOf(datePeriodForDuration(placementRequestWithBookingsAllCancelled.expectedArrival, placementRequestWithBookingsAllCancelled.duration)),
+                listOf(datePeriodForDuration(placementRequestWithBooking.expectedArrival, placementRequestWithBooking.duration)),
               ),
             )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3361,11 +3361,15 @@ class ApplicationTest : IntegrationTestBase() {
             }
 
             val expected = listOfNotNull(
-              if (role == UserRole.CAS1_WORKFLOW_MANAGER) Withdrawable(
-                application.id,
-                WithdrawableType.application,
-                emptyList(),
-              ) else null,
+              if (role == UserRole.CAS1_WORKFLOW_MANAGER) {
+                Withdrawable(
+                  application.id,
+                  WithdrawableType.application,
+                  emptyList(),
+                )
+              } else {
+                null
+              },
               Withdrawable(
                 booking1.id,
                 WithdrawableType.booking,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1695,6 +1695,5 @@ class PlacementRequestsTest : IntegrationTestBase() {
         }
       }
     }
-
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -597,7 +597,7 @@ class PlacementRequestServiceTest {
     }
 
     @Test
-    fun `getWithdrawablePlacementRequests doesn't return placement requests with bookings`() {
+    fun `getWithdrawablePlacementRequests returns placement requests with bookings`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
         .produce()
@@ -606,16 +606,16 @@ class PlacementRequestServiceTest {
         .withUnitTestControlProbationRegion()
         .produce()
 
-      val placementRequestWithdrawable = createValidPlacementRequest(application, user)
+      val placementRequestWithoutBooking = createValidPlacementRequest(application, user)
 
       val placementRequestWithBooking = createValidPlacementRequest(application, user)
       placementRequestWithBooking.booking = BookingEntityFactory().withDefaultPremises().produce()
 
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestWithBooking)
+      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithoutBooking, placementRequestWithBooking)
 
       val result = placementRequestService.getWithdrawablePlacementRequests(application)
 
-      assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
+      assertThat(result).isEqualTo(listOf(placementRequestWithoutBooking, placementRequestWithBooking))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -68,6 +68,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class PlacementRequestServiceTest {
@@ -549,6 +550,76 @@ class PlacementRequestServiceTest {
   }
 
   @Nested
+  inner class GetWithdrawablePlacementRequests {
+
+    @Test
+    fun `getWithdrawablePlacementRequests doesn't return reallocated placement requests`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
+        .produce()
+
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val placementRequestWithdrawable = createValidPlacementRequest(application, user)
+
+      val placementRequestReallocated = createValidPlacementRequest(application, user)
+      placementRequestReallocated.reallocatedAt = OffsetDateTime.now()
+
+      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestReallocated)
+
+      val result = placementRequestService.getWithdrawablePlacementRequests(application)
+
+      assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
+    }
+
+    @Test
+    fun `getWithdrawablePlacementRequests doesn't return withdrawn placement requests`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
+        .produce()
+
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val placementRequestWithdrawable = createValidPlacementRequest(application, user)
+
+      val placementRequestWithdrawn = createValidPlacementRequest(application, user)
+      placementRequestWithdrawn.isWithdrawn = true
+
+      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestWithdrawn)
+
+      val result = placementRequestService.getWithdrawablePlacementRequests(application)
+
+      assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
+    }
+
+    @Test
+    fun `getWithdrawablePlacementRequests doesn't return placement requests with bookings`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
+        .produce()
+
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val placementRequestWithdrawable = createValidPlacementRequest(application, user)
+
+      val placementRequestWithBooking = createValidPlacementRequest(application, user)
+      placementRequestWithBooking.booking = BookingEntityFactory().withDefaultPremises().produce()
+
+      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestWithBooking)
+
+      val result = placementRequestService.getWithdrawablePlacementRequests(application)
+
+      assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
+    }
+  }
+
+  @Nested
   inner class WithdrawPlacementRequest {
 
     @Test
@@ -787,33 +858,6 @@ class PlacementRequestServiceTest {
             "booking cancellation didn't work!",
         )
       }
-    }
-
-    private fun createValidPlacementRequest(
-      application: ApprovedPremisesApplicationEntity,
-      user: UserEntity,
-    ): PlacementRequestEntity {
-      val placementRequestId = UUID.fromString("49f3eef9-4770-4f00-8f31-8e6f4cb4fd9e")
-
-      val assessment = ApprovedPremisesAssessmentEntityFactory()
-        .withApplication(application)
-        .withAllocatedToUser(user)
-        .produce()
-
-      val placementRequest = PlacementRequestEntityFactory()
-        .withId(placementRequestId)
-        .withPlacementRequirements(
-          PlacementRequirementsEntityFactory()
-            .withApplication(application)
-            .withAssessment(assessment)
-            .produce(),
-        )
-        .withApplication(application)
-        .withAssessment(assessment)
-        .withAllocatedToUser(assigneeUser)
-        .produce()
-
-      return placementRequest
     }
   }
 
@@ -1073,5 +1117,32 @@ class PlacementRequestServiceTest {
         }
         .produce()
     }
+  }
+
+  private fun createValidPlacementRequest(
+    application: ApprovedPremisesApplicationEntity,
+    user: UserEntity,
+  ): PlacementRequestEntity {
+    val placementRequestId = UUID.fromString("49f3eef9-4770-4f00-8f31-8e6f4cb4fd9e")
+
+    val assessment = ApprovedPremisesAssessmentEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(user)
+      .produce()
+
+    val placementRequest = PlacementRequestEntityFactory()
+      .withId(placementRequestId)
+      .withPlacementRequirements(
+        PlacementRequirementsEntityFactory()
+          .withApplication(application)
+          .withAssessment(assessment)
+          .produce(),
+      )
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withAllocatedToUser(assigneeUser)
+      .produce()
+
+    return placementRequest
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -3,13 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -1527,7 +1525,7 @@ class UserAccessServiceTest {
         UserRoleAssignmentEntityFactory()
           .withUser(user)
           .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
-          .produce()
+          .produce(),
       )
 
       val application = ApprovedPremisesApplicationEntityFactory()
@@ -1548,7 +1546,7 @@ class UserAccessServiceTest {
         UserRoleAssignmentEntityFactory()
           .withUser(user)
           .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
-          .produce()
+          .produce(),
       )
 
       val application = ApprovedPremisesApplicationEntityFactory()


### PR DESCRIPTION
Relates to bullet point 1 on https://dsdmoj.atlassian.net/browse/APS-292

A placement request with a booking can be withdrawn, and with prioir changes this will automatically cascade to bookings.