### PR TITLE
CAS2 Timeline Events on an Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -42,7 +42,7 @@ data class Cas2StatusUpdateEntity(
   val statusUpdateDetails: List<Cas2StatusUpdateDetailEntity>? = null,
 
   @CreationTimestamp
-  var createdAt: OffsetDateTime? = null,
+  var createdAt: OffsetDateTime,
 ) {
   override fun toString() = "Cas2StatusEntity: $id"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
@@ -94,6 +94,7 @@ class Cas2ApplicationsSeedJob(
         description = status.description,
         label = status.label,
         statusId = status.id,
+        createdAt = OffsetDateTime.now(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -115,6 +115,7 @@ class Cas2AutoScript(
         description = status.description,
         label = status.label,
         statusId = status.id,
+        createdAt = OffsetDateTime.now(),
       ),
     )
     update.apply { this.createdAt = application.submittedAt!!.plusDays(idx + 1.toLong()) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -77,6 +77,7 @@ class StatusUpdateService(
         statusId = status.id,
         description = status.description,
         label = status.label,
+        createdAt = OffsetDateTime.now(),
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -16,6 +16,7 @@ class ApplicationsTransformer(
   private val personTransformer: PersonTransformer,
   private val nomisUserTransformer: NomisUserTransformer,
   private val statusUpdateTransformer: StatusUpdateTransformer,
+  private val timelineEventsTransformer: TimelineEventsTransformer,
 ) {
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult):
@@ -34,6 +35,7 @@ class ApplicationsTransformer(
       type = "CAS2",
       telephoneNumber = jpa.telephoneNumber,
       statusUpdates = jpa.statusUpdates?.map { statusUpdate -> statusUpdateTransformer.transformJpaToApi(statusUpdate) },
+      timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmittedApplicationTransformer.kt
@@ -18,6 +18,7 @@ class SubmittedApplicationTransformer(
   private val personTransformer: PersonTransformer,
   private val nomisUserTransformer: NomisUserTransformer,
   private val statusUpdateTransformer: StatusUpdateTransformer,
+  private val timelineEventsTransformer: TimelineEventsTransformer,
 ) {
 
   fun transformJpaToApiRepresentation(
@@ -38,6 +39,7 @@ class SubmittedApplicationTransformer(
       submittedAt = jpa.submittedAt?.toInstant(),
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       telephoneNumber = jpa.telephoneNumber,
+      timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/TimelineEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/TimelineEventsTransformer.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+
+@Component("Cas2TimelineEventsTransformer")
+class TimelineEventsTransformer {
+  fun transformApplicationToTimelineEvents(jpa: Cas2ApplicationEntity): List<Cas2TimelineEvent> {
+    val timelineEvents: MutableList<Cas2TimelineEvent> = mutableListOf()
+
+    addSubmittedEvent(jpa, timelineEvents)
+
+    addStatusUpdateEvents(jpa, timelineEvents)
+
+    addNoteEvents(jpa, timelineEvents)
+
+    return timelineEvents.sortedByDescending { it.occurredAt }
+  }
+
+  private fun addNoteEvents(jpa: Cas2ApplicationEntity, timelineEvents: MutableList<Cas2TimelineEvent>) {
+    jpa.notes?.forEach {
+      timelineEvents += Cas2TimelineEvent(
+        type = TimelineEventType.cas2Note,
+        occurredAt = it.createdAt.toInstant(),
+        label = "Note",
+        createdByName = it.createdByNomisUser.name,
+        body = it.body,
+      )
+    }
+  }
+
+  private fun addStatusUpdateEvents(jpa: Cas2ApplicationEntity, timelineEvents: MutableList<Cas2TimelineEvent>) {
+    jpa.statusUpdates?.forEach {
+      timelineEvents += Cas2TimelineEvent(
+        type = TimelineEventType.cas2StatusUpdate,
+        occurredAt = it.createdAt?.toInstant()!!,
+        label = it.label,
+        createdByName = it.assessor.name,
+        body = it.statusUpdateDetails?.joinToString { detail -> detail.label },
+      )
+    }
+  }
+
+  private fun addSubmittedEvent(jpa: Cas2ApplicationEntity, timelineEvents: MutableList<Cas2TimelineEvent>) {
+    if (jpa.submittedAt !== null) {
+      val submittedAtEvent = Cas2TimelineEvent(
+        type = TimelineEventType.cas2ApplicationSubmitted,
+        occurredAt = jpa.submittedAt?.toInstant()!!,
+        label = "Application submitted",
+        createdByName = jpa.createdByUser.name,
+      )
+      timelineEvents += submittedAtEvent
+    }
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1648,6 +1648,10 @@ components:
               type: array
               items:
                 $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
+            timelineEvents:
+              type: array
+              items:
+                $ref: '_shared.yml#/components/schemas/Cas2TimelineEvent'
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1682,6 +1682,10 @@ components:
             $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
         telephoneNumber:
           type: string
+        timelineEvents:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/Cas2TimelineEvent'
       required:
         - id
         - person
@@ -1690,6 +1694,7 @@ components:
         - schemaVersion
         - outdatedSchema
         - status
+        - timelineEvents
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3322,12 +3322,34 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+        - cas2_application_submitted
+        - cas2_note
+        - cas2_status_update
     TimelineEventUrlType:
       type: string
       enum:
         - application
         - booking
         - assessment
+    Cas2TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        occurredAt:
+          type: string
+          format: date-time
+        label:
+          type: string
+        body:
+          type: string
+        createdByName:
+          type: string
+      required:
+        - type
+        - occurredAt
+        - label
+        - createdByName
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6205,6 +6205,10 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2StatusUpdate'
+            timelineEvents:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2TimelineEvent'
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7879,12 +7879,34 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+        - cas2_application_submitted
+        - cas2_note
+        - cas2_status_update
     TimelineEventUrlType:
       type: string
       enum:
         - application
         - booking
         - assessment
+    Cas2TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        occurredAt:
+          type: string
+          format: date-time
+        label:
+          type: string
+        body:
+          type: string
+        createdByName:
+          type: string
+      required:
+        - type
+        - occurredAt
+        - label
+        - createdByName
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6239,6 +6239,10 @@ components:
             $ref: '#/components/schemas/Cas2StatusUpdate'
         telephoneNumber:
           type: string
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2TimelineEvent'
       required:
         - id
         - person
@@ -6247,6 +6251,7 @@ components:
         - schemaVersion
         - outdatedSchema
         - status
+        - timelineEvents
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2131,6 +2131,10 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2StatusUpdate'
+            timelineEvents:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2TimelineEvent'
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2165,6 +2165,10 @@ components:
             $ref: '#/components/schemas/Cas2StatusUpdate'
         telephoneNumber:
           type: string
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2TimelineEvent'
       required:
         - id
         - person
@@ -2173,6 +2177,7 @@ components:
         - schemaVersion
         - outdatedSchema
         - status
+        - timelineEvents
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3805,12 +3805,34 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+        - cas2_application_submitted
+        - cas2_note
+        - cas2_status_update
     TimelineEventUrlType:
       type: string
       enum:
         - application
         - booking
         - assessment
+    Cas2TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        occurredAt:
+          type: string
+          format: date-time
+        label:
+          type: string
+        body:
+          type: string
+        createdByName:
+          type: string
+      required:
+        - type
+        - occurredAt
+        - label
+        - createdByName
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1730,6 +1730,10 @@ components:
             $ref: '#/components/schemas/Cas2StatusUpdate'
         telephoneNumber:
           type: string
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2TimelineEvent'
       required:
         - id
         - person
@@ -1738,6 +1742,7 @@ components:
         - schemaVersion
         - outdatedSchema
         - status
+        - timelineEvents
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3370,12 +3370,34 @@ components:
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note
+        - cas2_application_submitted
+        - cas2_note
+        - cas2_status_update
     TimelineEventUrlType:
       type: string
       enum:
         - application
         - booking
         - assessment
+    Cas2TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        occurredAt:
+          type: string
+          format: date-time
+        label:
+          type: string
+        body:
+          type: string
+        createdByName:
+          type: string
+      required:
+        - type
+        - occurredAt
+        - label
+        - createdByName
     SeedRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1696,6 +1696,10 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2StatusUpdate'
+            timelineEvents:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2TimelineEvent'
           required:
             - createdBy
             - schemaVersion

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
@@ -29,6 +30,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
   private var telephoneNumber: Yielded<String?> = { randomNumberChars(12) }
+  private var notes: Yielded<MutableList<Cas2ApplicationNoteEntity>> = { mutableListOf() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -78,6 +80,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.statusUpdates = { statusUpdates }
   }
 
+  fun withNotes(notes: MutableList<Cas2ApplicationNoteEntity>) = apply {
+    this.notes = { notes }
+  }
+
   fun withEventNumber(eventNumber: String) = apply {
     this.eventNumber = { eventNumber }
   }
@@ -95,5 +101,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     schemaUpToDate = false,
     nomsNumber = this.nomsNumber(),
     telephoneNumber = this.telephoneNumber(),
+    notes = this.notes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
@@ -18,6 +19,7 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var label: Yielded<String> = { "More information requested" }
   private var description: Yielded<String> = { "More information about the application has been requested" }
+  private var statusUpdateDetails: Yielded<List<Cas2StatusUpdateDetailEntity>?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -47,6 +49,10 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
     this.description = { description }
   }
 
+  fun withStatusUpdateDetails(details: List<Cas2StatusUpdateDetailEntity>) = apply {
+    this.statusUpdateDetails = { details }
+  }
+
   override fun produce(): Cas2StatusUpdateEntity = Cas2StatusUpdateEntity(
     id = this.id(),
     assessor = this.assessor(),
@@ -55,5 +61,6 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
     createdAt = this.createdAt(),
     label = this.label(),
     description = this.description(),
+    statusUpdateDetails = this.statusUpdateDetails(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -37,6 +37,29 @@ class Cas2ApplicationTest : IntegrationTestBase() {
   @SpykBean
   lateinit var realApplicationRepository: ApplicationRepository
 
+  val schema = """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": {
+            "thingId": {
+              "description": "The unique identifier for a thing",
+              "type": "integer"
+            }
+          },
+          "required": [ "thingId" ]
+        }
+        """
+
+  val data = """
+          {
+             "thingId": 123
+          }
+          """
+
   @AfterEach
   fun afterEach() {
     // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
@@ -270,6 +293,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
   @Nested
   inner class GetToShow {
+
     @Test
     fun `Get single in progress application returns 200 with correct body`() {
       `Given a CAS2 User` { userEntity, jwt ->
@@ -280,22 +304,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             .produceAndPersist {
               withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
               withSchema(
-                """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
+                schema,
               )
             }
 
@@ -304,11 +313,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(userEntity)
             withData(
-              """
-          {
-             "thingId": 123
-          }
-          """,
+              data,
             )
           }
 
@@ -396,22 +401,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             .produceAndPersist {
               withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
               withSchema(
-                """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
+                schema,
               )
             }
 
@@ -527,22 +517,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withAddedAt(OffsetDateTime.now())
               withId(UUID.randomUUID())
               withSchema(
-                """
-                {
-                  "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-                  "${"\$id"}": "https://example.com/product.schema.json",
-                  "title": "Thing",
-                  "description": "A thing",
-                  "type": "object",
-                  "properties": {
-                    "thingId": {
-                      "description": "The unique identifier for a thing",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [ "thingId" ]
-                }
-              """,
+                schema,
               )
             }
 
@@ -591,22 +566,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     val jsonSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
       withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
       withSchema(
-        """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
+        schema,
       )
     }
 
@@ -615,11 +575,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       withCrn(crn)
       withCreatedByUser(userEntity)
       withData(
-        """
-          {
-             "thingId": 123
-          }
-          """,
+        data,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -419,6 +419,9 @@ class Cas2SubmissionTest(
                 .map { detail -> detail.label },
             )
               .isEqualTo(listOf("Detail on 3rd update"))
+
+            Assertions.assertThat(responseBody.timelineEvents.map { event -> event.label })
+              .isEqualTo(listOf("3rd update", "2nd update", "1st update", "Application submitted"))
           }
         }
       }
@@ -585,6 +588,9 @@ class Cas2SubmissionTest(
 
                 Assertions.assertThat(responseBody.statusUpdates!!.map { update -> update.label })
                   .isEqualTo(listOf("3rd update", "2nd update", "1st update"))
+
+                Assertions.assertThat(responseBody.timelineEvents.map { event -> event.label })
+                  .isEqualTo(listOf("3rd update", "2nd update", "1st update", "Application submitted"))
               }
             }
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -53,6 +53,23 @@ class Cas2SubmissionTest(
   @Autowired
   lateinit var nomisUserTransformer: NomisUserTransformer
 
+  val schema = """
+       {
+         "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+         "${"\$id"}": "https://example.com/product.schema.json",
+         "title": "Thing",
+         "description": "A thing",
+         "type": "object",
+         "properties": {
+            "thingId": {
+                "description": "The unique identifier for a thing",
+                "type": "integer"
+            }
+         },
+         "required": [ "thingId" ]
+       }
+  """
+
   @AfterEach
   fun afterEach() {
     // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
@@ -310,22 +327,7 @@ class Cas2SubmissionTest(
               .produceAndPersist {
                 withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
                 withSchema(
-                  """
-          {
-            "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-            "${"\$id"}": "https://example.com/product.schema.json",
-            "title": "Thing",
-            "description": "A thing",
-            "type": "object",
-            "properties": {
-              "thingId": {
-                "description": "The unique identifier for a thing",
-                "type": "integer"
-              }
-            },
-            "required": [ "thingId" ]
-          }
-          """,
+                  schema,
                 )
               }
 
@@ -438,22 +440,7 @@ class Cas2SubmissionTest(
               .produceAndPersist {
                 withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
                 withSchema(
-                  """
-          {
-            "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-            "${"\$id"}": "https://example.com/product.schema.json",
-            "title": "Thing",
-            "description": "A thing",
-            "type": "object",
-            "properties": {
-              "thingId": {
-                "description": "The unique identifier for a thing",
-                "type": "integer"
-              }
-            },
-            "required": [ "thingId" ]
-          }
-          """,
+                  schema,
                 )
               }
 
@@ -496,22 +483,7 @@ class Cas2SubmissionTest(
                   .produceAndPersist {
                     withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
                     withSchema(
-                      """
-                        {
-                          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-                          "${"\$id"}": "https://example.com/product.schema.json",
-                          "title": "Thing",
-                          "description": "A thing",
-                          "type": "object",
-                          "properties": {
-                            "thingId": {
-                              "description": "The unique identifier for a thing",
-                              "type": "integer"
-                            }
-                          },
-                          "required": [ "thingId" ]
-                        }
-                        """,
+                      schema,
                     )
                   }
 
@@ -608,22 +580,7 @@ class Cas2SubmissionTest(
                 .produceAndPersist {
                   withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
                   withSchema(
-                    """
-          {
-            "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-            "${"\$id"}": "https://example.com/product.schema.json",
-            "title": "Thing",
-            "description": "A thing",
-            "type": "object",
-            "properties": {
-              "thingId": {
-                "description": "The unique identifier for a thing",
-                "type": "integer"
-              }
-            },
-            "required": [ "thingId" ]
-          }
-          """,
+                    schema,
                   )
                 }
 
@@ -669,17 +626,7 @@ class Cas2SubmissionTest(
                 withAddedAt(OffsetDateTime.now())
                 withId(UUID.randomUUID())
                 withSchema(
-                  """
-                {
-                  "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-                  "${"\$id"}": "https://example.com/product.schema.json",
-                  "title": "Thing",
-                  "description": "A thing",
-                  "type": "object",
-                  "properties": {},
-                  "required": []
-                }
-              """,
+                  schema,
                 )
               }
 
@@ -691,8 +638,10 @@ class Cas2SubmissionTest(
               withCreatedByUser(submittingUser)
               withData(
                 """
-                {}
-              """,
+                        {
+                           "thingId": 123
+                        }
+               """,
               )
 
               val inmateDetail = InmateDetailFactory()
@@ -744,18 +693,7 @@ class Cas2SubmissionTest(
               withAddedAt(OffsetDateTime.now())
               withId(UUID.randomUUID())
               withSchema(
-                """
-            {
-              "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-              "${"\$id"}": "https://example.com/product.schema.json",
-              "title": "Thing",
-              "description": "A thing",
-              "type": "object",
-              "properties": {}
-              },
-              "required": [  ]
-            }
-          """,
+                schema,
               )
             }
 
@@ -767,8 +705,10 @@ class Cas2SubmissionTest(
             withCreatedByUser(submittingUser)
             withData(
               """
-                {}
-              """,
+            {
+               "thingId": 123
+            }
+            """,
             )
           }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/StatusUpdateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/StatusUpdateTransformerTest.kt
@@ -47,6 +47,7 @@ class StatusUpdateTransformerTest {
       description = jpaEntity.description,
       updatedBy = mockExternalUserApi,
       updatedAt = jpaEntity.createdAt?.toInstant(),
+      statusUpdateDetails = null,
     )
 
     val transformation = statusUpdateTransformer.transformJpaToApi(jpaEntity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmittedApplicationTransformerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
@@ -31,6 +33,7 @@ class SubmittedApplicationTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockNomisUserTransformer = mockk<NomisUserTransformer>()
   private val mockStatusUpdateTransformer = mockk<StatusUpdateTransformer>()
+  private val mockTimelineEventsTransformer = mockk<TimelineEventsTransformer>()
 
   private val objectMapper = ObjectMapper().apply {
     registerModule(Jdk8Module())
@@ -43,6 +46,7 @@ class SubmittedApplicationTransformerTest {
     mockPersonTransformer,
     mockNomisUserTransformer,
     mockStatusUpdateTransformer,
+    mockTimelineEventsTransformer,
   )
 
   private val user = NomisUserEntityFactory().produce()
@@ -62,6 +66,7 @@ class SubmittedApplicationTransformerTest {
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
     every { mockNomisUserTransformer.transformJpaToApi(any()) } returns mockNomisUser
     every { mockStatusUpdateTransformer.transformJpaToApi(any()) } returns mockStatusUpdateApi
+    every { mockTimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf(mockk<Cas2TimelineEvent>())
   }
 
   @Nested
@@ -89,6 +94,7 @@ class SubmittedApplicationTransformerTest {
         "submittedAt",
         "submittedBy",
         "telephoneNumber",
+        "timelineEvents",
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/TimelineEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/TimelineEventsTransformerTest.kt
@@ -1,0 +1,141 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas2
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class TimelineEventsTransformerTest {
+
+  private val user = NomisUserEntityFactory().produce()
+
+  private val cas2ApplicationFactory = Cas2ApplicationEntityFactory().withCreatedByUser(user)
+
+  private val submittedCas2ApplicationFactory = Cas2ApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .withSubmittedAt(OffsetDateTime.now())
+
+  private val timelineEventTransformer = TimelineEventsTransformer()
+
+  @Nested
+  inner class WhenThereAreTimelineEvents {
+    @Test
+    fun `transforms the timeline events from a submitted application`() {
+      val statusCreatedAt = OffsetDateTime.now().minusDays(2)
+      val statusUpdateEntity = Cas2StatusUpdateEntityFactory()
+        .withCreatedAt(statusCreatedAt)
+        .withLabel("status update")
+        .withApplication(submittedCas2ApplicationFactory.produce())
+        .withAssessor(
+          ExternalUserEntityFactory().withName("Anne Assessor")
+            .produce(),
+        ).produce()
+
+      val statusWithDetailCreatedAt = OffsetDateTime.now().minusDays(1)
+      val statusUpdateWithDetailsEntity = Cas2StatusUpdateEntityFactory()
+        .withStatusUpdateDetails(
+          listOf(
+            Cas2StatusUpdateDetailEntity(
+              id = UUID.randomUUID(),
+              statusDetailId = UUID.fromString("fc38f750-e9d2-4270-b542-d38286b9855c"),
+              label = "first detail",
+              statusUpdate = Cas2StatusUpdateEntityFactory().withApplication(submittedCas2ApplicationFactory.produce()).produce(),
+            ),
+            Cas2StatusUpdateDetailEntity(
+              id = UUID.randomUUID(),
+              statusDetailId = UUID.fromString("fc38f750-e9d2-4270-b542-d38286b9855c"),
+              label = "second detail",
+              statusUpdate = Cas2StatusUpdateEntityFactory().withApplication(submittedCas2ApplicationFactory.produce()).produce(),
+            ),
+          ),
+        )
+        .withCreatedAt(statusWithDetailCreatedAt)
+        .withLabel("status update with details")
+        .withApplication(submittedCas2ApplicationFactory.produce())
+        .withAssessor(
+          ExternalUserEntityFactory().withName("Anne Other Assessor")
+            .produce(),
+        )
+        .produce()
+
+      val nomisUser = NomisUserEntityFactory().withName("Some Nomis User").produce()
+
+      val noteCreatedAt = OffsetDateTime.now().minusDays(3)
+      val note = Cas2ApplicationNoteEntity(
+        id = UUID.randomUUID(),
+        createdAt = noteCreatedAt,
+        createdByNomisUser = nomisUser,
+        application = submittedCas2ApplicationFactory.produce(),
+        body = "a comment",
+      )
+
+      val submittedAt = OffsetDateTime.now().minusDays(4)
+
+      val jpaEntity = submittedCas2ApplicationFactory
+        .withSubmittedAt(submittedAt)
+        .withCreatedByUser(nomisUser)
+        .withStatusUpdates(mutableListOf(statusUpdateEntity, statusUpdateWithDetailsEntity))
+        .withNotes(mutableListOf(note))
+        .produce()
+
+      val transformation = timelineEventTransformer.transformApplicationToTimelineEvents(jpaEntity)
+
+      Assertions.assertThat(transformation).isEqualTo(
+        listOf(
+          Cas2TimelineEvent(
+            type = TimelineEventType.cas2StatusUpdate,
+            occurredAt = statusWithDetailCreatedAt.toInstant(),
+            label = statusUpdateWithDetailsEntity.label,
+            createdByName = statusUpdateWithDetailsEntity.assessor.name,
+            body = "first detail, second detail",
+          ),
+          Cas2TimelineEvent(
+            type = TimelineEventType.cas2StatusUpdate,
+            occurredAt = statusCreatedAt.toInstant(),
+            label = statusUpdateEntity.label,
+            createdByName = statusUpdateEntity.assessor.name,
+            body = null,
+          ),
+          Cas2TimelineEvent(
+            type = TimelineEventType.cas2Note,
+            occurredAt = noteCreatedAt.toInstant(),
+            label = "Note",
+            createdByName = note.createdByNomisUser.name,
+            body = "a comment",
+          ),
+          Cas2TimelineEvent(
+            type = TimelineEventType.cas2ApplicationSubmitted,
+            occurredAt = submittedAt.toInstant(),
+            label = "Application submitted",
+            createdByName = "Some Nomis User",
+          ),
+        ),
+      )
+    }
+  }
+
+  @Nested
+  inner class WhenThereAreNoTimelineEvents {
+    @Test
+    fun `returns an empty list on an in progress application`() {
+      val jpaEntity = cas2ApplicationFactory
+        .produce()
+
+      val transformation = timelineEventTransformer.transformApplicationToTimelineEvents(jpaEntity)
+
+      Assertions.assertThat(transformation).isEqualTo(
+        emptyList<Cas2TimelineEvent>(),
+      )
+    }
+  }
+}


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-213

In order to show several different types of events in a timeline component on the CAS2 UI, we are creating a standard shape for them on the presentation/transformation layer of the API. We currently need to show - notes, status updates,
and when the application was submitted.

![Screenshot 2024-02-14 at 12 21 01](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/374ccdba-ec71-4633-8fb1-f76d50424891)

([copy is slightly different to screenshot above](https://mojdt.slack.com/archives/C04T6SC31HA/p1707926701170309?thread_ts=1707926423.047549&cid=C04T6SC31HA))

We will follow an existing pattern set by CAS1 for an Application return a list of `TimelineEvents` components, but as our data has a different shape, and as we are already namespacing CAS2 work, we are creating a new `Cas2TimelineEvent` component.

We then introduce a `TimelineEventsTransformer` to take the relevant data on an Application and transform it into the generic TimelineEvent needed.

![Screenshot 2024-02-14 at 12 24 01](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/26eb335b-9560-49ba-a9bd-9c049500a701)

## Applications versus Submissions Controller

I've had to return the events on both the /applications and /submissions end points, even though these events will only appear on submitted applications currently. This is because we have a division between 'referrer' and 'assessor' journeys.
The `/submissions` endpoint is queried by the frontend to retrieve all submitted applications and is only viewable by CAS2_Admin and CAS2_Assessor user roles. 

The `/applications` endpoint is queried by the frontend to retrieve all applications regardless of whether they have been submitted, and is used currently by only POM user roles. The frontend doesn't distinguish when querying for a specific application whether it is submitted or not - it just gets `/applications/{applicationId}`. 

I feel like this could be tidied up a bit, but would need work on the frontend as well/a bit of architectural thinking. A 'submitted application' is currently just an `Application` class with a `submittedAt` date, but it could be we need to move to having what the other CAS's have - a concept of an `Assessment` as we are introducing assessing functionality?
