### PR TITLE
Add Booking Withdrawn Emails for Applicant and Premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -22,21 +22,21 @@ class EmailAddressConfig {
 }
 
 class NotifyTemplates {
-  var applicationSubmitted = "c9944bd8-63c4-473c-8dce-b3636e47d3dd"
-  var applicationWithdrawn = "ad6d2449-f5a1-432a-9a96-0835c3f92dad"
-  var assessmentAllocated = "f3d78814-383f-4b5f-a681-9bd3ab912888"
-  var assessmentDeallocated = "331ce452-ea83-4f0c-aec0-5eafe85094f2"
-  var assessmentAccepted = "ddf87b15-8866-4bad-a87b-47eba69eb6db"
-  var assessmentRejected = "b3a98c60-8fe0-4450-8fd0-6430198ee43b"
-  var assessmentWithdrawn = "44ade006-7ac6-4769-aa40-542da56f21b5"
-  var bookingMade = "1e3d2ee2-250e-4755-af38-80d24cdc3480"
-  var bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
-  var placementRequestAllocated = "375d83be-c973-44ed-939f-48ffc00230f3"
-  var placementRequestDecisionAccepted = "dd6f7526-05ce-4951-ba98-a2e68962fb43"
-  var placementRequestDecisionRejected = "b258a025-d1e8-47f2-833e-641d7c119ff5"
-  var placementRequestSubmitted = "deb11bc6-d424-4370-bbe5-41f6a823d292"
-  var placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
-  var cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
+  val applicationSubmitted = "c9944bd8-63c4-473c-8dce-b3636e47d3dd"
+  val applicationWithdrawn = "ad6d2449-f5a1-432a-9a96-0835c3f92dad"
+  val assessmentAllocated = "f3d78814-383f-4b5f-a681-9bd3ab912888"
+  val assessmentDeallocated = "331ce452-ea83-4f0c-aec0-5eafe85094f2"
+  val assessmentAccepted = "ddf87b15-8866-4bad-a87b-47eba69eb6db"
+  val assessmentRejected = "b3a98c60-8fe0-4450-8fd0-6430198ee43b"
+  val assessmentWithdrawn = "44ade006-7ac6-4769-aa40-542da56f21b5"
+  val bookingMade = "1e3d2ee2-250e-4755-af38-80d24cdc3480"
+  val bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
+  val placementRequestAllocated = "375d83be-c973-44ed-939f-48ffc00230f3"
+  val placementRequestDecisionAccepted = "dd6f7526-05ce-4951-ba98-a2e68962fb43"
+  val placementRequestDecisionRejected = "b258a025-d1e8-47f2-833e-641d7c119ff5"
+  val placementRequestSubmitted = "deb11bc6-d424-4370-bbe5-41f6a823d292"
+  val placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
+  val cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
 }
 
 enum class NotifyMode {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -31,6 +31,7 @@ class NotifyTemplates {
   val assessmentWithdrawn = "44ade006-7ac6-4769-aa40-542da56f21b5"
   val bookingMade = "1e3d2ee2-250e-4755-af38-80d24cdc3480"
   val bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
+  val bookingWithdrawn = "30cdc876-40a6-41b0-b642-a6b6115c835c"
   val placementRequestAllocated = "375d83be-c973-44ed-939f-48ffc00230f3"
   val placementRequestDecisionAccepted = "dd6f7526-05ce-4951-ba98-a2e68962fb43"
   val placementRequestDecisionRejected = "b258a025-d1e8-47f2-833e-641d7c119ff5"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -614,7 +614,7 @@ class ApplicationService(
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {
     user.email?.let { email ->
       emailNotificationService.sendEmail(
-        email = email,
+        recipientEmailAddress = email,
         templateId = notifyConfig.templates.applicationWithdrawn,
         personalisation = mapOf(
           "name" to user.name,
@@ -810,7 +810,7 @@ class ApplicationService(
 
   fun sendEmailApplicationSubmitted(user: UserEntity, application: ApplicationEntity) {
     emailNotificationService.sendEmail(
-      email = user.email!!,
+      recipientEmailAddress = user.email!!,
       templateId = notifyConfig.templates.applicationSubmitted,
       personalisation = mapOf(
         "name" to user.name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -222,7 +222,7 @@ class AssessmentService(
     if (allocatedUser != null) {
       if (allocatedUser.email != null) {
         emailNotificationService.sendEmail(
-          email = allocatedUser.email!!,
+          recipientEmailAddress = allocatedUser.email!!,
           templateId = notifyConfig.templates.assessmentAllocated,
           personalisation = mapOf(
             "name" to allocatedUser.name,
@@ -428,7 +428,7 @@ class AssessmentService(
 
       application.createdByUser.email?.let { email ->
         emailNotificationService.sendEmail(
-          email = email,
+          recipientEmailAddress = email,
           templateId = notifyConfig.templates.assessmentAccepted,
           personalisation = mapOf(
             "name" to application.createdByUser.name,
@@ -439,7 +439,7 @@ class AssessmentService(
 
         if (createPlacementRequest && sendPlacementRequestNotifications) {
           emailNotificationService.sendEmail(
-            email = email,
+            recipientEmailAddress = email,
             templateId = notifyConfig.templates.placementRequestSubmitted,
             personalisation = mapOf(
               "crn" to application.crn,
@@ -637,7 +637,7 @@ class AssessmentService(
       )
       if (application.createdByUser.email != null) {
         emailNotificationService.sendEmail(
-          email = application.createdByUser.email!!,
+          recipientEmailAddress = application.createdByUser.email!!,
           templateId = notifyConfig.templates.assessmentRejected,
           personalisation = mapOf(
             "name" to application.createdByUser.name,
@@ -770,7 +770,7 @@ class AssessmentService(
     if (application is ApprovedPremisesApplicationEntity) {
       if (assigneeUser.email != null) {
         emailNotificationService.sendEmail(
-          email = assigneeUser.email!!,
+          recipientEmailAddress = assigneeUser.email!!,
           templateId = notifyConfig.templates.assessmentAllocated,
           personalisation = mapOf(
             "name" to assigneeUser.name,
@@ -783,7 +783,7 @@ class AssessmentService(
       if (allocatedToUser != null) {
         if (allocatedToUser.email != null) {
           emailNotificationService.sendEmail(
-            email = allocatedToUser.email!!,
+            recipientEmailAddress = allocatedToUser.email!!,
             templateId = notifyConfig.templates.assessmentDeallocated,
             personalisation = mapOf(
               "name" to currentAssessment.allocatedToUser!!.name,
@@ -959,7 +959,7 @@ class AssessmentService(
         allocatedUserEmail != null
       ) {
         emailNotificationService.sendEmail(
-          email = allocatedUserEmail,
+          recipientEmailAddress = allocatedUserEmail,
           templateId = notifyConfig.templates.assessmentWithdrawn,
           personalisation = mapOf(
             "applicationUrl" to applicationUrlTemplate.resolve("id", assessment.application.id.toString()),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -31,7 +31,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
@@ -83,8 +82,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromNestedAuthorisableValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.Instant
 import java.time.LocalDate
@@ -104,7 +103,6 @@ class BookingService(
   private val cruService: CruService,
   private val applicationService: ApplicationService,
   private val workingDayCountService: WorkingDayCountService,
-  private val emailNotificationService: EmailNotificationService,
   private val placementRequestService: PlacementRequestService,
   private val communityApiClient: CommunityApiClient,
   private val bookingRepository: BookingRepository,
@@ -127,13 +125,12 @@ class BookingService(
   private val bedMoveRepository: BedMoveRepository,
   private val premisesRepository: PremisesRepository,
   private val assessmentRepository: AssessmentRepository,
-  private val notifyConfig: NotifyConfig,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
-  @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: String,
   @Value("\${arrived-departed-domain-events-disabled}") private val arrivedAndDepartedDomainEventsDisabled: Boolean,
   private val userService: UserService,
   private val userAccessService: UserAccessService,
   private val assessmentService: AssessmentService,
+  private val cas1BookingEmailService: Cas1BookingEmailService,
 ) {
   val approvedPremisesBookingAppealedCancellationReasonId: UUID =
     UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")
@@ -295,7 +292,7 @@ class BookingService(
         situation = application.situation,
       )
 
-      sendEmailNotifications(placementRequest.application, booking)
+      cas1BookingEmailService.bookingMade(placementRequest.application, booking)
 
       return@validated success(booking)
     }
@@ -440,7 +437,7 @@ class BookingService(
         createApprovedPremisesAdHocBookingDomainEvent(onlineApplication, offlineApplication, eventNumber, booking, user!!, bookingCreatedAt)
 
         if (onlineApplication != null) {
-          sendEmailNotifications(onlineApplication, booking)
+          cas1BookingEmailService.bookingMade(onlineApplication, booking)
         }
       }
 
@@ -476,43 +473,6 @@ class BookingService(
       sentenceType = onlineApplication?.sentenceType,
       situation = onlineApplication?.situation,
     )
-  }
-
-  private fun sendEmailNotifications(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
-    val applicationSubmittedByUser = application.createdByUser
-
-    val lengthOfStayDays = booking.arrivalDate.getDaysUntilInclusive(booking.departureDate).size
-    val lengthOfStayWeeks = lengthOfStayDays.toDouble() / 7
-    val lengthOfStayWeeksWholeNumber = (lengthOfStayDays.toDouble() % 7) == 0.0
-
-    val emailPersonalisation = mapOf(
-      "name" to applicationSubmittedByUser.name,
-      "apName" to booking.premises.name,
-      "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
-      "bookingUrl" to bookingUrlTemplate.replace("#premisesId", booking.premises.id.toString())
-        .replace("#bookingId", booking.id.toString()),
-      "crn" to application.crn,
-      "startDate" to booking.arrivalDate.toString(),
-      "endDate" to booking.departureDate.toString(),
-      "lengthStay" to if (lengthOfStayWeeksWholeNumber) lengthOfStayWeeks.toInt() else lengthOfStayDays,
-      "lengthStayUnit" to if (lengthOfStayWeeksWholeNumber) "weeks" else "days",
-    )
-
-    if (applicationSubmittedByUser.email != null) {
-      emailNotificationService.sendEmail(
-        recipientEmailAddress = applicationSubmittedByUser.email!!,
-        templateId = notifyConfig.templates.bookingMade,
-        personalisation = emailPersonalisation,
-      )
-    }
-
-    if (booking.premises.emailAddress != null) {
-      emailNotificationService.sendEmail(
-        recipientEmailAddress = booking.premises.emailAddress!!,
-        templateId = notifyConfig.templates.bookingMadePremises,
-        personalisation = emailPersonalisation,
-      )
-    }
   }
 
   private fun fetchApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -67,7 +67,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
@@ -501,7 +500,7 @@ class BookingService(
 
     if (applicationSubmittedByUser.email != null) {
       emailNotificationService.sendEmail(
-        email = applicationSubmittedByUser.email!!,
+        recipientEmailAddress = applicationSubmittedByUser.email!!,
         templateId = notifyConfig.templates.bookingMade,
         personalisation = emailPersonalisation,
       )
@@ -509,7 +508,7 @@ class BookingService(
 
     if (booking.premises.emailAddress != null) {
       emailNotificationService.sendEmail(
-        email = booking.premises.emailAddress!!,
+        recipientEmailAddress = booking.premises.emailAddress!!,
         templateId = notifyConfig.templates.bookingMadePremises,
         personalisation = emailPersonalisation,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1203,6 +1203,10 @@ class BookingService(
       isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.Booking
     )
 
+    booking.application?.let { application ->
+      cas1BookingEmailService.bookingWithdrawn(application, booking)
+    }
+
     return success(cancellationEntity)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
@@ -19,22 +19,22 @@ class EmailNotificationService(
 ) {
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
-  fun sendEmail(email: String, templateId: String, personalisation: Map<String, *>) {
-    applicationEventPublisher.publishEvent(SendEmailRequestedEvent(EmailRequest(email, templateId, personalisation)))
+  fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>) {
+    applicationEventPublisher.publishEvent(SendEmailRequestedEvent(EmailRequest(recipientEmailAddress, templateId, personalisation)))
 
     try {
       if (notifyConfig.mode == NotifyMode.DISABLED) {
-        log.info("Email sending is disabled - would have sent template $templateId to user $email")
+        log.info("Email sending is disabled - would have sent template $templateId to user $recipientEmailAddress")
         return
       }
 
       if (notifyConfig.mode == NotifyMode.TEST_AND_GUEST_LIST) {
-        guestListNotificationClient!!.sendEmail(templateId, email, personalisation, null)
+        guestListNotificationClient!!.sendEmail(templateId, recipientEmailAddress, personalisation, null)
       } else {
-        normalNotificationClient!!.sendEmail(templateId, email, personalisation, null)
+        normalNotificationClient!!.sendEmail(templateId, recipientEmailAddress, personalisation, null)
       }
     } catch (notificationClientException: NotificationClientException) {
-      log.error("Unable to send template $templateId to user $email", notificationClientException)
+      log.error("Unable to send template $templateId to user $recipientEmailAddress", notificationClientException)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -477,7 +477,7 @@ class PlacementApplicationService(
     val createdByUser = placementApplication.createdByUser
     createdByUser.email?.let { email ->
       emailNotificationService.sendEmail(
-        email = email,
+        recipientEmailAddress = email,
         templateId = notifyConfig.templates.placementRequestSubmitted,
         personalisation = mapOf(
           "crn" to placementApplication.application.crn,
@@ -494,7 +494,7 @@ class PlacementApplicationService(
     val createdByUser = placementApplication.createdByUser
     createdByUser.email?.let { email ->
       emailNotificationService.sendEmail(
-        email = email,
+        recipientEmailAddress = email,
         templateId = notifyConfig.templates.placementRequestAllocated,
         personalisation = mapOf(
           "crn" to placementApplication.application.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
+
+object Constants {
+  const val DAYS_IN_WEEK = 7
+}
+
+@Service
+class Cas1BookingEmailService(
+  private val emailNotificationService: EmailNotificationService,
+  private val notifyConfig: NotifyConfig,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: String,
+) {
+
+  fun bookingMade(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
+    val applicationSubmittedByUser = application.createdByUser
+
+    val lengthOfStayDays = booking.arrivalDate.getDaysUntilInclusive(booking.departureDate).size
+    val lengthOfStayWeeks = lengthOfStayDays.toDouble() / DAYS_IN_WEEK
+    val lengthOfStayWeeksWholeNumber = (lengthOfStayDays.toDouble() % DAYS_IN_WEEK) == 0.0
+
+    val emailPersonalisation = mapOf(
+      "name" to applicationSubmittedByUser.name,
+      "apName" to booking.premises.name,
+      "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
+      "bookingUrl" to bookingUrlTemplate.replace("#premisesId", booking.premises.id.toString())
+        .replace("#bookingId", booking.id.toString()),
+      "crn" to application.crn,
+      "startDate" to booking.arrivalDate.toString(),
+      "endDate" to booking.departureDate.toString(),
+      "lengthStay" to if (lengthOfStayWeeksWholeNumber) lengthOfStayWeeks.toInt() else lengthOfStayDays,
+      "lengthStayUnit" to if (lengthOfStayWeeksWholeNumber) "weeks" else "days",
+    )
+
+    if (applicationSubmittedByUser.email != null) {
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = applicationSubmittedByUser.email!!,
+        templateId = notifyConfig.templates.bookingMade,
+        personalisation = emailPersonalisation,
+      )
+    }
+
+    if (booking.premises.emailAddress != null) {
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = booking.premises.emailAddress!!,
+        templateId = notifyConfig.templates.bookingMadePremises,
+        personalisation = emailPersonalisation,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -69,6 +69,14 @@ class Cas1BookingEmailService(
       )
     }
 
+    val premises = booking.premises
+    premises.emailAddress?.let { email ->
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = email,
+        templateId = notifyConfig.templates.bookingWithdrawn,
+        personalisation = allPersonalisation,
+      )
+    }
   }
 
   fun buildCommonPersonalisation(application: ApplicationEntity, booking: BookingEntity): Map<String,Any> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 
 object Constants {
@@ -17,8 +18,8 @@ object Constants {
 class Cas1BookingEmailService(
   private val emailNotificationService: EmailNotificationService,
   private val notifyConfig: NotifyConfig,
-  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: String,
-  @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: String,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
 ) {
 
   fun bookingMade(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
@@ -31,9 +32,13 @@ class Cas1BookingEmailService(
     val emailPersonalisation = mapOf(
       "name" to applicationSubmittedByUser.name,
       "apName" to booking.premises.name,
-      "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
-      "bookingUrl" to bookingUrlTemplate.replace("#premisesId", booking.premises.id.toString())
-        .replace("#bookingId", booking.id.toString()),
+      "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+      "bookingUrl" to bookingUrlTemplate.resolve(
+        mapOf(
+          "premisesId" to booking.premises.id.toString(),
+          "bookingId" to booking.id.toString()
+        )
+      ),
       "crn" to application.crn,
       "startDate" to booking.arrivalDate.toString(),
       "endDate" to booking.departureDate.toString(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -300,7 +300,7 @@ class ApplicationService(
 
   private fun sendEmailApplicationSubmitted(user: NomisUserEntity, application: Cas2ApplicationEntity) {
     emailNotificationService.sendEmail(
-      email = notifyConfig.emailAddresses.cas2Assessors,
+      recipientEmailAddress = notifyConfig.emailAddresses.cas2Assessors,
       templateId = notifyConfig.templates.cas2ApplicationSubmitted,
       personalisation = mapOf(
         "name" to user.name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -38,6 +38,11 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
   private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.values().asList()) }
   private var point: Yielded<Point>? = null
 
+  fun withDefaults() = apply {
+    withDefaultProbationRegion()
+    withDefaultLocalAuthorityArea()
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
@@ -140,6 +145,10 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
 
   fun withPoint(point: Point) = apply {
     this.point = { point }
+  }
+
+  fun withEmailAddress(emailAddress: String) = apply {
+    this.emailAddress = { emailAddress }
   }
 
   override fun produce(): ApprovedPremisesEntity = ApprovedPremisesEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -31,7 +31,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
   private var addressLine2: Yielded<String> = { randomStringUpperCase(10) }
   private var town: Yielded<String> = { randomStringUpperCase(10) }
   private var notes: Yielded<String> = { randomStringUpperCase(15) }
-  private var emailAddress: Yielded<String> = { randomStringUpperCase(10) }
+  private var emailAddress: Yielded<String?> = { randomStringUpperCase(10) }
   private var service: Yielded<String> = { "CAS1" }
   private var qCode: Yielded<String> = { randomStringUpperCase(4) }
   private var characteristics: Yielded<MutableList<CharacteristicEntity>> = { mutableListOf() }
@@ -147,7 +147,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.point = { point }
   }
 
-  fun withEmailAddress(emailAddress: String) = apply {
+  fun withEmailAddress(emailAddress: String?) = apply {
     this.emailAddress = { emailAddress }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
@@ -13,6 +13,10 @@ class ProbationRegionEntityFactory : Factory<ProbationRegionEntity> {
   private var apArea: Yielded<ApAreaEntity>? = null
   private var deliusCode: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
 
+  fun withDefaults() = apply {
+    withDefaultApArea()
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -699,78 +699,90 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class CreateCas1Booking {
+  inner class CreateCas1AdhocBooking {
 
     @Test
-    fun `Create Approved Premises Booking returns OK with correct body emits domain event`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    fun `Create Approved Premises Booking returns OK with correct body emits domain event and sends emails`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { _, jwt ->
+        `Given a User` { applicant, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            val premises = approvedPremisesEntityFactory.produceAndPersist {
+              withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+              withYieldedProbationRegion {
+                probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+              }
             }
-          }
 
-          val linkedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
-            withCrn(offenderDetails.otherIds.crn)
-            withCreatedByUser(userEntity)
-            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-            withSubmittedAt(OffsetDateTime.now())
-          }
+            val linkedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(applicant)
+              withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+              withSubmittedAt(OffsetDateTime.now())
+            }
 
-          val room = roomEntityFactory.produceAndPersist {
-            withPremises(premises)
-          }
+            val room = roomEntityFactory.produceAndPersist {
+              withPremises(premises)
+            }
 
-          val bed = bedEntityFactory.produceAndPersist {
-            withRoom(room)
-          }
+            val bed = bedEntityFactory.produceAndPersist {
+              withRoom(room)
+            }
 
-          webTestClient.post()
-            .uri("/premises/${premises.id}/bookings")
-            .header("Authorization", "Bearer $jwt")
-            .bodyValue(
-              NewBooking(
-                crn = offenderDetails.otherIds.crn,
-                arrivalDate = LocalDate.parse("2022-08-12"),
-                departureDate = LocalDate.parse("2022-08-30"),
-                serviceName = ServiceName.approvedPremises,
-                bedId = bed.id,
-                eventNumber = "eventNumber",
-              ),
+            webTestClient.post()
+              .uri("/premises/${premises.id}/bookings")
+              .header("Authorization", "Bearer $jwt")
+              .bodyValue(
+                NewBooking(
+                  crn = offenderDetails.otherIds.crn,
+                  arrivalDate = LocalDate.parse("2022-08-12"),
+                  departureDate = LocalDate.parse("2022-08-30"),
+                  serviceName = ServiceName.approvedPremises,
+                  bedId = bed.id,
+                  eventNumber = "eventNumber",
+                ),
+              )
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
+              .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
+              .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
+              .jsonPath("$.departureDate").isEqualTo("2022-08-30")
+              .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
+              .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+              .jsonPath("$.keyWorker").isEqualTo(null)
+              .jsonPath("$.status").isEqualTo("awaiting-arrival")
+              .jsonPath("$.arrival").isEqualTo(null)
+              .jsonPath("$.departure").isEqualTo(null)
+              .jsonPath("$.nonArrival").isEqualTo(null)
+              .jsonPath("$.cancellation").isEqualTo(null)
+              .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
+              .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+              .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
+              .jsonPath("$.bed.name").isEqualTo(bed.name)
+
+            val emittedMessage = inboundMessageListener.blockForMessage()
+
+            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.booking.made")
+            assertThat(emittedMessage.description).isEqualTo("An Approved Premises booking has been made")
+            assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+            assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
+            assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
+              SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
+              SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
             )
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
-            .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
-            .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
-            .jsonPath("$.departureDate").isEqualTo("2022-08-30")
-            .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
-            .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
-            .jsonPath("$.keyWorker").isEqualTo(null)
-            .jsonPath("$.status").isEqualTo("awaiting-arrival")
-            .jsonPath("$.arrival").isEqualTo(null)
-            .jsonPath("$.departure").isEqualTo(null)
-            .jsonPath("$.nonArrival").isEqualTo(null)
-            .jsonPath("$.cancellation").isEqualTo(null)
-            .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
-            .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-            .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
-            .jsonPath("$.bed.name").isEqualTo(bed.name)
 
-          val emittedMessage = inboundMessageListener.blockForMessage()
-
-          assertThat(emittedMessage.eventType).isEqualTo("approved-premises.booking.made")
-          assertThat(emittedMessage.description).isEqualTo("An Approved Premises booking has been made")
-          assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
-          assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
-          assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
-            SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-            SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
-          )
+            emailNotificationAsserter.assertEmailsRequestedCount(2)
+            emailNotificationAsserter.assertEmailRequested(
+              applicant.email!!,
+              notifyConfig.templates.bookingMade,
+            )
+            emailNotificationAsserter.assertEmailRequested(
+              premises.emailAddress!!,
+              notifyConfig.templates.bookingMadePremises,
+            )
+          }
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -698,145 +698,150 @@ class BookingTest : IntegrationTestBase() {
       .isUnauthorized
   }
 
-  @Test
-  fun `Create Approved Premises Booking returns OK with correct body emits domain event`() {
-    `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
-      `Given an Offender` { offenderDetails, inmateDetails ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+  @Nested
+  inner class CreateCas1Booking {
+
+    @Test
+    fun `Create Approved Premises Booking returns OK with correct body emits domain event`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
           }
-        }
 
-        val linkedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
-          withCrn(offenderDetails.otherIds.crn)
-          withCreatedByUser(userEntity)
-          withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-          withSubmittedAt(OffsetDateTime.now())
-        }
+          val linkedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCrn(offenderDetails.otherIds.crn)
+            withCreatedByUser(userEntity)
+            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+            withSubmittedAt(OffsetDateTime.now())
+          }
 
-        val room = roomEntityFactory.produceAndPersist {
-          withPremises(premises)
-        }
+          val room = roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          }
 
-        val bed = bedEntityFactory.produceAndPersist {
-          withRoom(room)
-        }
+          val bed = bedEntityFactory.produceAndPersist {
+            withRoom(room)
+          }
 
-        webTestClient.post()
-          .uri("/premises/${premises.id}/bookings")
-          .header("Authorization", "Bearer $jwt")
-          .bodyValue(
-            NewBooking(
-              crn = offenderDetails.otherIds.crn,
-              arrivalDate = LocalDate.parse("2022-08-12"),
-              departureDate = LocalDate.parse("2022-08-30"),
-              serviceName = ServiceName.approvedPremises,
-              bedId = bed.id,
-              eventNumber = "eventNumber",
-            ),
+          webTestClient.post()
+            .uri("/premises/${premises.id}/bookings")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewBooking(
+                crn = offenderDetails.otherIds.crn,
+                arrivalDate = LocalDate.parse("2022-08-12"),
+                departureDate = LocalDate.parse("2022-08-30"),
+                serviceName = ServiceName.approvedPremises,
+                bedId = bed.id,
+                eventNumber = "eventNumber",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
+            .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
+            .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
+            .jsonPath("$.departureDate").isEqualTo("2022-08-30")
+            .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
+            .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+            .jsonPath("$.keyWorker").isEqualTo(null)
+            .jsonPath("$.status").isEqualTo("awaiting-arrival")
+            .jsonPath("$.arrival").isEqualTo(null)
+            .jsonPath("$.departure").isEqualTo(null)
+            .jsonPath("$.nonArrival").isEqualTo(null)
+            .jsonPath("$.cancellation").isEqualTo(null)
+            .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
+            .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+            .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
+            .jsonPath("$.bed.name").isEqualTo(bed.name)
+
+          val emittedMessage = inboundMessageListener.blockForMessage()
+
+          assertThat(emittedMessage.eventType).isEqualTo("approved-premises.booking.made")
+          assertThat(emittedMessage.description).isEqualTo("An Approved Premises booking has been made")
+          assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
+          assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
+          assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
+            SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
+            SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
           )
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
-          .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
-          .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
-          .jsonPath("$.departureDate").isEqualTo("2022-08-30")
-          .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
-          .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
-          .jsonPath("$.keyWorker").isEqualTo(null)
-          .jsonPath("$.status").isEqualTo("awaiting-arrival")
-          .jsonPath("$.arrival").isEqualTo(null)
-          .jsonPath("$.departure").isEqualTo(null)
-          .jsonPath("$.nonArrival").isEqualTo(null)
-          .jsonPath("$.cancellation").isEqualTo(null)
-          .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
-          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-          .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
-          .jsonPath("$.bed.name").isEqualTo(bed.name)
-
-        val emittedMessage = inboundMessageListener.blockForMessage()
-
-        assertThat(emittedMessage.eventType).isEqualTo("approved-premises.booking.made")
-        assertThat(emittedMessage.description).isEqualTo("An Approved Premises booking has been made")
-        assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
-        assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
-        assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(
-          SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
-          SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
-        )
+        }
       }
     }
-  }
 
-  @Test
-  fun `Create Approved Premises Booking returns OK with correct body when NOMS number is null`() {
-    `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
-      `Given an Offender`(
-        offenderDetailsConfigBlock = {
-          withNomsNumber(null)
-        },
-      ) { offenderDetails, _ ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+    @Test
+    fun `Create Approved Premises Booking returns OK with correct body when NOMS number is null`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
+        `Given an Offender`(
+          offenderDetailsConfigBlock = {
+            withNomsNumber(null)
+          },
+        ) { offenderDetails, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
           }
-        }
 
-        val linkedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
-          withCrn(offenderDetails.otherIds.crn)
-          withCreatedByUser(userEntity)
-          withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
-          withSubmittedAt(OffsetDateTime.now())
-        }
+          val linkedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCrn(offenderDetails.otherIds.crn)
+            withCreatedByUser(userEntity)
+            withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist())
+            withSubmittedAt(OffsetDateTime.now())
+          }
 
-        val room = roomEntityFactory.produceAndPersist {
-          withPremises(premises)
-        }
+          val room = roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          }
 
-        val bed = bedEntityFactory.produceAndPersist {
-          withRoom(room)
-        }
+          val bed = bedEntityFactory.produceAndPersist {
+            withRoom(room)
+          }
 
-        webTestClient.post()
-          .uri("/premises/${premises.id}/bookings")
-          .header("Authorization", "Bearer $jwt")
-          .bodyValue(
-            NewBooking(
-              crn = offenderDetails.otherIds.crn,
-              arrivalDate = LocalDate.parse("2022-08-12"),
-              departureDate = LocalDate.parse("2022-08-30"),
-              serviceName = ServiceName.approvedPremises,
-              bedId = bed.id,
-              eventNumber = "eventNumber",
-            ),
-          )
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
-          .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
-          .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
-          .jsonPath("$.departureDate").isEqualTo("2022-08-30")
-          .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
-          .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
-          .jsonPath("$.keyWorker").isEqualTo(null)
-          .jsonPath("$.status").isEqualTo("awaiting-arrival")
-          .jsonPath("$.arrival").isEqualTo(null)
-          .jsonPath("$.departure").isEqualTo(null)
-          .jsonPath("$.nonArrival").isEqualTo(null)
-          .jsonPath("$.cancellation").isEqualTo(null)
-          .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
-          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-          .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
-          .jsonPath("$.bed.name").isEqualTo(bed.name)
+          webTestClient.post()
+            .uri("/premises/${premises.id}/bookings")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewBooking(
+                crn = offenderDetails.otherIds.crn,
+                arrivalDate = LocalDate.parse("2022-08-12"),
+                departureDate = LocalDate.parse("2022-08-30"),
+                serviceName = ServiceName.approvedPremises,
+                bedId = bed.id,
+                eventNumber = "eventNumber",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
+            .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
+            .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
+            .jsonPath("$.departureDate").isEqualTo("2022-08-30")
+            .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
+            .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
+            .jsonPath("$.keyWorker").isEqualTo(null)
+            .jsonPath("$.status").isEqualTo("awaiting-arrival")
+            .jsonPath("$.arrival").isEqualTo(null)
+            .jsonPath("$.departure").isEqualTo(null)
+            .jsonPath("$.nonArrival").isEqualTo(null)
+            .jsonPath("$.cancellation").isEqualTo(null)
+            .jsonPath("$.serviceName").isEqualTo(ServiceName.approvedPremises.value)
+            .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+            .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
+            .jsonPath("$.bed.name").isEqualTo(bed.name)
+        }
       }
     }
+
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -2747,8 +2747,9 @@ class BookingTest : IntegrationTestBase() {
           val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(booking.application!!.id)!!
           assertThat(updatedApplication.status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
 
-          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailsRequestedCount(2)
           emailNotificationAsserter.assertEmailRequested(applicant.email!!, notifyConfig.templates.bookingWithdrawn)
+          emailNotificationAsserter.assertEmailRequested(booking.premises.emailAddress!!, notifyConfig.templates.bookingWithdrawn)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -569,13 +569,17 @@ class WithdrawalTest : IntegrationTestBase() {
           assertPlacementRequestWithdrawn(placementRequest3, PlacementRequestWithdrawalReason.RELATED_APPLICATION_WITHDRAWN)
           assertBookingNotWithdrawn(booking2HasArrival)
 
-          emailNotificationAsserter.assertEmailsRequestedCount(2)
+          emailNotificationAsserter.assertEmailsRequestedCount(3)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
             notifyConfig.templates.applicationWithdrawn,
           )
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            booking1NoArrival.premises.emailAddress!!,
             notifyConfig.templates.bookingWithdrawn,
           )
         }
@@ -650,9 +654,13 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementApplicationNotWithdrawn(placementApplication2)
 
-          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailsRequestedCount(2)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            booking1NoArrival.premises.emailAddress!!,
             notifyConfig.templates.bookingWithdrawn,
           )
         }
@@ -700,9 +708,13 @@ class WithdrawalTest : IntegrationTestBase() {
           assertPlacementRequestWithdrawn(placementRequest, PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
           assertBookingWithdrawn(bookingNoArrival, "Related placement request withdrawn")
 
-          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailsRequestedCount(2)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            bookingNoArrival.premises.emailAddress!!,
             notifyConfig.templates.bookingWithdrawn,
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -569,10 +569,14 @@ class WithdrawalTest : IntegrationTestBase() {
           assertPlacementRequestWithdrawn(placementRequest3, PlacementRequestWithdrawalReason.RELATED_APPLICATION_WITHDRAWN)
           assertBookingNotWithdrawn(booking2HasArrival)
 
-          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailsRequestedCount(2)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
             notifyConfig.templates.applicationWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            applicant.email!!,
+            notifyConfig.templates.bookingWithdrawn,
           )
         }
       }
@@ -594,9 +598,9 @@ class WithdrawalTest : IntegrationTestBase() {
      */
     @Test
     fun `Withdrawing a placement application cascades to applicable placement requests and bookings entities`() {
-      `Given a User` { user, jwt ->
+      `Given a User` { applicant, jwt ->
         `Given an Offender` { offenderDetails, _ ->
-          val (application, assessment) = createApplicationAndAssessment(user, user, offenderDetails)
+          val (application, assessment) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
           val placementApplication1 = createPlacementApplication(application)
           val placementRequest1 = createPlacementRequest(application) {
@@ -646,7 +650,11 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementApplicationNotWithdrawn(placementApplication2)
 
-          emailNotificationAsserter.assertNoEmailsRequested()
+          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailRequested(
+            applicant.email!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
         }
       }
     }
@@ -663,9 +671,9 @@ class WithdrawalTest : IntegrationTestBase() {
      */
     @Test
     fun `Withdrawing a placement request cascades to booking with arrival and updates the application status`() {
-      `Given a User` { user, jwt ->
+      `Given a User` { applicant, jwt ->
         `Given an Offender` { offenderDetails, _ ->
-          val (application, assessment) = createApplicationAndAssessment(user, user, offenderDetails)
+          val (application, assessment) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
           val placementRequest = createPlacementRequest(application)
           val bookingNoArrival = createBooking(
@@ -692,7 +700,11 @@ class WithdrawalTest : IntegrationTestBase() {
           assertPlacementRequestWithdrawn(placementRequest, PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
           assertBookingWithdrawn(bookingNoArrival, "Related placement request withdrawn")
 
-          emailNotificationAsserter.assertNoEmailsRequested()
+          emailNotificationAsserter.assertEmailsRequestedCount(1)
+          emailNotificationAsserter.assertEmailRequested(
+            applicant.email!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -133,6 +133,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
 import java.time.Instant
 import java.time.LocalDate
@@ -149,7 +150,7 @@ class BookingServiceTest {
   private val mockCruService = mockk<CruService>()
   private val mockApplicationService = mockk<ApplicationService>()
   private val mockWorkingDayCountService = mockk<WorkingDayCountService>()
-  private val mockEmailNotificationService = mockk<EmailNotificationService>()
+
   private val mockPlacementRequestService = mockk<PlacementRequestService>()
   private val mockCommunityApiClient = mockk<CommunityApiClient>()
   private val mockBookingRepository = mockk<BookingRepository>()
@@ -175,6 +176,7 @@ class BookingServiceTest {
   private val mockUserService = mockk<UserService>()
   private val mockUserAccessService = mockk<UserAccessService>()
   private val mockAssessmentService = mockk<AssessmentService>()
+  private val mockCas1BookingEmailService = mockk<Cas1BookingEmailService>()
 
   fun createBookingService(arrivedAndDepartedDomainEventsDisabled: Boolean): BookingService {
     return BookingService(
@@ -186,7 +188,6 @@ class BookingServiceTest {
       cruService = mockCruService,
       applicationService = mockApplicationService,
       workingDayCountService = mockWorkingDayCountService,
-      emailNotificationService = mockEmailNotificationService,
       placementRequestService = mockPlacementRequestService,
       communityApiClient = mockCommunityApiClient,
       bookingRepository = mockBookingRepository,
@@ -209,13 +210,12 @@ class BookingServiceTest {
       bedMoveRepository = mockBedMoveRepository,
       premisesRepository = mockPremisesRepository,
       assessmentRepository = mockAssessmentRepository,
-      notifyConfig = NotifyConfig(),
       applicationUrlTemplate = "http://frontend/applications/#id",
-      bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
       arrivedAndDepartedDomainEventsDisabled = arrivedAndDepartedDomainEventsDisabled,
       userService = mockUserService,
       userAccessService = mockUserAccessService,
       assessmentService = mockAssessmentService,
+      cas1BookingEmailService = mockCas1BookingEmailService,
     )
   }
 
@@ -4020,7 +4020,7 @@ class BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
       every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
       every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
-      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
     }
 
     @Test
@@ -4224,18 +4224,8 @@ class BookingServiceTest {
         )
       }
 
-      verify(exactly = 2) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          any(),
-          match {
-            it["name"] == user.name &&
-              (it["apName"] as String) == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-          },
-        )
-      }
+      val booking = (validatableResult as ValidatableActionResult.Success).entity
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(application, booking) }
     }
 
     @ParameterizedTest
@@ -4295,18 +4285,8 @@ class BookingServiceTest {
         )
       }
 
-      verify(exactly = 2) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          any(),
-          match {
-            it["name"] == user.name &&
-              (it["apName"] as String) == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-          },
-        )
-      }
+      val booking = (validatableResult as ValidatableActionResult.Success).entity
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(existingApplication, booking) }
     }
 
     @Test
@@ -4365,80 +4345,8 @@ class BookingServiceTest {
         )
       }
 
-      verify(exactly = 2) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          any(),
-          match {
-            it["name"] == user.name &&
-              (it["apName"] as String) == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-          },
-        )
-      }
-    }
-
-    @Test
-    fun `createApprovedPremisesAdHocBooking uses days in Booking length for email when not whole number of weeks`() {
-      user.addRoleForUnitTest(UserRole.CAS1_MANAGER)
-
-      val arrivalDate = LocalDate.parse("2023-02-22")
-      val departureDate = LocalDate.parse("2023-02-27")
-
-      every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
-      every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-
-      val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, premises, bed.id, "eventNumber")
-      assertThat(authorisableResult is AuthorisableActionResult.Success)
-      val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
-      assertThat(validatableResult is ValidatableActionResult.Success)
-
-      verify(exactly = 2) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          any(),
-          match {
-            it["name"] == user.name &&
-              (it["apName"] as String) == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["lengthStay"] as Int) == 6 &&
-              (it["lengthStayUnit"] as String) == "days"
-          },
-        )
-      }
-    }
-
-    @Test
-    fun `createApprovedPremisesAdHocBooking uses weeks in Booking length for email when whole number of weeks`() {
-      user.addRoleForUnitTest(UserRole.CAS1_MANAGER)
-
-      val arrivalDate = LocalDate.parse("2023-02-01")
-      val departureDate = LocalDate.parse("2023-02-14")
-
-      every { mockLostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
-      every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-
-      val authorisableResult = bookingService.createApprovedPremisesAdHocBooking(user, crn, "NOMS123", arrivalDate, departureDate, premises, bed.id, "eventNumber")
-      assertThat(authorisableResult is AuthorisableActionResult.Success)
-      val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
-      assertThat(validatableResult is ValidatableActionResult.Success)
-
-      verify(exactly = 2) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          any(),
-          match {
-            it["name"] == user.name &&
-              (it["apName"] as String) == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["lengthStay"] as Int) == 2 &&
-              (it["lengthStayUnit"] as String) == "weeks"
-          },
-        )
-      }
+      val booking = (validatableResult as ValidatableActionResult.Success).entity
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(existingApplication, booking) }
     }
 
     @ParameterizedTest
@@ -6220,8 +6128,7 @@ class BookingServiceTest {
       every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
       every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
-
-      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -6232,9 +6139,9 @@ class BookingServiceTest {
         departureDate = departureDate,
       )
 
-      assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
+      val booking = assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
       assertDomainEventSent(placementRequest, offenderDetails, premises, arrivalDate)
-      assertEmailsSent(otherUser, premises)
+      assertEmailsSent(application, booking)
     }
 
     @Test
@@ -6276,8 +6183,7 @@ class BookingServiceTest {
       every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
       every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
-
-      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -6288,9 +6194,9 @@ class BookingServiceTest {
         departureDate = departureDate,
       )
 
-      assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
+      val booking = assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
       assertDomainEventSent(placementRequest, offenderDetails, premises, arrivalDate)
-      assertEmailsSent(otherUser, premises)
+      assertEmailsSent(application, booking)
     }
 
     @Test
@@ -6357,8 +6263,7 @@ class BookingServiceTest {
       every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
       every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
-
-      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -6369,9 +6274,9 @@ class BookingServiceTest {
         departureDate = departureDate,
       )
 
-      assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
+      val booking = assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
       assertDomainEventSent(placementRequest, offenderDetails, premises, arrivalDate)
-      assertEmailsSent(otherUser, premises)
+      assertEmailsSent(application, booking)
     }
 
     @Test
@@ -6424,8 +6329,7 @@ class BookingServiceTest {
       every { mockCommunityApiClient.getStaffUserDetails(workflowManager.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { mockCruService.cruNameFromProbationAreaCode(staffUserDetails.probationArea.code) } returns "CRU NAME"
       every { mockDomainEventService.saveBookingMadeDomainEvent(any()) } just Runs
-
-      every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = workflowManager,
@@ -6436,9 +6340,9 @@ class BookingServiceTest {
         departureDate = departureDate,
       )
 
-      assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
+      val booking = assertBookingCreated(authorisableResult, application, premises, arrivalDate, departureDate)
       assertDomainEventSent(placementRequest, offenderDetails, premises, arrivalDate)
-      assertEmailsSent(otherUser, premises)
+      assertEmailsSent(application, booking)
     }
 
     private fun assertBookingCreated(
@@ -6447,7 +6351,7 @@ class BookingServiceTest {
       premises: ApprovedPremisesEntity,
       arrivalDate: LocalDate,
       departureDate: LocalDate,
-    ) {
+    ) : BookingEntity {
       assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
       val validatableResult = (authorisableResult as AuthorisableActionResult.Success).entity
       assertThat(validatableResult is ValidatableActionResult.Success).isTrue
@@ -6473,6 +6377,8 @@ class BookingServiceTest {
           },
         )
       }
+
+      return createdBooking
     }
 
     private fun assertDomainEventSent(
@@ -6512,19 +6418,8 @@ class BookingServiceTest {
       }
     }
 
-    private fun assertEmailsSent(user: UserEntity, premises: ApprovedPremisesEntity) {
-      verify(exactly = 2) {
-        mockEmailNotificationService.sendEmail(
-          any(),
-          any(),
-          match {
-            it["name"] == user.name &&
-              (it["apName"] as String) == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}/bookings/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-          },
-        )
-      }
+    private fun assertEmailsSent(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(application, booking) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/EmailNotificationServiceTest.kt
@@ -37,7 +37,7 @@ class EmailNotificationServiceTest {
     every { mockApplicationEventPublisher.publishEvent(any(SendEmailRequestedEvent::class)) } returns Unit
 
     emailNotificationService.sendEmail(
-      email = user.email!!,
+      recipientEmailAddress = user.email!!,
       templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888",
       personalisation = mapOf(
         "name" to "Jim",
@@ -62,7 +62,7 @@ class EmailNotificationServiceTest {
     every { mockApplicationEventPublisher.publishEvent(any(SendEmailRequestedEvent::class)) } returns Unit
 
     emailNotificationService.sendEmail(
-      email = user.email!!,
+      recipientEmailAddress = user.email!!,
       templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888",
       personalisation = mapOf(
         "name" to "Jim",
@@ -116,7 +116,7 @@ class EmailNotificationServiceTest {
 
     if (user.email != null) {
       emailNotificationService.sendEmail(
-        email = user.email!!,
+        recipientEmailAddress = user.email!!,
         templateId = templateId,
         personalisation = personalisation,
       )
@@ -162,7 +162,7 @@ class EmailNotificationServiceTest {
 
     if (user.email != null) {
       emailNotificationService.sendEmail(
-        email = user.email!!,
+        recipientEmailAddress = user.email!!,
         templateId = templateId,
         personalisation = personalisation,
       )
@@ -209,7 +209,7 @@ class EmailNotificationServiceTest {
     } returns mockk()
     if (user.email != null) {
       emailNotificationService.sendEmail(
-        email = user.email!!,
+        recipientEmailAddress = user.email!!,
         templateId = templateId,
         personalisation = personalisation,
       )
@@ -261,7 +261,7 @@ class EmailNotificationServiceTest {
     every { logger.error(any<String>(), any()) } returns Unit
 
     emailNotificationService.sendEmail(
-      email = user.email!!,
+      recipientEmailAddress = user.email!!,
       templateId = templateId,
       personalisation = personalisation,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -1,0 +1,210 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.APPLICANT_EMAIL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.CRN
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.PREMISES_EMAIL
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+object TestConstants {
+  const val APPLICANT_EMAIL = "applicantEmail@test.com"
+  const val CRN = "CRN123"
+  const val PREMISES_EMAIL = "premisesEmail@test.com"
+}
+
+class Cas1BookingEmailServiceTest {
+  private val mockEmailNotificationService = mockk<EmailNotificationService>()
+  private val notifyConfig = NotifyConfig()
+
+  val service = Cas1BookingEmailService(
+    mockEmailNotificationService,
+    notifyConfig = notifyConfig,
+    applicationUrlTemplate = "http://frontend/applications/#id",
+    bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
+  )
+
+  val premises = ApprovedPremisesEntityFactory()
+    .withDefaults()
+    .withEmailAddress(PREMISES_EMAIL)
+    .produce()
+
+  @Test
+  fun `bookingMade doesnt send email to applicant if no email address defined`() {
+    val applicant = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(null)
+      .produce()
+
+    val (application,booking) = createApplicationAndBooking(
+      applicant,
+      premises,
+      arrivalDate = LocalDate.of(2023,2,1),
+      departureDate = LocalDate.of(2023,2,14),
+    )
+
+    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
+
+    service.bookingMade(application, booking)
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(any(),any(),any())
+    }
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        PREMISES_EMAIL,
+        notifyConfig.templates.bookingMadePremises,
+        match {
+          it["name"] == applicant.name &&
+            it["apName"] == premises.name &&
+            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
+            (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
+            it["crn"] == CRN &&
+            it["startDate"] == "2023-02-01" &&
+            it["endDate"] == "2023-02-14" &&
+            (it["lengthStay"] as Int) == 2 &&
+            (it["lengthStayUnit"] as String) == "weeks"
+        },
+      )
+    }
+  }
+
+  @SuppressWarnings("CyclomaticComplexMethod")
+  @Test
+  fun `bookingMade sends email to applicant and premises email addresses when defined, when length of stay whole number of weeks`() {
+    val applicant = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(APPLICANT_EMAIL)
+      .produce()
+
+    val (application,booking) = createApplicationAndBooking(
+      applicant,
+      premises,
+      arrivalDate = LocalDate.of(2023,2,1),
+      departureDate = LocalDate.of(2023,2,14),
+    )
+
+    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
+
+    service.bookingMade(application, booking)
+
+    verify(exactly = 2) { mockEmailNotificationService.sendEmail(any(),any(),any()) }
+
+    verify(exactly = 1) {
+        mockEmailNotificationService.sendEmail(
+          APPLICANT_EMAIL,
+          notifyConfig.templates.bookingMade,
+          match {
+            it["name"] == applicant.name &&
+              it["apName"] == premises.name &&
+              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
+              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
+              it["crn"] == CRN &&
+              it["startDate"] == "2023-02-01" &&
+              it["endDate"] == "2023-02-14" &&
+              (it["lengthStay"] as Int) == 2 &&
+              it["lengthStayUnit"] as String == "weeks"
+          },
+        )
+      }
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        PREMISES_EMAIL,
+        notifyConfig.templates.bookingMadePremises,
+        match {
+          it["name"] == applicant.name &&
+            it["apName"] == premises.name &&
+            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
+            (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
+            it["crn"] == CRN &&
+            it["startDate"] == "2023-02-01" &&
+            it["endDate"] == "2023-02-14" &&
+            (it["lengthStay"] as Int) == 2 &&
+            it["lengthStayUnit"] as String == "weeks"
+        },
+      )
+    }
+  }
+
+  @Test
+  fun `bookingMade sends email to applicant and premises email addresses when defined, when length of stay not whole number of weeks`() {
+    val applicant = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(APPLICANT_EMAIL)
+      .produce()
+
+    val (application,booking) = createApplicationAndBooking(
+      applicant,
+      premises,
+      arrivalDate = LocalDate.of(2023,2,22),
+      departureDate = LocalDate.of(2023,2,27),
+    )
+
+    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
+
+    service.bookingMade(application, booking)
+
+    verify(exactly = 2) { mockEmailNotificationService.sendEmail(any(),any(),any()) }
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.bookingMade,
+        match {
+          (it["lengthStay"] as Int) == 6 &&
+          it["lengthStayUnit"] as String == "days"
+        },
+      )
+    }
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        PREMISES_EMAIL,
+        notifyConfig.templates.bookingMadePremises,
+        match {
+          (it["lengthStay"] as Int) == 6 &&
+          it["lengthStayUnit"] as String == "days"
+        },
+      )
+    }
+  }
+
+  private fun createApplicationAndBooking(
+    applicant: UserEntity,
+    premises: ApprovedPremisesEntity,
+    arrivalDate: LocalDate,
+    departureDate: LocalDate): Pair<ApprovedPremisesApplicationEntity,BookingEntity> {
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCrn(CRN)
+      .withCreatedByUser(applicant)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withApplication(application)
+      .withPremises(premises)
+      .withArrivalDate(arrivalDate)
+      .withDepartureDate(departureDate)
+      .produce()
+
+    return Pair(application,booking)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
-import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -9,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -19,6 +19,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.PREMISES_EMAIL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.PREMISES_NAME
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.REGION_NAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -27,6 +29,8 @@ object TestConstants {
   const val APPLICANT_EMAIL = "applicantEmail@test.com"
   const val CRN = "CRN123"
   const val PREMISES_EMAIL = "premisesEmail@test.com"
+  const val PREMISES_NAME = "The Premises Name"
+  const val REGION_NAME = "The Region Name"
 }
 
 class Cas1BookingEmailServiceTest {
@@ -38,11 +42,14 @@ class Cas1BookingEmailServiceTest {
     notifyConfig = notifyConfig,
     applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
     bookingUrlTemplate = UrlTemplate("http://frontend/premises/#premisesId/bookings/#bookingId"),
+    sendNewWithdrawalNotifications = true,
   )
 
   val premises = ApprovedPremisesEntityFactory()
     .withDefaults()
     .withEmailAddress(PREMISES_EMAIL)
+    .withName(PREMISES_NAME)
+    .withProbationRegion(ProbationRegionEntityFactory().withDefaults().withName(REGION_NAME).produce())
     .produce()
 
   @Test
@@ -73,7 +80,7 @@ class Cas1BookingEmailServiceTest {
         notifyConfig.templates.bookingMadePremises,
         match {
           it["name"] == applicant.name &&
-            it["apName"] == premises.name &&
+            it["apName"] == PREMISES_NAME &&
             (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
             (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
             it["crn"] == CRN &&
@@ -131,7 +138,7 @@ class Cas1BookingEmailServiceTest {
         notifyConfig.templates.bookingMadePremises,
         match {
           it["name"] == applicant.name &&
-            it["apName"] == premises.name &&
+            it["apName"] == PREMISES_NAME &&
             (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
             (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
             it["crn"] == CRN &&
@@ -184,6 +191,68 @@ class Cas1BookingEmailServiceTest {
           it["lengthStayUnit"] as String == "days"
         },
       )
+    }
+  }
+
+  @Test
+  fun `bookingWithdrawn sends email to applicant if email defined`() {
+    val applicant = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(APPLICANT_EMAIL)
+      .produce()
+
+    val (application,booking) = createApplicationAndBooking(
+      applicant,
+      premises,
+      arrivalDate = LocalDate.of(2023,2,1),
+      departureDate = LocalDate.of(2023,2,14),
+    )
+
+    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
+
+    service.bookingWithdrawn(application, booking)
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(any(),any(),any())
+    }
+
+    verify(exactly = 1) {
+      mockEmailNotificationService.sendEmail(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.bookingWithdrawn,
+        match {
+            it["apName"] == PREMISES_NAME &&
+            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
+            it["crn"] == CRN &&
+            it["startDate"] == "2023-02-01" &&
+            it["endDate"] == "2023-02-14" &&
+            it["region"] == REGION_NAME
+        },
+      )
+    }
+
+  }
+
+  @Test
+  fun `bookingWithdrawn doesn't send email to applicant if email not defined`() {
+    val applicant = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(null)
+      .produce()
+
+    val (application,booking) = createApplicationAndBooking(
+      applicant,
+      premises,
+      arrivalDate = LocalDate.of(2023,2,1),
+      departureDate = LocalDate.of(2023,2,14),
+    )
+
+    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
+
+    service.bookingWithdrawn(application, booking)
+
+    verify(exactly = 0) {
+      mockEmailNotificationService.sendEmail(any(),any(),any())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.PREMISES_EMAIL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -35,8 +36,8 @@ class Cas1BookingEmailServiceTest {
   val service = Cas1BookingEmailService(
     mockEmailNotificationService,
     notifyConfig = notifyConfig,
-    applicationUrlTemplate = "http://frontend/applications/#id",
-    bookingUrlTemplate = "http://frontend/premises/#premisesId/bookings/#bookingId",
+    applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
+    bookingUrlTemplate = UrlTemplate("http://frontend/premises/#premisesId/bookings/#bookingId"),
   )
 
   val premises = ApprovedPremisesEntityFactory()


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-299

Note that ticket requests that this email is sent to applicants, AP and cru mailboxes. In the interest of keeping this PR manageable, this PR only addresses sending the email to applicants and AP

As part of this PR i've added some more regression testing for the existing booking emails in integration tests, and moved the CAS1 booking email logic into a standalone class. See commits for more information.