### PR TITLE
(APS-384) Send notification email on successful appeal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -39,6 +39,7 @@ class NotifyTemplates {
   val placementRequestSubmitted = "deb11bc6-d424-4370-bbe5-41f6a823d292"
   val placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
   val cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
+  val appealSuccess = "ae21f3ae-3a4a-4df8-a1b8-2640ea80d101"
 }
 
 enum class NotifyMode {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -33,6 +34,7 @@ class AppealService(
   private val assessmentService: AssessmentService,
   private val domainEventService: DomainEventService,
   private val communityApiClient: CommunityApiClient,
+  private val cas1AppealEmailService: Cas1AppealEmailService,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-appeal}") private val applicationAppealUrlTemplate: UrlTemplate,
 ) {
@@ -92,6 +94,7 @@ class AppealService(
 
         if (decision == AppealDecision.accepted) {
           assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity, createdFromAppeal = true)
+          cas1AppealEmailService.appealSuccess(application, appeal)
         }
 
         success(appeal)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealEmailService.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+
+@Service
+class Cas1AppealEmailService(
+  private val emailNotificationService: EmailNotifier,
+  private val notifyConfig: NotifyConfig,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+) {
+  fun appealSuccess(application: ApplicationEntity, appeal: AppealEntity) {
+    appealSuccessRecipients(application, appeal).forEach { emailAddress ->
+      sendAppealSuccessEmailToEmailAddress(emailAddress, application)
+    }
+  }
+
+  private fun sendAppealSuccessEmailToEmailAddress(emailAddress: String, application: ApplicationEntity) {
+    emailNotificationService.sendEmail(
+      recipientEmailAddress = emailAddress,
+      templateId = notifyConfig.templates.appealSuccess,
+      personalisation = mapOf(
+        "crn" to application.crn,
+        "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+      ),
+    )
+  }
+
+  private fun appealSuccessRecipients(application: ApplicationEntity, appeal: AppealEntity): List<String> = listOfNotNull(
+    application.createdByUser.email,
+    appeal.createdBy.email,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -331,7 +331,7 @@ class AppealsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Create new appeal creates a new assessment and updates the application status if the appeal was accepted`() {
+  fun `Create new appeal creates a new assessment, updates the application status and sends notification emails if the appeal was accepted`() {
     `Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         `Given an Assessment for Approved Premises`(
@@ -380,6 +380,12 @@ class AppealsTest : IntegrationTestBase() {
           assertThat(newAssessment!!.createdFromAppeal).isTrue()
           assertThat(newAssessment.allocatedToUser).isNotNull()
           assertThat(newAssessment.allocatedToUser!!.id).isEqualTo(userEntity.id)
+
+          emailAsserter.assertEmailsRequestedCount(3)
+          emailAsserter.assertEmailRequested(userEntity.email!!, notifyConfig.templates.appealSuccess)
+          emailAsserter.assertEmailRequested(application.createdByUser.email!!, notifyConfig.templates.appealSuccess)
+
+          emailAsserter.assertEmailRequested(userEntity.email!!, notifyConfig.templates.assessmentAllocated)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AppealEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AppealEmailServiceTest.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockEmailNotificationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.OffsetDateTime
+
+object Cas1AppealEmailServiceTestConstants {
+  const val APPLICANT_EMAIL = "applicant@test.com"
+  const val APPEAL_ARBITRATOR_EMAIL = "arbitrator@test.com"
+  const val CRN = "CRN123"
+}
+
+class Cas1AppealEmailServiceTest {
+  private val notifyConfig = NotifyConfig()
+  private val mockEmailNotificationService = MockEmailNotificationService()
+
+  val service = Cas1AppealEmailService(
+    mockEmailNotificationService,
+    notifyConfig,
+    applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
+  )
+
+  @BeforeEach
+  fun beforeEach() {
+    mockEmailNotificationService.reset()
+  }
+
+  @Test
+  fun `appealSuccess doesn't send an email if the user does not have an email address`() {
+    val (application, appeal) = createApplicationAndAppeal(null, null)
+
+    service.appealSuccess(application, appeal)
+
+    mockEmailNotificationService.assertEmailRequestCount(0)
+  }
+
+  @Test
+  fun `appealSuccess sends an email to the applicant, but not the arbitrator if the applicant has an email address, but the arbitrator doesn't`() {
+    val (application, appeal) = createApplicationAndAppeal(Cas1AppealEmailServiceTestConstants.APPLICANT_EMAIL, null)
+
+    service.appealSuccess(application, appeal)
+
+    mockEmailNotificationService.assertEmailRequestCount(1)
+    mockEmailNotificationService.assertEmailRequested(
+      Cas1AppealEmailServiceTestConstants.APPLICANT_EMAIL,
+      notifyConfig.templates.appealSuccess,
+      expectedPersonalisationForAppealSuccess(application),
+    )
+  }
+
+  @Test
+  fun `appealSuccess sends an email to the arbitrator, but not the applicant if the arbitrator has an email address, but the applicant doesn't`() {
+    val (application, appeal) = createApplicationAndAppeal(null, Cas1AppealEmailServiceTestConstants.APPEAL_ARBITRATOR_EMAIL)
+
+    service.appealSuccess(application, appeal)
+
+    mockEmailNotificationService.assertEmailRequestCount(1)
+    mockEmailNotificationService.assertEmailRequested(
+      Cas1AppealEmailServiceTestConstants.APPEAL_ARBITRATOR_EMAIL,
+      notifyConfig.templates.appealSuccess,
+      expectedPersonalisationForAppealSuccess(application),
+    )
+  }
+
+  @Test
+  fun `appealSuccess sends an email to the arbitrator and applicant when both users have an email address`() {
+    val (application, appeal) = createApplicationAndAppeal(
+      Cas1AppealEmailServiceTestConstants.APPLICANT_EMAIL,
+      Cas1AppealEmailServiceTestConstants.APPEAL_ARBITRATOR_EMAIL,
+    )
+
+    service.appealSuccess(application, appeal)
+
+    mockEmailNotificationService.assertEmailRequestCount(2)
+    mockEmailNotificationService.assertEmailRequested(
+      Cas1AppealEmailServiceTestConstants.APPLICANT_EMAIL,
+      notifyConfig.templates.appealSuccess,
+      expectedPersonalisationForAppealSuccess(application),
+    )
+    mockEmailNotificationService.assertEmailRequested(
+      Cas1AppealEmailServiceTestConstants.APPEAL_ARBITRATOR_EMAIL,
+      notifyConfig.templates.appealSuccess,
+      expectedPersonalisationForAppealSuccess(application),
+    )
+  }
+
+  private fun expectedPersonalisationForAppealSuccess(application: ApprovedPremisesApplicationEntity) = mapOf(
+    "crn" to application.crn,
+    "applicationUrl" to "http://frontend/applications/${application.id}",
+  )
+
+  private fun createApplicationAndAppeal(
+    applicantEmail: String?,
+    arbitratorEmail: String?,
+  ): Pair<ApprovedPremisesApplicationEntity, AppealEntity> {
+    val applicant = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(applicantEmail)
+      .produce()
+
+    val arbitrator = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .withEmail(arbitratorEmail)
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withCrn(Cas1AppealEmailServiceTestConstants.CRN)
+      .withCreatedByUser(applicant)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    val appeal = AppealEntityFactory()
+      .withCreatedBy(arbitrator)
+      .produce()
+
+    return Pair(application, appeal)
+  }
+}


### PR DESCRIPTION
This sends notification emails to both the applicant and the appeal arbitrator if an appeal is upheld