### PR TITLE
Send booking withdrawl notification to CRU inbox

### DIFF
--- a/doc/how-to/example_csvs/approved_premises_ap_area_email_addresses.csv
+++ b/doc/how-to/example_csvs/approved_premises_ap_area_email_addresses.csv
@@ -1,0 +1,3 @@
+ap_area_identifier,email_address,
+SWSC,swsc@somewhere.com
+Mids,mids@other.com

--- a/doc/how-to/run_seed_job_remotely.md
+++ b/doc/how-to/run_seed_job_remotely.md
@@ -150,3 +150,12 @@ Required fields:
 - `notes`
   
 [Example CSV](./example_csvs/approved_premises_rooms_seeding_example.csv)
+
+### Approved Premises AP Area (CRU) Email Address Seed Job
+
+"seed type": `approved_premises_ap_area_email_addresses`
+
+Required fields:
+
+- `ap_area_identifier`
+- `email_address`

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
@@ -11,6 +13,11 @@ import javax.persistence.Table
 @Repository
 interface ApAreaRepository : JpaRepository<ApAreaEntity, UUID> {
   fun findByName(name: String): ApAreaEntity?
+  fun findByIdentifier(name: String): ApAreaEntity?
+
+  @Modifying
+  @Query("UPDATE ApAreaEntity set emailAddress = :emailAddress where id = :id")
+  fun updateEmailAddress(id: UUID, emailAddress: String)
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -22,4 +22,5 @@ data class ApAreaEntity(
   val identifier: String,
   @OneToMany(mappedBy = "apArea")
   val probationRegions: MutableList<ProbationRegionEntity>,
+  val emailAddress: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApAreaEmailAddressSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApAreaEmailAddressSeedJob.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.util.UUID
+
+class Cas1ApAreaEmailAddressSeedJob(
+  fileName: String,
+  private val apAreaRepository: ApAreaRepository,
+) : SeedJob<Cas1ApAreaEmailAddressSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "ap_area_identifier",
+    "email_address",
+  )
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1ApAreaEmailAddressSeedCsvRow(
+    apAreaIdentifier = columns["ap_area_identifier"]!!.trim(),
+    emailAddress = columns["email_address"]!!.trim(),
+  )
+
+  override fun processRow(row: Cas1ApAreaEmailAddressSeedCsvRow) {
+    val apArea = apAreaRepository.findByIdentifier(row.apAreaIdentifier)
+      ?: error("AP Area with identifier '${row.apAreaIdentifier}' does not exist")
+
+    val emailAddress = row.emailAddress
+    if(emailAddress.isBlank()) {
+      error("Email address for '${row.apAreaIdentifier}' is blank")
+    }
+
+    apAreaRepository.updateEmailAddress(apArea.id,emailAddress)
+
+    log.info("Updated email address for AP Area ${apArea.id} to $emailAddress")
+  }
+}
+
+data class Cas1ApAreaEmailAddressSeedCsvRow(
+  val apAreaIdentifier: String,
+  val emailAddress: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1155,6 +1155,11 @@ class BookingService(
       return success(existingCancellation)
     }
 
+    if(booking.application != null && booking.application !is ApprovedPremisesApplicationEntity) {
+      return generalError("Application is not for CAS1")
+    }
+    val application = booking.application as ApprovedPremisesApplicationEntity?
+
     if(!booking.isInCancellableStateCas1()) {
       return generalError("The Booking is not in a state that can be cancelled")
     }
@@ -1203,9 +1208,7 @@ class BookingService(
       isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.Booking
     )
 
-    booking.application?.let { application ->
-      cas1BookingEmailService.bookingWithdrawn(application, booking)
-    }
+    application?.let { cas1BookingEmailService.bookingWithdrawn(it, booking) }
 
     return success(cancellationEntity)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1150,26 +1150,20 @@ class BookingService(
     notes: String?,
     withdrawalContext: WithdrawalContext,
   ) = validated<CancellationEntity> {
+    if(booking.application != null && booking.application !is ApprovedPremisesApplicationEntity) {
+      return generalError("Application is not for CAS1")
+    }
+
     val existingCancellation = booking.cancellation
     if (booking.premises is ApprovedPremisesEntity && existingCancellation != null) {
       return success(existingCancellation)
     }
 
-    if(booking.application != null && booking.application !is ApprovedPremisesApplicationEntity) {
-      return generalError("Application is not for CAS1")
-    }
-    val application = booking.application as ApprovedPremisesApplicationEntity?
-
     if(!booking.isInCancellableStateCas1()) {
       return generalError("The Booking is not in a state that can be cancelled")
     }
 
-    val resolvedReasonId = when(withdrawalContext.triggeringEntityType) {
-      WithdrawableEntityType.Application -> CAS1_RELATED_APP_WITHDRAWN_ID
-      WithdrawableEntityType.PlacementApplication -> CAS1_RELATED_PLACEMENT_APP_WITHDRAWN_ID
-      WithdrawableEntityType.PlacementRequest -> CAS1_RELATED_PLACEMENT_REQ_WITHDRAWN_ID
-      WithdrawableEntityType.Booking -> userProvidedReason
-    }
+    val resolvedReasonId = toCas1CancellationReason(withdrawalContext, userProvidedReason)
 
     val reason = cancellationReasonRepository.findByIdOrNull(resolvedReasonId)
     if (reason == null) {
@@ -1208,9 +1202,20 @@ class BookingService(
       isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.Booking
     )
 
+    val application = booking.application as ApprovedPremisesApplicationEntity?
     application?.let { cas1BookingEmailService.bookingWithdrawn(it, booking) }
 
     return success(cancellationEntity)
+  }
+
+  private fun toCas1CancellationReason(
+    withdrawalContext: WithdrawalContext,
+    userProvidedReason: UUID?,
+  ) = when (withdrawalContext.triggeringEntityType) {
+    WithdrawableEntityType.Application -> CAS1_RELATED_APP_WITHDRAWN_ID
+    WithdrawableEntityType.PlacementApplication -> CAS1_RELATED_PLACEMENT_APP_WITHDRAWN_ID
+    WithdrawableEntityType.PlacementRequest -> CAS1_RELATED_PLACEMENT_REQ_WITHDRAWN_ID
+    WithdrawableEntityType.Booking -> userProvidedReason
   }
 
   private fun updateApplicationStatusOnCancellation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
@@ -11,15 +11,15 @@ import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 
 @Service
-class EmailNotificationService(
+class EmailNotificationService (
   private val notifyConfig: NotifyConfig,
   @Qualifier("normalNotificationClient") private val normalNotificationClient: NotificationClient?,
   @Qualifier("guestListNotificationClient") private val guestListNotificationClient: NotificationClient?,
   private val applicationEventPublisher: ApplicationEventPublisher,
-) {
+) : EmailNotifier {
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
-  fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>) {
+  override fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>) {
     applicationEventPublisher.publishEvent(SendEmailRequestedEvent(EmailRequest(recipientEmailAddress, templateId, personalisation)))
 
     try {
@@ -37,6 +37,10 @@ class EmailNotificationService(
       log.error("Unable to send template $templateId to user $recipientEmailAddress", notificationClientException)
     }
   }
+}
+
+interface EmailNotifier {
+  fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>)
 }
 
 data class EmailRequest(val email: String, val templateId: String, val personalisation: Map<String, *>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
@@ -42,6 +43,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationBedspaceSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
@@ -211,6 +213,11 @@ class SeedService(
           filename,
           applicationContext.getBean(BookingService::class.java),
           applicationContext.getBean(BookingRepository::class.java),
+        )
+
+        SeedFileType.approvedPremisesApAreaEmailAddresses -> Cas1ApAreaEmailAddressSeedJob(
+          filename,
+          applicationContext.getBean(ApAreaRepository::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -49,7 +49,7 @@ class Cas1BookingEmailService(
     }
   }
 
-  fun bookingWithdrawn(application: ApplicationEntity, booking: BookingEntity) {
+  fun bookingWithdrawn(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
     if(!sendNewWithdrawalNotifications) {
       return
     }
@@ -71,6 +71,15 @@ class Cas1BookingEmailService(
 
     val premises = booking.premises
     premises.emailAddress?.let { email ->
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = email,
+        templateId = notifyConfig.templates.bookingWithdrawn,
+        personalisation = allPersonalisation,
+      )
+    }
+
+    val area = application.apArea
+    area?.emailAddress?.let { email ->
       emailNotificationService.sendEmail(
         recipientEmailAddress = email,
         templateId = notifyConfig.templates.bookingWithdrawn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
@@ -17,7 +18,7 @@ object Constants {
 
 @Service
 class Cas1BookingEmailService(
-  private val emailNotificationService: EmailNotificationService,
+  private val emailNotificationService: EmailNotifier,
   private val notifyConfig: NotifyConfig,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,

--- a/src/main/resources/db/migration/all/20240216152435__add_email_address_to_ap_areas.sql
+++ b/src/main/resources/db/migration/all/20240216152435__add_email_address_to_ap_areas.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ap_areas ADD COLUMN email_address text NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3387,6 +3387,7 @@ components:
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings
+        - approved_premises_ap_area_email_addresses
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7944,6 +7944,7 @@ components:
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings
+        - approved_premises_ap_area_email_addresses
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3870,6 +3870,7 @@ components:
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings
+        - approved_premises_ap_area_email_addresses
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3435,6 +3435,7 @@ components:
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings
+        - approved_premises_ap_area_email_addresses
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -11,6 +11,7 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var identifier: Yielded<String> = { randomStringUpperCase(3) }
+  private var emailAddress: Yielded<String> = { randomStringUpperCase(10) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -29,5 +30,6 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
     name = this.name(),
     identifier = this.identifier(),
     probationRegions = mutableListOf(),
+    emailAddress = this.emailAddress(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -11,7 +11,7 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var identifier: Yielded<String> = { randomStringUpperCase(3) }
-  private var emailAddress: Yielded<String> = { randomStringUpperCase(10) }
+  private var emailAddress: Yielded<String?> = { randomStringUpperCase(10) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -23,6 +23,10 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
 
   fun withIdentifier(identifier: String) = apply {
     this.identifier = { identifier }
+  }
+
+  fun withEmailAddress(emailAddress: String?) = apply {
+    this.emailAddress = { emailAddress }
   }
 
   override fun produce(): ApAreaEntity = ApAreaEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCas1ApAreaEmailAddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCas1ApAreaEmailAddressTest.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedCsvRow
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedCas1ApAreaEmailAddressTest : SeedTestBase() {
+
+  @Test
+  fun `Attempting to seed email with an invalid ap area identifier logs an error`() {
+    withCsv(
+      "invalid-ap-area-id",
+      cas1ApAreaEmailAddressesCsvRowsToCsv(
+        listOf(
+          Cas1ApAreaEmailAddressSeedCsvRow(apAreaIdentifier = "the-invalid-id", emailAddress = "me@here.com"),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "invalid-ap-area-id")
+
+    Assertions.assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Error on row 1:" &&
+          it.throwable != null &&
+          it.throwable.message == "AP Area with identifier 'the-invalid-id' does not exist"
+      }
+  }
+
+  @Test
+  fun `Attempting to seed email with a blank email address logs an error`() {
+    withCsv(
+      "invalid-ap-area-id",
+      cas1ApAreaEmailAddressesCsvRowsToCsv(
+        listOf(
+          Cas1ApAreaEmailAddressSeedCsvRow(apAreaIdentifier = "SWSC", emailAddress = "    "),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "invalid-ap-area-id")
+
+    Assertions.assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Error on row 1:" &&
+          it.throwable != null &&
+          it.throwable.message == "Email address for 'SWSC' is blank"
+      }
+  }
+
+  @Test
+  fun `Attempting to seed email with missing required headers lists missing fields`() {
+    withCsv(
+      "missing-headers",
+      "totally,wrong_headers\n" +
+               "SWSC,me@here.com"
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "missing-headers")
+
+    val expectedErrorMessage = "The headers provided: " +
+      "[totally, wrong_headers] " +
+      "did not include required headers: " +
+      "[ap_area_identifier, email_address]"
+
+    Assertions.assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Unable to complete Seed Job" &&
+          it.throwable != null &&
+          it.throwable.message!!.contains(expectedErrorMessage)
+      }
+  }
+
+  @Test
+  fun `Updating email address persists correctly`() {
+    withCsv(
+      "valid-csv",
+      cas1ApAreaEmailAddressesCsvRowsToCsv(
+        listOf(
+          Cas1ApAreaEmailAddressSeedCsvRow(apAreaIdentifier = "SWSC", emailAddress = "swsc@test.com"),
+          Cas1ApAreaEmailAddressSeedCsvRow(apAreaIdentifier = "Mids", emailAddress = "mids@midlands.com"),
+        )
+      )
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "valid-csv")
+
+    assertThat(apAreaRepository.findByIdentifier("SWSC")!!.emailAddress).isEqualTo("swsc@test.com")
+    assertThat(apAreaRepository.findByIdentifier("Mids")!!.emailAddress).isEqualTo("mids@midlands.com")
+  }
+
+  private fun cas1ApAreaEmailAddressesCsvRowsToCsv(rows: List<Cas1ApAreaEmailAddressSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "ap_area_identifier",
+        "email_address",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.apAreaIdentifier)
+        .withQuotedField(it.emailAddress)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -569,7 +569,7 @@ class WithdrawalTest : IntegrationTestBase() {
           assertPlacementRequestWithdrawn(placementRequest3, PlacementRequestWithdrawalReason.RELATED_APPLICATION_WITHDRAWN)
           assertBookingNotWithdrawn(booking2HasArrival)
 
-          emailNotificationAsserter.assertEmailsRequestedCount(3)
+          emailNotificationAsserter.assertEmailsRequestedCount(4)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
             notifyConfig.templates.applicationWithdrawn,
@@ -580,6 +580,10 @@ class WithdrawalTest : IntegrationTestBase() {
           )
           emailNotificationAsserter.assertEmailRequested(
             booking1NoArrival.premises.emailAddress!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            application.apArea?.emailAddress!!,
             notifyConfig.templates.bookingWithdrawn,
           )
         }
@@ -654,13 +658,17 @@ class WithdrawalTest : IntegrationTestBase() {
 
           assertPlacementApplicationNotWithdrawn(placementApplication2)
 
-          emailNotificationAsserter.assertEmailsRequestedCount(2)
+          emailNotificationAsserter.assertEmailsRequestedCount(3)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
             notifyConfig.templates.bookingWithdrawn,
           )
           emailNotificationAsserter.assertEmailRequested(
             booking1NoArrival.premises.emailAddress!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            application.apArea?.emailAddress!!,
             notifyConfig.templates.bookingWithdrawn,
           )
         }
@@ -708,13 +716,17 @@ class WithdrawalTest : IntegrationTestBase() {
           assertPlacementRequestWithdrawn(placementRequest, PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
           assertBookingWithdrawn(bookingNoArrival, "Related placement request withdrawn")
 
-          emailNotificationAsserter.assertEmailsRequestedCount(2)
+          emailNotificationAsserter.assertEmailsRequestedCount(3)
           emailNotificationAsserter.assertEmailRequested(
             applicant.email!!,
             notifyConfig.templates.bookingWithdrawn,
           )
           emailNotificationAsserter.assertEmailRequested(
             bookingNoArrival.premises.emailAddress!!,
+            notifyConfig.templates.bookingWithdrawn,
+          )
+          emailNotificationAsserter.assertEmailRequested(
+            application.apArea?.emailAddress!!,
             notifyConfig.templates.bookingWithdrawn,
           )
         }
@@ -877,11 +889,16 @@ class WithdrawalTest : IntegrationTestBase() {
       withAddedAt(OffsetDateTime.now())
     }
 
+    val apArea = apAreaEntityFactory.produceAndPersist {
+      withEmailAddress("apAreaEmail@test.com")
+    }
+
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn(offenderDetails.otherIds.crn)
       withCreatedByUser(applicant)
       withApplicationSchema(applicationSchema)
       withSubmittedAt(OffsetDateTime.now())
+      withApArea(apArea)
     }
 
     val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApAreaTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApAreaTestRepository.kt
@@ -6,4 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import java.util.UUID
 
 @Repository
-interface ApAreaTestRepository : JpaRepository<ApAreaEntity, UUID>
+interface ApAreaTestRepository : JpaRepository<ApAreaEntity, UUID> {
+  fun findByIdentifier(identifier: String): ApAreaEntity?
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -16,7 +14,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.AP_AREA_EMAIL
@@ -24,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestCo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.PREMISES_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.PREMISES_NAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.TestConstants.REGION_NAME
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockEmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -38,8 +36,8 @@ object TestConstants {
 }
 
 class Cas1BookingEmailServiceTest {
-  private val mockEmailNotificationService = mockk<EmailNotificationService>()
   private val notifyConfig = NotifyConfig()
+  private val mockEmailNotificationService = MockEmailNotificationService()
 
   val service = Cas1BookingEmailService(
     mockEmailNotificationService,
@@ -56,6 +54,11 @@ class Cas1BookingEmailServiceTest {
     .withProbationRegion(ProbationRegionEntityFactory().withDefaults().withName(REGION_NAME).produce())
     .produce()
 
+  @BeforeEach
+  fun beforeEach() {
+    mockEmailNotificationService.reset()
+  }
+
   @Test
   fun `bookingMade doesnt send email to applicant if no email address defined`() {
     val applicant = UserEntityFactory()
@@ -70,31 +73,25 @@ class Cas1BookingEmailServiceTest {
       departureDate = LocalDate.of(2023,2,14),
     )
 
-    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
-
     service.bookingMade(application, booking)
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(any(),any(),any())
-    }
+    mockEmailNotificationService.assertEmailRequestCount(1)
+    mockEmailNotificationService.assertEmailRequested(
+      PREMISES_EMAIL,
+      notifyConfig.templates.bookingMadePremises,
+      mapOf(
+        "name" to applicant.name,
+        "apName" to PREMISES_NAME,
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",
+        "crn" to CRN,
+        "startDate" to "2023-02-01",
+        "endDate" to "2023-02-14",
+        "lengthStay" to 2,
+        "lengthStayUnit" to "weeks",
+      ),
+    )
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        PREMISES_EMAIL,
-        notifyConfig.templates.bookingMadePremises,
-        match {
-          it["name"] == applicant.name &&
-            it["apName"] == PREMISES_NAME &&
-            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
-            (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
-            it["crn"] == CRN &&
-            it["startDate"] == "2023-02-01" &&
-            it["endDate"] == "2023-02-14" &&
-            (it["lengthStay"] as Int) == 2 &&
-            (it["lengthStayUnit"] as String) == "weeks"
-        },
-      )
-    }
   }
 
   @SuppressWarnings("CyclomaticComplexMethod")
@@ -112,47 +109,33 @@ class Cas1BookingEmailServiceTest {
       departureDate = LocalDate.of(2023,2,14),
     )
 
-    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
-
     service.bookingMade(application, booking)
 
-    verify(exactly = 2) { mockEmailNotificationService.sendEmail(any(),any(),any()) }
+    mockEmailNotificationService.assertEmailRequestCount(2)
 
-    verify(exactly = 1) {
-        mockEmailNotificationService.sendEmail(
-          APPLICANT_EMAIL,
-          notifyConfig.templates.bookingMade,
-          match {
-            it["name"] == applicant.name &&
-              it["apName"] == premises.name &&
-              (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
-              (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
-              it["crn"] == CRN &&
-              it["startDate"] == "2023-02-01" &&
-              it["endDate"] == "2023-02-14" &&
-              (it["lengthStay"] as Int) == 2 &&
-              it["lengthStayUnit"] as String == "weeks"
-          },
-        )
-      }
+    val personalisation = mapOf(
+      "name" to applicant.name,
+      "apName" to PREMISES_NAME,
+      "applicationUrl" to "http://frontend/applications/${application.id}",
+      "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",
+      "crn" to CRN,
+      "startDate" to "2023-02-01",
+      "endDate" to "2023-02-14",
+      "lengthStay" to 2,
+      "lengthStayUnit" to "weeks",
+    )
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        PREMISES_EMAIL,
-        notifyConfig.templates.bookingMadePremises,
-        match {
-          it["name"] == applicant.name &&
-            it["apName"] == PREMISES_NAME &&
-            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
-            (it["bookingUrl"] as String).matches(Regex("http://frontend/premises/${premises.id}/bookings/${booking.id}")) &&
-            it["crn"] == CRN &&
-            it["startDate"] == "2023-02-01" &&
-            it["endDate"] == "2023-02-14" &&
-            (it["lengthStay"] as Int) == 2 &&
-            it["lengthStayUnit"] as String == "weeks"
-        },
-      )
-    }
+    mockEmailNotificationService.assertEmailRequested(
+      APPLICANT_EMAIL,
+      notifyConfig.templates.bookingMade,
+      personalisation,
+    )
+
+    mockEmailNotificationService.assertEmailRequested(
+      PREMISES_EMAIL,
+      notifyConfig.templates.bookingMadePremises,
+      personalisation,
+    )
   }
 
   @Test
@@ -169,33 +152,26 @@ class Cas1BookingEmailServiceTest {
       departureDate = LocalDate.of(2023,2,27),
     )
 
-    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
-
     service.bookingMade(application, booking)
 
-    verify(exactly = 2) { mockEmailNotificationService.sendEmail(any(),any(),any()) }
+    mockEmailNotificationService.assertEmailRequestCount(2)
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        APPLICANT_EMAIL,
-        notifyConfig.templates.bookingMade,
-        match {
-          (it["lengthStay"] as Int) == 6 &&
-          it["lengthStayUnit"] as String == "days"
-        },
-      )
-    }
+    val expectedPersonalisation = mapOf(
+      "lengthStay" to 6,
+      "lengthStayUnit" to "days",
+    )
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        PREMISES_EMAIL,
-        notifyConfig.templates.bookingMadePremises,
-        match {
-          (it["lengthStay"] as Int) == 6 &&
-          it["lengthStayUnit"] as String == "days"
-        },
-      )
-    }
+    mockEmailNotificationService.assertEmailRequested(
+      APPLICANT_EMAIL,
+      notifyConfig.templates.bookingMade,
+      expectedPersonalisation,
+    )
+
+    mockEmailNotificationService.assertEmailRequested(
+      PREMISES_EMAIL,
+      notifyConfig.templates.bookingMadePremises,
+      expectedPersonalisation,
+    )
   }
 
   @Test
@@ -212,58 +188,36 @@ class Cas1BookingEmailServiceTest {
       departureDate = LocalDate.of(2023,2,14),
     )
 
-    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
-
     service.bookingWithdrawn(application, booking)
 
-    verify(exactly = 3) {
-      mockEmailNotificationService.sendEmail(any(),any(),any())
-    }
+    val expectedPersonalisation = mapOf(
+      "apName" to PREMISES_NAME,
+      "applicationUrl" to "http://frontend/applications/${application.id}",
+      "crn" to CRN,
+      "startDate" to "2023-02-01",
+      "endDate" to "2023-02-14",
+      "region" to REGION_NAME,
+    )
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        APPLICANT_EMAIL,
-        notifyConfig.templates.bookingWithdrawn,
-        match {
-            it["apName"] == PREMISES_NAME &&
-            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
-            it["crn"] == CRN &&
-            it["startDate"] == "2023-02-01" &&
-            it["endDate"] == "2023-02-14" &&
-            it["region"] == REGION_NAME
-        },
-      )
-    }
+    mockEmailNotificationService.assertEmailRequestCount(3)
+    mockEmailNotificationService.assertEmailRequested(
+      APPLICANT_EMAIL,
+      notifyConfig.templates.bookingWithdrawn,
+      expectedPersonalisation,
+    )
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        PREMISES_EMAIL,
-        notifyConfig.templates.bookingWithdrawn,
-        match {
-          it["apName"] == PREMISES_NAME &&
-                  (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
-                  it["crn"] == CRN &&
-                  it["startDate"] == "2023-02-01" &&
-                  it["endDate"] == "2023-02-14" &&
-                  it["region"] == REGION_NAME
-        },
-      )
-    }
+    mockEmailNotificationService.assertEmailRequested(
+      PREMISES_EMAIL,
+      notifyConfig.templates.bookingWithdrawn,
+      expectedPersonalisation,
+    )
 
-    verify(exactly = 1) {
-      mockEmailNotificationService.sendEmail(
-        AP_AREA_EMAIL,
-        notifyConfig.templates.bookingWithdrawn,
-        match {
-          it["apName"] == PREMISES_NAME &&
-            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/${application.id}")) &&
-            it["crn"] == CRN &&
-            it["startDate"] == "2023-02-01" &&
-            it["endDate"] == "2023-02-14" &&
-            it["region"] == REGION_NAME
-        },
-      )
-    }
+    mockEmailNotificationService.assertEmailRequested(
+      AP_AREA_EMAIL,
+      notifyConfig.templates.bookingWithdrawn,
+      expectedPersonalisation,
+    )
+
   }
 
   @Test
@@ -288,13 +242,9 @@ class Cas1BookingEmailServiceTest {
       departureDate = LocalDate.of(2023,2,14),
     )
 
-    every { mockEmailNotificationService.sendEmail(any(),any(),any()) } returns Unit
-
     service.bookingWithdrawn(application, booking)
 
-    verify(exactly = 0) {
-      mockEmailNotificationService.sendEmail(any(),any(),any())
-    }
+    mockEmailNotificationService.assertNoEmailsRequested()
   }
 
   private fun createApplicationAndBooking(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -115,6 +115,7 @@ class BookingTransformerTest {
         identifier = "APA",
         name = "Ap Area",
         probationRegions = mutableListOf(),
+        emailAddress = "email@test.com",
       ),
     ).apply { apArea.probationRegions.add(this) },
     localAuthorityArea = LocalAuthorityAreaEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockEmailNotificationService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockEmailNotificationService.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
+import org.assertj.core.groups.Tuple
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailRequest
+
+/**
+ * This class is offered as an alternative to a Mockk version of EmailNotificationService,
+ * providing simpler syntax. If used, the 'reset' function should be called before each test
+ */
+class MockEmailNotificationService : EmailNotifier {
+  val requestedEmails = mutableListOf<EmailRequest>()
+
+  override fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>) {
+    requestedEmails.add(EmailRequest(recipientEmailAddress, templateId, personalisation))
+  }
+
+  fun assertNoEmailsRequested() {
+    assertEmailRequestCount(0)
+  }
+
+  fun assertEmailRequestCount(expectedCount: Int) {
+    assertThat(requestedEmails).hasSize(expectedCount)
+  }
+
+  fun assertEmailRequested(
+    recipientEmailAddress: String,
+    templateId: String,
+    personalisationSubSet: Map<String,Any>
+  ) {
+    assertThat(requestedEmails)
+      .extracting<Tuple> { tuple(it.email,it.templateId) }
+      .contains(tuple(recipientEmailAddress, templateId))
+
+    val emailRequest = requestedEmails.first { it.email == recipientEmailAddress && it.templateId == templateId }
+    assertThat(emailRequest.personalisation).containsAllEntriesOf(personalisationSubSet)
+  }
+
+  fun reset() {
+    requestedEmails.clear()
+  }
+}
+


### PR DESCRIPTION
Second PR for https://dsdmoj.atlassian.net/browse/APS-299

The intial PR sends the email to applicants and AP - https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1503

This PR adds sending email to CRU by introducing an email_address column the ap_areas table. A seed job is also introduced to populate the CRU email addresses in prod/pre-prod