### PR TITLE
Return Assessment on CAS2 Applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -30,20 +30,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationNotesTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getFullInfoForPersonOrThrow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.cas2.getInfoForPersonOrThrowInternalServerError
 import java.net.URI
 import java.util.UUID
-import javax.persistence.metamodel.EntityType
 
 @Service("Cas2SubmissionsController")
 class SubmissionsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
   private val applicationNoteService: ApplicationNoteService,
-  private val applicationTransformer: SubmittedApplicationTransformer,
+  private val submissionsTransformer: SubmissionsTransformer,
   private val applicationNotesTransformer: ApplicationNotesTransformer,
   private val offenderService: OffenderService,
   private val externalUserService: ExternalUserService,
@@ -181,7 +180,7 @@ class SubmissionsController(
     Cas2SubmittedApplicationSummary {
     val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
 
-    return applicationTransformer.transformJpaSummaryToApiRepresentation(
+    return submissionsTransformer.transformJpaSummaryToApiRepresentation(
       application,
       personInfo,
     )
@@ -192,7 +191,7 @@ class SubmissionsController(
   ): Cas2SubmittedApplication {
     val personInfo = offenderService.getFullInfoForPersonOrThrow(application.crn)
 
-    return applicationTransformer.transformJpaToApiRepresentation(
+    return submissionsTransformer.transformJpaToApiRepresentation(
       application,
       personInfo,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -4,6 +4,7 @@ import org.hibernate.annotations.OrderBy
 import org.hibernate.annotations.Type
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -73,6 +74,12 @@ WHERE a.submitted_at IS NOT NULL
   @Query("SELECT a FROM Cas2ApplicationEntity a WHERE a.id = :id")
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   fun findByIdOrNullWithWriteLock(id: UUID): Cas2ApplicationEntity?
+
+  @Query(
+    "SELECT a FROM Cas2ApplicationEntity a WHERE a.submittedAt IS NOT NULL " +
+      "AND a.id NOT IN (SELECT application FROM Cas2AssessmentEntity)",
+  )
+  fun findAllSubmittedApplicationsWithoutAssessments(): Slice<Cas2ApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2AssessmentEntity.kt
@@ -11,7 +11,9 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
-interface Cas2AssessmentRepository : JpaRepository<Cas2AssessmentEntity, UUID>
+interface Cas2AssessmentRepository : JpaRepository<Cas2AssessmentEntity, UUID> {
+  fun findFirstByApplicationId(applicationId: UUID): Cas2AssessmentEntity?
+}
 
 @Entity
 @Table(name = "cas_2_assessments")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas2AssessmentMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas2AssessmentMigrationJob.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Slice
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2AssessmentMigrationJob(
+  private val assessmentRepository: Cas2AssessmentRepository,
+  private val applicationRepository: Cas2ApplicationRepository,
+  private val transactionTemplate: TransactionTemplate,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = true
+
+  override fun process() {
+    log.info("Starting Cas2 Assessment Migration process...")
+
+    var hasNext = true
+    var slice: Slice<Cas2ApplicationEntity>
+
+    while (hasNext) {
+      slice = applicationRepository.findAllSubmittedApplicationsWithoutAssessments()
+      slice.content.forEach { application ->
+        transactionTemplate.executeWithoutResult {
+          log.info("Saving assessment for ${application.id}")
+          assessmentRepository.save(
+            Cas2AssessmentEntity(
+              id = UUID.randomUUID(),
+              application = application,
+              createdAt = OffsetDateTime.now(),
+            ),
+          )
+        }
+      }
+      hasNext = slice.hasNext()
+    }
+    log.info("CAS2 Assessment Migration process complete!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -14,10 +14,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJobApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.BookingStatusMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.InmateStatusOnSubmissionMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
@@ -78,6 +81,12 @@ class MigrationJobService(
           applicationContext.getBean(EntityManager::class.java),
           applicationContext.getBean(TaskDeadlineService::class.java),
           pageSize,
+        )
+
+        MigrationJobType.cas2ApplicationsWithAssessments -> Cas2AssessmentMigrationJob(
+          applicationContext.getBean(Cas2AssessmentRepository::class.java),
+          applicationContext.getBean(Cas2ApplicationRepository::class.java),
+          transactionTemplate,
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 
 @Component("Cas2SubmittedApplicationTransformer")
-class SubmittedApplicationTransformer(
+class SubmissionsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
   private val nomisUserTransformer: NomisUserTransformer,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
@@ -40,6 +41,7 @@ class SubmissionsTransformer(
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       telephoneNumber = jpa.telephoneNumber,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
+      assessment = Cas2Assessment(nacroReferralId = jpa.assessment?.nacroReferralId, assessorName = jpa.assessment?.assessorName),
     )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1705,6 +1705,9 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas2TimelineEvent'
+        assessment:
+          type: object
+          $ref: '_shared.yml#/components/schemas/Cas2Assessment'
       required:
         - id
         - person
@@ -1714,6 +1717,7 @@ components:
         - outdatedSchema
         - status
         - timelineEvents
+        - assessment
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -2439,6 +2443,13 @@ components:
           required:
             - application
             - summaryData
+    Cas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3428,6 +3428,7 @@ components:
         - update_booking_status
         - update_application_ap_areas
         - update_task_due_dates
+        - update_cas2_applications_with_assessments
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6274,6 +6274,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas2TimelineEvent'
+        assessment:
+          type: object
+          $ref: '#/components/schemas/Cas2Assessment'
       required:
         - id
         - person
@@ -6283,6 +6286,7 @@ components:
         - outdatedSchema
         - status
         - timelineEvents
+        - assessment
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -7008,6 +7012,13 @@ components:
           required:
             - application
             - summaryData
+    Cas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7997,6 +7997,7 @@ components:
         - update_booking_status
         - update_application_ap_areas
         - update_task_due_dates
+        - update_cas2_applications_with_assessments
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3911,6 +3911,7 @@ components:
         - update_booking_status
         - update_application_ap_areas
         - update_task_due_dates
+        - update_cas2_applications_with_assessments
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2188,6 +2188,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas2TimelineEvent'
+        assessment:
+          type: object
+          $ref: '#/components/schemas/Cas2Assessment'
       required:
         - id
         - person
@@ -2197,6 +2200,7 @@ components:
         - outdatedSchema
         - status
         - timelineEvents
+        - assessment
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -2922,6 +2926,13 @@ components:
           required:
             - application
             - summaryData
+    Cas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3476,6 +3476,7 @@ components:
         - update_booking_status
         - update_application_ap_areas
         - update_task_due_dates
+        - update_cas2_applications_with_assessments
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1753,6 +1753,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas2TimelineEvent'
+        assessment:
+          type: object
+          $ref: '#/components/schemas/Cas2Assessment'
       required:
         - id
         - person
@@ -1762,6 +1765,7 @@ components:
         - outdatedSchema
         - status
         - timelineEvents
+        - assessment
     TemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/Application'
@@ -2487,6 +2491,13 @@ components:
           required:
             - application
             - summaryData
+    Cas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
     AssessmentSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
@@ -31,6 +32,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
   private var telephoneNumber: Yielded<String?> = { randomNumberChars(12) }
   private var notes: Yielded<MutableList<Cas2ApplicationNoteEntity>> = { mutableListOf() }
+  private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -88,6 +90,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.eventNumber = { eventNumber }
   }
 
+  fun withAssessment(assessmentEntity: Cas2AssessmentEntity) = apply {
+    this.assessment = { assessmentEntity }
+  }
+
   override fun produce(): Cas2ApplicationEntity = Cas2ApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -102,5 +108,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     nomsNumber = this.nomsNumber(),
     telephoneNumber = this.telephoneNumber(),
     notes = this.notes(),
+    assessment = this.assessment(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2AssessmentEntityFactory.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2AssessmentEntityFactory : Factory<Cas2AssessmentEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var application: Yielded<Cas2ApplicationEntity> = {
+    Cas2ApplicationEntityFactory()
+      .withCreatedByUser(NomisUserEntityFactory().produce())
+      .produce()
+  }
+  private var nacroReferralId: Yielded<String?> = { null }
+  private var assessorName: Yielded<String?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withApplication(application: Cas2ApplicationEntity) = apply {
+    this.application = { application }
+  }
+
+  fun withNacroReferralId(id: String) = apply {
+    this.nacroReferralId = { id }
+  }
+
+  fun withAssessorName(name: String) = apply {
+    this.assessorName = { name }
+  }
+
+  override fun produce(): Cas2AssessmentEntity = Cas2AssessmentEntity(
+    id = this.id(),
+    createdAt = this.createdAt(),
+    application = this.application(),
+    nacroReferralId = this.nacroReferralId(),
+    assessorName = this.assessorName(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
@@ -109,6 +110,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
@@ -374,6 +377,9 @@ abstract class IntegrationTestBase {
   lateinit var cas2ApplicationRepository: Cas2ApplicationTestRepository
 
   @Autowired
+  lateinit var cas2AssessmentRepository: Cas2AssessmentRepository
+
+  @Autowired
   lateinit var cas2StatusUpdateRepository: Cas2StatusUpdateTestRepository
 
   @Autowired
@@ -522,6 +528,7 @@ abstract class IntegrationTestBase {
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
   lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
   lateinit var cas2ApplicationEntityFactory: PersistedFactory<Cas2ApplicationEntity, UUID, Cas2ApplicationEntityFactory>
+  lateinit var cas2AssessmentEntityFactory: PersistedFactory<Cas2AssessmentEntity, UUID, Cas2AssessmentEntityFactory>
   lateinit var cas2StatusUpdateEntityFactory: PersistedFactory<Cas2StatusUpdateEntity, UUID, Cas2StatusUpdateEntityFactory>
   lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
   lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
@@ -608,6 +615,7 @@ abstract class IntegrationTestBase {
     nonArrivalReasonEntityFactory = PersistedFactory({ NonArrivalReasonEntityFactory() }, nonArrivalReasonRepository)
     approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)
     cas2ApplicationEntityFactory = PersistedFactory({ Cas2ApplicationEntityFactory() }, cas2ApplicationRepository)
+    cas2AssessmentEntityFactory = PersistedFactory({ Cas2AssessmentEntityFactory() }, cas2AssessmentRepository)
     cas2StatusUpdateEntityFactory = PersistedFactory({ Cas2StatusUpdateEntityFactory() }, cas2StatusUpdateRepository)
     temporaryAccommodationApplicationEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationEntityFactory() }, temporaryAccommodationApplicationRepository)
     offlineApplicationEntityFactory = PersistedFactory({ OfflineApplicationEntityFactory() }, offlineApplicationRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateAssessmentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateAssessmentsTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2MigrateAssessmentsTest : MigrationJobTestBase() {
+
+  @SpykBean
+  lateinit var realAssessmentRepository: Cas2AssessmentRepository
+
+  @SpykBean
+  lateinit var realApplicationRepository: Cas2ApplicationRepository
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realAssessmentRepository)
+    clearMocks(realApplicationRepository)
+  }
+
+  @Test
+  fun `Should create assessments for CAS2 Applications that are submitted and returns 202 response`() {
+    `Given a CAS2 User` { userEntity, _ ->
+      val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withAddedAt(OffsetDateTime.now())
+        withId(UUID.randomUUID())
+      }
+
+      val submittedAt = OffsetDateTime.now().minusDays(1)
+
+      val unsubmittedApp = createApplicationEntity(applicationSchema, userEntity, null)
+
+      val submittedWithoutAssessment = createApplicationEntity(applicationSchema, userEntity, submittedAt)
+
+      val submittedWithAssessment = createApplicationEntity(applicationSchema, userEntity, submittedAt)
+
+      cas2AssessmentEntityFactory.produceAndPersist {
+        withApplication(submittedWithAssessment)
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas2ApplicationsWithAssessments, 1)
+
+      checkUnsubmittedDoesNotHaveAssessment(unsubmittedApp)
+
+      checkAssessmentWasCreated(submittedWithoutAssessment)
+
+      checkApplicationHasAssociationWithAssessment(submittedWithoutAssessment)
+    }
+  }
+
+  private fun checkApplicationHasAssociationWithAssessment(submittedWithoutAssessment: Cas2ApplicationEntity) {
+    val application = realApplicationRepository.findById(submittedWithoutAssessment.id)
+    Assertions.assertThat(application.get().assessment).isNotNull()
+  }
+
+  private fun checkAssessmentWasCreated(submittedWithoutAssessment: Cas2ApplicationEntity) {
+    val newAssessment = realAssessmentRepository.findFirstByApplicationId(submittedWithoutAssessment.id)
+    Assertions.assertThat(newAssessment).isNotNull()
+  }
+
+  private fun checkUnsubmittedDoesNotHaveAssessment(unsubmittedApp: Cas2ApplicationEntity) {
+    val unsubmittedApplication = realApplicationRepository.findById(unsubmittedApp.id)
+    Assertions.assertThat(unsubmittedApplication.get().assessment).isNull()
+  }
+
+  private fun createApplicationEntity(applicationSchema: Cas2ApplicationJsonSchemaEntity, userEntity: NomisUserEntity, submittedAt: OffsetDateTime?) =
+    cas2ApplicationEntityFactory.produceAndPersist {
+      withId(UUID.randomUUID())
+      withApplicationSchema(applicationSchema)
+      withCreatedByUser(userEntity)
+      withData("{}")
+      withSubmittedAt(submittedAt)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -350,6 +350,12 @@ class Cas2SubmissionTest(
               )
             }
 
+            val assessmentEntity = cas2AssessmentEntityFactory.produceAndPersist {
+              withApplication(applicationEntity)
+              withNacroReferralId("OH123")
+              withAssessorName("Assessor name")
+            }
+
             val update1 = cas2StatusUpdateEntityFactory.produceAndPersist {
               withApplication(applicationEntity)
               withAssessor(assessor)
@@ -415,7 +421,9 @@ class Cas2SubmissionTest(
                 applicant == it.submittedBy &&
                 applicationEntity.submittedAt?.toInstant() == it.submittedAt &&
                 serializableToJsonNode(applicationEntity.document) == serializableToJsonNode(it.document) &&
-                newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
+                newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema &&
+                assessmentEntity.assessorName == it.assessment.assessorName &&
+                assessmentEntity.nacroReferralId == it.assessment.nacroReferralId
             }
 
             Assertions.assertThat(responseBody.statusUpdates!!.map { update -> update.label })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentServiceTest.kt
@@ -6,11 +6,9 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatcher
 import org.mockito.kotlin.times
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import java.time.OffsetDateTime
@@ -54,13 +52,6 @@ class AssessmentServiceTest {
           match { it.application == application },
         )
       }
-    }
-  }
-
-  class AssessmentMatcher(var application: Cas2ApplicationEntity) : ArgumentMatcher<Cas2AssessmentEntity> {
-
-    override fun matches(assessment: Cas2AssessmentEntity): Boolean {
-      return assessment.application.id == application.id
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpd
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmittedApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
@@ -29,7 +29,7 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class SubmittedApplicationTransformerTest {
+class SubmissionsTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockNomisUserTransformer = mockk<NomisUserTransformer>()
   private val mockStatusUpdateTransformer = mockk<StatusUpdateTransformer>()
@@ -41,7 +41,7 @@ class SubmittedApplicationTransformerTest {
     registerKotlinModule()
   }
 
-  private val applicationTransformer = SubmittedApplicationTransformer(
+  private val applicationTransformer = SubmissionsTransformer(
     objectMapper,
     mockPersonTransformer,
     mockNomisUserTransformer,


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-251

We previously created the `Assessment` model, with a view to expanding its use on CAS2 here https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1514

Now we want to return it on the `Application` so that the frontend can render it. This may be an interim solution until we have completed all the [phases of our suggested Application refactoring ](doc/architecture/decisions/0021-introduce-cas2-assessments.md)

In a previous commit we introduced functionality to [create an Assessment whenever a CAS2
application is submitted](https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/e479df3f5556005cafb15598aed944668b67353e). This will have left any applications in Production that had already been submitted without an Assessment model. In order to allow the frontend to expect that all submitted applications have an assessment, and to ensure all our data is consistent, we introduce a migration here to add an Assessment to any Application that has been submitted and does not yet have one.


