### PR TITLE
Update application status on withdrawal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -247,7 +247,9 @@ data class BookingEntity(
   val arrival: ArrivalEntity?
     get() = arrivals.maxByOrNull { it.createdAt }
 
-  fun isInCancellableStateCas1() = (cancellation == null) && (arrivals.isEmpty())
+  fun isInCancellableStateCas1() = !isCancelled && arrivals.isEmpty()
+
+  fun isActive() = !isCancelled
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -171,12 +171,15 @@ data class PlacementRequestEntity(
   @Enumerated(value = EnumType.STRING)
   var withdrawalReason: PlacementRequestWithdrawalReason?,
 ) {
-  fun isInWithdrawableState() =
-    reallocatedAt == null && !isWithdrawn
+  fun isInWithdrawableState() = isActive()
 
   fun hasActiveBooking() = booking != null && booking?.cancellations.isNullOrEmpty()
 
   fun expectedDeparture() = expectedArrival.plusDays(duration.toLong())
+
+  fun isReallocated() = reallocatedAt != null
+
+  fun isActive() = !isWithdrawn && !isReallocated()
 }
 
 enum class PlacementRequestWithdrawalReason {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+
 enum class ApprovedPremisesApplicationStatus {
   STARTED,
   SUBMITTED,
@@ -7,10 +11,26 @@ enum class ApprovedPremisesApplicationStatus {
   AWAITING_ASSESSMENT,
   UNALLOCATED_ASSESSMENT,
   ASSESSMENT_IN_PROGRESS,
+
+  /**
+   * An application has been assessed and a [PlacementRequestEntity] has been created which requires a [BookingEntity].
+   *
+   * Note - If a [PlacementApplicationEntity] is assessed the application _will not_ enter this state
+   * (it will remain as PENDING_PLACEMENT_REQUEST)
+   */
   AWAITING_PLACEMENT,
+
+  /**
+   * A [BookingEntity] has been created for a [PlacementRequestEntity]
+   */
   PLACEMENT_ALLOCATED,
   INAPPLICABLE,
   WITHDRAWN,
   REQUESTED_FURTHER_INFORMATION,
+
+  /**
+   * An application has been assessed. Because no arrival date was defined,
+   * one or more [PlacementApplicationEntity]s are required
+   */
   PENDING_PLACEMENT_REQUEST,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -526,6 +526,10 @@ class ApplicationService(
     )
   }
 
+  fun updateApprovedPremisesApplicationStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus) {
+    applicationRepository.updateStatus(applicationId,status)
+  }
+
   @Transactional
   fun withdrawApprovedPremisesApplication(
     applicationId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1234,6 +1234,20 @@ class BookingService(
     updateBooking(booking)
     booking.cancellations += cancellationEntity
 
+    createPlacementRequestIfBookingAppealed(reason, booking)
+
+    val user = withdrawalContext.triggeringUser
+    if (shouldCreateDomainEventForBooking(booking, user)) {
+      createCas1CancellationDomainEvent(booking, user, cancelledAt, reason)
+    }
+
+    return success(cancellationEntity)
+  }
+
+  private fun createPlacementRequestIfBookingAppealed(
+    reason: CancellationReasonEntity,
+    booking: BookingEntity,
+  ) {
     if (reason.id == approvedPremisesBookingAppealedCancellationReasonId && booking.placementRequest != null) {
       val placementRequest = booking.placementRequest!!
       placementRequestService.createPlacementRequest(
@@ -1246,14 +1260,7 @@ class BookingService(
         isParole = false,
         null,
       )
-    }
-
-    val user = withdrawalContext.triggeringUser
-    if (shouldCreateDomainEventForBooking(booking, user)) {
-      createCas1CancellationDomainEvent(booking, user, cancelledAt, reason)
-    }
-
-    return success(cancellationEntity)
+      }
   }
 
   @SuppressWarnings("LongMethod")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -67,6 +67,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
@@ -76,6 +77,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundRep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
@@ -1241,7 +1243,31 @@ class BookingService(
       createCas1CancellationDomainEvent(booking, user, cancelledAt, reason)
     }
 
+    updateApplicationStatusOnCancellation(
+      booking = booking,
+      isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.Booking
+    )
+
     return success(cancellationEntity)
+  }
+
+  private fun updateApplicationStatusOnCancellation(
+    booking: BookingEntity,
+    isUserRequestedWithdrawal: Boolean
+  ) {
+    if(!isUserRequestedWithdrawal || booking.application == null) {
+      return
+    }
+
+    val application = booking.application!!
+    val bookings = bookingRepository.findAllByApplication(application)
+    val anyActiveBookings = bookings.any { it.isActive() }
+    if(!anyActiveBookings) {
+      applicationService.updateApprovedPremisesApplicationStatus(
+        application.id,
+        ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT
+      )
+    }
   }
 
   private fun createPlacementRequestIfBookingAppealed(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
@@ -2767,49 +2768,63 @@ class BookingTest : IntegrationTestBase() {
 
   @ParameterizedTest
   @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_WORKFLOW_MANAGER"])
-  fun `Create Cancellation on Booking returns OK with correct body when user has one of roles MANAGER, WORKFLOW_MANAGER`(role: UserRole) {
-    `Given a User`(roles = listOf(role)) { _, jwt ->
-      val booking = bookingEntityFactory.produceAndPersist {
-        withYieldedPremises {
-          approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+  fun `Create Cancellation on CAS1 Booking returns OK with correct body when user has one of roles MANAGER, WORKFLOW_MANAGER`(role: UserRole) {
+    `Given a User`(roles = listOf(role)) { user, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(user)
+          withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+          withSubmittedAt(OffsetDateTime.now())
+        }
+
+        val booking = bookingEntityFactory.produceAndPersist {
+          withYieldedPremises {
+            approvedPremisesEntityFactory.produceAndPersist {
+              withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+              withYieldedProbationRegion {
+                probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+              }
             }
           }
+          withCrn(offenderDetails.otherIds.crn)
+          withApplication(application)
         }
-      }
 
-      val cancellationReason = cancellationReasonEntityFactory.produceAndPersist {
-        withServiceScope("*")
-      }
+        val cancellationReason = cancellationReasonEntityFactory.produceAndPersist {
+          withServiceScope("*")
+        }
 
-      webTestClient.post()
-        .uri("/premises/${booking.premises.id}/bookings/${booking.id}/cancellations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewCancellation(
-            date = LocalDate.parse("2022-08-17"),
-            reason = cancellationReason.id,
-            notes = null,
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectBody()
-        .jsonPath(".bookingId").isEqualTo(booking.id.toString())
-        .jsonPath(".date").isEqualTo("2022-08-17")
-        .jsonPath(".notes").isEqualTo(null)
-        .jsonPath(".reason.id").isEqualTo(cancellationReason.id.toString())
-        .jsonPath(".reason.name").isEqualTo(cancellationReason.name)
-        .jsonPath(".reason.isActive").isEqualTo(true)
-        .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+        webTestClient.post()
+          .uri("/premises/${booking.premises.id}/bookings/${booking.id}/cancellations")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCancellation(
+              date = LocalDate.parse("2022-08-17"),
+              reason = cancellationReason.id,
+              notes = null,
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".bookingId").isEqualTo(booking.id.toString())
+          .jsonPath(".date").isEqualTo("2022-08-17")
+          .jsonPath(".notes").isEqualTo(null)
+          .jsonPath(".reason.id").isEqualTo(cancellationReason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(cancellationReason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+
+        val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(booking.application!!.id)!!
+        assertThat(updatedApplication.status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
+      }
     }
   }
 
   @Test
-  fun `Create Cancellation on Temporary Accommodation Booking on a premises that's not in the user's region returns 403 Forbidden`() {
+  fun `Create Cancellation on CAS3 Booking on a premises that's not in the user's region returns 403 Forbidden`() {
     `Given a User` { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
         withYieldedPremises {
@@ -2847,7 +2862,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Create Cancellation on Temporary Accommodation Booking when a cancellation already exists returns OK with correct body and send cancelled-updated event`() {
+  fun `Create Cancellation on CAS3 Booking when a cancellation already exists returns OK with correct body and send cancelled-updated event`() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
         withYieldedPremises {
@@ -2901,7 +2916,7 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Create Cancellation on Temporary Accommodation Booking when a no cancellation exists returns OK with correct body and send cancelled event`() {
+  fun `Create Cancellation on CAS3 Booking when a no cancellation exists returns OK with correct body and send cancelled event`() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
         withYieldedPremises {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -597,16 +597,19 @@ class PlacementRequestServiceTest {
 
   @Nested
   inner class WithdrawPlacementRequest {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .produce()
+
+    val placementRequest = createValidPlacementRequest(application, user)
+    val placementRequestId = placementRequest.id
 
     @Test
     fun `withdrawPlacementRequest returns Not Found if no Placement Request with ID exists`() {
-      val placementRequestId = UUID.fromString("49f3eef9-4770-4f00-8f31-8e6f4cb4fd9e")
-
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-        .addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
-
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns null
 
       val result = placementRequestService.withdrawPlacementRequest(
@@ -627,17 +630,6 @@ class PlacementRequestServiceTest {
     fun `withdrawPlacementRequest returns Success and saves withdrawn PlacementRequest`(
       reason: PlacementRequestWithdrawalReason?,
     ) {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
@@ -672,17 +664,6 @@ class PlacementRequestServiceTest {
 
     @Test
     fun `withdrawPlacementRequest updates application status to 'PENDING_PLACEMENT_REQUEST' if no other non-active placement requests`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
@@ -724,17 +705,6 @@ class PlacementRequestServiceTest {
 
     @Test
     fun `withdrawPlacementRequest does not update application status to 'PENDING_PLACEMENT_REQUEST' if there are other active placement requests`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
@@ -770,18 +740,7 @@ class PlacementRequestServiceTest {
     }
 
     @Test
-    fun `withdrawPlacementRequest doesnt updates application status if user didn't trigger withdrawl`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
+    fun `withdrawPlacementRequest doesnt updates application status if user didn't trigger withdrawal`() {
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
@@ -816,17 +775,6 @@ class PlacementRequestServiceTest {
     @ParameterizedTest
     @EnumSource(value = WithdrawableEntityType::class, names = ["Booking","PlacementRequest"], mode = EnumSource.Mode.EXCLUDE)
     fun `withdrawPlacementRequest sets correct reason if withdrawal triggered by other entity and user permissions not checked`(triggeringEntity: WithdrawableEntityType) {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
 
@@ -864,7 +812,7 @@ class PlacementRequestServiceTest {
 
     @ParameterizedTest
     @EnumSource(value = WithdrawableEntityType::class, names = ["Booking"], mode = EnumSource.Mode.INCLUDE)
-    fun `withdrawPlacementRequest is triggered by an entity that shouldn't cascade to placement requests, throws exception`(triggeringEntity: WithdrawableEntityType) {
+    fun `withdrawPlacementRequest throws exception if withdrawal triggered by invalid entity`(triggeringEntity: WithdrawableEntityType) {
       val user = UserEntityFactory()
         .withUnitTestControlProbationRegion()
         .produce()
@@ -895,16 +843,6 @@ class PlacementRequestServiceTest {
 
     @Test
     fun `withdrawPlacementRequest is idempotent if placement request already withdrawn`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-      val placementRequestId = UUID.fromString("49f3eef9-4770-4f00-8f31-8e6f4cb4fd9e")
-
-      val placementRequest = createValidPlacementRequest(application, user)
       placementRequest.isWithdrawn = true
 
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
@@ -928,17 +866,6 @@ class PlacementRequestServiceTest {
     @Test
     fun `withdrawPlacementRequest cascades to booking if defined`() {
       val reason = PlacementRequestWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
       val booking = BookingEntityFactory().withDefaultPremises().produce()
       placementRequest.booking = booking
 
@@ -994,16 +921,6 @@ class PlacementRequestServiceTest {
       placementRequestService.log = logger
 
       val reason = PlacementRequestWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
 
       val booking = BookingEntityFactory().withDefaultPremises().produce()
       placementRequest.booking = booking
@@ -1052,32 +969,6 @@ class PlacementRequestServiceTest {
 
     @Test
     fun `withdrawPlacementRequest returns Unauthorised if user directly requested withdrawal and user does not have permission`() {
-      val placementRequestId = UUID.fromString("49f3eef9-4770-4f00-8f31-8e6f4cb4fd9e")
-
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
-        .produce()
-
-      val assessment = ApprovedPremisesAssessmentEntityFactory()
-        .withApplication(application)
-        .produce()
-
-      val placementRequest = PlacementRequestEntityFactory()
-        .withId(placementRequestId)
-        .withApplication(application)
-        .withPlacementRequirements(
-          PlacementRequirementsEntityFactory()
-            .withApplication(application)
-            .withAssessment(assessment)
-            .produce(),
-        )
-        .withAssessment(assessment)
-        .produce()
-
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns false
 
@@ -1095,17 +986,6 @@ class PlacementRequestServiceTest {
 
     @Test
     fun `withdrawPlacementRequest returns Authorised if user directly requested withdrawal and user does not have permission`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
-        .produce()
-
-      val placementRequest = createValidPlacementRequest(application, user)
-      val placementRequestId = placementRequest.id
-
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }


### PR DESCRIPTION
If an entity is withdrawn directly by a user (i.e. it's not a casacading withdrawal), we will update the application status in the following circumstances:

1. If a placement request is withdrawn and there are no other active placement requests, change the status to 'PENDING_PLACEMENT_REQUEST' (meaning a placement_application is required)
2. If a booking is withdrawn and there are no other active bookings, change the status to 'AWAITING_PLACEMENT'