### PR TITLE
Remove required field from domain events

### DIFF
--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1302,7 +1302,6 @@ components:
         - deliusEventNumber
         - createdAt
         - createdBy
-        - reviewer
         - appealDetail
         - decision
         - decisionDetail


### PR DESCRIPTION
This shouldn’t be there as the `reviewer` field was removed in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1518