### PR TITLE
Placement Application Withdrawal Changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -122,7 +122,13 @@ class PlacementApplicationsController(
       WithdrawPlacementRequestReason.errorInPlacementRequest -> PlacementApplicationWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST
       null -> null
     }
-    val result = placementApplicationService.withdrawPlacementApplication(id, withdrawalReason)
+
+    val result = placementApplicationService.withdrawPlacementApplication(
+      id,
+      userService.getUserForRequest(),
+      withdrawalReason,
+      checkUserPermissions = true,
+    )
 
     val validationResult = extractEntityFromAuthorisableActionResult(result)
     val placementApplication = extractEntityFromValidatableActionResult(validationResult)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingNotMadeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NewPlacementRequestBookingConfirmationTransformer
@@ -179,6 +180,7 @@ class PlacementRequestsController(
 
   override fun placementRequestsIdWithdrawalPost(id: UUID, body: WithdrawPlacementRequest?): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
+
     val reason = when (body?.reason) {
       WithdrawPlacementRequestReason.duplicatePlacementRequest -> PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
       WithdrawPlacementRequestReason.alternativeProvisionIdentified -> PlacementRequestWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED
@@ -192,7 +194,11 @@ class PlacementRequestsController(
     }
 
     val result = extractEntityFromAuthorisableActionResult(
-      placementRequestService.withdrawPlacementRequest(id, user, reason),
+      placementRequestService.withdrawPlacementRequest(
+        id,
+        user,
+        reason,
+        checkUserPermissions = true),
     )
 
     return ResponseEntity.ok(result)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -247,6 +247,8 @@ data class BookingEntity(
   val arrival: ArrivalEntity?
     get() = arrivals.maxByOrNull { it.createdAt }
 
+  fun isInCancellableStateCas1() = (cancellation == null) && (arrivals.isEmpty())
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is BookingEntity) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -96,7 +96,7 @@ data class PlacementApplicationEntity(
 
   fun hasADecision() = decision != null
 
-  fun canBeWithdrawn() = !isReallocated() && !hasADecision()
+  fun isInWithdrawableState() = !isReallocated() && !hasADecision()
 
   override fun toString() = "PlacementApplicationEntity: $id"
   fun isWithdrawn(): Boolean = decision?.let { listOf(PlacementApplicationDecision.WITHDRAWN_BY_PP,PlacementApplicationDecision.WITHDRAW).contains(it) } ?: false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -98,6 +98,8 @@ data class PlacementApplicationEntity(
 
   fun isInWithdrawableState() = !isReallocated() && !hasADecision()
 
+  fun isSubmitted() = submittedAt != null
+
   override fun toString() = "PlacementApplicationEntity: $id"
   fun isWithdrawn(): Boolean = decision?.let { listOf(PlacementApplicationDecision.WITHDRAWN_BY_PP,PlacementApplicationDecision.WITHDRAW).contains(it) } ?: false
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -94,9 +94,7 @@ data class PlacementApplicationEntity(
 ) {
   fun isReallocated() = reallocatedAt != null
 
-  fun hasADecision() = decision != null
-
-  fun isInWithdrawableState() = !isReallocated() && !hasADecision()
+  fun isInWithdrawableState() = !isReallocated() && !isWithdrawn()
 
   fun isSubmitted() = submittedAt != null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -171,7 +171,7 @@ data class PlacementRequestEntity(
   @Enumerated(value = EnumType.STRING)
   var withdrawalReason: PlacementRequestWithdrawalReason?,
 ) {
-  fun canBeWithdrawn() =
+  fun isInWithdrawableState() =
     reallocatedAt == null && !isWithdrawn
 
   fun hasActiveBooking() = booking != null && booking?.cancellations.isNullOrEmpty()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -39,6 +39,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -536,7 +536,7 @@ class ApplicationService(
     val application = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (!isWithdrawable(application, user)) {
+    if (!isWithdrawableForUser(user, application)) {
       return AuthorisableActionResult.Unauthorised()
     }
 
@@ -604,7 +604,7 @@ class ApplicationService(
     )
   }
 
-  fun isWithdrawable(application: ApplicationEntity, user: UserEntity) =
+  fun isWithdrawableForUser(user: UserEntity, application: ApplicationEntity) =
     userAccessService.userCanWithdrawApplication(user, application)
 
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -547,7 +547,7 @@ class ApplicationService(
         }
 
         if (application.isWithdrawn) {
-          return@validated generalError("applicationAlreadyWithdrawn")
+          return@validated success(Unit)
         }
 
         if (withdrawalReason == WithdrawalReason.other.value && otherReason == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1194,11 +1194,8 @@ class BookingService(
 
   fun getCancelleableCas1BookingsForUser(user: UserEntity, application: ApprovedPremisesApplicationEntity): List<BookingEntity> =
     bookingRepository.findAllByApplication(application).filter { booking ->
-      isInCancellableStateCas1(booking) && userAccessService.userCanCancelBooking(user, booking)
+      booking.isInCancellableStateCas1() && userAccessService.userCanCancelBooking(user, booking)
     }
-
-  private fun isInCancellableStateCas1(booking: BookingEntity)
-    = (booking.cancellation == null) && (booking.arrivals.isEmpty())
 
   private fun createCas1Cancellation(
     user: UserEntity?,
@@ -1212,7 +1209,7 @@ class BookingService(
       return success(existingCancellation)
     }
 
-    if(!isInCancellableStateCas1(booking)) {
+    if(!booking.isInCancellableStateCas1()) {
       return generalError("The Booking is not in a state that can be cancelled")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -41,6 +41,7 @@ class PlacementApplicationService(
   private val userAllocator: UserAllocator,
   private val emailNotificationService: EmailNotificationService,
   private val notifyConfig: NotifyConfig,
+  private val userAccessService: UserAccessService,
   @Value("\${notify.send-placement-request-notifications}")
   private val sendPlacementRequestNotifications: Boolean,
 ) {
@@ -158,8 +159,10 @@ class PlacementApplicationService(
     )
   }
 
-  fun getWithdrawablePlacementApplications(application: ApprovedPremisesApplicationEntity) =
-    placementApplicationRepository.findByApplication(application).filter { it.isInWithdrawableState() }
+  fun getWithdrawablePlacementApplicationsForUser(user: UserEntity, application: ApprovedPremisesApplicationEntity) =
+    placementApplicationRepository
+      .findByApplication(application)
+      .filter { it.isInWithdrawableState() && userAccessService.userCanWithdrawPlacemenApplication(user, it)}
 
   @Transactional
   fun withdrawPlacementApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -159,7 +159,7 @@ class PlacementApplicationService(
   }
 
   fun getWithdrawablePlacementApplications(application: ApprovedPremisesApplicationEntity) =
-    placementApplicationRepository.findByApplication(application).filter { it.canBeWithdrawn() }
+    placementApplicationRepository.findByApplication(application).filter { it.isInWithdrawableState() }
 
   @Transactional
   fun withdrawPlacementApplication(
@@ -176,7 +176,7 @@ class PlacementApplicationService(
 
     val placementApplicationEntity = placementApplicationAuthorisationResult.entity
 
-    if (!placementApplicationEntity.canBeWithdrawn()) {
+    if (!placementApplicationEntity.isInWithdrawableState()) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("The Placement Application cannot be withdrawn because it has an associated decision"),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -181,6 +181,12 @@ class PlacementApplicationService(
 
     val placementApplicationEntity = placementApplicationAuthorisationResult.entity
 
+    if(placementApplicationEntity.isWithdrawn()) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.Success(placementApplicationEntity),
+      )
+    }
+
     if(checkUserPermissions && !userAccessService.userCanWithdrawPlacemenApplication(user, placementApplicationEntity)) {
       return AuthorisableActionResult.Unauthorised()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -199,7 +199,7 @@ class PlacementApplicationService(
 
     if (!placementApplication.isInWithdrawableState()) {
       return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The Placement Application cannot be withdrawn because it has an associated decision"),
+        ValidatableActionResult.GeneralValidationError("The Placement Application cannot be withdrawn as it's not in a withdrawable state"),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -158,6 +158,9 @@ class PlacementApplicationService(
     )
   }
 
+  fun getWithdrawablePlacementApplications(application: ApprovedPremisesApplicationEntity) =
+    placementApplicationRepository.findByApplication(application).filter { it.canBeWithdrawn() }
+
   @Transactional
   fun withdrawPlacementApplication(
     id: UUID,
@@ -371,9 +374,6 @@ class PlacementApplicationService(
       ApiPlacementType.releaseFollowingDecision -> PlacementType.RELEASE_FOLLOWING_DECISION
     }
   }
-
-  fun getWithdrawablePlacementApplications(application: ApprovedPremisesApplicationEntity) =
-    placementApplicationRepository.findByApplication(application).filter { it.canBeWithdrawn() }
 
   private fun setSchemaUpToDate(placementApplicationEntity: PlacementApplicationEntity): PlacementApplicationEntity {
     val latestSchema = jsonSchemaService.getNewestSchema(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -167,7 +167,9 @@ class PlacementApplicationService(
   @Transactional
   fun withdrawPlacementApplication(
     id: UUID,
+    user: UserEntity,
     reason: PlacementApplicationWithdrawalReason?,
+    checkUserPermissions: Boolean,
   ): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
     val placementApplicationAuthorisationResult = getApplicationForUpdateOrSubmit(id)
 
@@ -178,6 +180,10 @@ class PlacementApplicationService(
     }
 
     val placementApplicationEntity = placementApplicationAuthorisationResult.entity
+
+    if(checkUserPermissions && !userAccessService.userCanWithdrawPlacemenApplication(user, placementApplicationEntity)) {
+      return AuthorisableActionResult.Unauthorised()
+    }
 
     if (!placementApplicationEntity.isInWithdrawableState()) {
       return AuthorisableActionResult.Success(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -65,6 +65,7 @@ class PlacementRequestService(
   private val cancellationRepository: CancellationRepository,
   private val userAllocator: UserAllocator,
   @Lazy private val bookingService: BookingService,
+  private val userAccessService: UserAccessService,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
 ) {
 
@@ -304,7 +305,7 @@ class PlacementRequestService(
       return AuthorisableActionResult.Success(Unit)
     }
 
-    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && placementRequest.application.createdByUser != user) {
+    if(!userAccessService.userCanWithdrawPlacementRequest(user, placementRequest)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -288,10 +288,13 @@ class PlacementRequestService(
     )
   }
 
-  fun getWithdrawablePlacementRequests(
+  fun getWithdrawablePlacementRequestsForUser(
+    user: UserEntity,
     application: ApprovedPremisesApplicationEntity,
   ): List<PlacementRequestEntity> =
-    placementRequestRepository.findByApplication(application).filter { it.isInWithdrawableState() }
+    placementRequestRepository
+      .findByApplication(application)
+      .filter { it.isInWithdrawableState() && userAccessService.userCanWithdrawPlacementRequest(user, it) }
 
   fun withdrawPlacementRequest(
     placementRequestId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -300,6 +300,7 @@ class PlacementRequestService(
     placementRequestId: UUID,
     user: UserEntity,
     reason: PlacementRequestWithdrawalReason?,
+    checkUserPermissions: Boolean,
   ): AuthorisableActionResult<Unit> {
     val placementRequest = placementRequestRepository.findByIdOrNull(placementRequestId)
       ?: return AuthorisableActionResult.NotFound("PlacementRequest", placementRequestId.toString())
@@ -308,7 +309,7 @@ class PlacementRequestService(
       return AuthorisableActionResult.Success(Unit)
     }
 
-    if(!userAccessService.userCanWithdrawPlacementRequest(user, placementRequest)) {
+    if(checkUserPermissions && !userAccessService.userCanWithdrawPlacementRequest(user, placementRequest)) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -287,6 +287,11 @@ class PlacementRequestService(
     )
   }
 
+  fun getWithdrawablePlacementRequests(
+    application: ApprovedPremisesApplicationEntity,
+  ): List<PlacementRequestEntity> =
+    placementRequestRepository.findByApplication(application).filter { it.isInWithdrawableState() }
+
   fun withdrawPlacementRequest(
     placementRequestId: UUID,
     user: UserEntity,
@@ -329,11 +334,6 @@ class PlacementRequestService(
 
     return AuthorisableActionResult.Success(Unit)
   }
-
-  fun getWithdrawablePlacementRequests(
-    application: ApprovedPremisesApplicationEntity,
-  ): List<PlacementRequestEntity> =
-    placementRequestRepository.findByApplication(application).filter { it.canBeWithdrawn() }
 
   private fun saveBookingNotMadeDomainEvent(
     user: UserEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -192,6 +193,11 @@ class UserAccessService(
     else -> false
   }
 
+  /**
+   * This function only checks if the user has the correct permissions to withdraw the given application.
+   *
+   * It doesn't consider if the application is in a withdrawable state
+   */
   fun userCanWithdrawApplication(user: UserEntity, application: ApplicationEntity): Boolean = when (application) {
     is ApprovedPremisesApplicationEntity ->
       application.createdByUser == user || (
@@ -199,6 +205,16 @@ class UserAccessService(
         )
     else -> false
   }
+
+  /**
+   * This function only checks if the user has the correct permissions to withdraw the given placement request.
+   *
+   * It doesn't consider if the placement request is in a withdrawable state
+   */
+  fun userCanWithdrawPlacementRequest(user: UserEntity, placementRequest: PlacementRequestEntity)
+    = placementRequest.application.createdByUser == user ||
+      user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+
 }
 
 enum class ApprovedPremisesApplicationAccessLevel {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -214,6 +215,15 @@ class UserAccessService(
   fun userCanWithdrawPlacementRequest(user: UserEntity, placementRequest: PlacementRequestEntity)
     = placementRequest.application.createdByUser == user ||
       user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+
+  /**
+   * This function only checks if the user has the correct permissions to withdraw the given placement application.
+   *
+   * It doesn't consider if the placement request is in a withdrawable state
+   */
+  fun userCanWithdrawPlacemenApplication(user: UserEntity, placementApplication: PlacementApplicationEntity)
+    = placementApplication.createdByUser == user ||
+      (placementApplication.isSubmitted() && user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER))
 
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -47,7 +47,9 @@ class WithdrawableService(
     withdrawables.placementApplications.forEach {
       placementApplicationService.withdrawPlacementApplication(
         it.id,
+        user,
         PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP,
+        checkUserPermissions = false,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -28,7 +28,7 @@ class WithdrawableService(
     val placementApplications = placementApplicationService.getWithdrawablePlacementApplicationsForUser(user, application)
 
     return Withdrawables(
-      applicationService.isWithdrawable(application, user),
+      applicationService.isWithdrawableForUser(user, application),
       placementRequests = placementRequests,
       bookings = bookings,
       placementApplications = placementApplications,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository.Constants.CAS1_WITHDRAWN_BY_PP_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
@@ -24,7 +23,7 @@ class WithdrawableService(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
   ): Withdrawables {
-    val placementRequests = placementRequestService.getWithdrawablePlacementRequests(application)
+    val placementRequests = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
     val bookings = bookingService.getCancelleableCas1BookingsForUser(user, application)
     val placementApplications = placementApplicationService.getWithdrawablePlacementApplications(application)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -56,6 +56,7 @@ class WithdrawableService(
         it.id,
         user,
         PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP,
+        checkUserPermissions = false,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -25,7 +25,7 @@ class WithdrawableService(
   ): Withdrawables {
     val placementRequests = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
     val bookings = bookingService.getCancelleableCas1BookingsForUser(user, application)
-    val placementApplications = placementApplicationService.getWithdrawablePlacementApplications(application)
+    val placementApplications = placementApplicationService.getWithdrawablePlacementApplicationsForUser(user, application)
 
     return Withdrawables(
       applicationService.isWithdrawable(application, user),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -28,7 +28,7 @@ class PlacementApplicationTransformer(
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       outdatedSchema = !jpa.schemaUpToDate,
       submittedAt = jpa.submittedAt?.toInstant(),
-      canBeWithdrawn = jpa.canBeWithdrawn(),
+      canBeWithdrawn = jpa.isInWithdrawableState(),
       isWithdrawn = jpa.isWithdrawn(),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3243,8 +3243,8 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get withdrawables for an application returns withdrawable placement applications`() {
-      `Given a User` { applicant, _ ->
-        `Given a User` { allocatedTo, jwt ->
+      `Given a User` { applicant, jwt ->
+        `Given a User` { allocatedTo, _ ->
           `Given an Offender` { offenderDetails, _ ->
 
             val (application, _) = produceAndPersistApplicationAndAssessment(applicant, allocatedTo, offenderDetails)
@@ -3299,6 +3299,11 @@ class ApplicationTest : IntegrationTestBase() {
             }
 
             val expected = listOf(
+              Withdrawable(
+                application.id,
+                WithdrawableType.application,
+                emptyList(),
+              ),
               Withdrawable(
                 submittedPlacementApplication1.id,
                 WithdrawableType.placementApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3173,9 +3173,9 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get withdrawables for an application returns withdrawable placement requests`() {
-      `Given a User` { applicant, _ ->
-        `Given a User` { allocatedTo, jwt ->
+    fun `Get withdrawables for an application returns withdrawable placement requests for application creator`() {
+      `Given a User` { applicant, jwt ->
+        `Given a User` { allocatedTo, _ ->
           `Given an Offender` { offenderDetails, _ ->
 
             val (application, _) = produceAndPersistApplicationAndAssessment(applicant, allocatedTo, offenderDetails)
@@ -3205,6 +3205,11 @@ class ApplicationTest : IntegrationTestBase() {
             }
 
             val expected = listOf(
+              Withdrawable(
+                application.id,
+                WithdrawableType.application,
+                emptyList(),
+              ),
               Withdrawable(
                 placementRequest1.id,
                 WithdrawableType.placementRequest,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3262,18 +3262,18 @@ class ApplicationTest : IntegrationTestBase() {
               ),
             )
 
-            val submittedApplication2ExpectedArrival1 = LocalDate.now().plusDays(50)
-            val submittedApplication2Duration1 = 6
+            val submittedApplication2ExpectedArrival = LocalDate.now().plusDays(50)
+            val submittedApplication2Duration = 6
             val submittedPlacementApplication2 = produceAndPersistPlacementApplication(
               application,
-              listOf(submittedApplication2ExpectedArrival1 to submittedApplication2Duration1),
+              listOf(submittedApplication2ExpectedArrival to submittedApplication2Duration),
             )
 
-            val unsubmittedApplicationExpectedArrival1 = LocalDate.now().plusDays(50)
-            val unsubmittedApplicationDuration1 = 6
+            val unsubmittedApplicationExpectedArrival = LocalDate.now().plusDays(50)
+            val unsubmittedApplicationDuration = 6
             val unsubmittedPlacementApplication = produceAndPersistPlacementApplication(
               application,
-              listOf(unsubmittedApplicationExpectedArrival1 to unsubmittedApplicationDuration1),
+              listOf(unsubmittedApplicationExpectedArrival to unsubmittedApplicationDuration),
             ) {
               withSubmittedAt(null)
             }
@@ -3282,7 +3282,11 @@ class ApplicationTest : IntegrationTestBase() {
               withReallocatedAt(OffsetDateTime.now())
             }
 
-            produceAndPersistPlacementApplication(application, listOf(LocalDate.now() to 2)) {
+            val applicationWithAcceptedDecisionExpectedArrival = LocalDate.now().plusDays(50)
+            val applicationWithAcceptedDecisionDuration = 6
+            val applicationWithAcceptedDecision = produceAndPersistPlacementApplication(
+              application,
+              listOf(applicationWithAcceptedDecisionExpectedArrival to applicationWithAcceptedDecisionDuration)) {
               withDecision(PlacementApplicationDecision.ACCEPTED)
             }
 
@@ -3294,7 +3298,11 @@ class ApplicationTest : IntegrationTestBase() {
               withDecision(PlacementApplicationDecision.WITHDRAWN_BY_PP)
             }
 
-            produceAndPersistPlacementApplication(application, listOf(LocalDate.now() to 2)) {
+            val applicationWithRejectedDecisionExpectedArrival = LocalDate.now().plusDays(50)
+            val applicationWithRejectedDecisionDuration = 6
+            val applicationWithRejectedDecision = produceAndPersistPlacementApplication(
+              application,
+              listOf(applicationWithRejectedDecisionExpectedArrival to applicationWithRejectedDecisionDuration)) {
               withDecision(PlacementApplicationDecision.REJECTED)
             }
 
@@ -3315,12 +3323,22 @@ class ApplicationTest : IntegrationTestBase() {
               Withdrawable(
                 submittedPlacementApplication2.id,
                 WithdrawableType.placementApplication,
-                listOf(datePeriodForDuration(submittedApplication2ExpectedArrival1, submittedApplication2Duration1)),
+                listOf(datePeriodForDuration(submittedApplication2ExpectedArrival, submittedApplication2Duration)),
               ),
               Withdrawable(
                 unsubmittedPlacementApplication.id,
                 WithdrawableType.placementApplication,
-                listOf(datePeriodForDuration(unsubmittedApplicationExpectedArrival1, unsubmittedApplicationDuration1)),
+                listOf(datePeriodForDuration(unsubmittedApplicationExpectedArrival, unsubmittedApplicationDuration)),
+              ),
+              Withdrawable(
+                applicationWithAcceptedDecision.id,
+                WithdrawableType.placementApplication,
+                listOf(datePeriodForDuration(applicationWithAcceptedDecisionExpectedArrival, applicationWithAcceptedDecisionDuration)),
+              ),
+              Withdrawable(
+                applicationWithRejectedDecision.id,
+                WithdrawableType.placementApplication,
+                listOf(datePeriodForDuration(applicationWithRejectedDecisionExpectedArrival, applicationWithRejectedDecisionDuration)),
               ),
             )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1041,7 +1041,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `withdrawing an in-progress placement request application returns successfully and updates decision field`() {
+    fun `withdrawing an in-progress placement application returns successfully and updates decision field`() {
       `Given a User`(roles = listOf(UserRole.CAS1_MATCHER), qualifications = listOf()) { _, _ ->
         `Given a User` { user, jwt ->
           `Given a Placement Application`(
@@ -1091,7 +1091,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `withdrawing a submitted placement request application returns successfully`() {
+    fun `withdrawing a submitted placement application returns successfully`() {
       `Given a User`(roles = listOf(UserRole.CAS1_MATCHER), qualifications = listOf()) { _, _ ->
         `Given a User` { user, jwt ->
           `Given a Placement Application`(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -84,6 +84,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -537,6 +537,27 @@ class PlacementApplicationServiceTest {
 
       assertThat(entity.decision).isEqualTo(PlacementApplicationDecision.WITHDRAWN_BY_PP)
     }
+    
+    @Test
+    fun `it is idempotent, returning success if application already withdrawn`() {
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
+        .withDecision(PlacementApplicationDecision.WITHDRAW)
+        .withCreatedByUser(user)
+        .produce()
+
+      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
+
+      val result = placementApplicationService.withdrawPlacementApplication(
+        placementApplication.id,
+        user,
+        PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED,
+        checkUserPermissions = false,
+      )
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+    }
 
     @Test
     fun `it returns unauthorised if a user did not create the placement application`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
@@ -54,6 +55,7 @@ class PlacementApplicationServiceTest {
   private val emailNotificationService = mockk<EmailNotificationService>()
   private val userAllocator = mockk<UserAllocator>()
   private val notifyConfig = mockk<NotifyConfig>()
+  private val userAccessService = mockk<UserAccessService>()
 
   private val placementApplicationService = PlacementApplicationService(
     placementApplicationRepository,
@@ -64,6 +66,7 @@ class PlacementApplicationServiceTest {
     userAllocator,
     emailNotificationService,
     notifyConfig,
+    userAccessService,
     sendPlacementRequestNotifications = true,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -740,34 +740,5 @@ class PlacementApplicationServiceTest {
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
     }
-
-    @Test
-    fun `it does not allow placement applications to be withdrawn if a decision has been made`() {
-      val placementApplication = PlacementApplicationEntityFactory()
-        .withApplication(application)
-        .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
-        .withDecision(PlacementApplicationDecision.ACCEPTED)
-        .withCreatedByUser(user)
-        .produce()
-
-      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
-
-      val result = placementApplicationService.withdrawPlacementApplication(
-        placementApplication.id,
-        user,
-        PlacementApplicationWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
-        checkUserPermissions = false,
-      )
-
-      assertThat(result is AuthorisableActionResult.Success).isTrue
-      val validationResult = (result as AuthorisableActionResult.Success).entity
-
-      assertThat(validationResult is ValidatableActionResult.GeneralValidationError).isTrue()
-      (validationResult as ValidatableActionResult.GeneralValidationError).let {
-        assertThat(validationResult.message).isEqualTo("The Placement Application cannot be withdrawn because it has an associated decision")
-      }
-    }
-
-
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -515,10 +515,10 @@ class PlacementRequestServiceTest {
 
 
   @Nested
-  inner class GetWithdrawablePlacementRequests {
+  inner class GetWithdrawablePlacementRequestsForUser {
 
     @Test
-    fun `getWithdrawablePlacementRequests doesn't return reallocated placement requests`() {
+    fun `getWithdrawablePlacementRequestsForUser doesn't return reallocated placement requests`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
         .produce()
@@ -533,14 +533,15 @@ class PlacementRequestServiceTest {
       placementRequestReallocated.reallocatedAt = OffsetDateTime.now()
 
       every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestReallocated)
+      every { userAccessService.userCanWithdrawPlacementRequest(user, placementRequestWithdrawable) } returns true
 
-      val result = placementRequestService.getWithdrawablePlacementRequests(application)
+      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
 
       assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
     }
 
     @Test
-    fun `getWithdrawablePlacementRequests doesn't return withdrawn placement requests`() {
+    fun `getWithdrawablePlacementRequestsForUser doesn't return withdrawn placement requests`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
         .produce()
@@ -555,14 +556,15 @@ class PlacementRequestServiceTest {
       placementRequestWithdrawn.isWithdrawn = true
 
       every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestWithdrawn)
+      every { userAccessService.userCanWithdrawPlacementRequest(user, placementRequestWithdrawable) } returns true
 
-      val result = placementRequestService.getWithdrawablePlacementRequests(application)
+      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
 
       assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
     }
 
     @Test
-    fun `getWithdrawablePlacementRequests returns placement requests with bookings`() {
+    fun `getWithdrawablePlacementRequestsForUser returns placement requests with bookings`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
         .produce()
@@ -577,8 +579,10 @@ class PlacementRequestServiceTest {
       placementRequestWithBooking.booking = BookingEntityFactory().withDefaultPremises().produce()
 
       every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithoutBooking, placementRequestWithBooking)
+      every { userAccessService.userCanWithdrawPlacementRequest(user, placementRequestWithoutBooking) } returns true
+      every { userAccessService.userCanWithdrawPlacementRequest(user, placementRequestWithBooking) } returns true
 
-      val result = placementRequestService.getWithdrawablePlacementRequests(application)
+      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
 
       assertThat(result).isEqualTo(listOf(placementRequestWithoutBooking, placementRequestWithBooking))
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
@@ -1646,4 +1647,90 @@ class UserAccessServiceTest {
       assertThat(userAccessService.userCanWithdrawPlacementRequest(workflowManager, placementRequest)).isTrue
     }
   }
+
+  @Nested
+  inner class UserCanWithdrawPlacementApplication {
+
+    @Test
+    fun `userCanWithdrawPlacementApplication returns true if application was created by user`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(user)
+        .produce()
+
+      assertThat(userAccessService.userCanWithdrawPlacemenApplication(user, placementApplication)).isTrue
+    }
+
+    @Test
+    fun `userCanWithdrawPlacementApplication returns false if application was not created by user`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(anotherUserInRegion)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(anotherUserInRegion)
+        .produce()
+
+      assertThat(userAccessService.userCanWithdrawPlacemenApplication(user, placementApplication)).isFalse
+    }
+
+    @Test
+    fun `userCanWithdrawPlacementApplication returns true if submitted and has CAS1_WORKFLOW_MANAGER role`() {
+      val workflowManager = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+
+      workflowManager.roles.add(
+        UserRoleAssignmentEntityFactory()
+          .withUser(user)
+          .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
+          .produce(),
+      )
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(user)
+        .produce()
+
+      assertThat(userAccessService.userCanWithdrawPlacemenApplication(user, placementApplication)).isTrue
+    }
+
+    @Test
+    fun `userCanWithdrawPlacementApplication returns false if not submitted and has CAS1_WORKFLOW_MANAGER role`() {
+      val workflowManager = UserEntityFactory()
+        .withProbationRegion(probationRegion)
+        .produce()
+
+      workflowManager.roles.add(
+        UserRoleAssignmentEntityFactory()
+          .withUser(user)
+          .withRole(UserRole.CAS1_WORKFLOW_MANAGER)
+          .produce(),
+      )
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(anotherUserInRegion)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(anotherUserInRegion)
+        .withSubmittedAt(null)
+        .produce()
+
+      assertThat(userAccessService.userCanWithdrawPlacemenApplication(user, placementApplication)).isFalse
+    }
+
+  }
+
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -100,7 +100,7 @@ class WithdrawableServiceTest {
   @BeforeEach
   fun setup() {
     every {
-      mockPlacementRequestService.getWithdrawablePlacementRequests(application)
+      mockPlacementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
     } returns placementRequests
     every {
       mockPlacementApplicationService.getWithdrawablePlacementApplications(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -149,7 +149,7 @@ class WithdrawableServiceTest {
     } returns mockk<AuthorisableActionResult<Unit>>()
 
     every {
-      mockPlacementApplicationService.withdrawPlacementApplication(any(), PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP)
+      mockPlacementApplicationService.withdrawPlacementApplication(any(), user, PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP, checkUserPermissions = false)
     } returns mockk<AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>>>()
 
     withdrawableService.withdrawAllForApplication(application, user)
@@ -174,7 +174,7 @@ class WithdrawableServiceTest {
 
     placementApplications.forEach {
       verify {
-        mockPlacementApplicationService.withdrawPlacementApplication(it.id, PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP)
+        mockPlacementApplicationService.withdrawPlacementApplication(it.id, user, PlacementApplicationWithdrawalReason.WITHDRAWN_BY_PP, checkUserPermissions = false)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -145,7 +145,7 @@ class WithdrawableServiceTest {
     } returns mockk<ValidatableActionResult<CancellationEntity>>()
 
     every {
-      mockPlacementRequestService.withdrawPlacementRequest(any(), user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+      mockPlacementRequestService.withdrawPlacementRequest(any(), user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP, checkUserPermissions = false)
     } returns mockk<AuthorisableActionResult<Unit>>()
 
     every {
@@ -168,7 +168,7 @@ class WithdrawableServiceTest {
 
     placementRequests.forEach {
       verify {
-        mockPlacementRequestService.withdrawPlacementRequest(it.id, user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP)
+        mockPlacementRequestService.withdrawPlacementRequest(it.id, user, PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP, checkUserPermissions = false)
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -112,7 +112,7 @@ class WithdrawableServiceTest {
 
   @Test
   fun `allWithdrawables returns all withdrawable information`() {
-    every { mockApplicationService.isWithdrawable(application, user) } returns true
+    every { mockApplicationService.isWithdrawableForUser(user, application) } returns true
     val result = withdrawableService.allWithdrawables(application, user)
 
     assertThat(result.application).isEqualTo(true)
@@ -124,7 +124,7 @@ class WithdrawableServiceTest {
   @ParameterizedTest
   @ValueSource(booleans = [true, false])
   fun `allWithdrawables returns if application can't be withdrawn`(canBeWithdrawn: Boolean) {
-    every { mockApplicationService.isWithdrawable(application, user) } returns canBeWithdrawn
+    every { mockApplicationService.isWithdrawableForUser(user, application) } returns canBeWithdrawn
     val result = withdrawableService.allWithdrawables(application, user)
 
     assertThat(result.application).isEqualTo(canBeWithdrawn)
@@ -132,7 +132,7 @@ class WithdrawableServiceTest {
 
   @Test
   fun `withdrawAllForApplication withdraws all withdrawable entities`() {
-    every { mockApplicationService.isWithdrawable(application, user) } returns true
+    every { mockApplicationService.isWithdrawableForUser(user, application) } returns true
 
     every {
       mockBookingService.createCancellation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -103,7 +103,7 @@ class WithdrawableServiceTest {
       mockPlacementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
     } returns placementRequests
     every {
-      mockPlacementApplicationService.getWithdrawablePlacementApplications(application)
+      mockPlacementApplicationService.getWithdrawablePlacementApplicationsForUser(user, application)
     } returns placementApplications
     every {
       mockBookingService.getCancelleableCas1BookingsForUser(user, application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -111,7 +111,7 @@ class PlacementApplicationTransformerTest {
   }
 
   @Test
-  fun `transformJpaToApi returns canBeWithdrawn false if a decision has been made`() {
+  fun `transformJpaToApi returns canBeWithdrawn false if already withdrawn`() {
     val data = "{\"data\": \"something\"}"
     val document = "{\"document\": \"something\"}"
     val placementApplication = PlacementApplicationEntityFactory()
@@ -119,7 +119,7 @@ class PlacementApplicationTransformerTest {
       .withApplication(applicationMock)
       .withData(data)
       .withDocument(document)
-      .withDecision(PlacementApplicationDecision.ACCEPTED)
+      .withDecision(PlacementApplicationDecision.WITHDRAW)
       .produce()
 
     val result = placementApplicationTransformer.transformJpaToApi(placementApplication)


### PR DESCRIPTION
Relates to [APS-293](https://dsdmoj.atlassian.net/browse/APS-293)

I've made the changes specified in the associated ticket, and at the same time i've made the withdrawal logic work in the same way for all 4 entity types, making things more predictable and, hopefully, easier to change. Specifically:
 
 - add a method to determine if entity is withdrawble for the user to all four entity services
 - calling code is now responsible for checking if user has permissions to withdraw (this required for cascading where this check is to be skipped)
 - withdrawing is always idempotent
 - withdrawing will cascade down to child types and log errors if those cascading withdrawals unexpectedly fail
   
Because of the cascading, withdrawals are now effectively depth-first traversing a tree made up of applications, placement applications, placement requests and bookings.

[APS-293]: https://dsdmoj.atlassian.net/browse/APS-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ