### PR TITLE
[APS-427] Enable AP Delius Context API as the offender data source for test env

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -72,8 +72,8 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
-    DATA-SOURCES_OFFENDER-DETAILS: community_api
-    DATA-SOURCES_OFFENDER-RISKS: community_api
+    DATA-SOURCES_OFFENDER-DETAILS: ap_delius_context_api
+    DATA-SOURCES_OFFENDER-RISKS: ap_delius_context_api
 
     USER-ALLOCATIONS_RULES_LEGACY-ALLOCATOR_ENABLED: true
     USER-ALLOCATIONS_RULES_LEGACY-ALLOCATOR_PRIORITY: -1

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -718,7 +718,7 @@ components:
         mapping:
           FullPerson: '#/components/schemas/FullPerson'
           RestrictedPerson: '#/components/schemas/RestrictedPerson'
-          UnknownPerson: '#/components/schemas/FullPerson'
+          UnknownPerson: '#/components/schemas/UnknownPerson'
       required:
         - crn
         - type

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5293,7 +5293,7 @@ components:
         mapping:
           FullPerson: '#/components/schemas/FullPerson'
           RestrictedPerson: '#/components/schemas/RestrictedPerson'
-          UnknownPerson: '#/components/schemas/FullPerson'
+          UnknownPerson: '#/components/schemas/UnknownPerson'
       required:
         - crn
         - type

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1271,7 +1271,7 @@ components:
         mapping:
           FullPerson: '#/components/schemas/FullPerson'
           RestrictedPerson: '#/components/schemas/RestrictedPerson'
-          UnknownPerson: '#/components/schemas/FullPerson'
+          UnknownPerson: '#/components/schemas/UnknownPerson'
       required:
         - crn
         - type

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -766,7 +766,7 @@ components:
         mapping:
           FullPerson: '#/components/schemas/FullPerson'
           RestrictedPerson: '#/components/schemas/RestrictedPerson'
-          UnknownPerson: '#/components/schemas/FullPerson'
+          UnknownPerson: '#/components/schemas/UnknownPerson'
       required:
         - crn
         - type

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/FactoryUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/FactoryUtils.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.typeOf
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified F : Factory<T>, reified T : Any> F.from(value: T): F = apply {
+  val yieldedProperties = F::class
+    .memberProperties
+    .filter { it.returnType.jvmErasure == typeOf<Yielded<*>>().jvmErasure }
+    .mapNotNull { it as? KMutableProperty1<F, Any?> }
+
+  val valueProperties = T::class.memberProperties.associateBy { it.name }
+
+  yieldedProperties.forEach { prop ->
+    val propertyName = prop.name
+    val propertyValue = valueProperties[propertyName]?.get(value)
+
+    propertyValue?.let { prop.set(this, { it }) }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -40,13 +40,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitPlacemen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulRegistrationsCall
@@ -81,12 +84,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserTeamMembership
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseDetail
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.ZonedDateTime
 import java.util.UUID
 
 class ApplicationReportsTest : IntegrationTestBase() {
@@ -542,6 +548,23 @@ class ApplicationReportsTest : IntegrationTestBase() {
             .produce(),
         ),
       ),
+    )
+
+    APDeliusContext_mockSuccessfulCaseDetailCall(
+      offenderDetails.otherIds.crn,
+      CaseDetailFactory()
+        .from(offenderDetails.asCaseDetail())
+        .withMappaDetail(
+          MappaDetail(
+            2,
+            "M2",
+            2,
+            "M2",
+            LocalDate.parse("2022-09-06"),
+            ZonedDateTime.parse("2022-09-06T00:00:00Z"),
+          ),
+        )
+        .produce(),
     )
 
     val basicInformationJson =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -42,11 +42,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarifi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CacheKeySet
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given Some Offenders`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Temporary Accommodation`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_mockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockOffenderUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -1532,6 +1534,15 @@ class AssessmentTest : IntegrationTestBase() {
           crn = offenderDetails.otherIds.crn,
           inclusion = false,
           exclusion = false,
+        )
+
+        ApDeliusContext_mockUserAccess(
+          CaseAccessFactory()
+            .withCrn(offenderDetails.otherIds.crn)
+            .withUserExcluded(false)
+            .withUserRestricted(false)
+            .produce(),
+          userEntity.deliusUsername,
         )
 
         val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.junit.jupiter.api.AfterEach
@@ -828,10 +830,16 @@ abstract class IntegrationTestBase {
       )
     }
 
-  fun mockSuccessfulGetCallWithBodyAndJsonResponse(url: String, requestBody: StringValuePattern, responseBody: Any, responseStatus: Int = 200) =
+  fun mockSuccessfulGetCallWithBodyAndJsonResponse(
+    url: String,
+    requestBody: StringValuePattern,
+    responseBody: Any,
+    responseStatus: Int = 200,
+    additionalConfig: MappingBuilder.() -> Unit = { },
+  ) =
     mockOAuth2ClientCredentialsCallIfRequired {
       wiremockServer.stubFor(
-        WireMock.get(urlEqualTo(url))
+        WireMock.get(urlPathEqualTo(url))
           .withRequestBody(requestBody)
           .willReturn(
             aResponse()
@@ -840,12 +848,19 @@ abstract class IntegrationTestBase {
               .withBody(
                 objectMapper.writeValueAsString(responseBody),
               ),
-          ),
+          )
+          .apply(additionalConfig),
       )
     }
 
-  fun editGetStubWithBodyAndJsonResponse(url: String, uuid: UUID, requestBody: StringValuePattern, responseBody: Any) = wiremockServer.editStub(
-    WireMock.get(WireMock.urlEqualTo(url)).withId(uuid)
+  fun editGetStubWithBodyAndJsonResponse(
+    url: String,
+    uuid: UUID,
+    requestBody: StringValuePattern,
+    responseBody: Any,
+    additionalConfig: MappingBuilder.() -> Unit = { },
+  ) = wiremockServer.editStub(
+    WireMock.get(WireMock.urlPathEqualTo(url)).withId(uuid)
       .withRequestBody(requestBody)
       .willReturn(
         WireMock.aResponse()
@@ -854,7 +869,8 @@ abstract class IntegrationTestBase {
           .withBody(
             objectMapper.writeValueAsString(responseBody),
           ),
-      ),
+      )
+      .apply(additionalConfig),
   )
 
   fun mockUnsuccessfulGetCall(url: String, responseStatus: Int) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -10,21 +10,28 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulRegistrationsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.HMPPSTier_mockSuccessfulTierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Registration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseDetail
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import java.util.UUID
 
 class PersonRisksTest : IntegrationTestBase() {
@@ -124,6 +131,28 @@ class PersonRisksTest : IntegrationTestBase() {
                 .produce(),
             ),
           ),
+        )
+
+        APDeliusContext_mockSuccessfulCaseDetailCall(
+          offenderDetails.otherIds.crn,
+          CaseDetailFactory()
+            .from(offenderDetails.asCaseDetail())
+            .withRegistrations(
+              listOf(
+                Registration("FLAG", "RISK FLAG", LocalDate.now()),
+              ),
+            )
+            .withMappaDetail(
+              MappaDetail(
+                1,
+                "L1",
+                1,
+                "C1",
+                LocalDate.parse("2022-09-06"),
+                ZonedDateTime.parse("2022-09-06T00:00:00Z"),
+              ),
+            )
+            .produce(),
         )
 
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -42,13 +42,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacemen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulRegistrationsCall
@@ -84,12 +87,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserTeamMembership
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.PlacementApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseDetail
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.ZonedDateTime
 import java.util.UUID
 
 class PlacementApplicationReportsTest : IntegrationTestBase() {
@@ -674,6 +680,23 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
             .produce(),
         ),
       ),
+    )
+
+    APDeliusContext_mockSuccessfulCaseDetailCall(
+      offenderDetails.otherIds.crn,
+      CaseDetailFactory()
+        .from(offenderDetails.asCaseDetail())
+        .withMappaDetail(
+          MappaDetail(
+            2,
+            "M2",
+            2,
+            "M2",
+            LocalDate.parse("2022-09-06"),
+            ZonedDateTime.parse("2022-09-06T00:00:00Z"),
+          ),
+        )
+        .produce(),
     )
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -14,12 +14,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockOffenderUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -1200,6 +1202,13 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 crn = offenderDetails.otherIds.crn,
                 inclusion = false,
                 exclusion = false,
+              )
+
+              ApDeliusContext_addResponseToUserAccessCall(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+                user.deliusUsername,
               )
 
               webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -31,6 +31,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_mockCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_mockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -1592,12 +1594,12 @@ class PremisesTest : IntegrationTestBase() {
       }
 
       bookings.forEach {
-        ApDeliusContext_addCaseSummaryToBulkResponse(
+        ApDeliusContext_mockCaseSummary(
           CaseSummaryFactory()
             .withCrn(it.crn)
             .produce(),
         )
-        ApDeliusContext_addResponseToUserAccessCall(
+        ApDeliusContext_mockUserAccess(
           CaseAccessFactory()
             .withCrn(it.crn)
             .produce(),
@@ -1610,18 +1612,6 @@ class PremisesTest : IntegrationTestBase() {
         withPremises(premises)
         withBed(null)
       }
-
-      ApDeliusContext_addCaseSummaryToBulkResponse(
-        CaseSummaryFactory()
-          .withCrn(cancelledBooking.crn)
-          .produce(),
-      )
-      ApDeliusContext_addResponseToUserAccessCall(
-        CaseAccessFactory()
-          .withCrn(cancelledBooking.crn)
-          .produce(),
-        user.deliusUsername,
-      )
 
       cancellationEntityFactory.produceAndPersist {
         withBooking(cancelledBooking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderUtils.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProfileFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+
+fun OffenderDetailSummary.asCaseDetail() =
+  CaseDetailFactory().withCase(
+    CaseSummaryFactory()
+      .withCrn(this.otherIds.crn)
+      .withNomsId(this.otherIds.nomsNumber)
+      .withGender(this.gender)
+      .withPnc(this.otherIds.pncNumber)
+      .withName(
+        NameFactory()
+          .withForename(this.firstName)
+          .withSurname(this.surname)
+          .withMiddleNames(
+            this.middleNames?.let {
+              this.middleNames
+            } ?: emptyList(),
+          )
+          .produce(),
+      )
+      .withDateOfBirth(this.dateOfBirth)
+      .withProfile(
+        ProfileFactory()
+          .withReligion(this.offenderProfile.religion)
+          .withEthnicity(this.offenderProfile.ethnicity)
+          .withNationality(this.offenderProfile.nationality)
+          .withGenderIdentity(
+            when (this.offenderProfile.genderIdentity) {
+              "Prefer to self-describe" -> this.offenderProfile.selfDescribedGender
+              else -> this.offenderProfile.genderIdentity
+            },
+          )
+          .produce(),
+      )
+      .withCurrentExclusion(this.currentExclusion)
+      .withCurrentRestriction(this.currentRestriction)
+      .produce(),
+  ).produce()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -166,8 +166,8 @@ manual-bookings-domain-events-disabled: false
 upstream-timeout-ms: 2000
 
 data-sources:
-  offender-details: community_api
-  offender-risks: community_api
+  offender-details: ap_delius_context_api
+  offender-risks: ap_delius_context_api
 
 migration-job:
   throttle-enabled: false


### PR DESCRIPTION
> See [APS-427 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-427).

This PR updates the configuration to switch the data source for offender details and offender risks to the AP Delius Context API in the `test` environment. This will allow us to manually test that we get the information we expect from the AP Delius Context API and confirm that it is safe to disable the Community API as a source of this information.

In order to enable this change, several integration tests have been modified in order to mock/expect the AP Delius Context API as the source of this information. These changes include:
- Updating the API specification to prevent a `Person` with `UnknownPerson` incorrectly being deserialised as a `FullPerson` instance
- Modifying the WireMock stubs for the AP Delius Context API's `/users/access` and `/probation-cases/summaries` endpoints to support both bulk and individual fetch cases
- Modifying the `/users/access` WireMock stub to correctly handle the 'any username' case
- Introducing `Factory<T>.from(T)` as a method of creating a factory configured to produce a duplicate of an object (with optional further changes) in situations where the original factory is unavailable
- Modifying `Given an Offender` and `Given Some Offenders` to setup the necessary AP Delius Context API mocks
- Using `Given an Offender` in most cases where `OffenderDetailSummaryFactory` was explicitly constructed and used
- Explicitly setting up the required AP Delius Context API mocks to mimic the Community API mocks where the above was not suitable

See the PRs below for more context about this configuration change:
- #1200
- #1220 
- #1257 
- #1298 
- #1317 
- #1354 
- #1404 