### PR TITLE
Add option to filter on multiple types to /tasks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -134,12 +134,13 @@ class TasksController(
 
   override fun tasksGet(
     type: TaskType?,
+    types: List<TaskType>?,
     page: Int?,
     sortBy: TaskSortField?,
     sortDirection: SortDirection?,
     allocatedFilter: AllocatedFilter?,
     apAreaId: UUID?,
-    allocatedToUserId: UUID?,
+    allocatedToUserId: UUID?
   ): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
@@ -147,17 +148,12 @@ class TasksController(
       throw ForbiddenProblem()
     }
 
-    val taskEntityTypes = if (type == null) {
-      TaskEntityType.entries
+    val taskEntityTypes = if (types != null) {
+      types.map { toTaskEntityType(it) }
+    } else if (type != null) {
+      listOf(toTaskEntityType(type))
     } else {
-      listOf(
-        when (type) {
-          TaskType.assessment -> TaskEntityType.ASSESSMENT
-          TaskType.placementRequest -> TaskEntityType.PLACEMENT_REQUEST
-          TaskType.placementApplication -> TaskEntityType.PLACEMENT_APPLICATION
-          TaskType.bookingAppeal -> throw BadRequestProblem()
-        },
-      )
+      TaskEntityType.entries
     }
 
     return getAll(
@@ -169,6 +165,13 @@ class TasksController(
       apAreaId = apAreaId,
       allocatedToUserId = allocatedToUserId,
     )
+  }
+
+  private fun toTaskEntityType(taskType: TaskType) =  when (taskType) {
+    TaskType.assessment -> TaskEntityType.ASSESSMENT
+    TaskType.placementRequest -> TaskEntityType.PLACEMENT_REQUEST
+    TaskType.placementApplication -> TaskEntityType.PLACEMENT_APPLICATION
+    TaskType.bookingAppeal -> throw BadRequestProblem()
   }
 
   @Deprecated("Use tasksGet, specifying the allocatedToUserId")

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2769,9 +2769,18 @@ paths:
         - name: type
           in: query
           required: false
-          description: Returns tasks that match the given type. BookingAppeal is not supported
+          description: Returns tasks that match the given type. BookingAppeal is not supported. Deprecated - use 'types'
+          deprecated: true
           schema:
             $ref: '_shared.yml#/components/schemas/TaskType'
+        - name: types
+          in: query
+          required: false
+          description: Returns tasks that match the given types. BookingAppeal is not supported
+          schema:
+            type: array
+            items:
+              $ref: '_shared.yml#/components/schemas/TaskType'
         - name: page
           in: query
           required: false

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2771,9 +2771,18 @@ paths:
         - name: type
           in: query
           required: false
-          description: Returns tasks that match the given type. BookingAppeal is not supported
+          description: Returns tasks that match the given type. BookingAppeal is not supported. Deprecated - use 'types'
+          deprecated: true
           schema:
             $ref: '#/components/schemas/TaskType'
+        - name: types
+          in: query
+          required: false
+          description: Returns tasks that match the given types. BookingAppeal is not supported
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/TaskType'
         - name: page
           in: query
           required: false


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-343

Previously the caller could get tasks of all types, of a specific type. The new ‘types’ param allow the caller to specify multiple types to be returned.

The existing ‘type’ param is deprecated in favour of the new more flexible ‘types’ param