### PR TITLE
[CAS-209] - CAS3 - Store release_date as first class field and populate referral report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -404,6 +404,7 @@ class TemporaryAccommodationApplicationEntity(
   var eligibilityReason: String?,
   var dutyToReferLocalAuthorityAreaName: String?,
   var prisonNameOnCreation: String?,
+  var personReleaseDate: LocalDate?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
@@ -45,7 +45,7 @@ class TransitionalAccommodationReferralReportGenerator : ReportGenerator<
         rejectionDate = if (AssessmentDecision.REJECTED.name == referralData.assessmentDecision) referralData.assessmentSubmittedDate else null,
         sourceOfReferral = referralData.referralEligibilityReason,
         prisonAtReferral = referralData.prisonNameOnCreation,
-        prisonReleaseDate = null,
+        releaseDate = referralData.personReleaseDate,
         accommodationRequiredDate = referralData.accommodationRequiredDate?.toLocalDateTime()?.toLocalDate(),
         bookingOffered = referralData.bookingId != null,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
@@ -25,7 +25,7 @@ data class TransitionalAccommodationReferralReportRow(
   val rejectionDate: LocalDate?,
   val sourceOfReferral: String?,
   val prisonAtReferral: String?,
-  val prisonReleaseDate: LocalDate?,
+  val releaseDate: LocalDate?,
   val accommodationRequiredDate: LocalDate?,
   val bookingOffered: Boolean?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
@@ -31,7 +31,8 @@ interface TransitionalAccommodationReferralReportRepository : JpaRepository<Book
       taa.eligibility_reason AS referralEligibilityReason,
       ap.noms_number as nomsNumber,
       taa.arrival_date as accommodationRequiredDate,
-      taa.prison_name_on_creation as prisonNameOnCreation
+      taa.prison_name_on_creation as prisonNameOnCreation,
+      taa.person_release_date as personReleaseDate
     FROM temporary_accommodation_assessments aa
     JOIN assessments a on aa.assessment_id = a.id AND a.service='temporary-accommodation' AND a.reallocated_at IS NULL
     JOIN applications ap on a.application_id = ap.id AND ap.service='temporary-accommodation'
@@ -75,4 +76,5 @@ interface TransitionalAccommodationReferralReportData {
   val referralEligibilityReason: String?
   val accommodationRequiredDate: Timestamp?
   val prisonNameOnCreation: String?
+  val personReleaseDate: LocalDate?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -470,6 +470,7 @@ class ApplicationService(
       eligibilityReason = null,
       dutyToReferLocalAuthorityAreaName = null,
       prisonNameOnCreation = prisonName,
+      personReleaseDate = null,
     )
   }
 
@@ -858,6 +859,7 @@ class ApplicationService(
       isEligible = submitApplication.isApplicationEligible
       eligibilityReason = submitApplication.eligibilityReason
       dutyToReferLocalAuthorityAreaName = submitApplication.dutyToReferLocalAuthorityAreaName
+      personReleaseDate = submitApplication.personReleaseDate
     }
 
     assessmentService.createTemporaryAccommodationAssessment(application, submitApplication.summaryData)

--- a/src/main/resources/db/migration/all/20240222161046__add_releasedate_to_cas3_application.sql
+++ b/src/main/resources/db/migration/all/20240222161046__add_releasedate_to_cas3_application.sql
@@ -1,0 +1,2 @@
+-- Alter table temporary_accommodation_applications by adding new optional column person_release_date
+ALTER TABLE temporary_accommodation_applications ADD COLUMN person_release_date DATE NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2218,6 +2218,10 @@ components:
               type: string
             dutyToReferLocalAuthorityAreaName:
               type: string
+            personReleaseDate:
+              type: string
+              format: date
+              example: '2024-02-21'
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6775,6 +6775,10 @@ components:
               type: string
             dutyToReferLocalAuthorityAreaName:
               type: string
+            personReleaseDate:
+              type: string
+              format: date
+              example: '2024-02-21'
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2701,6 +2701,10 @@ components:
               type: string
             dutyToReferLocalAuthorityAreaName:
               type: string
+            personReleaseDate:
+              type: string
+              format: date
+              example: '2024-02-21'
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2266,6 +2266,10 @@ components:
               type: string
             dutyToReferLocalAuthorityAreaName:
               type: string
+            personReleaseDate:
+              type: string
+              format: date
+              example: '2024-02-21'
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -46,6 +46,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var eligibilityReason: Yielded<String?> = { null }
   private var dutyToReferLocalAuthorityAreaName: Yielded<String?> = { null }
   private var prisonNameAtReferral: Yielded<String?> = { null }
+  private var personReleaseDate: Yielded<LocalDate?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -159,6 +160,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.prisonNameAtReferral = { prisonNameAtReferral }
   }
 
+  fun withPersonReleaseDate(personReleaseDate: LocalDate?) = apply {
+    this.personReleaseDate = { personReleaseDate }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -186,5 +191,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     eligibilityReason = this.eligibilityReason(),
     dutyToReferLocalAuthorityAreaName = this.dutyToReferLocalAuthorityAreaName(),
     prisonNameOnCreation = this.prisonNameAtReferral(),
+    personReleaseDate = this.personReleaseDate(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
@@ -464,6 +464,8 @@ class TransitionalAccommodationReferralReportsTest : IntegrationTestBase() {
     assertThat(actualReferralReportRow.rejectionDate).isEqualTo(rejectedDate?.toLocalDate())
     assertThat(actualReferralReportRow.rejectionReason).isEqualTo(expectedAssessment.rejectionRationale)
     assertThat(actualReferralReportRow.accommodationRequiredDate).isEqualTo(application.arrivalDate?.toLocalDate())
+    assertThat(actualReferralReportRow.prisonAtReferral).isEqualTo(application.prisonNameOnCreation)
+    assertThat(actualReferralReportRow.releaseDate).isEqualTo(application.personReleaseDate)
   }
 
   private fun createTemporaryAccommodationAssessmentForStatus(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
@@ -184,6 +184,7 @@ class TransitionalAccommodationReferralReportsTest : IntegrationTestBase() {
             )
           }
           withPrisonNameAtReferral("HM Hounslow")
+          withPersonReleaseDate(LocalDate.now())
         }
 
         val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1389,6 +1389,7 @@ class ApplicationServiceTest {
       isApplicationEligible = true,
       eligibilityReason = "homelessFromApprovedPremises",
       dutyToReferLocalAuthorityAreaName = "Aberdeen City",
+      personReleaseDate = LocalDate.now().plusDays(1),
     )
 
     @BeforeEach
@@ -1954,6 +1955,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.isEligible).isEqualTo(true)
       assertThat(persistedApplication.eligibilityReason).isEqualTo("homelessFromApprovedPremises")
       assertThat(persistedApplication.dutyToReferLocalAuthorityAreaName).isEqualTo("Aberdeen City")
+      assertThat(persistedApplication.personReleaseDate).isEqualTo(submitTemporaryAccommodationApplicationWithMiReportingData.personReleaseDate)
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/ReportServiceTest.kt
@@ -96,6 +96,7 @@ class ReportServiceTest {
     referralEligibilityReason = "reason",
     accommodationRequiredDate = Timestamp.valueOf(LocalDateTime.now()),
     prisonNameOnCreation = null,
+    personReleaseDate = null,
   )
 
   @Suppress("LongParameterList")
@@ -121,5 +122,6 @@ class ReportServiceTest {
     override val referralEligibilityReason: String?,
     override val accommodationRequiredDate: Timestamp?,
     override val prisonNameOnCreation: String?,
+    override val personReleaseDate: LocalDate?,
   ) : TransitionalAccommodationReferralReportData
 }


### PR DESCRIPTION
# Changes in this PR

Refer [CAS-209](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-209) for more information.

This PR contains below two changes:
1. Capture and store `release_date` as first class field in CAS3 application.
2. Populate the stored `release_date` into CAS3's referral report

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.

[CAS-209]: https://dsdmoj.atlassian.net/browse/CAS-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ