### PR TITLE
Remove otherReason validation on CAS1 Withdrawal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -561,10 +561,6 @@ class ApplicationService(
           return@validated success(Unit)
         }
 
-        if (withdrawalReason == WithdrawalReason.other.value && otherReason == null) {
-          return@validated "$.otherReason" hasSingleValidationError "empty"
-        }
-
         applicationRepository.save(
           application.apply {
             this.isWithdrawn = true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -2295,34 +2295,6 @@ class ApplicationServiceTest {
     }
 
     @Test
-    fun `withdrawApprovedPremisesApplication returns FieldValidationError if the reason is null and the otherReason has not been set`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(user)
-        .produce()
-
-      every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
-      every { mockUserAccessService.userMayWithdrawApplication(user, application) } returns true
-
-      val authorisableActionResult =
-        applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", null)
-
-      assertThat(authorisableActionResult is AuthorisableActionResult.Success).isTrue
-
-      val validatableActionResult = (authorisableActionResult as AuthorisableActionResult.Success).entity
-
-      assertThat(validatableActionResult is ValidatableActionResult.FieldValidationError).isTrue
-
-      val validationMessages =
-        (validatableActionResult as ValidatableActionResult.FieldValidationError).validationMessages
-
-      assertThat(validationMessages).containsEntry("$.otherReason", "empty")
-    }
-
-    @Test
     fun `withdrawApprovedPremisesApplication returns Success and saves Application with isWithdrawn set to true, emits domain event`() {
       val user = UserEntityFactory()
         .withUnitTestControlProbationRegion()


### PR DESCRIPTION
Before this commit the API would ensure that when the user chooses ‘otherReason’ when withdrawing an application that free text was provided explaining why. This is no longer required in the new withdrawal solution as this reason isn’t available.