### PR TITLE
Applicants shouldn't be able to withdraw bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -524,7 +524,7 @@ class PremisesController(
 
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
-    if (!userAccessService.currentUserCanManagePremisesBookings(booking.premises)) {
+    if (!userAccessService.userCanCancelBooking(user, booking)) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1192,8 +1192,10 @@ class BookingService(
     else -> throw RuntimeException("Unknown premises type ${booking.premises::class.qualifiedName}")
   }
 
-  fun getCancelleableBookings(application: ApprovedPremisesApplicationEntity): List<BookingEntity> =
-    bookingRepository.findAllByApplication(application).filter { isCancellableCas1(it) }
+  fun getCancelleableCas1Bookings(user: UserEntity, application: ApprovedPremisesApplicationEntity): List<BookingEntity> =
+    bookingRepository.findAllByApplication(application).filter { booking ->
+      isCancellableCas1(booking) && userAccessService.userCanCancelBooking(user, booking)
+    }
 
   private fun isCancellableCas1(booking: BookingEntity) = (booking.cancellation == null) && (booking.arrivals.isEmpty())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1192,12 +1192,13 @@ class BookingService(
     else -> throw RuntimeException("Unknown premises type ${booking.premises::class.qualifiedName}")
   }
 
-  fun getCancelleableCas1Bookings(user: UserEntity, application: ApprovedPremisesApplicationEntity): List<BookingEntity> =
+  fun getCancelleableCas1BookingsForUser(user: UserEntity, application: ApprovedPremisesApplicationEntity): List<BookingEntity> =
     bookingRepository.findAllByApplication(application).filter { booking ->
-      isCancellableCas1(booking) && userAccessService.userCanCancelBooking(user, booking)
+      isInCancellableStateCas1(booking) && userAccessService.userCanCancelBooking(user, booking)
     }
 
-  private fun isCancellableCas1(booking: BookingEntity) = (booking.cancellation == null) && (booking.arrivals.isEmpty())
+  private fun isInCancellableStateCas1(booking: BookingEntity)
+    = (booking.cancellation == null) && (booking.arrivals.isEmpty())
 
   private fun createCas1Cancellation(
     user: UserEntity?,
@@ -1209,6 +1210,10 @@ class BookingService(
     val existingCancellation = booking.cancellation
     if (booking.premises is ApprovedPremisesEntity && existingCancellation != null) {
       return success(existingCancellation)
+    }
+
+    if(!isInCancellableStateCas1(booking)) {
+      return generalError("The Booking is not in a state that can be cancelled")
     }
 
     val reason = cancellationReasonRepository.findByIdOrNull(reasonId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -78,7 +78,7 @@ class UserAccessService(
   }
 
   fun userCanCancelBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
-    is ApprovedPremisesEntity -> userCanManagePremisesBookings(user, booking.premises) || booking.application?.createdByUser == user
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER) || booking.application?.createdByUser == user
     is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
     else -> false
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -78,7 +78,7 @@ class UserAccessService(
   }
 
   fun userCanCancelBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER) || booking.application?.createdByUser == user
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER)
     is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
     else -> false
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -17,14 +17,12 @@ class WithdrawableService(
   @Lazy private val placementRequestService: PlacementRequestService,
   @Lazy private val bookingService: BookingService,
   @Lazy private val placementApplicationService: PlacementApplicationService,
-  @Lazy private val userAccessService: UserAccessService,
   @Lazy private val applicationService: ApplicationService,
 ) {
 
   fun allWithdrawables(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
-    onlyUserManageableBookings: Boolean = true,
   ): Withdrawables {
     val placementRequests = placementRequestService.getWithdrawablePlacementRequests(application)
     val bookings = bookingService.getCancelleableCas1BookingsForUser(user, application)
@@ -33,7 +31,7 @@ class WithdrawableService(
     return Withdrawables(
       applicationService.isWithdrawable(application, user),
       placementRequests = placementRequests,
-      bookings = if (onlyUserManageableBookings) { onlyUserManageable(bookings) } else { bookings },
+      bookings = bookings,
       placementApplications = placementApplications,
     )
   }
@@ -45,7 +43,6 @@ class WithdrawableService(
     val withdrawables = allWithdrawables(
       application,
       user,
-      onlyUserManageableBookings = false,
     )
 
     withdrawables.placementApplications.forEach {
@@ -74,7 +71,4 @@ class WithdrawableService(
       )
     }
   }
-
-  private fun onlyUserManageable(bookings: List<BookingEntity>) =
-    bookings.filter { userAccessService.currentUserCanManagePremisesBookings(it.premises) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -27,7 +27,7 @@ class WithdrawableService(
     onlyUserManageableBookings: Boolean = true,
   ): Withdrawables {
     val placementRequests = placementRequestService.getWithdrawablePlacementRequests(application)
-    val bookings = bookingService.getCancelleableCas1Bookings(user, application)
+    val bookings = bookingService.getCancelleableCas1BookingsForUser(user, application)
     val placementApplications = placementApplicationService.getWithdrawablePlacementApplications(application)
 
     return Withdrawables(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -27,7 +27,7 @@ class WithdrawableService(
     onlyUserManageableBookings: Boolean = true,
   ): Withdrawables {
     val placementRequests = placementRequestService.getWithdrawablePlacementRequests(application)
-    val bookings = bookingService.getCancelleableBookings(application)
+    val bookings = bookingService.getCancelleableCas1Bookings(user, application)
     val placementApplications = placementApplicationService.getWithdrawablePlacementApplications(application)
 
     return Withdrawables(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -85,26 +85,24 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.probationRegion = { probationRegion }
   }
 
+  fun withDefaultProbationRegion() = withProbationRegion(
+    ProbationRegionEntityFactory()
+      .withDefaultApArea()
+      .produce(),
+  )
+
   fun withYieldedProbationRegion(probationRegion: Yielded<ProbationRegionEntity>) = apply {
     this.probationRegion = probationRegion
-  }
-
-  fun withDefaultProbationRegion() = withYieldedProbationRegion {
-    ProbationRegionEntityFactory()
-      .withYieldedApArea { ApAreaEntityFactory().produce() }
-      .produce()
   }
 
   fun withLocalAuthorityArea(localAuthorityAreaEntity: LocalAuthorityAreaEntity) = apply {
     this.localAuthorityArea = { localAuthorityAreaEntity }
   }
 
+  fun withDefaultLocalAuthorityArea() = withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+
   fun withYieldedLocalAuthorityArea(localAuthorityAreaEntity: Yielded<LocalAuthorityAreaEntity>) = apply {
     this.localAuthorityArea = localAuthorityAreaEntity
-  }
-
-  fun withDefaultLocalAuthorityArea() = withYieldedLocalAuthorityArea {
-    LocalAuthorityEntityFactory().produce()
   }
 
   fun withQCode(qCode: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -36,6 +36,8 @@ class CancellationEntityFactory : Factory<CancellationEntity> {
     this.reason = { reason }
   }
 
+  fun withDefaultReason() = withReason(CancellationReasonEntityFactory().produce())
+
   fun withNotes(notes: String) = apply {
     this.notes = { notes }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
@@ -29,6 +29,10 @@ class ProbationRegionEntityFactory : Factory<ProbationRegionEntity> {
     this.apArea = { apArea }
   }
 
+  fun withDefaultApArea() = withApArea(
+    ApAreaEntityFactory().produce(),
+  )
+
   fun withDeliusCode(deliusCode: String) = apply {
     this.deliusCode = { deliusCode }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3049,23 +3049,6 @@ class ApplicationTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           val (application, assessment) = produceAndPersistApplicationAndAssessment(user, user, offenderDetails)
 
-          val booking1ExpectedArrival = LocalDate.now().plusDays(1)
-          val booking1ExpectedDeparture = LocalDate.now().plusDays(6)
-          val booking1 = produceAndPersistBooking(
-            application,
-            booking1ExpectedArrival,
-            booking1ExpectedDeparture,
-          )
-
-          val bookingWithArrival = produceAndPersistBooking(
-            application,
-            LocalDate.now(),
-            LocalDate.now().plusDays(1),
-          )
-          arrivalEntityFactory.produceAndPersist() {
-            withBooking(bookingWithArrival)
-          }
-
           val placementApplicationExpectedArrival = LocalDate.now().plusDays(1)
           val placementApplicationDuration = 5
 
@@ -3074,7 +3057,29 @@ class ApplicationTest : IntegrationTestBase() {
             listOf(placementApplicationExpectedArrival to placementApplicationDuration),
           )
 
-          val placementRequest = produceAndPersistPlacementRequest(application)
+          val placementRequest1 = produceAndPersistPlacementRequest(application)
+
+          val booking1NoArrival = produceAndPersistBooking(
+            application,
+            startDate = LocalDate.now().plusDays(1),
+            endDate = LocalDate.now().plusDays(6),
+          )
+
+          placementRequest1.booking = booking1NoArrival
+          placementRequestRepository.save(placementRequest1)
+
+          val placementRequest2 = produceAndPersistPlacementRequest(application)
+          val booking2HasArrival = produceAndPersistBooking(
+            application,
+            LocalDate.now(),
+            LocalDate.now().plusDays(1),
+          )
+          arrivalEntityFactory.produceAndPersist {
+            withBooking(booking2HasArrival)
+          }
+
+          placementRequest2.booking = booking2HasArrival
+          placementRequestRepository.save(placementRequest2)
 
           webTestClient.post()
             .uri("/applications/${application.id}/withdrawal")
@@ -3094,20 +3099,23 @@ class ApplicationTest : IntegrationTestBase() {
           val updatedAssessment = approvedPremisesAssessmentRepository.findByIdOrNull(assessment.id)!!
           assertThat(updatedAssessment.isWithdrawn).isTrue
 
-          val updatedBooking = bookingRepository.findByIdOrNull(booking1.id)!!
-          val cancellation = updatedBooking.cancellation
-          assertThat(cancellation).isNotNull
-          assertThat(cancellation!!.reason.name).isEqualTo("The probation practitioner requested it")
-
-          val updatedBookingWithArrival = bookingRepository.findByIdOrNull(bookingWithArrival.id)!!
-          assertThat(updatedBookingWithArrival.cancellation).isNull()
-
           val updatedPlacementApplication = placementApplicationRepository.findByIdOrNull(placementApplication.id)!!
           assertThat(updatedPlacementApplication.decision).isEqualTo(PlacementApplicationDecision.WITHDRAWN_BY_PP)
 
-          val updatedPlacementRequest = placementRequestRepository.findByIdOrNull(placementRequest.id)!!
-          assertThat(updatedPlacementRequest.isWithdrawn).isEqualTo(true)
-          assertThat(updatedPlacementRequest.withdrawalReason).isEqualTo(PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+          val updatedPlacementRequest1 = placementRequestRepository.findByIdOrNull(placementRequest1.id)!!
+          assertThat(updatedPlacementRequest1.isWithdrawn).isEqualTo(true)
+          assertThat(updatedPlacementRequest1.withdrawalReason).isEqualTo(PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+
+          val updatedPlacementRequest2 = placementRequestRepository.findByIdOrNull(placementRequest2.id)!!
+          assertThat(updatedPlacementRequest2.isWithdrawn).isEqualTo(true)
+          assertThat(updatedPlacementRequest2.withdrawalReason).isEqualTo(PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+
+          val updatedBooking1 = bookingRepository.findByIdOrNull(booking1NoArrival.id)!!
+          assertThat(updatedBooking1.isCancelled).isTrue()
+          assertThat(updatedBooking1.cancellation!!.reason.name).isEqualTo("The probation practitioner requested it")
+
+          val updatedBooking2WithArrival = bookingRepository.findByIdOrNull(booking2HasArrival.id)!!
+          assertThat(updatedBooking2WithArrival.isCancelled).isFalse()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3321,7 +3321,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_WORKFLOW_MANAGER"])
     fun `Get withdrawables for an application returns withdrawable bookings when a user can manage bookings`(role: UserRole) {
       `Given a User` { applicant, _ ->
         `Given a User`(roles = listOf(role)) { allocatedTo, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -2765,9 +2765,9 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-  fun `Create Cancellation on Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
-    `Given a User`(roles = listOf(role)) { userEntity, jwt ->
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_WORKFLOW_MANAGER"])
+  fun `Create Cancellation on Booking returns OK with correct body when user has one of roles MANAGER, WORKFLOW_MANAGER`(role: UserRole) {
+    `Given a User`(roles = listOf(role)) { _, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
         withYieldedPremises {
           approvedPremisesEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -5751,6 +5751,94 @@ class BookingServiceTest {
   }
 
   @Nested
+  inner class GetCancellableCas1Bookings {
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withDefaultProbationRegion()
+      .withDefaultLocalAuthorityArea()
+      .produce()
+
+    val cancellableBooking = BookingEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    @Test
+    fun `getCancellableCas1Bookings returns cancellable bookings`() {
+      every { mockUserAccessService.userCanCancelBooking(user, any()) } returns true
+      every { mockBookingRepository.findAllByApplication(application) } returns listOf(cancellableBooking)
+
+      val result = bookingService.getCancelleableCas1Bookings(user, application)
+
+      assertThat(result).isEqualTo(listOf(cancellableBooking))
+    }
+
+    @Test
+    fun `getCancellableCas1Bookings doesn't return cancelled bookings`() {
+      val cancelledBooking = BookingEntityFactory()
+        .withPremises(premises)
+        .produce()
+
+      cancelledBooking.cancellations.add(
+        CancellationEntityFactory()
+          .withBooking(cancelledBooking)
+          .withDefaultReason()
+          .produce(),
+      )
+
+      every { mockUserAccessService.userCanCancelBooking(user, any()) } returns true
+      every { mockBookingRepository.findAllByApplication(application) } returns listOf(cancellableBooking, cancelledBooking)
+
+      val result = bookingService.getCancelleableCas1Bookings(user, application)
+
+      assertThat(result).isEqualTo(listOf(cancellableBooking))
+    }
+
+    @Test
+    fun `getCancellableCas1Bookings doesn't return bookings with arrivals`() {
+      val bookingWithArrival = BookingEntityFactory()
+        .withPremises(premises)
+        .produce()
+
+      bookingWithArrival.arrivals.add(
+        ArrivalEntityFactory()
+          .withBooking(bookingWithArrival)
+          .produce(),
+      )
+
+      every { mockUserAccessService.userCanCancelBooking(user, any()) } returns true
+      every { mockBookingRepository.findAllByApplication(application) } returns listOf(cancellableBooking, bookingWithArrival)
+
+      val result = bookingService.getCancelleableCas1Bookings(user, application)
+
+      assertThat(result).isEqualTo(listOf(cancellableBooking))
+    }
+
+    @Test
+    fun `getCancellableCas1Bookings doesn't return bookings if user can't cancel them`() {
+      val bookingUserCantCancel = BookingEntityFactory()
+        .withPremises(premises)
+        .produce()
+
+      every { mockUserAccessService.userCanCancelBooking(user, cancellableBooking) } returns true
+      every { mockUserAccessService.userCanCancelBooking(user, bookingUserCantCancel) } returns false
+      every { mockBookingRepository.findAllByApplication(application) } returns listOf(cancellableBooking, bookingUserCantCancel)
+
+      val result = bookingService.getCancelleableCas1Bookings(user, application)
+
+      assertThat(result).isEqualTo(listOf(cancellableBooking))
+    }
+  }
+
+  @Nested
   inner class MoveBooking {
     val user = UserEntityFactory()
       .withUnitTestControlProbationRegion()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -526,15 +526,6 @@ class UserAccessServiceTest {
     }
 
     @Test
-    fun `userCanCancelBooking returns true if the given premises is a CAS1 premises and the user created the application`() {
-      currentRequestIsFor(ServiceName.approvedPremises)
-
-      val application = ApprovedPremisesApplicationEntityFactory().withCreatedByUser(user).produce()
-
-      assertThat(userAccessService.userCanCancelBooking(user, cas1Booking.copy(application = application))).isTrue
-    }
-
-    @Test
     fun `userCanCancelBooking returns false if the given premises is a CAS1 premises and the user has no suitable role`() {
       currentRequestIsFor(ServiceName.approvedPremises)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -512,15 +512,17 @@ class UserAccessServiceTest {
       .produce()
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
-    fun `userCanCancelBooking returns true if the given premises is a CAS1 premises and the user has either the MANAGER or MATCHER user role`(
+    @EnumSource(value = UserRole::class)
+    fun `userCanCancelBooking returns true if the given premises is a CAS1 premises and the user has either the MANAGER or CAS1_WORKFLOW_MANAGER user role`(
       role: UserRole,
     ) {
       currentRequestIsFor(ServiceName.approvedPremises)
 
       user.addRoleForUnitTest(role)
 
-      assertThat(userAccessService.userCanCancelBooking(user, cas1Booking)).isTrue
+      val canCancelBooking = listOf(UserRole.CAS1_MANAGER,UserRole.CAS1_WORKFLOW_MANAGER).contains(role)
+
+      assertThat(userAccessService.userCanCancelBooking(user, cas1Booking)).isEqualTo(canCancelBooking)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
 import java.time.LocalDate
 
@@ -38,14 +37,12 @@ class WithdrawableServiceTest {
   private val mockPlacementRequestService = mockk<PlacementRequestService>()
   private val mockBookingService = mockk<BookingService>()
   private val mockPlacementApplicationService = mockk<PlacementApplicationService>()
-  private val mockUserAccessService = mockk<UserAccessService>()
   private val mockApplicationService = mockk<ApplicationService>()
 
   private val withdrawableService = WithdrawableService(
     mockPlacementRequestService,
     mockBookingService,
     mockPlacementApplicationService,
-    mockUserAccessService,
     mockApplicationService,
   )
 
@@ -116,69 +113,26 @@ class WithdrawableServiceTest {
   @Test
   fun `allWithdrawables returns all withdrawable information`() {
     every { mockApplicationService.isWithdrawable(application, user) } returns true
-    every { mockUserAccessService.currentUserCanManagePremisesBookings(any()) } returns true
     val result = withdrawableService.allWithdrawables(application, user)
 
     assertThat(result.application).isEqualTo(true)
     assertThat(result.bookings).isEqualTo(bookings)
     assertThat(result.placementRequests).isEqualTo(placementRequests)
     assertThat(result.placementApplications).isEqualTo(placementApplications)
-
-    bookings.forEach {
-      verify(exactly = 1) {
-        mockUserAccessService.currentUserCanManagePremisesBookings(it.premises)
-      }
-    }
   }
 
   @ParameterizedTest
   @ValueSource(booleans = [true, false])
   fun `allWithdrawables returns if application can't be withdrawn`(canBeWithdrawn: Boolean) {
     every { mockApplicationService.isWithdrawable(application, user) } returns canBeWithdrawn
-    every { mockUserAccessService.currentUserCanManagePremisesBookings(any()) } returns true
     val result = withdrawableService.allWithdrawables(application, user)
 
     assertThat(result.application).isEqualTo(canBeWithdrawn)
   }
 
   @Test
-  fun `allWithdrawables filters out bookings that the user cannot manage by default`() {
-    every { mockApplicationService.isWithdrawable(application, user) } returns true
-    every { mockUserAccessService.currentUserCanManagePremisesBookings(bookings[0].premises) } returns true
-    every { mockUserAccessService.currentUserCanManagePremisesBookings(bookings[1].premises) } returns false
-    every { mockUserAccessService.currentUserCanManagePremisesBookings(bookings[2].premises) } returns false
-
-    val result = withdrawableService.allWithdrawables(application, user)
-
-    assertThat(result.bookings).isEqualTo(listOf(bookings[0]))
-    assertThat(result.placementRequests).isEqualTo(placementRequests)
-    assertThat(result.placementApplications).isEqualTo(placementApplications)
-
-    bookings.forEach {
-      verify(exactly = 1) {
-        mockUserAccessService.currentUserCanManagePremisesBookings(it.premises)
-      }
-    }
-  }
-
-  @Test
-  fun `allWithdrawables doesnt filter out bookings when onlyUserManageableBookings is false`() {
-    every { mockApplicationService.isWithdrawable(application, user) } returns true
-    val result = withdrawableService.allWithdrawables(application, user, false)
-
-    assertThat(result.bookings).isEqualTo(bookings)
-    assertThat(result.placementRequests).isEqualTo(placementRequests)
-    assertThat(result.placementApplications).isEqualTo(placementApplications)
-
-    verify(exactly = 0) {
-      mockUserAccessService.currentUserCanManagePremisesBookings(any())
-    }
-  }
-
-  @Test
   fun `withdrawAllForApplication withdraws all withdrawable entities`() {
     every { mockApplicationService.isWithdrawable(application, user) } returns true
-    every { mockUserAccessService.currentUserCanManagePremisesBookings(any()) } returns true
 
     every {
       mockBookingService.createCancellation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -109,7 +109,7 @@ class WithdrawableServiceTest {
       mockPlacementApplicationService.getWithdrawablePlacementApplications(application)
     } returns placementApplications
     every {
-      mockBookingService.getCancelleableBookings(application)
+      mockBookingService.getCancelleableCas1Bookings(user, application)
     } returns bookings
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -109,7 +109,7 @@ class WithdrawableServiceTest {
       mockPlacementApplicationService.getWithdrawablePlacementApplications(application)
     } returns placementApplications
     every {
-      mockBookingService.getCancelleableCas1Bookings(user, application)
+      mockBookingService.getCancelleableCas1BookingsForUser(user, application)
     } returns bookings
   }
 


### PR DESCRIPTION
Note - A majority of the change to stop applicants being able to remove bookings was already implemented via commit 0f15943e. But, additional changes were required for APS-294 specifically:

* Removing some permissions removal not captured by 0f15943e
* Removing some complexity in withdrawables service that is no longer required because withdrawals cascade from placement requests to bookings (i.e. an applicant withdrawing a placement request or 'parent' entity is sufficient for it to cascade down to a booking)
* Updating integration tests to ensure cascades happen from placement request to booking for applicants