### PR TITLE
(APS-368) Add an appeal URL to timeline events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -317,7 +317,6 @@ class ApplicationsController(
 
   override fun applicationsApplicationIdTimelineGet(applicationId: UUID, xServiceName: ServiceName):
     ResponseEntity<List<TimelineEvent>> {
-    val user = userService.getUserForRequest()
     if (xServiceName != ServiceName.approvedPremises) {
       throw NotImplementedProblem("Timeline is only supported for Approved Premises applications")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -5,10 +5,10 @@ import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
@@ -39,9 +39,11 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
         cast(d.application_id as TEXT) as applicationId,
         cast(d.assessment_id as TEXT) as assessmentId,
         cast(d.booking_id as TEXT) as bookingId,
-        cast(b.premises_id as TEXT) as premisesId
+        cast(b.premises_id as TEXT) as premisesId,
+        cast(a.id as TEXT) as appealId
       FROM domain_events d 
       LEFT OUTER JOIN bookings b ON b.id = d.booking_id
+      LEFT OUTER JOIN appeals a ON d.application_id = a.application_id
       WHERE d.application_id = :applicationId
     """,
     nativeQuery = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
@@ -12,4 +12,5 @@ interface DomainEventSummary {
   val assessmentId: UUID?
   val bookingId: UUID?
   val premisesId: UUID?
+  val appealId: UUID?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -526,7 +526,7 @@ class ApplicationService(
   }
 
   fun updateApprovedPremisesApplicationStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus) {
-    applicationRepository.updateStatus(applicationId,status)
+    applicationRepository.updateStatus(applicationId, status)
   }
 
   @Transactional

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3341,6 +3341,7 @@ components:
         - application
         - booking
         - assessment
+        - assessmentAppeal
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7898,6 +7898,7 @@ components:
         - application
         - booking
         - assessment
+        - assessmentAppeal
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3824,6 +3824,7 @@ components:
         - application
         - booking
         - assessment
+        - assessmentAppeal
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3389,6 +3389,7 @@ components:
         - application
         - booking
         - assessment
+        - assessmentAppeal
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -11,7 +11,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
@@ -448,10 +450,14 @@ class AppealsTest : IntegrationTestBase() {
             .isOk
             .returnResult(String::class.java)
 
+          val appeal = result.responseBody.blockFirst()!!
           val timeline = objectMapper.readValue<List<TimelineEvent>>(timelineResult.responseBody.blockFirst()!!)
 
           assertThat(timeline).anyMatch {
-            it.type == TimelineEventType.approvedPremisesAssessmentAppealed
+            it.type == TimelineEventType.approvedPremisesAssessmentAppealed &&
+              it.associatedUrls?.contains(
+              TimelineEventAssociatedUrl(TimelineEventUrlType.assessmentAppeal, "http://frontend/applications/${application.id}/appeals/${appeal.id}"),
+            ) == true
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -267,6 +267,7 @@ data class DomainEventSummaryImpl(
   override val assessmentId: UUID?,
   override val bookingId: UUID?,
   override val premisesId: UUID?,
+  override val appealId: UUID?,
 ) : DomainEventSummary {
   companion object {
     fun ofType(type: DomainEventType) = DomainEventSummaryImpl(
@@ -277,6 +278,7 @@ data class DomainEventSummaryImpl(
       assessmentId = null,
       bookingId = null,
       premisesId = null,
+      appealId = null,
     )
   }
 }


### PR DESCRIPTION
This adds an appeal URL to timeline events (when an appeal ID is present). This will allow the timeline view to link directly to an appeal when one has occurred.