### PR TITLE
[CAS-176]-Move the CAS3 assessment to read-to-place state when the corresponding booking is cancelled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -547,6 +547,7 @@ class PremisesController(
         cancelledAt = body.date,
         reasonId = body.reason,
         notes = body.notes,
+        user = user,
       )
 
       else -> throw NotImplementedProblem("Unsupported premises type ${booking.premises::class.qualifiedName}")


### PR DESCRIPTION
# Changes in this PR
Refer [CAS-176](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-176) for more information

This PR is to change in the CAS3 booking's cancellation by adding additional steps to move the corresponding assessment to ready-to-place state. 

We already completed the change to move the assessment to closed state(Refer [CAS-50](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-50)) and this is reverse flow of moving from closed assessment to ready-to-place when booking is cancelled.

This change to achieved by calling existing service `AssessmentService.acceptAssessment()` and intentionally catching all the exception thrown from new service call to preserve the existing cancellation flow. 

The user has alternative option to move the assessment to ready-to-place state, hence we are not propagating any exception from `AssessmentService.acceptAssessment()` call.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.

[CAS-176]: https://dsdmoj.atlassian.net/browse/CAS-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CAS-50]: https://dsdmoj.atlassian.net/browse/CAS-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ