### PR TITLE
Add ability to assert on emails in int-tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3018,6 +3018,32 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `Withdrawing an application sends a withdrawal email`() {
+      `Given a User` { user, jwt ->
+        `Given an Offender` { offenderDetails, _ ->
+          val (application, _) = produceAndPersistApplicationAndAssessment(user, user, offenderDetails)
+
+          webTestClient.post()
+            .uri("/applications/${application.id}/withdrawal")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewWithdrawal(
+                reason = WithdrawalReason.duplicateApplication,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+
+          emailNotificationAsserter.assertEmailRequested(
+            user.email!!,
+            notifyConfig.templates.applicationWithdrawn,
+          )
+        }
+      }
+    }
+
+    @Test
     fun `Withdrawing an application withdraws all related entities`() {
       `Given a User` { user, jwt ->
         `Given an Offender` { offenderDetails, _ ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -24,6 +24,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTeamCodeEntityFactory
@@ -83,6 +84,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.notification.EmailNotificationAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
@@ -487,6 +489,12 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var appealTestRepository: AppealTestRepository
+
+  @Autowired
+  lateinit var emailNotificationAsserter: EmailNotificationAsserter
+
+  @Autowired
+  lateinit var notifyConfig: NotifyConfig
 
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.notification
+
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SendEmailRequestedEvent
+
+@Component
+class EmailNotificationAsserter {
+
+  private val requestedEmails = mutableListOf<EmailRequest>()
+
+  @EventListener
+  fun emailRequested(emailRequested: SendEmailRequestedEvent) {
+    requestedEmails.add(emailRequested.request)
+  }
+
+  fun assertEmailRequested(toEmailAddress: String, templateId: String) {
+    val anyMatch = requestedEmails.any { toEmailAddress == it.email && templateId == it.templateId }
+
+    assertThat(anyMatch)
+      .withFailMessage {
+        "Could not find email request. Provided email requests are $requestedEmails"
+      }.isTrue
+  }
+}


### PR DESCRIPTION
The application withdrawal tests have been updated to demonstrate asserting that an email has been sent