### PR TITLE
[CAS-208]- Store prison-name in CAS3 application table and show in referral report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -228,6 +228,7 @@ class ApplicationsController(
             body.deliusEventNumber,
             body.offenceId,
             createWithRisks,
+            personInfo,
           )
       ) {
         is AuthorisableActionResult.NotFound -> throw NotFoundProblem(actionResult.id!!, actionResult.entityType!!)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -403,6 +403,7 @@ class TemporaryAccommodationApplicationEntity(
   var isEligible: Boolean?,
   var eligibilityReason: String?,
   var dutyToReferLocalAuthorityAreaName: String?,
+  var prisonNameOnCreation: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
@@ -44,7 +44,7 @@ class TransitionalAccommodationReferralReportGenerator : ReportGenerator<
         rejectionReason = referralData.assessmentRejectionReason,
         rejectionDate = if (AssessmentDecision.REJECTED.name == referralData.assessmentDecision) referralData.assessmentSubmittedDate else null,
         sourceOfReferral = referralData.referralEligibilityReason,
-        prisonName = "",
+        prisonAtReferral = referralData.prisonNameOnCreation,
         prisonReleaseDate = null,
         accommodationRequiredDate = referralData.accommodationRequiredDate?.toLocalDateTime()?.toLocalDate(),
         bookingOffered = referralData.bookingId != null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
@@ -24,7 +24,7 @@ data class TransitionalAccommodationReferralReportRow(
   val rejectionReason: String?,
   val rejectionDate: LocalDate?,
   val sourceOfReferral: String?,
-  val prisonName: String?,
+  val prisonAtReferral: String?,
   val prisonReleaseDate: LocalDate?,
   val accommodationRequiredDate: LocalDate?,
   val bookingOffered: Boolean?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
@@ -30,7 +30,8 @@ interface TransitionalAccommodationReferralReportRepository : JpaRepository<Book
       taa.is_eligible AS isReferralEligibleForCas3,
       taa.eligibility_reason AS referralEligibilityReason,
       ap.noms_number as nomsNumber,
-      taa.arrival_date as accommodationRequiredDate
+      taa.arrival_date as accommodationRequiredDate,
+      taa.prison_name_on_creation as prisonNameOnCreation
     FROM temporary_accommodation_assessments aa
     JOIN assessments a on aa.assessment_id = a.id AND a.service='temporary-accommodation' AND a.reallocated_at IS NULL
     JOIN applications ap on a.application_id = ap.id AND ap.service='temporary-accommodation'
@@ -73,4 +74,5 @@ interface TransitionalAccommodationReferralReportData {
   val referralEligibleForCas3: Boolean?
   val referralEligibilityReason: String?
   val accommodationRequiredDate: Timestamp?
+  val prisonNameOnCreation: String?
 }

--- a/src/main/resources/db/migration/all/20240219141046__add_prisonname_to_cas3_application.sql
+++ b/src/main/resources/db/migration/all/20240219141046__add_prisonname_to_cas3_application.sql
@@ -1,0 +1,2 @@
+-- Alter table temporary_accommodation_applications by adding new optional column prison_name_on_creation
+ALTER TABLE temporary_accommodation_applications ADD COLUMN prison_name_on_creation TEXT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -45,6 +45,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var isEligible: Yielded<Boolean?> = { null }
   private var eligibilityReason: Yielded<String?> = { null }
   private var dutyToReferLocalAuthorityAreaName: Yielded<String?> = { null }
+  private var prisonNameAtReferral: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -154,6 +155,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.dutyToReferLocalAuthorityAreaName = { dutyToReferLocalAuthorityAreaName }
   }
 
+  fun withPrisonNameAtReferral(prisonNameAtReferral: String?) = apply {
+    this.prisonNameAtReferral = { prisonNameAtReferral }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -180,5 +185,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     isEligible = this.isEligible(),
     eligibilityReason = this.eligibilityReason(),
     dutyToReferLocalAuthorityAreaName = this.dutyToReferLocalAuthorityAreaName(),
+    prisonNameOnCreation = this.prisonNameAtReferral(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
@@ -183,6 +183,7 @@ class TransitionalAccommodationReferralReportsTest : IntegrationTestBase() {
               ),
             )
           }
+          withPrisonNameAtReferral("HM Hounslow")
         }
 
         val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/ReportServiceTest.kt
@@ -94,7 +94,8 @@ class ReportServiceTest {
     assessmentSubmittedDate = LocalDate.now(),
     referralEligibleForCas3 = true,
     referralEligibilityReason = "reason",
-    accommodationRequiredDate = Timestamp.valueOf(LocalDateTime.now())
+    accommodationRequiredDate = Timestamp.valueOf(LocalDateTime.now()),
+    prisonNameOnCreation = null,
   )
 
   @Suppress("LongParameterList")
@@ -119,5 +120,6 @@ class ReportServiceTest {
     override val referralEligibleForCas3: Boolean?,
     override val referralEligibilityReason: String?,
     override val accommodationRequiredDate: Timestamp?,
+    override val prisonNameOnCreation: String?,
   ) : TransitionalAccommodationReferralReportData
 }


### PR DESCRIPTION
# Changes in this PR
Refer [CAS-208](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-208) for more information.

This PR contains below two changes:
1. Store `prison-name` at time of referral creation in CAS3 specific `temporary_accommadation_applications` table, the prison-name is retrieved from existing service `offenderService.getInfoForPerson()`. 
2. Populate the stored prison-name into existing cas3's `referral` report.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.

[CAS-208]: https://dsdmoj.atlassian.net/browse/CAS-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ