### PR TITLE
CAS2 Assessors can create Notes on an Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -59,7 +59,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
-        authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasRole("POM"))
+        authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("POM", "CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
@@ -19,9 +19,8 @@ data class Cas2ApplicationNoteEntity(
   @Id
   val id: UUID,
 
-  @ManyToOne
-  @JoinColumn(name = "created_by_nomis_user_id")
-  val createdByNomisUser: NomisUserEntity,
+  @Transient
+  final val createdByUser: Cas2User,
 
   @ManyToOne
   @JoinColumn(name = "application_id")
@@ -31,5 +30,29 @@ data class Cas2ApplicationNoteEntity(
 
   var body: String,
 ) {
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_nomis_user_id")
+  var createdByNomisUser: NomisUserEntity? = null
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_external_user_id")
+  var createdByExternalUser: ExternalUserEntity? = null
+
+  init {
+    when (this.createdByUser) {
+      is NomisUserEntity -> this.createdByNomisUser = this.createdByUser
+      is ExternalUserEntity -> this.createdByExternalUser = this.createdByUser
+    }
+  }
+
+  fun getUser(): Cas2User {
+    return if (this.createdByNomisUser != null) {
+      this.createdByNomisUser!!
+    } else {
+      this.createdByExternalUser!!
+    }
+  }
+
   override fun toString() = "Cas2ApplicationNoteEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2User.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2User.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+sealed interface User
+
+sealed interface Cas2User : User {
+  val name: String
+  val email: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExternalUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExternalUserEntity.kt
@@ -22,11 +22,11 @@ data class ExternalUserEntity(
   val username: String,
   var isEnabled: Boolean,
   var origin: String,
-  var name: String,
-  var email: String,
+  override var name: String,
+  override var email: String,
 
   @CreationTimestamp
   private val createdAt: OffsetDateTime? = null,
-) {
+) : Cas2User {
   override fun toString() = "External user $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NomisUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NomisUserEntity.kt
@@ -22,17 +22,17 @@ data class NomisUserEntity(
   val id: UUID,
   val nomisUsername: String,
   var nomisStaffId: Long,
-  var name: String,
+  override var name: String,
   var accountType: String,
   var isEnabled: Boolean,
   var isActive: Boolean,
-  var email: String?,
+  override var email: String?,
 
   @CreationTimestamp
   private val createdAt: OffsetDateTime? = null,
 
   @OneToMany(mappedBy = "createdByUser")
   val applications: MutableList<Cas2ApplicationEntity>,
-) {
+) : Cas2User {
   override fun toString() = "Nomis user $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationNoteService.kt
@@ -32,12 +32,10 @@ class ApplicationNoteService(
       ?: return AuthorisableActionResult.NotFound()
 
     val isExternalUser = httpAuthService.getCas2AuthenticatedPrincipalOrThrow().isExternalUser()
-    val user = getExternalOrNomisUser(isExternalUser)
+    val user = getCas2User(isExternalUser)
 
-    if (!isExternalUser) {
-      if (!isApplicationCreatedByUser(application, user as NomisUserEntity)) {
-        return AuthorisableActionResult.Unauthorised()
-      }
+    if (!isExternalUser && !isApplicationCreatedByUser(application, user as NomisUserEntity)) {
+      return AuthorisableActionResult.Unauthorised()
     }
 
     if (application.submittedAt == null) {
@@ -55,7 +53,7 @@ class ApplicationNoteService(
     )
   }
 
-  private fun getExternalOrNomisUser(isExternalUser: Boolean): Cas2User {
+  private fun getCas2User(isExternalUser: Boolean): Cas2User {
     return if (isExternalUser) {
       externalUserService.getUserForRequest()
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationNoteService.kt
@@ -3,11 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -17,6 +22,8 @@ class ApplicationNoteService(
   private val applicationRepository: Cas2ApplicationRepository,
   private val applicationNoteRepository: Cas2ApplicationNoteRepository,
   private val userService: NomisUserService,
+  private val externalUserService: ExternalUserService,
+  private val httpAuthService: HttpAuthService,
 ) {
 
   fun createApplicationNote(applicationId: UUID, note: NewCas2ApplicationNote):
@@ -24,10 +31,13 @@ class ApplicationNoteService(
     val application = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()
 
-    val user = userService.getUserForRequest()
+    val isExternalUser = httpAuthService.getCas2AuthenticatedPrincipalOrThrow().isExternalUser()
+    val user = getExternalOrNomisUser(isExternalUser)
 
-    if (application.createdByUser != user) {
-      return AuthorisableActionResult.Unauthorised()
+    if (!isExternalUser) {
+      if (!isApplicationCreatedByUser(application, user as NomisUserEntity)) {
+        return AuthorisableActionResult.Unauthorised()
+      }
     }
 
     if (application.submittedAt == null) {
@@ -36,20 +46,35 @@ class ApplicationNoteService(
       )
     }
 
-    val note = Cas2ApplicationNoteEntity(
-      id = UUID.randomUUID(),
-      application = application,
-      body = note.note,
-      createdAt = OffsetDateTime.now(),
-      createdByNomisUser = user,
-    )
-
-    val savedNote = applicationNoteRepository.save(note)
+    val savedNote = saveNote(application, note.note, user)
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
         savedNote,
       ),
     )
+  }
+
+  private fun getExternalOrNomisUser(isExternalUser: Boolean): Cas2User {
+    return if (isExternalUser) {
+      externalUserService.getUserForRequest()
+    } else {
+      userService.getUserForRequest()
+    }
+  }
+
+  private fun isApplicationCreatedByUser(application: Cas2ApplicationEntity, user: NomisUserEntity) =
+    application.createdByUser.id == user.id
+
+  private fun saveNote(application: Cas2ApplicationEntity, body: String, user: Cas2User): Cas2ApplicationNoteEntity {
+    val newNote = Cas2ApplicationNoteEntity(
+      id = UUID.randomUUID(),
+      application = application,
+      body = body,
+      createdAt = OffsetDateTime.now(),
+      createdByUser = user,
+    )
+
+    return applicationNoteRepository.save(newNote)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationNotesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationNotesTransformer.kt
@@ -11,10 +11,12 @@ class ApplicationNotesTransformer {
     jpa: Cas2ApplicationNoteEntity,
   ):
     Cas2ApplicationNote {
+    val name = jpa.getUser().name
+    val email = jpa.getUser().email ?: "Not found"
     return Cas2ApplicationNote(
       id = jpa.id,
-      name = jpa.createdByNomisUser.name,
-      email = jpa.createdByNomisUser.email ?: "Not found",
+      name = name,
+      email = email,
       body = jpa.body,
       createdAt = jpa.createdAt.toInstant(),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/TimelineEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/TimelineEventsTransformer.kt
@@ -25,7 +25,7 @@ class TimelineEventsTransformer {
         type = TimelineEventType.cas2Note,
         occurredAt = it.createdAt.toInstant(),
         label = "Note",
-        createdByName = it.createdByNomisUser.name,
+        createdByName = it.getUser().name,
         body = it.body,
       )
     }
@@ -35,7 +35,7 @@ class TimelineEventsTransformer {
     jpa.statusUpdates?.forEach {
       timelineEvents += Cas2TimelineEvent(
         type = TimelineEventType.cas2StatusUpdate,
-        occurredAt = it.createdAt?.toInstant()!!,
+        occurredAt = it.createdAt.toInstant(),
         label = it.label,
         createdByName = it.assessor.name,
         body = it.statusUpdateDetails?.joinToString { detail -> detail.label },

--- a/src/main/resources/db/migration/all/20240214170259__add_external_users_to_cas2_notes.sql
+++ b/src/main/resources/db/migration/all/20240214170259__add_external_users_to_cas2_notes.sql
@@ -1,0 +1,23 @@
+BEGIN TRANSACTION;
+-- add external users to notes table
+ALTER TABLE cas_2_application_notes
+    ADD COLUMN created_by_external_user_id UUID;
+-- add fk for external users
+ALTER TABLE cas_2_application_notes
+    ADD CONSTRAINT fk_created_by_external_user_id
+        FOREIGN KEY(created_by_external_user_id)
+        	REFERENCES external_users(id);
+
+-- make nomis users nullable
+ALTER TABLE cas_2_application_notes
+    ALTER COLUMN created_by_nomis_user_id DROP NOT NULL;
+
+-- must have either nomis or external user
+ALTER TABLE cas_2_application_notes
+    ADD CONSTRAINT has_user
+        CHECK
+        ((created_by_nomis_user_id is not null and created_by_external_user_id is null)
+            OR
+        (created_by_nomis_user_id is null and created_by_external_user_id is not null));
+
+COMMIT TRANSACTION;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationNoteServiceTest.kt
@@ -4,17 +4,22 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
@@ -24,11 +29,15 @@ class ApplicationNoteServiceTest {
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
   private val mockApplicationNoteRepository = mockk<Cas2ApplicationNoteRepository>()
   private val mockUserService = mockk<NomisUserService>()
+  private val mockExternalUserService = mockk<ExternalUserService>()
+  private val mockHttpAuthService = mockk<HttpAuthService>()
 
   private val applicationNoteService = uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationNoteService(
     mockApplicationRepository,
     mockApplicationNoteRepository,
     mockUserService,
+    mockExternalUserService,
+    mockHttpAuthService,
   )
 
   @Nested
@@ -37,120 +46,239 @@ class ApplicationNoteServiceTest {
     private val referrer = NomisUserEntityFactory().produce()
 
     @Nested
-    inner class WhenSuccessful {
-      private val submittedApplication = Cas2ApplicationEntityFactory()
-        .withCreatedByUser(referrer)
-        .withCrn("CRN123")
-        .withNomsNumber("NOMSABC")
-        .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
-        .produce()
-      private val applicationId = submittedApplication.id
-      private val noteEntity = Cas2ApplicationNoteEntity(
-        id = UUID.randomUUID(),
-        createdByNomisUser = referrer,
-        application = submittedApplication,
-        body = "new note",
-        createdAt = OffsetDateTime.now().randomDateTimeBefore(1),
-      )
+    inner class AsNomisUser {
 
-      @Test
-      fun `returns Success result with entity from db`() {
-        every { mockApplicationRepository.findByIdOrNull(applicationId) } answers
-          {
-            submittedApplication
-          }
-        every { mockUserService.getUserForRequest() } returns referrer
-        every { mockApplicationNoteRepository.save(any()) } answers
-          {
-            noteEntity
-          }
-
-        val result = applicationNoteService.createApplicationNote(
-          applicationId = applicationId,
-          NewCas2ApplicationNote(note = "new note"),
-        )
-
-        verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
-
-        Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
-        result as AuthorisableActionResult.Success
-
-        Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
-        val validatableActionResult = result.entity as ValidatableActionResult.Success
-
-        val createdNote = validatableActionResult.entity
-
-        Assertions.assertThat(createdNote).isEqualTo(noteEntity)
-      }
-    }
-
-    @Nested
-    inner class WhenUnsuccessful {
-      @Test
-      fun `returns Not Found when application not found`() {
-        every { mockApplicationRepository.findByIdOrNull(any()) } answers
-          {
-            null
-          }
-
-        Assertions.assertThat(
-          applicationNoteService.createApplicationNote(
-            applicationId = UUID.randomUUID(),
-            note = NewCas2ApplicationNote(note = "note for missing app"),
-          ) is AuthorisableActionResult.NotFound,
-        ).isTrue
+      @BeforeEach
+      fun setup() {
+        val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+        every { mockHttpAuthService.getCas2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+        every { mockPrincipal.isExternalUser() } returns false
       }
 
-      @Test
-      fun `returns Not Authorised when application was not created by user`() {
-        val applicationCreatedByOtherUser = Cas2ApplicationEntityFactory()
-          .withCreatedByUser(NomisUserEntityFactory().produce())
+      @Nested
+      inner class WhenSuccessful {
+        private val submittedApplication = Cas2ApplicationEntityFactory()
+          .withCreatedByUser(referrer)
           .withCrn("CRN123")
           .withNomsNumber("NOMSABC")
           .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
           .produce()
+        private val applicationId = submittedApplication.id
+        private val noteEntity = Cas2ApplicationNoteEntity(
+          id = UUID.randomUUID(),
+          createdByUser = referrer,
+          application = submittedApplication,
+          body = "new note",
+          createdAt = OffsetDateTime.now().randomDateTimeBefore(1),
+        )
 
-        every { mockApplicationRepository.findByIdOrNull(applicationCreatedByOtherUser.id) } answers
-          {
-            applicationCreatedByOtherUser
-          }
+        @Test
+        fun `returns Success result with entity from db`() {
+          every { mockApplicationRepository.findByIdOrNull(applicationId) } answers
+            {
+              submittedApplication
+            }
+          every { mockUserService.getUserForRequest() } returns referrer
+          every { mockApplicationNoteRepository.save(any()) } answers
+            {
+              noteEntity
+            }
 
-        every { mockUserService.getUserForRequest() } returns referrer
+          val result = applicationNoteService.createApplicationNote(
+            applicationId = applicationId,
+            NewCas2ApplicationNote(note = "new note"),
+          )
 
-        Assertions.assertThat(
-          applicationNoteService.createApplicationNote(
-            applicationId = applicationCreatedByOtherUser.id,
-            note = NewCas2ApplicationNote(note = "note for unauthorised app"),
-          ) is AuthorisableActionResult.Unauthorised,
-        ).isTrue
+          verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
+
+          Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+          result as AuthorisableActionResult.Success
+
+          Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
+          val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+          val createdNote = validatableActionResult.entity
+
+          Assertions.assertThat(createdNote).isEqualTo(noteEntity)
+        }
       }
 
-      @Test
-      fun `returns Validation error when application is not submitted`() {
-        val applicationNotSubmitted = Cas2ApplicationEntityFactory()
+      @Nested
+      inner class WhenUnsuccessful {
+        @Test
+        fun `returns Not Found when application not found`() {
+          every { mockApplicationRepository.findByIdOrNull(any()) } answers
+            {
+              null
+            }
+
+          Assertions.assertThat(
+            applicationNoteService.createApplicationNote(
+              applicationId = UUID.randomUUID(),
+              note = NewCas2ApplicationNote(note = "note for missing app"),
+            ) is AuthorisableActionResult.NotFound,
+          ).isTrue
+        }
+
+        @Test
+        fun `returns Not Authorised when application was not created by user`() {
+          val applicationCreatedByOtherUser = Cas2ApplicationEntityFactory()
+            .withCreatedByUser(NomisUserEntityFactory().produce())
+            .withCrn("CRN123")
+            .withNomsNumber("NOMSABC")
+            .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+            .produce()
+
+          every { mockApplicationRepository.findByIdOrNull(applicationCreatedByOtherUser.id) } answers
+            {
+              applicationCreatedByOtherUser
+            }
+
+          every { mockUserService.getUserForRequest() } returns referrer
+
+          Assertions.assertThat(
+            applicationNoteService.createApplicationNote(
+              applicationId = applicationCreatedByOtherUser.id,
+              note = NewCas2ApplicationNote(note = "note for unauthorised app"),
+            ) is AuthorisableActionResult.Unauthorised,
+          ).isTrue
+        }
+
+        @Test
+        fun `returns Validation error when application is not submitted`() {
+          val applicationNotSubmitted = Cas2ApplicationEntityFactory()
+            .withCreatedByUser(referrer)
+            .withCrn("CRN123")
+            .withNomsNumber("NOMSABC")
+            .produce()
+
+          every { mockApplicationRepository.findByIdOrNull(any()) } answers
+            {
+              applicationNotSubmitted
+            }
+
+          every { mockUserService.getUserForRequest() } returns referrer
+
+          val result = applicationNoteService.createApplicationNote(
+            applicationId = applicationNotSubmitted.id,
+            note = NewCas2ApplicationNote(note = "note for in progress app"),
+          )
+          Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+          result as AuthorisableActionResult.Success
+
+          Assertions.assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
+          val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+
+          Assertions.assertThat(validatableActionResult.message).isEqualTo("This application has not been submitted")
+        }
+      }
+    }
+
+    @Nested
+    inner class AsExternalUser {
+      private val externalUser = ExternalUserEntityFactory().produce()
+
+      @BeforeEach
+      fun setup() {
+        val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+        every { mockHttpAuthService.getCas2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+        every { mockPrincipal.isExternalUser() } returns true
+      }
+
+      @Nested
+      inner class WhenSuccessful {
+        private val submittedApplication = Cas2ApplicationEntityFactory()
           .withCreatedByUser(referrer)
           .withCrn("CRN123")
           .withNomsNumber("NOMSABC")
+          .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
           .produce()
-
-        every { mockApplicationRepository.findByIdOrNull(any()) } answers
-          {
-            applicationNotSubmitted
-          }
-
-        every { mockUserService.getUserForRequest() } returns referrer
-
-        val result = applicationNoteService.createApplicationNote(
-          applicationId = applicationNotSubmitted.id,
-          note = NewCas2ApplicationNote(note = "note for in progress app"),
+        private val applicationId = submittedApplication.id
+        private val noteEntity = Cas2ApplicationNoteEntity(
+          id = UUID.randomUUID(),
+          createdByUser = externalUser,
+          application = submittedApplication,
+          body = "new note",
+          createdAt = OffsetDateTime.now().randomDateTimeBefore(1),
         )
-        Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
-        result as AuthorisableActionResult.Success
 
-        Assertions.assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
-        val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+        @Test
+        fun `returns Success result with entity from db`() {
+          every { mockApplicationRepository.findByIdOrNull(applicationId) } answers
+            {
+              submittedApplication
+            }
+          every { mockExternalUserService.getUserForRequest() } returns externalUser
+          every { mockApplicationNoteRepository.save(any()) } answers
+            {
+              noteEntity
+            }
 
-        Assertions.assertThat(validatableActionResult.message).isEqualTo("This application has not been submitted")
+          val result = applicationNoteService.createApplicationNote(
+            applicationId = applicationId,
+            NewCas2ApplicationNote(note = "new note"),
+          )
+
+          verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
+
+          Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+          result as AuthorisableActionResult.Success
+
+          Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
+          val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+          val createdNote = validatableActionResult.entity
+
+          Assertions.assertThat(createdNote).isEqualTo(noteEntity)
+        }
+      }
+
+      @Nested
+      inner class WhenUnsuccessful {
+        @Test
+        fun `returns Not Found when application not found`() {
+          every { mockApplicationRepository.findByIdOrNull(any()) } answers
+            {
+              null
+            }
+
+          every { mockExternalUserService.getUserForRequest() } returns externalUser
+
+          Assertions.assertThat(
+            applicationNoteService.createApplicationNote(
+              applicationId = UUID.randomUUID(),
+              note = NewCas2ApplicationNote(note = "note for missing app"),
+            ) is AuthorisableActionResult.NotFound,
+          ).isTrue
+        }
+
+        @Test
+        fun `returns Validation error when application is not submitted`() {
+          val applicationNotSubmitted = Cas2ApplicationEntityFactory()
+            .withCreatedByUser(referrer)
+            .withCrn("CRN123")
+            .withNomsNumber("NOMSABC")
+            .produce()
+
+          every { mockApplicationRepository.findByIdOrNull(any()) } answers
+            {
+              applicationNotSubmitted
+            }
+
+          every { mockExternalUserService.getUserForRequest() } returns externalUser
+
+          val result = applicationNoteService.createApplicationNote(
+            applicationId = applicationNotSubmitted.id,
+            note = NewCas2ApplicationNote(note = "note for in progress app"),
+          )
+          Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+          result as AuthorisableActionResult.Success
+
+          Assertions.assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
+          val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+
+          Assertions.assertThat(validatableActionResult.message).isEqualTo("This application has not been submitted")
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationNoteTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationNoteTransformerTest.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas2
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationNotesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ApplicationNoteTransformerTest {
+  private val user = NomisUserEntityFactory().produce()
+  private val submittedApplication = Cas2ApplicationEntityFactory()
+    .withCreatedByUser(user)
+    .withSubmittedAt(OffsetDateTime.now())
+    .produce()
+
+  private val applicationNotesTransformer = ApplicationNotesTransformer()
+
+  @Nested
+  inner class WithExternalUser {
+    @Test
+    fun `transforms JPA Cas2ApplicationNote db entity to API representation`() {
+      val externalUser = ExternalUserEntityFactory().produce()
+      val createdAt = OffsetDateTime.now().randomDateTimeBefore(1)
+      val jpaEntity = Cas2ApplicationNoteEntity(
+        id = UUID.randomUUID(),
+        createdByUser = externalUser,
+        application = submittedApplication,
+        body = "new note",
+        createdAt = createdAt,
+      )
+
+      val expectedRepresentation = Cas2ApplicationNote(
+        id = jpaEntity.id,
+        createdAt = createdAt.toInstant(),
+        email = jpaEntity.getUser().email!!,
+        name = jpaEntity.getUser().name,
+        body = jpaEntity.body,
+      )
+
+      val transformation = applicationNotesTransformer.transformJpaToApi(jpaEntity)
+
+      Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
+    }
+  }
+
+  @Nested
+  inner class WithNomisUser {
+    @Test
+    fun `transforms JPA Cas2ApplicationNote db entity to API representation`() {
+      val nomisUser = NomisUserEntityFactory().produce()
+      val createdAt = OffsetDateTime.now().randomDateTimeBefore(1)
+      val jpaEntity = Cas2ApplicationNoteEntity(
+        id = UUID.randomUUID(),
+        createdByUser = nomisUser,
+        application = submittedApplication,
+        body = "new note",
+        createdAt = createdAt,
+      )
+
+      val expectedRepresentation = Cas2ApplicationNote(
+        id = jpaEntity.id,
+        createdAt = createdAt.toInstant(),
+        email = jpaEntity.getUser().email!!,
+        name = jpaEntity.getUser().name,
+        body = jpaEntity.body,
+      )
+
+      val transformation = applicationNotesTransformer.transformJpaToApi(jpaEntity)
+
+      Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/TimelineEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/TimelineEventsTransformerTest.kt
@@ -74,7 +74,7 @@ class TimelineEventsTransformerTest {
       val note = Cas2ApplicationNoteEntity(
         id = UUID.randomUUID(),
         createdAt = noteCreatedAt,
-        createdByNomisUser = nomisUser,
+        createdByUser = nomisUser,
         application = submittedCas2ApplicationFactory.produce(),
         body = "a comment",
       )
@@ -110,7 +110,7 @@ class TimelineEventsTransformerTest {
             type = TimelineEventType.cas2Note,
             occurredAt = noteCreatedAt.toInstant(),
             label = "Note",
-            createdByName = note.createdByNomisUser.name,
+            createdByName = note.getUser().name,
             body = "a comment",
           ),
           Cas2TimelineEvent(


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-212 

We previously introduced Notes on an Application https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1470 that could be added a by a Nomis user (e.g. a Referrer/`POM`).

This PR allows users with the CAS2_ASSESSOR role to add notes to any submitted applications.

![Screenshot 2024-02-19 at 12 17 27](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/388fb39d-8a73-42ee-ad3b-3fdfd838fc59)


This is the first time we've come across an entity that could have either an ExternalUser or a NomisUser belonging to it - we discussed [introducing polymorphism in the previous PR, but tabled it at the time.](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1470#pullrequestreview-1875714328).
In this PR, rather than representing the polymorphism on the database level, I've [introduced a Sealed Class](https://kotlinlang.org/docs/sealed-classes.html) for a `CAS2User` which gives us a couple of benefits:
 - to construct `when` blocks that the compiler will warn us about if we leave out any possibilities. 
 - add helper methods to the `CAS2NoteEntity` to assign a user and ensure it always has either a Nomis or ExternalUser. 

On the database level, there is a constraint on the database that a note has either a `nomis` or an `external` user ID foreign key. 
 
 
