### PR TITLE
(APS 370) Surface that an assessment is an appealed assessment so that staff are aware

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -276,6 +276,7 @@ class ApprovedPremisesAssessmentEntity(
   referralHistoryNotes: MutableList<AssessmentReferralHistoryNoteEntity>,
   schemaUpToDate: Boolean,
   isWithdrawn: Boolean,
+  val createdFromAppeal: Boolean,
 ) : AssessmentEntity(
   id,
   application,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -97,7 +97,7 @@ class AppealService(
         saveEvent(appeal)
 
         if (decision == AppealDecision.accepted) {
-          assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity)
+          assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity, createdFromAppeal = true)
         }
 
         success(appeal)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -192,7 +192,7 @@ class AssessmentService(
     return AuthorisableActionResult.Success(assessment)
   }
 
-  fun createApprovedPremisesAssessment(application: ApprovedPremisesApplicationEntity): ApprovedPremisesAssessmentEntity {
+  fun createApprovedPremisesAssessment(application: ApprovedPremisesApplicationEntity, createdFromAppeal: Boolean = false): ApprovedPremisesAssessmentEntity {
     val dateTimeNow = OffsetDateTime.now()
 
     var assessment = ApprovedPremisesAssessmentEntity(
@@ -212,7 +212,7 @@ class AssessmentService(
       clarificationNotes = mutableListOf(),
       referralHistoryNotes = mutableListOf(),
       isWithdrawn = false,
-      createdFromAppeal = false,
+      createdFromAppeal = createdFromAppeal,
     )
 
     val allocatedUser = userAllocator.getUserForAssessmentAllocation(assessment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -212,6 +212,7 @@ class AssessmentService(
       clarificationNotes = mutableListOf(),
       referralHistoryNotes = mutableListOf(),
       isWithdrawn = false,
+      createdFromAppeal = false,
     )
 
     val allocatedUser = userAllocator.getUserForAssessmentAllocation(assessment)
@@ -764,6 +765,7 @@ class AssessmentService(
         clarificationNotes = mutableListOf(),
         referralHistoryNotes = mutableListOf(),
         isWithdrawn = false,
+        createdFromAppeal = currentAssessment.createdFromAppeal,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -54,6 +54,7 @@ class AssessmentTransformer(
       rejectionRationale = jpa.rejectionRationale,
       status = getStatusForApprovedPremisesAssessment(jpa),
       service = "CAS1",
+      createdFromAppeal = jpa.createdFromAppeal,
     )
 
     is TemporaryAccommodationAssessmentEntity -> TemporaryAccommodationAssessment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
@@ -38,6 +39,10 @@ class TaskTransformer(
     status = getAssessmentStatus(assessment),
     taskType = TaskType.assessment,
     apArea = getApArea(assessment.application),
+    createdFromAppeal = when (assessment) {
+      is ApprovedPremisesAssessmentEntity -> assessment.createdFromAppeal
+      else -> false
+    },
   )
 
   fun transformPlacementRequestToTask(placementRequest: PlacementRequestEntity, personName: String) = PlacementRequestTask(

--- a/src/main/resources/db/migration/all/20240221091158__add_created_from_appeal_to_assessments.sql
+++ b/src/main/resources/db/migration/all/20240221091158__add_created_from_appeal_to_assessments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_assessments ADD COLUMN created_from_appeal BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2399,8 +2399,11 @@ components:
               $ref: '#/components/schemas/ApprovedPremisesUser'
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            createdFromAppeal:
+              type: boolean
           required:
             - application
+            - createdFromAppeal
     TemporaryAccommodationAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -295,6 +295,12 @@ components:
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            createdFromAppeal:
+              type: boolean
+          required:
+            - createdFromAppeal
     PlacementRequestTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6956,8 +6956,11 @@ components:
               $ref: '#/components/schemas/ApprovedPremisesUser'
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            createdFromAppeal:
+              type: boolean
           required:
             - application
+            - createdFromAppeal
     TemporaryAccommodationAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4852,6 +4852,12 @@ components:
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            createdFromAppeal:
+              type: boolean
+          required:
+            - createdFromAppeal
     PlacementRequestTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2882,8 +2882,11 @@ components:
               $ref: '#/components/schemas/ApprovedPremisesUser'
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            createdFromAppeal:
+              type: boolean
           required:
             - application
+            - createdFromAppeal
     TemporaryAccommodationAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -778,6 +778,12 @@ components:
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            createdFromAppeal:
+              type: boolean
+          required:
+            - createdFromAppeal
     PlacementRequestTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -343,6 +343,12 @@ components:
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            createdFromAppeal:
+              type: boolean
+          required:
+            - createdFromAppeal
     PlacementRequestTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2447,8 +2447,11 @@ components:
               $ref: '#/components/schemas/ApprovedPremisesUser'
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            createdFromAppeal:
+              type: boolean
           required:
             - application
+            - createdFromAppeal
     TemporaryAccommodationAssessment:
       allOf:
         - $ref: '#/components/schemas/Assessment'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
@@ -36,6 +36,7 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
   private var clarificationNotes: Yielded<MutableList<AssessmentClarificationNoteEntity>> = { mutableListOf() }
   private var referralHistoryNotes: Yielded<MutableList<AssessmentReferralHistoryNoteEntity>> = { mutableListOf() }
   private var isWithdrawn: Yielded<Boolean> = { false }
+  private var createdFromAppeal: Yielded<Boolean> = { false }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -101,6 +102,10 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
     this.isWithdrawn = { isWithdrawn }
   }
 
+  fun withCreatedFromAppeal(createdFromAppeal: Boolean) = apply {
+    this.createdFromAppeal = { createdFromAppeal }
+  }
+
   override fun produce(): ApprovedPremisesAssessmentEntity = ApprovedPremisesAssessmentEntity(
     id = this.id(),
     data = this.data(),
@@ -118,5 +123,6 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
     clarificationNotes = this.clarificationNotes(),
     referralHistoryNotes = this.referralHistoryNotes(),
     isWithdrawn = this.isWithdrawn(),
+    createdFromAppeal = this.createdFromAppeal(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Appeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
@@ -385,9 +386,16 @@ class AppealsTest : IntegrationTestBase() {
 
           assertThat(applicationBody.status).isEqualTo(ApprovedPremisesApplicationStatus.unallocatedAssesment)
 
+          assertThat(applicationBody.assessmentId).isNotNull()
           assertThat(applicationBody.assessmentId).isNotEqualTo(assessment.id)
           assertThat(applicationBody.assessmentDecision).isNull()
           assertThat(applicationBody.assessmentDecisionDate).isNull()
+
+          val newAssessment = approvedPremisesAssessmentRepository.findByIdOrNull(applicationBody.assessmentId!!)
+
+          assertThat(newAssessment).isNotNull()
+
+          assertThat(newAssessment!!.createdFromAppeal).isTrue()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1976,6 +1976,7 @@ class ApplicationTest : IntegrationTestBase() {
           val createdAssessment =
             approvedPremisesAssessmentRepository.findAll().first { it.application.id == applicationId }
           assertThat(createdAssessment.allocatedToUser!!.id).isEqualTo(assessorUser.id)
+          assertThat(createdAssessment.createdFromAppeal).isFalse()
 
           val persistedDomainEvent = domainEventRepository.findAll().firstOrNull { it.applicationId == applicationId }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -244,7 +244,7 @@ class AppealServiceTest {
       val now = LocalDate.now()
 
       every { appealRepository.save(any()) } returnsArgument 0
-      every { assessmentService.createApprovedPremisesAssessment(any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
+      every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
       every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
       every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
@@ -288,7 +288,7 @@ class AppealServiceTest {
       val now = LocalDate.now()
 
       every { appealRepository.save(any()) } returnsArgument 0
-      every { assessmentService.createApprovedPremisesAssessment(any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
+      every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
       every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
       every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
@@ -366,7 +366,7 @@ class AppealServiceTest {
       val now = LocalDate.now()
 
       every { appealRepository.save(any()) } returnsArgument 0
-      every { assessmentService.createApprovedPremisesAssessment(any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
+      every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
       every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
       every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
@@ -391,7 +391,7 @@ class AppealServiceTest {
         assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
 
         verify(exactly = 1) {
-          assessmentService.createApprovedPremisesAssessment(application)
+          assessmentService.createApprovedPremisesAssessment(application, createdFromAppeal = true)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -162,6 +162,7 @@ class AssessmentTransformerTest {
     assertThat(result.createdAt).isEqualTo(Instant.parse("2022-12-14T12:05:00Z"))
     assertThat(result.submittedAt).isEqualTo(Instant.parse("2022-12-14T12:06:00Z"))
     assertThat(result.allocatedToStaffMember).isEqualTo(approvedPremisesUser)
+    assertThat(result.createdFromAppeal).isEqualTo(assessment.createdFromAppeal)
 
     verify { mockUserTransformer.transformJpaToApi(allocatedToUser, ServiceName.approvedPremises) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
@@ -29,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
@@ -185,6 +187,29 @@ class TaskTransformerTest {
       verify {
         mockApAreaTransformer.transformJpaToApi(apArea)
       }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `assessment with createdFromAppeal is transformed correctly`(createdFromAppeal: Boolean) {
+      val assessment = assessmentFactory.withCreatedFromAppeal(createdFromAppeal).produce()
+
+      val result = taskTransformer.transformAssessmentToTask(assessment, "First Last")
+
+      assertThat(result.createdFromAppeal).isEqualTo(createdFromAppeal)
+    }
+
+    @Test
+    fun `Temporary Accommodation assessment returns false for createdFromAppeal`() {
+      val assessment = TemporaryAccommodationAssessmentEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(user)
+        .withCreatedAt(OffsetDateTime.parse("2022-12-07T10:40:00Z"))
+        .produce()
+
+      val result = taskTransformer.transformAssessmentToTask(assessment, "First Last")
+
+      assertThat(result.createdFromAppeal).isEqualTo(false)
     }
   }
 


### PR DESCRIPTION
This adds a `createdFromAppeal` flag to Approved Premises assessments. If an appeal is accepted and a new assessment is created as a result, this flag is set to `true` in the database. This is then sent across in the API, so we can add the relevant flags on the frontend. It will also allow us to automatically allocate to CRU managers in a future PR.