### PR TITLE
(APS-385) Send notification email on unsuccessful appeal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -40,6 +40,7 @@ class NotifyTemplates {
   val placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
   val cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
   val appealSuccess = "ae21f3ae-3a4a-4df8-a1b8-2640ea80d101"
+  val appealReject = "32c9c282-198d-4d43-960e-89c97f1bcf81"
 }
 
 enum class NotifyMode {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -92,9 +92,14 @@ class AppealService(
 
         saveEvent(appeal)
 
-        if (decision == AppealDecision.accepted) {
-          assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity, createdFromAppeal = true)
-          cas1AppealEmailService.appealSuccess(application, appeal)
+        when (decision) {
+          AppealDecision.accepted -> {
+            assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity, createdFromAppeal = true)
+            cas1AppealEmailService.appealSuccess(application, appeal)
+          }
+          AppealDecision.rejected -> {
+            cas1AppealEmailService.appealFailed(application)
+          }
         }
 
         success(appeal)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealEmailService.kt
@@ -20,6 +20,19 @@ class Cas1AppealEmailService(
     }
   }
 
+  fun appealFailed(application: ApplicationEntity) {
+    application.createdByUser.email?.let { emailAddress ->
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = emailAddress,
+        templateId = notifyConfig.templates.appealReject,
+        personalisation = mapOf(
+          "crn" to application.crn,
+          "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+        ),
+      )
+    }
+  }
+
   private fun sendAppealSuccessEmailToEmailAddress(emailAddress: String, application: ApplicationEntity) {
     emailNotificationService.sendEmail(
       recipientEmailAddress = emailAddress,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/AssessmentTestRepository.kt
@@ -4,13 +4,15 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
 
 @Repository
-interface AssessmentTestRepository : JpaRepository<BookingNotMadeEntity, UUID> {
+interface AssessmentTestRepository : JpaRepository<ApprovedPremisesAssessmentEntity, UUID> {
+  fun findAllByApplication(application: ApplicationEntity): List<ApprovedPremisesAssessmentEntity>
 
   @Transactional
   @Modifying

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -309,7 +309,7 @@ class AppealServiceTest {
       every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
       every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
-      every { cas1AppealEmailService.appealSuccess(any(), any()) } returns Unit
+      every { cas1AppealEmailService.appealFailed(any()) } returns Unit
 
       mockkStatic(UUID::class) {
         every { UUID.randomUUID() } returns appealId
@@ -335,7 +335,7 @@ class AppealServiceTest {
     }
 
     @Test
-    fun `Does not send a success email if the appeal was rejected`() {
+    fun `Sends a failure email if the appeal was rejected`() {
       createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
 
       val now = LocalDate.now()
@@ -346,6 +346,7 @@ class AppealServiceTest {
       every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
       every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
       every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
+      every { cas1AppealEmailService.appealFailed(any()) } returns Unit
 
       mockkStatic(UUID::class) {
         every { UUID.randomUUID() } returns appealId
@@ -364,8 +365,8 @@ class AppealServiceTest {
         result as AuthorisableActionResult.Success
         assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
 
-        verify(exactly = 0) {
-          cas1AppealEmailService.appealSuccess(any(), any())
+        verify(exactly = 1) {
+          cas1AppealEmailService.appealFailed(application)
         }
       }
     }


### PR DESCRIPTION
This updates the Appeals Email service to add an email to be sent when an appeal is _unsuccessful_