### PR TITLE
Add unique UUID's for seeded statusDetails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -181,17 +181,17 @@ object Cas2ApplicationStatusSeeding {
         description = "The application has been cancelled.",
         statusDetails = listOf(
           Cas2PersistedApplicationStatusDetail(
-            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            id = UUID.fromString("ba46bbe0-8fb6-4539-895d-5586e6bfe8b6"),
             name = "assessedAsHighRisk",
             label = "Assessed as High Risk",
           ),
           Cas2PersistedApplicationStatusDetail(
-            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            id = UUID.fromString("522bb736-aeb6-480f-a51a-2bf3dcfcd482"),
             name = "notEligible",
             label = "Not Eligible",
           ),
           Cas2PersistedApplicationStatusDetail(
-            id = UUID.fromString("f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9"),
+            id = UUID.fromString("ccf43af1-359b-4a14-8941-85eefa88f016"),
             name = "noRecourseToPublicFunds",
             label = "No Recourse to Public Funds",
           ),


### PR DESCRIPTION
These were previously not unique and causing
problems. There have been no Status
Details created by the frontend yet so I don't
think there's a problem changing these ID's now.