### PR TITLE
(APS-383) Make appeal manager the arbitrator of an appeal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -445,7 +445,6 @@ class ApplicationsController(
     val createAppealResult = appealService.createAppeal(
       appealDate = body.appealDate,
       appealDetail = body.appealDetail,
-      reviewer = body.reviewer,
       decision = body.decision,
       decisionDetail = body.decisionDetail,
       application = application,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
@@ -21,7 +21,6 @@ data class AppealEntity(
   val id: UUID,
   val appealDate: LocalDate,
   val appealDetail: String,
-  val reviewer: String,
   var decision: String,
   var decisionDetail: String,
   val createdAt: OffsetDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -48,7 +48,6 @@ class AppealService(
   fun createAppeal(
     appealDate: LocalDate,
     appealDetail: String,
-    reviewer: String,
     decision: AppealDecision,
     decisionDetail: String,
     application: ApplicationEntity,
@@ -67,10 +66,6 @@ class AppealService(
           "$.appealDetail" hasValidationError "empty"
         }
 
-        if (reviewer.isBlank()) {
-          "$.reviewer" hasValidationError "empty"
-        }
-
         if (decisionDetail.isBlank()) {
           "$.decisionDetail" hasValidationError "empty"
         }
@@ -84,7 +79,6 @@ class AppealService(
             id = UUID.randomUUID(),
             appealDate = appealDate,
             appealDetail = appealDetail,
-            reviewer = reviewer,
             decision = decision.value,
             decisionDetail = decisionDetail,
             createdAt = OffsetDateTime.now(),
@@ -146,7 +140,6 @@ class AppealService(
               surname = staffDetails.staff.surname,
               username = staffDetails.username,
             ),
-            reviewer = appeal.reviewer,
             appealDetail = appeal.appealDetail,
             decision = parseDecision(appeal.decision),
             decisionDetail = appeal.decisionDetail,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AppealTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AppealTransformer.kt
@@ -12,7 +12,6 @@ class AppealTransformer(private val userTransformer: UserTransformer) {
     id = jpa.id,
     appealDate = jpa.appealDate,
     appealDetail = jpa.appealDetail,
-    reviewer = jpa.reviewer,
     createdAt = jpa.createdAt.toInstant(),
     applicationId = jpa.application.id,
     createdByUser = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AppealTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AppealTransformer.kt
@@ -3,10 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Appeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 
 @Component
-class AppealTransformer {
+class AppealTransformer(private val userTransformer: UserTransformer) {
   fun transformJpaToApi(jpa: AppealEntity): Appeal = Appeal(
     id = jpa.id,
     appealDate = jpa.appealDate,
@@ -14,7 +15,7 @@ class AppealTransformer {
     reviewer = jpa.reviewer,
     createdAt = jpa.createdAt.toInstant(),
     applicationId = jpa.application.id,
-    createdByUserId = jpa.createdBy.id,
+    createdByUser = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
     decision = AppealDecision.entries.first { it.value == jpa.decision },
     decisionDetail = jpa.decisionDetail,
     assessmentId = jpa.assessment.id,

--- a/src/main/resources/db/migration/all/20240222105554__remove_reviewer_from_appeals.sql
+++ b/src/main/resources/db/migration/all/20240222105554__remove_reviewer_from_appeals.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "appeals" DROP COLUMN "reviewer";

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4281,8 +4281,6 @@ components:
           format: date
         appealDetail:
           type: string
-        reviewer:
-          type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
         decisionDetail:
@@ -4290,7 +4288,6 @@ components:
       required:
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
     Appeal:
@@ -4303,8 +4300,6 @@ components:
           type: string
           format: date
         appealDetail:
-          type: string
-        reviewer:
           type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
@@ -4325,7 +4320,6 @@ components:
         - id
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
         - createdAt

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4319,9 +4319,8 @@ components:
         assessmentId:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
       required:
         - id
         - appealDate
@@ -4331,7 +4330,7 @@ components:
         - decisionDetail
         - createdAt
         - applicationId
-        - createdByUserId
+        - createdByUser
     AppealDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8876,9 +8876,8 @@ components:
         assessmentId:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
       required:
         - id
         - appealDate
@@ -8888,7 +8887,7 @@ components:
         - decisionDetail
         - createdAt
         - applicationId
-        - createdByUserId
+        - createdByUser
     AppealDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8838,8 +8838,6 @@ components:
           format: date
         appealDetail:
           type: string
-        reviewer:
-          type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
         decisionDetail:
@@ -8847,7 +8845,6 @@ components:
       required:
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
     Appeal:
@@ -8860,8 +8857,6 @@ components:
           type: string
           format: date
         appealDetail:
-          type: string
-        reviewer:
           type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
@@ -8882,7 +8877,6 @@ components:
         - id
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
         - createdAt

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4802,9 +4802,8 @@ components:
         assessmentId:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
       required:
         - id
         - appealDate
@@ -4814,7 +4813,7 @@ components:
         - decisionDetail
         - createdAt
         - applicationId
-        - createdByUserId
+        - createdByUser
     AppealDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4764,8 +4764,6 @@ components:
           format: date
         appealDetail:
           type: string
-        reviewer:
-          type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
         decisionDetail:
@@ -4773,7 +4771,6 @@ components:
       required:
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
     Appeal:
@@ -4786,8 +4783,6 @@ components:
           type: string
           format: date
         appealDetail:
-          type: string
-        reviewer:
           type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
@@ -4808,7 +4803,6 @@ components:
         - id
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
         - createdAt

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4367,9 +4367,8 @@ components:
         assessmentId:
           type: string
           format: uuid
-        createdByUserId:
-          type: string
-          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
       required:
         - id
         - appealDate
@@ -4379,7 +4378,7 @@ components:
         - decisionDetail
         - createdAt
         - applicationId
-        - createdByUserId
+        - createdByUser
     AppealDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4329,8 +4329,6 @@ components:
           format: date
         appealDetail:
           type: string
-        reviewer:
-          type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
         decisionDetail:
@@ -4338,7 +4336,6 @@ components:
       required:
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
     Appeal:
@@ -4351,8 +4348,6 @@ components:
           type: string
           format: date
         appealDetail:
-          type: string
-        reviewer:
           type: string
         decision:
           $ref: '#/components/schemas/AppealDecision'
@@ -4373,7 +4368,6 @@ components:
         - id
         - appealDate
         - appealDetail
-        - reviewer
         - decision
         - decisionDetail
         - createdAt

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1287,8 +1287,6 @@ components:
           format: date-time
         createdBy:
           $ref: '#/components/schemas/StaffMember'
-        reviewer:
-          type: string
         appealDetail:
           type: string
         decision:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AppealEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AppealEntityFactory.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
@@ -19,7 +18,6 @@ class AppealEntityFactory : Factory<AppealEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var appealDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var appealDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
-  private var reviewer: Yielded<String> = { randomEmailAddress() }
   private var decision: Yielded<String> = { randomOf(AppealDecision.entries).value }
   private var decisionDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
@@ -55,10 +53,6 @@ class AppealEntityFactory : Factory<AppealEntity> {
 
   fun withAppealDetail(appealDetail: String) = apply {
     this.appealDetail = { appealDetail }
-  }
-
-  fun withReviewer(reviewer: String) = apply {
-    this.reviewer = { reviewer }
   }
 
   fun withDecision(decision: AppealDecision) = apply {
@@ -101,7 +95,6 @@ class AppealEntityFactory : Factory<AppealEntity> {
     id = this.id(),
     appealDate = this.appealDate(),
     appealDetail = this.appealDetail(),
-    reviewer = this.reviewer(),
     decision = this.decision(),
     decisionDetail = this.decisionDetail(),
     createdAt = this.createdAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAppealedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAppealedFactory.kt
@@ -21,7 +21,6 @@ class AssessmentAppealedFactory : Factory<AssessmentAppealed> {
   private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var createdAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
   private var createdBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
-  private var reviewer: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
   private var appealDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var decision: Yielded<AppealDecision> = { randomOf(AppealDecision.entries) }
   private var decisionDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
@@ -62,10 +61,6 @@ class AssessmentAppealedFactory : Factory<AssessmentAppealed> {
     this.createdBy = { StaffMemberFactory().apply(configuration).produce() }
   }
 
-  fun withReviewer(reviewer: String) = apply {
-    this.reviewer = { reviewer }
-  }
-
   fun withAppealDetail(appealDetail: String) = apply {
     this.appealDetail = { appealDetail }
   }
@@ -87,7 +82,6 @@ class AssessmentAppealedFactory : Factory<AssessmentAppealed> {
     deliusEventNumber = this.deliusEventNumber(),
     createdAt = this.createdAt(),
     createdBy = this.createdBy(),
-    reviewer = this.reviewer(),
     appealDetail = this.appealDetail(),
     decision = this.decision(),
     decisionDetail = this.decisionDetail(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -101,7 +101,6 @@ class AppealsTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("$.appealDate").isEqualTo(appeal.appealDate.toString())
           .jsonPath("$.appealDetail").isEqualTo(appeal.appealDetail)
-          .jsonPath("$.reviewer").isEqualTo(appeal.reviewer)
           .jsonPath("$.createdAt").isEqualTo(appeal.createdAt.toString())
           .jsonPath("$.applicationId").isEqualTo(application.id.toString())
           .jsonPath("$.decision").isEqualTo(appeal.decision)
@@ -121,7 +120,6 @@ class AppealsTest : IntegrationTestBase() {
         NewAppeal(
           appealDate = LocalDate.parse("2024-01-01"),
           appealDetail = "Some details about the appeal.",
-          reviewer = "Someone Else",
           decision = AppealDecision.accepted,
           decisionDetail = "Some details about the decision.",
         ),
@@ -140,7 +138,6 @@ class AppealsTest : IntegrationTestBase() {
           NewAppeal(
             appealDate = LocalDate.parse("2024-01-01"),
             appealDetail = "Some details about the appeal.",
-            reviewer = "Someone Else",
             decision = AppealDecision.accepted,
             decisionDetail = "Some details about the decision.",
           ),
@@ -163,7 +160,6 @@ class AppealsTest : IntegrationTestBase() {
               NewAppeal(
                 appealDate = LocalDate.parse("2024-01-01"),
                 appealDetail = "Some details about the appeal.",
-                reviewer = "Someone Else",
                 decision = AppealDecision.accepted,
                 decisionDetail = "Some details about the decision.",
               ),
@@ -187,7 +183,6 @@ class AppealsTest : IntegrationTestBase() {
             NewAppeal(
               appealDate = LocalDate.parse("2024-01-01"),
               appealDetail = "Some details about the appeal.",
-              reviewer = "Someone Else",
               decision = AppealDecision.accepted,
               decisionDetail = "Some details about the decision.",
             ),
@@ -210,7 +205,6 @@ class AppealsTest : IntegrationTestBase() {
             NewAppeal(
               appealDate = LocalDate.now().plusDays(1),
               appealDetail = "  ",
-              reviewer = "\t",
               decision = AppealDecision.rejected,
               decisionDetail = "\n",
             ),
@@ -233,7 +227,6 @@ class AppealsTest : IntegrationTestBase() {
             NewAppeal(
               appealDate = LocalDate.parse("2024-01-01"),
               appealDetail = "Some details about the appeal.",
-              reviewer = "Someone Else",
               decision = AppealDecision.accepted,
               decisionDetail = "Some details about the decision.",
             ),
@@ -265,7 +258,6 @@ class AppealsTest : IntegrationTestBase() {
               NewAppeal(
                 appealDate = LocalDate.parse("2024-01-01"),
                 appealDetail = "Some details about the appeal.",
-                reviewer = "Someone Else",
                 decision = AppealDecision.rejected,
                 decisionDetail = "Some details about the decision.",
               ),
@@ -279,7 +271,6 @@ class AppealsTest : IntegrationTestBase() {
             .expectBody()
             .jsonPath("$.appealDate").isEqualTo("2024-01-01")
             .jsonPath("$.appealDetail").isEqualTo("Some details about the appeal.")
-            .jsonPath("$.reviewer").isEqualTo("Someone Else")
             .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
             .jsonPath("$.applicationId").isEqualTo(application.id.toString())
             .jsonPath("$.decision").isEqualTo(AppealDecision.rejected.value)
@@ -309,7 +300,6 @@ class AppealsTest : IntegrationTestBase() {
               NewAppeal(
                 appealDate = LocalDate.parse("2024-01-01"),
                 appealDetail = "Some details about the appeal.",
-                reviewer = "Someone Else",
                 decision = AppealDecision.rejected,
                 decisionDetail = "Some details about the decision.",
               ),
@@ -357,7 +347,6 @@ class AppealsTest : IntegrationTestBase() {
               NewAppeal(
                 appealDate = LocalDate.parse("2024-01-01"),
                 appealDetail = "Some details about the appeal.",
-                reviewer = "Someone Else",
                 decision = AppealDecision.accepted,
                 decisionDetail = "Some details about the decision.",
               ),
@@ -412,7 +401,6 @@ class AppealsTest : IntegrationTestBase() {
               NewAppeal(
                 appealDate = LocalDate.parse("2024-01-01"),
                 appealDetail = "Some details about the appeal.",
-                reviewer = "Someone Else",
                 decision = AppealDecision.accepted,
                 decisionDetail = "Some details about the decision.",
               ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AppealTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AppealTestRepository.kt
@@ -6,4 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import java.util.UUID
 
 @Repository
-interface AppealTestRepository : JpaRepository<AppealEntity, UUID>
+interface AppealTestRepository : JpaRepository<AppealEntity, UUID> {
+  fun findByApplication_Id(applicationId: UUID): AppealEntity?
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -132,7 +132,6 @@ class AppealServiceTest {
       val result = appealService.createAppeal(
         LocalDate.now(),
         "Some information about why the appeal is being made",
-        "ReviewBot 9000",
         AppealDecision.accepted,
         "Some information about the decision made",
         application,
@@ -150,7 +149,6 @@ class AppealServiceTest {
       val result = appealService.createAppeal(
         LocalDate.now().plusDays(1),
         "Some information about why the appeal is being made",
-        "ReviewBot 9000",
         AppealDecision.accepted,
         "Some information about the decision made",
         application,
@@ -174,7 +172,6 @@ class AppealServiceTest {
       val result = appealService.createAppeal(
         LocalDate.now(),
         appealDetail,
-        "ReviewBot 9000",
         AppealDecision.accepted,
         "Some information about the decision made",
         application,
@@ -192,37 +189,12 @@ class AppealServiceTest {
     @ParameterizedTest
     @EmptySource
     @ValueSource(strings = ["  ", "\t", "\n"])
-    fun `Returns FieldValidationError if the reviewer is blank`(reviewer: String) {
-      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
-
-      val result = appealService.createAppeal(
-        LocalDate.now(),
-        "Some information about why the appeal is being made",
-        reviewer,
-        AppealDecision.accepted,
-        "Some information about the decision made",
-        application,
-        assessment,
-        createdByUser,
-      )
-
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      result as AuthorisableActionResult.Success
-      assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
-      val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
-      assertThat(resultEntity.validationMessages).containsEntry("$.reviewer", "empty")
-    }
-
-    @ParameterizedTest
-    @EmptySource
-    @ValueSource(strings = ["  ", "\t", "\n"])
     fun `Returns FieldValidationError if the decision detail is blank`(decisionDetail: String) {
       createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
 
       val result = appealService.createAppeal(
         LocalDate.now(),
         "Some information about why the appeal is being made",
-        "ReviewBot 9000",
         AppealDecision.accepted,
         decisionDetail,
         application,
@@ -256,7 +228,6 @@ class AppealServiceTest {
         val result = appealService.createAppeal(
           now,
           "Some information about why the appeal is being made",
-          "ReviewBot 9000",
           AppealDecision.accepted,
           "Some information about the decision made",
           application,
@@ -300,7 +271,6 @@ class AppealServiceTest {
         val result = appealService.createAppeal(
           now,
           "Some information about why the appeal is being made",
-          "ReviewBot 9000",
           AppealDecision.accepted,
           "Some information about the decision made",
           application,
@@ -341,7 +311,6 @@ class AppealServiceTest {
         val result = appealService.createAppeal(
           now,
           "Some information about why the appeal is being made",
-          "ReviewBot 9000",
           AppealDecision.rejected,
           "Some information about the decision made",
           application,
@@ -378,7 +347,6 @@ class AppealServiceTest {
         val result = appealService.createAppeal(
           now,
           "Some information about why the appeal is being made",
-          "ReviewBot 9000",
           AppealDecision.accepted,
           "Some information about the decision made",
           application,
@@ -400,7 +368,6 @@ class AppealServiceTest {
       this.id == appealId &&
         this.appealDate == now &&
         this.appealDetail == "Some information about why the appeal is being made" &&
-        this.reviewer == "ReviewBot 9000" &&
         this.decision == AppealDecision.accepted.value &&
         this.decisionDetail == "Some information about the decision made" &&
         this.application == application &&
@@ -425,7 +392,6 @@ class AppealServiceTest {
         this.eventDetails.deliusEventNumber == application.eventNumber &&
         withinSeconds(10).matches(this.eventDetails.createdAt.toString()) &&
         this.eventDetails.createdBy.matches() &&
-        this.eventDetails.reviewer == "ReviewBot 9000" &&
         this.eventDetails.appealDetail == "Some information about why the appeal is being made" &&
         this.eventDetails.decision == DomainEventApiAppealDecision.accepted &&
         this.eventDetails.decisionDetail == "Some information about the decision made"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AppealTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AppealTransformerTest.kt
@@ -1,15 +1,30 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AppealTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class AppealTransformerTest {
-  private val appealTransformer = AppealTransformer()
+  private val mockUserTransformer = mockk<UserTransformer>()
+  private val appealTransformer = AppealTransformer(mockUserTransformer)
+
+  private val mockUser = mockk<User>()
+
+  @BeforeEach
+  fun setup() {
+    every { mockUserTransformer.transformJpaToApi(any(), any()) } returns mockUser
+  }
 
   @Test
   fun `A newly created appeal is transformed correctly`() {
@@ -24,9 +39,11 @@ class AppealTransformerTest {
     assertThat(transformedAppeal.reviewer).isEqualTo(appealEntity.reviewer)
     assertThat(transformedAppeal.createdAt).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS))
     assertThat(transformedAppeal.applicationId).isEqualTo(appealEntity.application.id)
-    assertThat(transformedAppeal.createdByUserId).isEqualTo(appealEntity.createdBy.id)
+    assertThat(transformedAppeal.createdByUser).isEqualTo(mockUser)
     assertThat(transformedAppeal.decision.value).isEqualTo(appealEntity.decision)
     assertThat(transformedAppeal.decisionDetail).isEqualTo(appealEntity.decisionDetail)
     assertThat(transformedAppeal.assessmentId).isEqualTo(appealEntity.assessment.id)
+
+    verify(exactly = 1) { mockUserTransformer.transformJpaToApi(appealEntity.createdBy, ServiceName.approvedPremises) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AppealTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AppealTransformerTest.kt
@@ -36,7 +36,6 @@ class AppealTransformerTest {
     assertThat(transformedAppeal.id).isEqualTo(appealEntity.id)
     assertThat(transformedAppeal.appealDate).isEqualTo(appealEntity.appealDate)
     assertThat(transformedAppeal.appealDetail).isEqualTo(appealEntity.appealDetail)
-    assertThat(transformedAppeal.reviewer).isEqualTo(appealEntity.reviewer)
     assertThat(transformedAppeal.createdAt).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS))
     assertThat(transformedAppeal.applicationId).isEqualTo(appealEntity.application.id)
     assertThat(transformedAppeal.createdByUser).isEqualTo(mockUser)


### PR DESCRIPTION
This adds a `createdByUser` to the appeals response, rather than just the ID, allowing us to get more information about the user who created the appeal.

We also remove the `reviewer` field, as now the person who created the appeal is also considered to be the arbitrator of the appeal, so we no longer need this field.