### PR TITLE
Add BookingMadeDate to App and PA Reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -42,6 +42,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
       cast(withdrawl_event.data -> 'eventDetails' ->> 'withdrawnAt' as date) as applicationWithdrawalDate,
       withdrawl_event.data -> 'eventDetails' ->> 'withdrawalReason' as applicationWithdrawalReason,
       cast(booking_made_event.booking_id as text) as bookingID,
+      booking_made_event.occurred_at as bookingMadeDate,
       booking_cancelled_event.data -> 'eventDetails' ->> 'cancellationReason' as bookingCancellationReason,
       cast(booking_cancelled_event.data -> 'eventDetails' ->> 'cancelledAt' as date) as bookingCancellationDate,
       cast(booking_made_event.data -> 'eventDetails' ->> 'arrivalOn' as date) as expectedArrivalDate,
@@ -131,6 +132,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
       ) as applicationWithdrawalDate,
       withdrawl_event.data -> 'eventDetails' ->> 'withdrawalReason' as applicationWithdrawalReason,
       cast(booking_made_event.booking_id as text) as bookingID,
+      booking_made_event.occurred_at as bookingMadeDate,
       booking_cancelled_event.data -> 'eventDetails' ->> 'cancellationReason' as bookingCancellationReason,
       cast(
         booking_cancelled_event.data -> 'eventDetails' ->> 'cancelledAt' as date
@@ -213,6 +215,7 @@ interface ApplicationEntityReportRow {
   fun getApplicationWithdrawalDate(): Date?
   fun getApplicationWithdrawalReason(): String?
   fun getBookingID(): String?
+  fun getBookingMadeDate(): Timestamp?
   fun getBookingCancellationReason(): String?
   fun getBookingCancellationDate(): Date?
   fun getExpectedArrivalDate(): Date?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntityReportRow.kt
@@ -48,6 +48,7 @@ interface PlacementApplicationEntityReportRowRepository : JpaRepository<Placemen
         cast(withdrawl_event.data -> 'eventDetails' ->> 'withdrawnAt' as date) as applicationWithdrawalDate,
         withdrawl_event.data -> 'eventDetails' ->> 'withdrawalReason' as applicationWithdrawalReason,
         cast(booking_made_event.booking_id as text) as bookingID,
+        booking_made_event.occurred_at as bookingMadeDate,
         booking_cancelled_event.data -> 'eventDetails' ->> 'cancellationReason' as bookingCancellationReason,
         cast(
           booking_cancelled_event.data -> 'eventDetails' ->> 'cancelledAt' as date
@@ -137,6 +138,7 @@ interface PlacementApplicationEntityReportRow {
   fun getApplicationWithdrawalDate(): Date?
   fun getApplicationWithdrawalReason(): String?
   fun getBookingID(): String?
+  fun getBookingMadeDate(): Timestamp?
   fun getBookingCancellationReason(): String?
   fun getBookingCancellationDate(): Date?
   fun getExpectedArrivalDate(): Date?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -36,6 +36,7 @@ class ApplicationReportGenerator : ReportGenerator<ApplicationEntityReportRow, A
         applicationWithdrawalReason = this.getApplicationWithdrawalReason(),
         applicationWithdrawalDate = this.getApplicationWithdrawalDate()?.toLocalDate(),
         bookingID = this.getBookingID(),
+        bookingMadeDate = this.getBookingMadeDate()?.toLocalDateTime()?.toLocalDate(),
         bookingCancellationReason = this.getBookingCancellationReason(),
         bookingCancellationDate = this.getBookingCancellationDate()?.toLocalDate(),
         expectedArrivalDate = this.getExpectedArrivalDate()?.toLocalDate(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/PlacementApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/PlacementApplicationReportGenerator.kt
@@ -41,6 +41,7 @@ class PlacementApplicationReportGenerator :
         applicationWithdrawalDate = this.getApplicationWithdrawalDate()?.toLocalDate(),
         applicationWithdrawalReason = this.getApplicationWithdrawalReason(),
         bookingID = this.getBookingID(),
+        bookingMadeDate = this.getBookingMadeDate()?.toLocalDateTime()?.toLocalDate(),
         bookingCancellationReason = this.getBookingCancellationReason(),
         bookingCancellationDate = this.getBookingCancellationDate()?.toLocalDate(),
         expectedArrivalDate = this.getExpectedArrivalDate()?.toLocalDate(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class ApplicationReportRow(
   val id: String,
@@ -27,6 +28,7 @@ data class ApplicationReportRow(
   val applicationWithdrawalDate: LocalDate?,
   val applicationWithdrawalReason: String?,
   val bookingID: String?,
+  val bookingMadeDate: LocalDate?,
   val bookingCancellationReason: String?,
   val bookingCancellationDate: LocalDate?,
   val expectedArrivalDate: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/PlacementApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/PlacementApplicationReportRow.kt
@@ -30,6 +30,7 @@ data class PlacementApplicationReportRow(
   val applicationWithdrawalDate: LocalDate?,
   val applicationWithdrawalReason: String?,
   val bookingID: String?,
+  val bookingMadeDate: LocalDate?,
   val bookingCancellationReason: String?,
   val bookingCancellationDate: LocalDate?,
   val expectedArrivalDate: LocalDate?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -74,6 +74,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -356,6 +357,7 @@ class ApplicationReportsTest : IntegrationTestBase() {
 
     if (booking != null) {
       assertThat(reportRow.bookingID).isEqualTo(booking.id.toString())
+      assertThat(reportRow.bookingMadeDate).isToday()
       assertThat(reportRow.expectedArrivalDate).isEqualTo(booking.arrivalDate)
       assertThat(reportRow.expectedDepartureDate).isEqualTo("2022-08-30")
       assertThat(reportRow.premisesName).isEqualTo(booking.premises.name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -77,6 +77,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.PlacementApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -493,6 +494,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
       checkNotNull(booking)
 
       assertThat(reportRow.bookingID).isEqualTo(booking.id.toString())
+      assertThat(reportRow.bookingMadeDate).isToday()
 
       if (expectedRow.hasCancellation) {
         val cancellation = booking.cancellation!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssertJExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssertJExtensions.kt
@@ -1,10 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import org.assertj.core.api.AbstractLocalDateTimeAssert
 import org.assertj.core.api.AbstractOffsetDateTimeAssert
 import org.assertj.core.api.Assertions
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 
 fun AbstractOffsetDateTimeAssert<*>.isWithinTheLastMinute() {
   this.isCloseTo(OffsetDateTime.now(), Assertions.within(1, ChronoUnit.MINUTES))
+}
+
+fun AbstractLocalDateTimeAssert<*>.isWithinTheLastMinute() {
+  this.isCloseTo(LocalDateTime.now(), Assertions.within(1, ChronoUnit.MINUTES))
 }


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-372

Use the ‘booking made’ domain event’s creation timestamp to determine when a booking was made