### PR TITLE
(Chore) Allow all users to see appeals data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -417,7 +417,7 @@ class ApplicationsController(
       is AuthorisableActionResult.Success -> applicationResult.entity
     }
 
-    val appeal = when (val getAppealResult = appealService.getAppeal(appealId, application, user)) {
+    val appeal = when (val getAppealResult = appealService.getAppeal(appealId, application)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(appealId, "Appeal")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> getAppealResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -36,9 +36,7 @@ class AppealService(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-appeal}") private val applicationAppealUrlTemplate: UrlTemplate,
 ) {
-  fun getAppeal(appealId: UUID, application: ApplicationEntity, user: UserEntity): AuthorisableActionResult<AppealEntity> {
-    if (!user.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return AuthorisableActionResult.Unauthorised()
-
+  fun getAppeal(appealId: UUID, application: ApplicationEntity): AuthorisableActionResult<AppealEntity> {
     val appeal = appealRepository.findByIdOrNull(appealId)
       ?: return AuthorisableActionResult.NotFound("Appeal", appealId.toString())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -67,26 +67,6 @@ class AppealsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get appeal returns 403 when user does not have CAS1_APPEALS_MANAGER role`() {
-    `Given a User` { userEntity, jwt ->
-      `Given an Assessment for Approved Premises`(userEntity, userEntity) { assessment, application ->
-        val appeal = appealEntityFactory.produceAndPersist {
-          withApplication(application)
-          withAssessment(assessment as ApprovedPremisesAssessmentEntity)
-          withCreatedBy(userEntity)
-        }
-
-        webTestClient.get()
-          .uri("/applications/${application.id}/appeals/${appeal.id}")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isForbidden
-      }
-    }
-  }
-
-  @Test
   fun `Get appeal returns 404 when appeal could not be found`() {
     `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { userEntity, jwt ->
       `Given an Application`(userEntity) { application ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -88,60 +88,28 @@ class AppealServiceTest {
   @Nested
   inner class GetAppeal {
     @Test
-    fun `Returns Unauthorised if the user does not have the CAS1_APPEALS_MANAGER role`() {
-      val user = UserEntityFactory()
-        .withProbationRegion(probationRegion)
-        .produce()
-
-      val appeal = AppealEntityFactory()
-        .withApplication(application)
-        .produce()
-
-      every { appealRepository.findById(appeal.id) } returns Optional.of(appeal)
-
-      val result = appealService.getAppeal(appeal.id, application, user)
-
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Unauthorised::class.java)
-    }
-
-    @Test
     fun `Returns NotFound if the appeal does not exist`() {
-      val user = UserEntityFactory()
-        .withProbationRegion(probationRegion)
-        .produce()
-        .addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
-
       every { appealRepository.findById(any()) } returns Optional.empty()
 
-      val result = appealService.getAppeal(UUID.randomUUID(), application, user)
+      val result = appealService.getAppeal(UUID.randomUUID(), application)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
     }
 
     @Test
     fun `Returns NotFound if the appeal is not for the given application`() {
-      val user = UserEntityFactory()
-        .withProbationRegion(probationRegion)
-        .produce()
-        .addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
-
       val appeal = AppealEntityFactory()
         .produce()
 
       every { appealRepository.findById(appeal.id) } returns Optional.of(appeal)
 
-      val result = appealService.getAppeal(appeal.id, application, user)
+      val result = appealService.getAppeal(appeal.id, application)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
     }
 
     @Test
     fun `Returns Success containing expected appeal`() {
-      val user = UserEntityFactory()
-        .withProbationRegion(probationRegion)
-        .produce()
-        .addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
-
       val appeal = AppealEntityFactory()
         .withApplication(application)
         .withAssessment(assessment)
@@ -149,7 +117,7 @@ class AppealServiceTest {
 
       every { appealRepository.findById(appeal.id) } returns Optional.of(appeal)
 
-      val result = appealService.getAppeal(appeal.id, application, user)
+      val result = appealService.getAppeal(appeal.id, application)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
       result as AuthorisableActionResult.Success


### PR DESCRIPTION
We want to link to appeals in the timeline, so all users should be able to see data for an appeal.