### PR TITLE
Add IT regression tests for withdrawal emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -612,9 +612,9 @@ class ApplicationService(
     userAccessService.userMayWithdrawApplication(user, application)
 
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {
-    if (user.email != null) {
+    user.email?.let { email ->
       emailNotificationService.sendEmail(
-        email = user.email!!,
+        email = email,
         templateId = notifyConfig.templates.applicationWithdrawn,
         personalisation = mapOf(
           "name" to user.name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3010,6 +3010,7 @@ class ApplicationTest : IntegrationTestBase() {
         val updatedAssessment = approvedPremisesAssessmentRepository.findByIdOrNull(assessment.id)!!
         assertThat(updatedAssessment.isWithdrawn).isTrue
 
+        emailNotificationAsserter.assertEmailsRequestedCount(1)
         emailNotificationAsserter.assertEmailRequested(
           user.email!!,
           notifyConfig.templates.applicationWithdrawn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -2819,6 +2819,7 @@ class BookingTest : IntegrationTestBase() {
 
         val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(booking.application!!.id)!!
         assertThat(updatedApplication.status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
+        emailNotificationAsserter.assertNoEmailsRequested()
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1135,6 +1135,8 @@ class PlacementApplicationsTest : IntegrationTestBase() {
                 placementApplicationEntity.createdAt.toInstant() == it.createdAt &&
                 serializableToJsonNode(placementApplicationEntity.document) == serializableToJsonNode(it.document)
             }
+
+            emailNotificationAsserter.assertNoEmailsRequested()
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1635,6 +1635,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
               val persistedPlacementRequest = placementRequestRepository.findByIdOrNull(placementRequest.id)!!
               assertThat(persistedPlacementRequest.isWithdrawn).isTrue
               assertThat(persistedPlacementRequest.withdrawalReason).isEqualTo(PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
+
+              emailNotificationAsserter.assertNoEmailsRequested()
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -523,9 +523,9 @@ class WithdrawalTest : IntegrationTestBase() {
      */
     @Test
     fun `Withdrawing an application cascades to all possible entities`() {
-      `Given a User` { user, jwt ->
+      `Given a User` { applicant, jwt ->
         `Given an Offender` { offenderDetails, _ ->
-          val (application, assessment) = createApplicationAndAssessment(user, user, offenderDetails)
+          val (application, assessment) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
           val placementApplication = createPlacementApplication(application)
           val placementRequest1 = createPlacementRequest(application) {
@@ -568,6 +568,12 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementRequestWithdrawn(placementRequest3, PlacementRequestWithdrawalReason.RELATED_APPLICATION_WITHDRAWN)
           assertBookingNotWithdrawn(booking2HasArrival)
+
+          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailRequested(
+            applicant.email!!,
+            notifyConfig.templates.applicationWithdrawn,
+          )
         }
       }
     }
@@ -634,6 +640,8 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementRequestWithdrawn(placementRequest2, PlacementRequestWithdrawalReason.RELATED_PLACEMENT_APPLICATION_WITHDRAWN)
           assertBookingNotWithdrawn(booking2HasArrival)
+
+          emailNotificationAsserter.assertNoEmailsRequested()
         }
       }
     }
@@ -678,6 +686,8 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementRequestWithdrawn(placementRequest, PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
           assertBookingWithdrawn(bookingNoArrival, "Related placement request withdrawn")
+
+          emailNotificationAsserter.assertNoEmailsRequested()
         }
       }
     }
@@ -718,10 +728,11 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementRequestWithdrawn(placementRequest, PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
           assertBookingNotWithdrawn(bookingNoArrival)
+
+          emailNotificationAsserter.assertNoEmailsRequested()
         }
       }
     }
-
   }
 
   private fun addBookingToPlacementRequest(placementRequest: PlacementRequestEntity, booking: BookingEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
@@ -12,7 +12,7 @@ class EmailNotificationAsserter {
   private val requestedEmails = mutableListOf<EmailRequest>()
 
   @EventListener
-  fun emailRequested(emailRequested: SendEmailRequestedEvent) {
+  fun consumeEmailRequestedEvent(emailRequested: SendEmailRequestedEvent) {
     requestedEmails.add(emailRequested.request)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
@@ -23,6 +23,10 @@ class EmailNotificationAsserter {
     requestedEmails.clear()
   }
 
+  fun assertNoEmailsRequested() {
+    assertEmailsRequestedCount(0)
+  }
+
   fun assertEmailRequested(toEmailAddress: String, templateId: String) {
     val anyMatch = requestedEmails.any { toEmailAddress == it.email && templateId == it.templateId }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.notificatio
 import org.assertj.core.api.Assertions.assertThat
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
+import org.springframework.test.context.event.annotation.BeforeTestMethod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SendEmailRequestedEvent
+import kotlin.math.exp
 
 @Component
 class EmailNotificationAsserter {
@@ -16,6 +18,11 @@ class EmailNotificationAsserter {
     requestedEmails.add(emailRequested.request)
   }
 
+  @BeforeTestMethod
+  fun resetEmailList() {
+    requestedEmails.clear()
+  }
+
   fun assertEmailRequested(toEmailAddress: String, templateId: String) {
     val anyMatch = requestedEmails.any { toEmailAddress == it.email && templateId == it.templateId }
 
@@ -23,5 +30,9 @@ class EmailNotificationAsserter {
       .withFailMessage {
         "Could not find email request. Provided email requests are $requestedEmails"
       }.isTrue
+  }
+
+  fun assertEmailsRequestedCount(expectedCount: Int) {
+    assertThat(requestedEmails.size).isEqualTo(expectedCount)
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -199,3 +199,7 @@ user-allocations:
         nat: JIMSNOWLDAP
     female-assessments:
       enabled: true
+
+notify:
+  send-placement-request-notifications: false
+  send-new-withdrawal-notifications: true


### PR DESCRIPTION
This relates to https://dsdmoj.atlassian.net/browse/APS-308

This is regression testing existing emails in code for withdrawal scenarios