### PR TITLE
[APS-289] Create a new assessment when an appeal is accepted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealD
 @Service
 class AppealService(
   private val appealRepository: AppealRepository,
+  private val assessmentService: AssessmentService,
   private val domainEventService: DomainEventService,
   private val communityApiClient: CommunityApiClient,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
@@ -96,6 +97,10 @@ class AppealService(
         )
 
         saveEvent(appeal)
+
+        if (decision == AppealDecision.accepted) {
+          assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity)
+        }
 
         success(appeal)
       },


### PR DESCRIPTION
> See [APS-289 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-289).

This PR updates the `AppealService.createAppeal` method to automatically create a new assessment for the application if the appeal was accepted.

The application will automatically be moved into the `"unallocatedAssessment"` status when this occurs due to the `@PrePersist` annotated method on the [`AssessmentListener` class](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt), so no explicit update of the status is needed within this PR, although the integration tests assert that this expected status change occurs.