### PR TITLE
Cas2 193 add started at to submitted applications report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -23,7 +23,7 @@ interface Cas2SubmittedApplicationReportRepository : JpaRepository<DomainEventEn
           CAST(events.data -> 'eventDetails' ->> 'submittedAt' AS TIMESTAMP),
           'YYYY-MM-DD"T"HH24:MI:SS'
         ) AS submittedAt,
-        TO_CHAR(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS createdAt
+        TO_CHAR(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS startedAt
       FROM domain_events events
       JOIN cas_2_applications applications
       ON events.application_id = applications.id      
@@ -48,5 +48,5 @@ interface Cas2SubmittedApplicationReportRow {
   fun getPreferredAreas(): String
   fun getHdcEligibilityDate(): String
   fun getConditionalReleaseDate(): String
-  fun getCreatedAt(): String
+  fun getStartedAt(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -36,6 +36,7 @@ interface Cas2SubmittedApplicationReportRepository : JpaRepository<DomainEventEn
   fun generateSubmittedApplicationReportRows(): List<Cas2SubmittedApplicationReportRow>
 }
 
+@SuppressWarnings("TooManyFunctions")
 interface Cas2SubmittedApplicationReportRow {
   fun getId(): String
   fun getApplicationId(): String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -22,8 +22,11 @@ interface Cas2SubmittedApplicationReportRepository : JpaRepository<DomainEventEn
         TO_CHAR(
           CAST(events.data -> 'eventDetails' ->> 'submittedAt' AS TIMESTAMP),
           'YYYY-MM-DD"T"HH24:MI:SS'
-        ) AS submittedAt
+        ) AS submittedAt,
+        TO_CHAR(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS createdAt
       FROM domain_events events
+      JOIN cas_2_applications applications
+      ON events.application_id = applications.id      
       WHERE events.type = 'CAS2_APPLICATION_SUBMITTED'
         AND events.occurred_at  > CURRENT_DATE - 365
       ORDER BY submittedAt DESC;
@@ -44,4 +47,5 @@ interface Cas2SubmittedApplicationReportRow {
   fun getPreferredAreas(): String
   fun getHdcEligibilityDate(): String
   fun getConditionalReleaseDate(): String
+  fun getCreatedAt(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/SubmittedApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/SubmittedApplicationReportRow.kt
@@ -11,4 +11,5 @@ data class SubmittedApplicationReportRow(
   val conditionalReleaseDate: String?,
   val submittedAt: String,
   val submittedBy: String,
+  val createdAt: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/SubmittedApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/SubmittedApplicationReportRow.kt
@@ -11,5 +11,5 @@ data class SubmittedApplicationReportRow(
   val conditionalReleaseDate: String?,
   val submittedAt: String,
   val submittedBy: String,
-  val createdAt: String,
+  val startedAt: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -42,7 +42,7 @@ class ReportsService(
         conditionalReleaseDate = row.getConditionalReleaseDate(),
         submittedBy = row.getSubmittedBy(),
         submittedAt = row.getSubmittedAt(),
-        createdAt = row.getCreatedAt(),
+        startedAt = row.getStartedAt(),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -42,6 +42,7 @@ class ReportsService(
         conditionalReleaseDate = row.getConditionalReleaseDate(),
         submittedBy = row.getSubmittedBy(),
         submittedAt = row.getSubmittedAt(),
+        createdAt = row.getCreatedAt(),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -243,7 +243,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           conditionalReleaseDate = event2Details.conditionalReleaseDate.toString(),
           submittedAt = event2Details.submittedAt.toString().split(".").first(),
           submittedBy = event2Details.submittedBy.staffMember.username.toString(),
-          createdAt = application2.createdAt.toString().split(".").first(),
+          startedAt = application2.createdAt.toString().split(".").first(),
         ),
         SubmittedApplicationReportRow(
           eventId = event1Id.toString(),
@@ -256,7 +256,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           conditionalReleaseDate = event1Details.conditionalReleaseDate.toString(),
           submittedAt = event1Details.submittedAt.toString().split(".").first(),
           submittedBy = event1Details.submittedBy.staffMember.username.toString(),
-          createdAt = application1.createdAt.toString().split(".").first(),
+          startedAt = application1.createdAt.toString().split(".").first(),
         ),
       )
         .toDataFrame()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -116,18 +116,72 @@ class Cas2ReportsTest : IntegrationTestBase() {
       val event2Id = UUID.randomUUID()
       val event3Id = UUID.randomUUID()
 
-      val old = Instant.now().minusSeconds(daysInSeconds(365))
-      val newer = Instant.now().minusSeconds(daysInSeconds(100))
-      val tooOld = Instant.now().minusSeconds(daysInSeconds(366))
+      val oldSubmitted = Instant.now().minusSeconds(daysInSeconds(365))
+      val oldCreated = oldSubmitted.minusSeconds(daysInSeconds(7))
+
+      val newerSubmitted = Instant.now().minusSeconds(daysInSeconds(100))
+      val newerCreated = newerSubmitted.minusSeconds(daysInSeconds(7))
+
+      val tooOldSubmitted = Instant.now().minusSeconds(daysInSeconds(366))
+      val tooOldCreated = tooOldSubmitted.minusSeconds(daysInSeconds(7))
+
+      val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withAddedAt(OffsetDateTime.now())
+        withId(UUID.randomUUID())
+      }
+
+      val user1 = nomisUserEntityFactory.produceAndPersist {
+        withNomisUsername("NOMIS_USER_1")
+      }
+
+      val user2 = nomisUserEntityFactory.produceAndPersist {
+        withNomisUsername("NOMIS_USER_2")
+      }
+
+      val applicationId1 = UUID.randomUUID()
+      val applicationId2 = UUID.randomUUID()
+      val applicationId3 = UUID.randomUUID()
+
+      val application1 = cas2ApplicationEntityFactory.produceAndPersist {
+        withId(applicationId1)
+        withApplicationSchema(applicationSchema)
+        withCreatedByUser(user1)
+        withCrn("CRN_1")
+        withNomsNumber("NOMS_1")
+        withCreatedAt(oldCreated.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withData("{}")
+        withSubmittedAt(oldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+      }
+
+      val application2 = cas2ApplicationEntityFactory.produceAndPersist {
+        withId(applicationId2)
+        withApplicationSchema(applicationSchema)
+        withCreatedByUser(user2)
+        withCrn("CRN_2")
+        withNomsNumber("NOMS_2")
+        withCreatedAt(newerCreated.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withData("{}")
+        withSubmittedAt(newerSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+      }
+
+      // outside time limit -- should not feature in report
+      cas2ApplicationEntityFactory.produceAndPersist {
+        withId(applicationId3)
+        withApplicationSchema(applicationSchema)
+        withCreatedByUser(user2)
+        withCreatedAt(tooOldCreated.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withData("{}")
+        withSubmittedAt(tooOldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+      }
 
       val event1Details = Cas2ApplicationSubmittedEventDetailsFactory()
-        .withSubmittedAt(old)
+        .withSubmittedAt(oldSubmitted)
         .produce()
       val event2Details = Cas2ApplicationSubmittedEventDetailsFactory()
-        .withSubmittedAt(newer)
+        .withSubmittedAt(newerSubmitted)
         .produce()
       val event3Details = Cas2ApplicationSubmittedEventDetailsFactory()
-        .withSubmittedAt(tooOld)
+        .withSubmittedAt(tooOldSubmitted)
         .produce()
 
       val event1ToSave = Cas2ApplicationSubmittedEvent(
@@ -155,14 +209,16 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withId(event1Id)
         withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
         withData(objectMapper.writeValueAsString(event1ToSave))
-        withOccurredAt(old.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withOccurredAt(oldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withApplicationId(applicationId1)
       }
 
       val event2 = domainEventFactory.produceAndPersist {
         withId(event2Id)
         withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
         withData(objectMapper.writeValueAsString(event2ToSave))
-        withOccurredAt(newer.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withOccurredAt(newerSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withApplicationId(applicationId2)
       }
 
       // we don't expect this event to be included as it relates to an application
@@ -171,7 +227,8 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withId(event3Id)
         withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
         withData(objectMapper.writeValueAsString(event3ToSave))
-        withOccurredAt(tooOld.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withOccurredAt(tooOldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withApplicationId(applicationId3)
       }
 
       val expectedDataFrame = listOf(
@@ -186,6 +243,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           conditionalReleaseDate = event2Details.conditionalReleaseDate.toString(),
           submittedAt = event2Details.submittedAt.toString().split(".").first(),
           submittedBy = event2Details.submittedBy.staffMember.username.toString(),
+          createdAt = application2.createdAt.toString().split(".").first(),
         ),
         SubmittedApplicationReportRow(
           eventId = event1Id.toString(),
@@ -198,6 +256,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           conditionalReleaseDate = event1Details.conditionalReleaseDate.toString(),
           submittedAt = event1Details.submittedAt.toString().split(".").first(),
           submittedBy = event1Details.submittedBy.staffMember.username.toString(),
+          createdAt = application1.createdAt.toString().split(".").first(),
         ),
       )
         .toDataFrame()


### PR DESCRIPTION
References:

- https://dsdmoj.atlassian.net/browse/CAS2-193
- https://dsdmoj.atlassian.net/browse/CAS2-198

**User Story:**

As a Performance Analyst I want the created_at field adding to the list of fields extracted for the submitted applications report so that when I refresh a PowerBI dashboard with this information, the dashboard user can determine the time taken to complete an application.

**Further information:**

The time taken to complete an application is the difference between the application submitted_at timestamp and the application created_at timestamp.  This calculation is done in the dashboard itself so there is no requirement to calculate it during the report extraction.

The created_at field is included in the unsubmitted applications report but is renamed to startedAt, therefore to ensure consistency the created_at field should be renamed to startedAt for the submitted applications.

There is no requirement to change any of the existing columns extracted.  Existing column names should be kept the same.  Reporting period should stay the same (12 months).  The sort order should stay as it is and the report type should stay as Excel.

**Technical Tasks:**

- update unsubmitted applications report query to include cas_2_applications.created_at; tables will need to be joined by application_id

**Acceptance Criteria:**

Tests to demonstrate requirement has been satisfied:

- unit tests
- integration tests
- e2e tests

Given I am logged in as an MI user when I download the submitted applications report then the startedAt (i.e. created_at) field is contained and populated for all records.