### PR TITLE
The only withdrawable match request is the one created from the original application date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -181,7 +181,7 @@ data class PlacementRequestEntity(
 
   fun isActive() = !isWithdrawn && !isReallocated()
 
-  fun isFromApplicationsArrivalDate() = placementApplication == null
+  fun isForApplicationsArrivalDate() = placementApplication == null
 }
 
 enum class PlacementRequestWithdrawalReason {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -292,13 +292,21 @@ class PlacementRequestService(
     )
   }
 
+  /**
+   * This should return a maximum of one placement request, representing the dates known
+   * at the point of application submission
+   */
   fun getWithdrawablePlacementRequestsForUser(
     user: UserEntity,
     application: ApprovedPremisesApplicationEntity,
   ): List<PlacementRequestEntity> =
     placementRequestRepository
       .findByApplication(application)
-      .filter { it.isInWithdrawableState() && userAccessService.userMayWithdrawPlacementRequest(user, it) }
+      .filter {
+        it.isInWithdrawableState() &&
+        it.isForApplicationsArrivalDate() &&
+        userAccessService.userMayWithdrawPlacementRequest(user, it)
+      }
 
   @Transactional
   fun withdrawPlacementRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -26,7 +26,7 @@ class Cas1PlacementRequestEmailService(
       "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
     )
 
-    if (placementRequest.isFromApplicationsArrivalDate()) {
+    if (placementRequest.isForApplicationsArrivalDate()) {
       val applicant = application.createdByUser
       applicant.email?.let { applicantEmail ->
         emailNotifier.sendEmail(


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-388

When returning a list of withdrawable elements, the only time a Match Request should be returned is when it represents the start date/duration specified on the original application (i.e. the one that is automatically created when the application is assessed).

This provides a method for the applicant to withdraw a request for a booking on the original dates without withdrawing the whole application.

Previously we would also return the match requests created for Reuqests for Placements created after the application had been submitted. This is not required because the user can withdraw the Request for Placements themselves which will cascade down the corresponding Match Requests.

As part of this commit general improvements have been made to the Withdrawals integration test when checking the correct elements are being returned as withdrawable, testing against more complex application structures