### PR TITLE
Allow Nomis users to add a Note to CAS2 Applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -59,6 +59,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
+        authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasRole("POM"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -5,12 +5,15 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.zalando.problem.AbstractThrowableProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.SubmissionsCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
@@ -22,20 +25,26 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationNotesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getFullInfoForPersonOrThrow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getInfoForPersonOrThrowInternalServerError
+import java.net.URI
 import java.util.UUID
+import javax.persistence.metamodel.EntityType
 
 @Service("Cas2SubmissionsController")
 class SubmissionsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
+  private val applicationNoteService: ApplicationNoteService,
   private val applicationTransformer: SubmittedApplicationTransformer,
+  private val applicationNotesTransformer: ApplicationNotesTransformer,
   private val offenderService: OffenderService,
   private val externalUserService: ExternalUserService,
   private val nomisUserService: NomisUserService,
@@ -120,9 +129,23 @@ class SubmissionsController(
     return ResponseEntity(HttpStatus.CREATED)
   }
 
-  private fun processAuthorisationFor(
+  override fun submissionsApplicationIdNotesPost(applicationId: UUID, body: NewCas2ApplicationNote): ResponseEntity<Cas2ApplicationNote> {
+    val noteResult = applicationNoteService.createApplicationNote(applicationId, body)
+
+    val validationResult = processAuthorisationFor(applicationId, noteResult) as ValidatableActionResult<Cas2ApplicationNote>
+
+    val note = processValidation(validationResult) as Cas2ApplicationNoteEntity
+
+    return ResponseEntity
+      .created(URI.create("/cas2/applications/$applicationId/notes/${note.id}"))
+      .body(
+        applicationNotesTransformer.transformJpaToApi(note),
+      )
+  }
+
+  private fun <EntityType> processAuthorisationFor(
     applicationId: UUID,
-    result: AuthorisableActionResult<ValidatableActionResult<Cas2StatusUpdateEntity>>,
+    result: AuthorisableActionResult<ValidatableActionResult<EntityType>>,
   ): Any {
     return when (result) {
       is AuthorisableActionResult.NotFound -> throwProblem(NotFoundProblem(applicationId, "Cas2Application"))
@@ -131,12 +154,12 @@ class SubmissionsController(
     }
   }
 
-  private fun processValidation(validationResult: ValidatableActionResult<Cas2StatusUpdateEntity>) {
+  private fun <EntityType : Any> processValidation(validationResult: ValidatableActionResult<EntityType>): Any {
     return when (validationResult) {
       is ValidatableActionResult.GeneralValidationError -> throwProblem(BadRequestProblem(errorDetail = validationResult.message))
       is ValidatableActionResult.FieldValidationError -> throwProblem(BadRequestProblem(invalidParams = validationResult.validationMessages))
       is ValidatableActionResult.ConflictError -> throwProblem(ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message))
-      is ValidatableActionResult.Success -> Unit
+      is ValidatableActionResult.Success -> validationResult.entity
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -102,6 +102,10 @@ data class Cas2ApplicationEntity(
   @OrderBy(clause = "createdAt DESC")
   var statusUpdates: MutableList<Cas2StatusUpdateEntity>? = null,
 
+  @OneToMany(mappedBy = "application")
+  @OrderBy(clause = "createdAt DESC")
+  var notes: MutableList<Cas2ApplicationNoteEntity>? = null,
+
   @Transient
   var schemaUpToDate: Boolean,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface Cas2ApplicationNoteRepository : JpaRepository<Cas2ApplicationNoteEntity, UUID>
+
+@Entity
+@Table(name = "cas_2_application_notes")
+data class Cas2ApplicationNoteEntity(
+  @Id
+  val id: UUID,
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_nomis_user_id")
+  val createdByNomisUser: NomisUserEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "application_id")
+  val application: Cas2ApplicationEntity,
+
+  val createdAt: OffsetDateTime,
+
+  var body: String,
+) {
+  override fun toString() = "Cas2ApplicationNoteEntity: $id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationNoteService.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service("Cas2ApplicationNoteService")
+class ApplicationNoteService(
+  private val applicationRepository: Cas2ApplicationRepository,
+  private val applicationNoteRepository: Cas2ApplicationNoteRepository,
+  private val userService: NomisUserService,
+) {
+
+  fun createApplicationNote(applicationId: UUID, note: NewCas2ApplicationNote):
+    AuthorisableActionResult<ValidatableActionResult<Cas2ApplicationNoteEntity>> {
+    val application = applicationRepository.findByIdOrNull(applicationId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    val user = userService.getUserForRequest()
+
+    if (application.createdByUser != user) {
+      return AuthorisableActionResult.Unauthorised()
+    }
+
+    if (application.submittedAt == null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("This application has not been submitted"),
+      )
+    }
+
+    val note = Cas2ApplicationNoteEntity(
+      id = UUID.randomUUID(),
+      application = application,
+      body = note.note,
+      createdAt = OffsetDateTime.now(),
+      createdByNomisUser = user,
+    )
+
+    val savedNote = applicationNoteRepository.save(note)
+
+    return AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(
+        savedNote,
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationNotesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationNotesTransformer.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+
+@Component("Cas2ApplicationNoteTransformer")
+class ApplicationNotesTransformer {
+
+  fun transformJpaToApi(
+    jpa: Cas2ApplicationNoteEntity,
+  ):
+    Cas2ApplicationNote {
+    return Cas2ApplicationNote(
+      id = jpa.id,
+      name = jpa.createdByNomisUser.name,
+      email = jpa.createdByNomisUser.email ?: "Not found",
+      body = jpa.body,
+      createdAt = jpa.createdAt.toInstant(),
+    )
+  }
+}

--- a/src/main/resources/db/migration/all/20240213111046__create_cas2_application_notes_table.sql
+++ b/src/main/resources/db/migration/all/20240213111046__create_cas2_application_notes_table.sql
@@ -1,0 +1,25 @@
+-- create new table for CAS2 status updates
+CREATE TABLE cas_2_application_notes (
+    id                           UUID                        NOT NULL,
+    application_id               UUID                        NOT NULL,
+    created_by_nomis_user_id     UUID                        NOT NULL,
+    body                         TEXT                        NOT NULL,
+    created_at       TIMESTAMP WITH TIME ZONE                NOT NULL,
+
+    PRIMARY KEY (id),
+
+    CONSTRAINT fk_application_id
+        FOREIGN KEY(application_id)
+    	    REFERENCES cas_2_applications(id),
+
+    CONSTRAINT fk_created_by_nomis_user_id
+        FOREIGN KEY(created_by_nomis_user_id)
+    	    REFERENCES nomis_users(id)
+);
+
+-- index for foreign key to applications table
+CREATE INDEX ON cas_2_application_notes(application_id);
+
+-- index for foreign key to nomis users table
+CREATE INDEX ON cas_2_application_notes(created_by_nomis_user_id);
+

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1810,6 +1810,38 @@ components:
           required:
             - createdByUserId
             - status
+    NewCas2ApplicationNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    Cas2ApplicationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          example: 'roger@example.com'
+        name:
+          type: string
+          example: 'Roger Smith'
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - username
+        - email
+        - name
+        - body
+        - createdAt
+      description: Notes added to an application
     Cas2ApplicationStatus:
       type: object
       properties:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -250,6 +250,46 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /submissions/{applicationId}/notes:
+    post:
+      tags:
+        - Operations on CAS2 applications
+      summary: Add a note to an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the note to add
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewCas2ApplicationNote'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2ApplicationNote'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /people/search:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6352,6 +6352,38 @@ components:
           required:
             - createdByUserId
             - status
+    NewCas2ApplicationNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    Cas2ApplicationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          example: 'roger@example.com'
+        name:
+          type: string
+          example: 'Roger Smith'
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - username
+        - email
+        - name
+        - body
+        - createdAt
+      description: Notes added to an application
     Cas2ApplicationStatus:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -252,6 +252,46 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /submissions/{applicationId}/notes:
+    post:
+      tags:
+        - Operations on CAS2 applications
+      summary: Add a note to an application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the note to add
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewCas2ApplicationNote'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2ApplicationNote'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid applicationId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /people/search:
     get:
       tags:
@@ -2253,6 +2293,38 @@ components:
           required:
             - createdByUserId
             - status
+    NewCas2ApplicationNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    Cas2ApplicationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          example: 'roger@example.com'
+        name:
+          type: string
+          example: 'Roger Smith'
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - username
+        - email
+        - name
+        - body
+        - createdAt
+      description: Notes added to an application
     Cas2ApplicationStatus:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1858,6 +1858,38 @@ components:
           required:
             - createdByUserId
             - status
+    NewCas2ApplicationNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    Cas2ApplicationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          example: 'roger@example.com'
+        name:
+          type: string
+          example: 'Roger Smith'
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - username
+        - email
+        - name
+        - body
+        - createdAt
+      description: Notes added to an application
     Cas2ApplicationStatus:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
@@ -1,0 +1,191 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2ApplicationNotesTest : IntegrationTestBase() {
+
+  @SpykBean
+  lateinit var realNotesRepository: Cas2ApplicationNoteRepository
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realNotesRepository)
+  }
+
+  @Nested
+  inner class MissingJwt {
+    @Test
+    fun `creating a note without JWT returns 401`() {
+      webTestClient.post()
+        .uri("/cas2/submissions/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+  }
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `creating a note is forbidden to external users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "auth",
+        roles = listOf("ROLE_CAS2_ADMIN"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/submissions/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class ControlsOnInternalUsers {
+    @Test
+    fun `creating a note is forbidden to nomis users based on role`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_CAS2_ADMIN"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/submissions/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class PostToCreate {
+    @Test
+    fun `referrer create note returns 201`() {
+      val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+      `Given a CAS2 User` { referrer, jwt ->
+        val applicationSchema =
+          cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withAddedAt(OffsetDateTime.now())
+            withId(UUID.randomUUID())
+            withSchema(
+              """
+                {
+                  "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+                  "${"\$id"}": "https://example.com/product.schema.json",
+                  "title": "Thing",
+                  "description": "A thing",
+                  "type": "object",
+                  "properties": {},
+                  "required": []
+                }
+              """,
+            )
+          }
+
+        cas2ApplicationEntityFactory.produceAndPersist {
+          withId(applicationId)
+          withCreatedByUser(referrer)
+          withApplicationSchema(applicationSchema)
+          withSubmittedAt(OffsetDateTime.now())
+        }
+
+        Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+        val rawResponseBody = webTestClient.post()
+          .uri("/cas2/submissions/$applicationId/notes")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.cas2.value)
+          .bodyValue(
+            NewCas2ApplicationNote(note = "New note content"),
+          )
+          .exchange()
+          .expectStatus()
+          .isCreated()
+          .returnResult<String>()
+          .responseBody
+          .blockFirst()
+
+        Assertions.assertThat(realNotesRepository.count()).isEqualTo(1)
+
+        val responseBody =
+          objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+
+        Assertions.assertThat(responseBody.body).isEqualTo("New note content")
+      }
+    }
+
+    @Test
+    fun `referrer cannot create note for an application they did not create`() {
+      val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+      `Given a CAS2 User` { referrer, jwt ->
+        `Given a CAS2 User` { aDifferentReferrer, _ ->
+          val applicationSchema =
+            cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withAddedAt(OffsetDateTime.now())
+              withId(UUID.randomUUID())
+              withSchema(
+                """
+                {
+                  "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+                  "${"\$id"}": "https://example.com/product.schema.json",
+                  "title": "Thing",
+                  "description": "A thing",
+                  "type": "object",
+                  "properties": {},
+                  "required": []
+                }
+              """,
+              )
+            }
+
+          cas2ApplicationEntityFactory.produceAndPersist {
+            withId(applicationId)
+            withCreatedByUser(aDifferentReferrer)
+            withApplicationSchema(applicationSchema)
+            withSubmittedAt(OffsetDateTime.now())
+          }
+
+          Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+          val rawResponseBody = webTestClient.post()
+            .uri("/cas2/submissions/$applicationId/notes")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.cas2.value)
+            .bodyValue(
+              NewCas2ApplicationNote(note = "New note content"),
+            )
+            .exchange()
+            .expectStatus()
+            .isForbidden
+
+          Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationNoteServiceTest.kt
@@ -1,0 +1,157 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas2
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApplicationNoteServiceTest {
+  private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
+  private val mockApplicationNoteRepository = mockk<Cas2ApplicationNoteRepository>()
+  private val mockUserService = mockk<NomisUserService>()
+
+  private val applicationNoteService = uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationNoteService(
+    mockApplicationRepository,
+    mockApplicationNoteRepository,
+    mockUserService,
+  )
+
+  @Nested
+  inner class CreateApplicationNote {
+
+    private val referrer = NomisUserEntityFactory().produce()
+
+    @Nested
+    inner class WhenSuccessful {
+      private val submittedApplication = Cas2ApplicationEntityFactory()
+        .withCreatedByUser(referrer)
+        .withCrn("CRN123")
+        .withNomsNumber("NOMSABC")
+        .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+        .produce()
+      private val applicationId = submittedApplication.id
+      private val noteEntity = Cas2ApplicationNoteEntity(
+        id = UUID.randomUUID(),
+        createdByNomisUser = referrer,
+        application = submittedApplication,
+        body = "new note",
+        createdAt = OffsetDateTime.now().randomDateTimeBefore(1),
+      )
+
+      @Test
+      fun `returns Success result with entity from db`() {
+        every { mockApplicationRepository.findByIdOrNull(applicationId) } answers
+          {
+            submittedApplication
+          }
+        every { mockUserService.getUserForRequest() } returns referrer
+        every { mockApplicationNoteRepository.save(any()) } answers
+          {
+            noteEntity
+          }
+
+        val result = applicationNoteService.createApplicationNote(
+          applicationId = applicationId,
+          NewCas2ApplicationNote(note = "new note"),
+        )
+
+        verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
+
+        Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+        result as AuthorisableActionResult.Success
+
+        Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
+        val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+        val createdNote = validatableActionResult.entity
+
+        Assertions.assertThat(createdNote).isEqualTo(noteEntity)
+      }
+    }
+
+    @Nested
+    inner class WhenUnsuccessful {
+      @Test
+      fun `returns Not Found when application not found`() {
+        every { mockApplicationRepository.findByIdOrNull(any()) } answers
+          {
+            null
+          }
+
+        Assertions.assertThat(
+          applicationNoteService.createApplicationNote(
+            applicationId = UUID.randomUUID(),
+            note = NewCas2ApplicationNote(note = "note for missing app"),
+          ) is AuthorisableActionResult.NotFound,
+        ).isTrue
+      }
+
+      @Test
+      fun `returns Not Authorised when application was not created by user`() {
+        val applicationCreatedByOtherUser = Cas2ApplicationEntityFactory()
+          .withCreatedByUser(NomisUserEntityFactory().produce())
+          .withCrn("CRN123")
+          .withNomsNumber("NOMSABC")
+          .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+          .produce()
+
+        every { mockApplicationRepository.findByIdOrNull(applicationCreatedByOtherUser.id) } answers
+          {
+            applicationCreatedByOtherUser
+          }
+
+        every { mockUserService.getUserForRequest() } returns referrer
+
+        Assertions.assertThat(
+          applicationNoteService.createApplicationNote(
+            applicationId = applicationCreatedByOtherUser.id,
+            note = NewCas2ApplicationNote(note = "note for unauthorised app"),
+          ) is AuthorisableActionResult.Unauthorised,
+        ).isTrue
+      }
+
+      @Test
+      fun `returns Validation error when application is not submitted`() {
+        val applicationNotSubmitted = Cas2ApplicationEntityFactory()
+          .withCreatedByUser(referrer)
+          .withCrn("CRN123")
+          .withNomsNumber("NOMSABC")
+          .produce()
+
+        every { mockApplicationRepository.findByIdOrNull(any()) } answers
+          {
+            applicationNotSubmitted
+          }
+
+        every { mockUserService.getUserForRequest() } returns referrer
+
+        val result = applicationNoteService.createApplicationNote(
+          applicationId = applicationNotSubmitted.id,
+          note = NewCas2ApplicationNote(note = "note for in progress app"),
+        )
+        Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+        result as AuthorisableActionResult.Success
+
+        Assertions.assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
+        val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+
+        Assertions.assertThat(validatableActionResult.message).isEqualTo("This application has not been submitted")
+      }
+    }
+  }
+}


### PR DESCRIPTION
We would like CAS2 users to add notes to submitted applications. 

We are introducing this in parts - initially just enabling the ability for Nomis users to create notes on any applications they have submitted.

![Screenshot 2024-02-09 at 15 48 09](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/ba46a458-b2ed-458f-82cc-a6b086eb6a3b)

In this PR we have

* Introduced `cas2_application_notes` new table, with foreign keys to `cas2_applications` and `nomis_users`. 
* Introduced new endpoint `submissions/{applicationId}/notes` restricted to users with POM role
* Added Service layer logic that restricts Note creation to submitted apps, and only if user created application

This is following a similar pattern in CAS1, but as our users and application models are different we've continued to use our own namespace/new tables. 

We will introduce the functionality to return Notes on a SubmittedApplication shortly. 

We will also very shortly be introducing the ability for External Users to create notes on any submitted application, which means some of the logic will need to change.


