### PR TITLE
[Cas-217] - Close cas3 referral after booking is confirmed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -811,10 +811,6 @@ class BookingService(
 
       cas3DomainEventService.saveBookingProvisionallyMadeEvent(booking, user)
 
-      if (assessmentId != null) {
-        closeTransitionalAccommodationAssessment(assessmentId, user, booking)
-      }
-
       success(booking)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1430,6 +1430,7 @@ class BookingService(
 
     if (booking.premises is TemporaryAccommodationPremisesEntity) {
       cas3DomainEventService.saveBookingConfirmedEvent(booking, user)
+      findAndCloseCAS3Assessment(booking, user)
     }
 
     return success(confirmationEntity)
@@ -1853,6 +1854,16 @@ class BookingService(
     val submittedAt = application?.submittedAt ?: offlineApplication?.createdAt as OffsetDateTime
 
     return Triple(applicationId, eventNumber, submittedAt)
+  }
+
+  private fun findAndCloseCAS3Assessment(booking: BookingEntity, user: UserEntity) {
+    booking.application?.let {
+      val assessment =
+        assessmentRepository.findByApplication_IdAndReallocatedAtNull(booking.application!!.id)
+      if (assessment != null) {
+        closeTransitionalAccommodationAssessment(assessment.id, user, booking)
+      }
+    }
   }
 
   @SuppressWarnings("TooGenericExceptionCaught")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -3725,6 +3725,68 @@ class BookingTest : IntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `Create Confirmation on Temporary Accommodation Booking returns OK with correct body and close associated referral`() {
+    `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        }
+        val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withProbationRegion(userEntity.probationRegion)
+          withCreatedByUser(userEntity)
+          withApplicationSchema(applicationSchema)
+          withCrn(offenderDetails.otherIds.crn)
+        }
+
+        val assessmentSchema = temporaryAccommodationAssessmentJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+          withAddedAt(OffsetDateTime.now())
+        }
+
+        val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
+          withApplication(application)
+          withAssessmentSchema(assessmentSchema)
+        }
+        assessment.schemaUpToDate = true
+
+        val booking = bookingEntityFactory.produceAndPersist {
+          withYieldedPremises {
+            temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+              withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+              withYieldedProbationRegion {
+                probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+              }
+            }
+          }
+          withApplication(application)
+          withServiceName(ServiceName.temporaryAccommodation)
+        }
+
+        assertCAS3AssessmentIsNotClosed(assessment)
+
+        webTestClient.post()
+          .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewConfirmation(
+              notes = null,
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
+          .jsonPath("$.dateTime").value(withinSeconds(5L), OffsetDateTime::class.java)
+          .jsonPath("$.notes").isEqualTo(null)
+          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+
+        assertCAS3AssessmentIsClosed(assessment)
+      }
+    }
+  }
+
   @ParameterizedTest
   @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `Create Non Arrival on Approved Premises Booking returns 200 with correct body when user has one of roles MANAGER, MATCHER`(
@@ -3984,11 +4046,11 @@ class BookingTest : IntegrationTestBase() {
     )
   }
 
-  private fun assertClosedCAS3Assessment(assessment: TemporaryAccommodationAssessmentEntity) {
+  private fun assertCAS3AssessmentIsNotClosed(assessment: TemporaryAccommodationAssessmentEntity) {
     val temporaryAccommodationAssessmentEntity =
       temporaryAccommodationAssessmentRepository.findByIdOrNull(assessment.id)
 
-    assertThat(temporaryAccommodationAssessmentEntity!!.completedAt).isNotNull()
+    assertThat(temporaryAccommodationAssessmentEntity!!.completedAt).isNull()
   }
 
   private fun assertCAS3AssessmentIsReadyToPlace(assessment: TemporaryAccommodationAssessmentEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -919,95 +919,6 @@ class BookingTest : IntegrationTestBase() {
           .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
           .jsonPath("$.bed.name").isEqualTo("test-bed")
           .jsonPath("$.assessmentId").isEqualTo("${assessment.id}")
-
-        assertClosedCAS3Assessment(assessment)
-      }
-    }
-  }
-
-  @Test
-  fun `Create Temporary Accommodation Booking returns OK with correct body even closing assessment is failed for schema validation`() {
-    `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      `Given an Offender` { offenderDetails, inmateDetails ->
-        val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
-        }
-
-        val bed = bedEntityFactory.produceAndPersist {
-          withName("test-bed")
-          withYieldedRoom {
-            roomEntityFactory.produceAndPersist {
-              withName("test-room")
-              withYieldedPremises { premises }
-            }
-          }
-        }
-
-        val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        }
-
-        val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
-          withCreatedByUser(userEntity)
-          withCrn(offenderDetails.otherIds.crn)
-          withProbationRegion(userEntity.probationRegion)
-          withApplicationSchema(applicationSchema)
-        }
-
-        val assessmentSchema = temporaryAccommodationAssessmentJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        }
-
-        val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
-          withApplication(application)
-          withAssessmentSchema(assessmentSchema)
-        }
-        assessment.schemaUpToDate = true
-
-        GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
-
-        webTestClient.post()
-          .uri("/premises/${premises.id}/bookings")
-          .header("Authorization", "Bearer $jwt")
-          .bodyValue(
-            NewBooking(
-              crn = offenderDetails.otherIds.crn,
-              arrivalDate = LocalDate.parse("2022-08-12"),
-              departureDate = LocalDate.parse("2022-08-30"),
-              serviceName = ServiceName.temporaryAccommodation,
-              bedId = bed.id,
-              assessmentId = assessment.id,
-            ),
-          )
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .jsonPath("$.person.crn").isEqualTo(offenderDetails.otherIds.crn)
-          .jsonPath("$.person.name").isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
-          .jsonPath("$.arrivalDate").isEqualTo("2022-08-12")
-          .jsonPath("$.departureDate").isEqualTo("2022-08-30")
-          .jsonPath("$.originalArrivalDate").isEqualTo("2022-08-12")
-          .jsonPath("$.originalDepartureDate").isEqualTo("2022-08-30")
-          .jsonPath("$.keyWorker").isEqualTo(null)
-          .jsonPath("$.status").isEqualTo("provisional")
-          .jsonPath("$.arrival").isEqualTo(null)
-          .jsonPath("$.departure").isEqualTo(null)
-          .jsonPath("$.nonArrival").isEqualTo(null)
-          .jsonPath("$.cancellation").isEqualTo(null)
-          .jsonPath("$.confirmation").isEqualTo(null)
-          .jsonPath("$.serviceName").isEqualTo(ServiceName.temporaryAccommodation.value)
-          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-          .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
-          .jsonPath("$.bed.name").isEqualTo("test-bed")
-          .jsonPath("$.assessmentId").isEqualTo("${assessment.id}")
-
-        // Assert the assessment is not closed
-        val temporaryAccommodationAssessmentEntity = temporaryAccommodationAssessmentRepository.findByIdOrNull(assessment.id)
-        assertThat(temporaryAccommodationAssessmentEntity!!.completedAt).isNull()
       }
     }
   }
@@ -1108,8 +1019,6 @@ class BookingTest : IntegrationTestBase() {
           .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
           .jsonPath("$.bed.name").isEqualTo("test-bed")
           .jsonPath("$.assessmentId").isEqualTo("${assessment.id}")
-
-        assertClosedCAS3Assessment(assessment)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -4694,10 +4694,6 @@ class BookingServiceTest {
 
       every { mockCas3DomainEventService.saveBookingProvisionallyMadeEvent(any(), user) } just Runs
 
-      every { mockAssessmentService.closeAssessment(user, application.id) } returns AuthorisableActionResult.Success(ValidatableActionResult.Success(assessment))
-
-      mockkStatic(Sentry::class)
-
       val authorisableResult = bookingService.createTemporaryAccommodationBooking(
         user,
         premises,
@@ -4738,12 +4734,6 @@ class BookingServiceTest {
           },
           user,
         )
-      }
-      verify(exactly = 1) {
-        mockAssessmentService.closeAssessment(user, application.id)
-      }
-      verify(exactly = 0) {
-        Sentry.captureException(any())
       }
     }
 
@@ -4822,12 +4812,6 @@ class BookingServiceTest {
 
       verify(exactly = 0) {
         mockAssessmentRepository.findByIdOrNull(any())
-      }
-      verify(exactly = 0) {
-        mockAssessmentService.closeAssessment(user, any())
-      }
-      verify(exactly = 0) {
-        Sentry.captureException(any())
       }
     }
 
@@ -5069,8 +5053,6 @@ class BookingServiceTest {
 
       every { mockCas3DomainEventService.saveBookingProvisionallyMadeEvent(any(), user) } just Runs
 
-      every { mockAssessmentService.closeAssessment(user, application.id) } returns AuthorisableActionResult.Unauthorised()
-
       mockkStatic(Sentry::class)
       every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
 
@@ -5114,12 +5096,6 @@ class BookingServiceTest {
           },
           user,
         )
-      }
-      verify(exactly = 1) {
-        mockAssessmentService.closeAssessment(user, application.id)
-      }
-      verify(exactly = 1) {
-        Sentry.captureException(any())
       }
     }
 
@@ -5175,13 +5151,6 @@ class BookingServiceTest {
 
       every { mockCas3DomainEventService.saveBookingProvisionallyMadeEvent(any(), user) } just Runs
 
-      every { mockAssessmentService.closeAssessment(user, application.id) } returns AuthorisableActionResult.Success(
-        ValidatableActionResult.FieldValidationError(ValidationErrors()),
-      )
-
-      mockkStatic(Sentry::class)
-      every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
-
       val authorisableResult = bookingService.createTemporaryAccommodationBooking(
         user,
         premises,
@@ -5222,12 +5191,6 @@ class BookingServiceTest {
           },
           user,
         )
-      }
-      verify(exactly = 1) {
-        mockAssessmentService.closeAssessment(user, application.id)
-      }
-      verify(exactly = 1) {
-        Sentry.captureException(any())
       }
     }
 
@@ -5283,11 +5246,6 @@ class BookingServiceTest {
 
       every { mockCas3DomainEventService.saveBookingProvisionallyMadeEvent(any(), user) } just Runs
 
-      every { mockAssessmentService.closeAssessment(user, application.id) } throws RuntimeException("A database exception")
-
-      mockkStatic(Sentry::class)
-      every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
-
       val authorisableResult = bookingService.createTemporaryAccommodationBooking(
         user,
         premises,
@@ -5328,9 +5286,6 @@ class BookingServiceTest {
           },
           user,
         )
-      }
-      verify(exactly = 1) {
-        mockAssessmentService.closeAssessment(user, application.id)
       }
     }
 
@@ -5395,9 +5350,6 @@ class BookingServiceTest {
         entry("$.assessmentId", "doesNotExist"),
       )
 
-      verify(exactly = 0) {
-        mockAssessmentService.closeAssessment(user, assessmentId)
-      }
     }
 
     @Test
@@ -5452,10 +5404,6 @@ class BookingServiceTest {
 
       every { mockCas3DomainEventService.saveBookingProvisionallyMadeEvent(any(), user) } just Runs
 
-      every { mockAssessmentService.closeAssessment(user, application.id) } returns AuthorisableActionResult.Success(ValidatableActionResult.Success(assessment))
-
-      mockkStatic(Sentry::class)
-
       assertThatExceptionOfType(RuntimeException::class.java)
         .isThrownBy {
           bookingService.createTemporaryAccommodationBooking(
@@ -5495,9 +5443,6 @@ class BookingServiceTest {
           },
           user,
         )
-      }
-      verify(exactly = 0) {
-        mockAssessmentService.closeAssessment(user, application.id)
       }
     }
   }


### PR DESCRIPTION
# Changes in this PR

Refer [CAS-217](https://dsdmoj.atlassian.net/browse/CAS-217) for more information

The PR contains below 2 changes:
1. Revert the changes done as part of CAS-50, so that we are not closing referral after 'provisional-booking' is made.
2. Instead, close the CAS3 referral after booking is `confirmed`.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.

[CAS-217]: https://dsdmoj.atlassian.net/browse/CAS-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ