### PR TITLE
Add additional fields to withdrawal emails and send email per placement request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
@@ -41,4 +41,30 @@ data class PlacementDateEntity(
 ) {
   fun expectedDeparture() = expectedArrival.plusDays(duration.toLong())
   override fun toString() = "PlacementDateEntity: $id"
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as PlacementDateEntity
+
+    if (id != other.id) return false
+    if (createdAt != other.createdAt) return false
+    if (placementApplication.id != other.placementApplication.id) return false
+    if (placementRequest != other.placementRequest) return false
+    if (expectedArrival != other.expectedArrival) return false
+    if (duration != other.duration) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = id.hashCode()
+    result = 31 * result + createdAt.hashCode()
+    result = 31 * result + placementApplication.id.hashCode()
+    result = 31 * result + (placementRequest?.hashCode() ?: 0)
+    result = 31 * result + expectedArrival.hashCode()
+    result = 31 * result + duration
+    return result
+  }
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -331,9 +331,11 @@ class PlacementApplicationService(
       saveDatesOnSubmissionToASingleApp(baselinePlacementApplication, apiPlacementDates)
     }
 
-    cas1PlacementApplicationEmailService.placementApplicationSubmitted(baselinePlacementApplication)
-    if (baselinePlacementApplication.allocatedToUser != null) {
-      cas1PlacementApplicationEmailService.placementApplicationAllocated(baselinePlacementApplication)
+    placementApplicationsWithDates.forEach { placementApplication ->
+      cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication)
+      if (baselinePlacementApplication.allocatedToUser != null) {
+        cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication)
+      }
     }
 
     return AuthorisableActionResult.Success(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
@@ -27,9 +27,7 @@ class Cas1PlacementApplicationEmailService(
       emailNotifier.sendEmail(
         recipientEmailAddress = email,
         templateId = notifyConfig.templates.placementRequestSubmitted,
-        personalisation = mapOf(
-          "crn" to placementApplication.application.crn,
-        ),
+        personalisation = getPersonalisation(placementApplication),
       )
     }
   }
@@ -44,9 +42,7 @@ class Cas1PlacementApplicationEmailService(
       emailNotifier.sendEmail(
         recipientEmailAddress = email,
         templateId = notifyConfig.templates.placementRequestAllocated,
-        personalisation = mapOf(
-          "crn" to placementApplication.application.crn,
-        ),
+        personalisation = getPersonalisation(placementApplication),
       )
     }
   }
@@ -56,17 +52,7 @@ class Cas1PlacementApplicationEmailService(
       return
     }
 
-    val application = placementApplication.application
-    val dates = placementApplication.placementDates
-
-    val personalisation = mapOf(
-      "crn" to application.crn,
-      "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
-      "applicationArea" to application.apArea?.name,
-      "startDate" to dates.getOrNull(0)?.expectedArrival.toString(),
-      "endDate" to dates.getOrNull(0)?.expectedDeparture().toString(),
-      "additionalDatesSet" to if (dates.size > 1) "yes" else "no",
-    )
+    val personalisation = getPersonalisation(placementApplication)
 
     val createdByUserEmail = placementApplication.createdByUser.email
     createdByUserEmail?.let { email ->
@@ -85,5 +71,19 @@ class Cas1PlacementApplicationEmailService(
         personalisation = personalisation,
       )
     }
+  }
+
+  private fun getPersonalisation(placementApplication: PlacementApplicationEntity): Map<String,String?> {
+    val application = placementApplication.application
+    val dates = placementApplication.placementDates
+
+    return mapOf(
+      "crn" to application.crn,
+      "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+      "applicationArea" to application.apArea?.name,
+      "startDate" to dates.getOrNull(0)?.expectedArrival.toString(),
+      "endDate" to dates.getOrNull(0)?.expectedDeparture().toString(),
+      "additionalDatesSet" to if (dates.size > 1) "yes" else "no",
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
@@ -57,10 +57,15 @@ class Cas1PlacementApplicationEmailService(
     }
 
     val application = placementApplication.application
+    val dates = placementApplication.placementDates
 
     val personalisation = mapOf(
       "crn" to application.crn,
       "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+      "applicationArea" to application.apArea?.name,
+      "startDate" to dates.getOrNull(0)?.expectedArrival.toString(),
+      "endDate" to dates.getOrNull(0)?.expectedDeparture().toString(),
+      "additionalDatesSet" to if (dates.size > 1) "yes" else "no",
     )
 
     val createdByUserEmail = placementApplication.createdByUser.email

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -34,7 +34,11 @@ class Cas1PlacementRequestEmailService(
       applicant.email?.let { applicantEmail ->
         emailNotifier.sendEmail(
           recipientEmailAddress = applicantEmail,
-          templateId = notifyConfig.templates.matchRequestWithdrawn,
+          /**
+           * For information on why we send a request for placement email
+           * instead of match request, see [PlacementRequestEntity.isForApplicationsArrivalDate]
+           **/
+          templateId = notifyConfig.templates.placementRequestWithdrawn,
           personalisation = personalisation,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -24,6 +24,9 @@ class Cas1PlacementRequestEmailService(
     val personalisation = mapOf(
       "crn" to application.crn,
       "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+      "applicationArea" to application.apArea?.name,
+      "startDate" to placementRequest.expectedArrival.toString(),
+      "endDate" to placementRequest.expectedDeparture().toString(),
     )
 
     if (placementRequest.isForApplicationsArrivalDate()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1660,7 +1660,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
             )
             emailAsserter.assertEmailRequested(
               placementRequest.application.createdByUser.email!!,
-              notifyConfig.templates.matchRequestWithdrawn,
+              notifyConfig.templates.placementRequestWithdrawn,
             )
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
@@ -31,13 +31,18 @@ class EmailNotificationAsserter {
     assertEmailsRequestedCount(0)
   }
 
-  fun assertEmailRequested(toEmailAddress: String, templateId: String) {
-    val anyMatch = requestedEmails.any { toEmailAddress == it.email && templateId == it.templateId }
+  fun assertEmailRequested(toEmailAddress: String, templateId: String, personalisation: Map<String,Any> = emptyMap()) {
+    val anyMatch = requestedEmails.any {
+      toEmailAddress == it.email &&
+      templateId == it.templateId &&
+      it.personalisation.entries.containsAll(personalisation.entries)
+    }
 
     assertThat(anyMatch)
       .withFailMessage {
         "Could not find email request. Provided email requests are $requestedEmails"
       }.isTrue
+
   }
 
   fun assertEmailsRequestedCount(expectedCount: Int) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -683,7 +683,6 @@ class PlacementApplicationServiceTest {
         .withCreatedByUser(user)
         .produce()
 
-      val templateId = UUID.randomUUID().toString()
       val withdrawalContext = WithdrawalContext(
         user,
         WithdrawableEntityType.PlacementApplication,
@@ -691,7 +690,6 @@ class PlacementApplicationServiceTest {
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { userAccessService.userMayWithdrawPlacementApplication(any(), any()) } returns true
-      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(placementApplication, withdrawalContext) } returns Unit
@@ -725,10 +723,7 @@ class PlacementApplicationServiceTest {
         .withCreatedByUser(user)
         .produce()
 
-      val templateId = UUID.randomUUID().toString()
-
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
-      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(any(), any()) } returns Unit
@@ -766,10 +761,7 @@ class PlacementApplicationServiceTest {
         .withCreatedByUser(user)
         .produce()
 
-      val templateId = UUID.randomUUID().toString()
-
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
-      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
 
@@ -800,11 +792,8 @@ class PlacementApplicationServiceTest {
       val placementRequest2 = createValidPlacementRequest(application, user)
       placementApplication.placementRequests.add(placementRequest2)
 
-      val templateId = UUID.randomUUID().toString()
-
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { userAccessService.userMayWithdrawPlacementApplication(any(), any()) } returns true
-      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(any(), any()) } returns Unit
@@ -862,11 +851,8 @@ class PlacementApplicationServiceTest {
       val placementRequest1 = createValidPlacementRequest(application, user)
       placementApplication.placementRequests.add(placementRequest1)
 
-      val templateId = UUID.randomUUID().toString()
-
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { userAccessService.userMayWithdrawPlacementApplication(any(), any()) } returns true
-      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(any(), any()) } returns Unit
@@ -955,11 +941,8 @@ class PlacementApplicationServiceTest {
         .withCreatedByUser(user)
         .produce()
 
-      val templateId = UUID.randomUUID().toString()
-
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { userAccessService.userMayWithdrawPlacementApplication(user, placementApplication) } returns false
-      every { notifyConfig.templates.placementRequestWithdrawn } answers { templateId }
       every { emailNotificationService.sendEmail(any(), any(), any()) } returns Unit
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -167,7 +167,7 @@ class PlacementApplicationServiceTest {
     }
 
     @Test
-    fun `Submitting an application triggers allocation and submission emails and returns successfully`() {
+    fun `Submitting an application triggers allocation and sets a due date`() {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java) } returns placementApplication.schemaVersion
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
@@ -190,18 +190,10 @@ class PlacementApplicationServiceTest {
       val updatedApplication = (validatableActionResult as ValidatableActionResult.Success).entity
 
       assertThat(updatedApplication[0].dueAt).isEqualTo(dueAt)
-
-      verify(exactly = 1) {
-        cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication)
-      }
-
-      verify(exactly = 1) {
-        cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication)
-      }
     }
 
     @Test
-    fun `Submitting an application saves a single date to a placement application`() {
+    fun `Submitting an application saves a single date to a placement application and triggers emails`() {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java) } returns placementApplication.schemaVersion
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
@@ -225,22 +217,26 @@ class PlacementApplicationServiceTest {
 
       assertThat(updatedPlacementApplications).hasSize(1)
 
-      val firstSubmissionGroupId = updatedPlacementApplications[0].submissionGroupId
+      val updatedPlacementApp = updatedPlacementApplications[0]
+      assertThat(updatedPlacementApp.submissionGroupId).isNotNull()
 
-      assertThat(updatedPlacementApplications[0].placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
-      assertThat(updatedPlacementApplications[0].placementDates[0].duration).isEqualTo(5)
+      assertThat(updatedPlacementApp.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
+      assertThat(updatedPlacementApp.placementDates[0].duration).isEqualTo(5)
+
+      verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp) }
     }
 
     @Test
-    fun `Submitting an application saves multiple dates to individual placement applications`() {
+    fun `Submitting an application saves multiple dates to individual placement applications and triggers emails per resultant placement application`() {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java) } returns placementApplication.schemaVersion
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { placementDateRepository.save(any()) } answers { it.invocation.args[0] as PlacementDateEntity }
 
-      every { cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication) } returns Unit
-      every { cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication) } returns Unit
+      every { cas1PlacementApplicationEmailService.placementApplicationSubmitted(any()) } returns Unit
+      every { cas1PlacementApplicationEmailService.placementApplicationAllocated(any()) } returns Unit
 
       val result = placementApplicationService.submitApplication(
         placementApplication.id,
@@ -260,19 +256,30 @@ class PlacementApplicationServiceTest {
 
       val firstSubmissionGroupId = updatedPlacementApplications[0].submissionGroupId
 
-      assertThat(updatedPlacementApplications[0].placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
-      assertThat(updatedPlacementApplications[0].placementDates[0].duration).isEqualTo(5)
-      assertThat(updatedPlacementApplications[0].submissionGroupId).isEqualTo(firstSubmissionGroupId)
-      assertThat(updatedPlacementApplications[1].placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 5, 2))
-      assertThat(updatedPlacementApplications[1].placementDates[0].duration).isEqualTo(10)
-      assertThat(updatedPlacementApplications[1].submissionGroupId).isEqualTo(firstSubmissionGroupId)
-      assertThat(updatedPlacementApplications[2].placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 6, 3))
-      assertThat(updatedPlacementApplications[2].placementDates[0].duration).isEqualTo(15)
-      assertThat(updatedPlacementApplications[2].submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      val updatedPlacementApp1 = updatedPlacementApplications[0]
+      assertThat(updatedPlacementApp1.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
+      assertThat(updatedPlacementApp1.placementDates[0].duration).isEqualTo(5)
+      assertThat(updatedPlacementApp1.submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp1) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp1) }
+
+      val updatedPlacementApp2 = updatedPlacementApplications[1]
+      assertThat(updatedPlacementApp2.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 5, 2))
+      assertThat(updatedPlacementApp2.placementDates[0].duration).isEqualTo(10)
+      assertThat(updatedPlacementApp2.submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp2) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp2) }
+
+      val updatedPlacementApp3 = updatedPlacementApplications[2]
+      assertThat(updatedPlacementApp3.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 6, 3))
+      assertThat(updatedPlacementApp3.placementDates[0].duration).isEqualTo(15)
+      assertThat(updatedPlacementApp3.submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp3) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp3) }
     }
 
     @Test
-    fun `Submitting an application saves multiple dates to a single placement application (legacy logic)`() {
+    fun `Submitting an application saves multiple dates to a single placement application (legacy logic) and triggers a single set of emails`() {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java) } returns placementApplication.schemaVersion
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
@@ -297,7 +304,11 @@ class PlacementApplicationServiceTest {
       val updatedPlacementApplications = extractEntityFromNestedAuthorisableValidatableActionResult(result)
 
       assertThat(updatedPlacementApplications).hasSize(1)
-      val dates = updatedPlacementApplications[0].placementDates
+
+      val updatedPlacementApp = updatedPlacementApplications[0]
+      assertThat(updatedPlacementApp.submissionGroupId).isNotNull()
+
+      val dates = updatedPlacementApp.placementDates
       assertThat(dates).hasSize(3)
       assertThat(dates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
       assertThat(dates[0].duration).isEqualTo(5)
@@ -305,6 +316,9 @@ class PlacementApplicationServiceTest {
       assertThat(dates[1].duration).isEqualTo(10)
       assertThat(dates[2].expectedArrival).isEqualTo(LocalDate.of(2024, 6, 3))
       assertThat(dates[2].duration).isEqualTo(15)
+
+      verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -471,7 +471,7 @@ class PlacementApplicationServiceTest {
         createdAt = OffsetDateTime.now(),
         duration = 12,
         expectedArrival = LocalDate.now(),
-        placementApplication = mockk<PlacementApplicationEntity>(),
+        placementApplication = previousPlacementApplication,
       ),
     )
 
@@ -486,13 +486,20 @@ class PlacementApplicationServiceTest {
 
       previousPlacementApplication.placementDates = placementDates
 
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(assigneeUser)
+        .withDecision(null)
+        .withCreatedByUser(assigneeUser)
+        .produce()
+
       val newPlacementDates = mutableListOf(
         PlacementDateEntity(
           id = UUID.randomUUID(),
           createdAt = OffsetDateTime.now(),
           duration = 12,
           expectedArrival = LocalDate.now(),
-          placementApplication = mockk<PlacementApplicationEntity>(),
+          placementApplication = placementApplication,
         ),
       )
 
@@ -501,7 +508,7 @@ class PlacementApplicationServiceTest {
       every { taskDeadlineServiceMock.getDeadline(any<PlacementApplicationEntity>()) } returns dueAt
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
-      every { placementApplicationRepository.save(previousPlacementApplication) } answers { it.invocation.args[0] as PlacementApplicationEntity }
+      every { placementApplicationRepository.save(previousPlacementApplication) } answers { previousPlacementApplication }
       every { placementApplicationRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every {
         placementDateRepository.saveAll<PlacementDateEntity>(
@@ -546,13 +553,20 @@ class PlacementApplicationServiceTest {
       previousPlacementApplication.placementDates = placementDates
       previousPlacementApplication.allocatedToUser = null
 
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(assigneeUser)
+        .withDecision(null)
+        .withCreatedByUser(assigneeUser)
+        .produce()
+
       val newPlacementDates = mutableListOf(
         PlacementDateEntity(
           id = UUID.randomUUID(),
           createdAt = OffsetDateTime.now(),
           duration = 12,
           expectedArrival = LocalDate.now(),
-          placementApplication = mockk<PlacementApplicationEntity>(),
+          placementApplication = placementApplication,
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
@@ -2,21 +2,25 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationEmailServiceTest.TestConstants.APPLICANT_EMAIL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationEmailServiceTest.TestConstants.AREA_NAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationEmailServiceTest.TestConstants.ASSESSOR_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockEmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class Cas1PlacementApplicationEmailServiceTest {
-
   private object TestConstants {
     const val APPLICANT_EMAIL = "applicantEmail@test.com"
+    const val AREA_NAME = "theAreaName"
     const val CRN = "CRN123"
     const val ASSESSOR_EMAIL = "matcherEmail@test.com"
   }
@@ -154,15 +158,8 @@ class Cas1PlacementApplicationEmailServiceTest {
 
   @Test
   fun `placementApplicationWithdrawn doesnt send email to applicant or assessor if no email addresses defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+    val applicant = createUser(emailAddress = null)
+    val assessor = createUser(emailAddress = null)
 
     val application = createApplicationForApplicant(applicant)
 
@@ -179,10 +176,7 @@ class Cas1PlacementApplicationEmailServiceTest {
 
   @Test
   fun `placementApplicationWithdrawn sends an email to applicant if email addresses defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
+    val applicant = createUser(emailAddress = APPLICANT_EMAIL)
 
     val application = createApplicationForApplicant(applicant)
 
@@ -191,6 +185,14 @@ class Cas1PlacementApplicationEmailServiceTest {
       .withCreatedByUser(applicant)
       .produce()
 
+    placementApplication.placementDates = mutableListOf(
+      PlacementDateEntityFactory()
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
+        .withPlacementApplication(placementApplication)
+        .produce(),
+    )
+
     service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = null)
 
     mockEmailNotificationService.assertEmailRequestCount(1)
@@ -198,6 +200,10 @@ class Cas1PlacementApplicationEmailServiceTest {
     val personalisation = mapOf(
       "applicationUrl" to "http://frontend/applications/${application.id}",
       "crn" to TestConstants.CRN,
+      "applicationArea" to AREA_NAME,
+      "startDate" to "2020-03-12",
+      "endDate" to "2020-03-22",
+      "additionalDatesSet" to "no",
     )
 
     mockEmailNotificationService.assertEmailRequested(
@@ -209,15 +215,8 @@ class Cas1PlacementApplicationEmailServiceTest {
 
   @Test
   fun `placementApplicationWithdrawn sends an email to assessor if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(ASSESSOR_EMAIL)
-      .produce()
+    val applicant = createUser(emailAddress = null)
+    val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
 
     val application = createApplicationForApplicant(applicant)
 
@@ -227,6 +226,14 @@ class Cas1PlacementApplicationEmailServiceTest {
       .withAllocatedToUser(assessor)
       .produce()
 
+    placementApplication.placementDates = mutableListOf(
+      PlacementDateEntityFactory()
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
+        .withPlacementApplication(placementApplication)
+        .produce(),
+    )
+
     service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
 
     mockEmailNotificationService.assertEmailRequestCount(1)
@@ -234,6 +241,10 @@ class Cas1PlacementApplicationEmailServiceTest {
     val personalisation = mapOf(
       "applicationUrl" to "http://frontend/applications/${application.id}",
       "crn" to TestConstants.CRN,
+      "applicationArea" to AREA_NAME,
+      "startDate" to "2020-03-12",
+      "endDate" to "2020-03-22",
+      "additionalDatesSet" to "no",
     )
 
     mockEmailNotificationService.assertEmailRequested(
@@ -243,9 +254,56 @@ class Cas1PlacementApplicationEmailServiceTest {
     )
   }
 
+  @Test
+  fun `placementApplicationWithdrawn sends an email with 'additionalDates' if multiple dates defined due to a legacy placement application`() {
+    val applicant = createUser(emailAddress = null)
+    val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
+
+    val application = createApplicationForApplicant(applicant)
+
+    val placementApplication = PlacementApplicationEntityFactory()
+      .withApplication(application)
+      .withCreatedByUser(applicant)
+      .withAllocatedToUser(assessor)
+      .produce()
+
+    placementApplication.placementDates = mutableListOf(
+      PlacementDateEntityFactory()
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
+        .withPlacementApplication(placementApplication)
+        .produce(),
+      PlacementDateEntityFactory()
+        .withExpectedArrival(LocalDate.of(2021, 3, 12))
+        .withDuration(10)
+        .withPlacementApplication(placementApplication)
+        .produce(),
+    )
+
+    service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
+
+    mockEmailNotificationService.assertEmailRequestCount(1)
+
+    val personalisation = mapOf(
+      "additionalDatesSet" to "yes",
+    )
+
+    mockEmailNotificationService.assertEmailRequested(
+      ASSESSOR_EMAIL,
+      notifyConfig.templates.placementRequestWithdrawn,
+      personalisation,
+    )
+  }
+
+  private fun createUser(emailAddress: String?) = UserEntityFactory()
+    .withUnitTestControlProbationRegion()
+    .withEmail(emailAddress)
+    .produce()
+
   private fun createApplicationForApplicant(applicant: UserEntity) = ApprovedPremisesApplicationEntityFactory()
     .withCrn(TestConstants.CRN)
     .withCreatedByUser(applicant)
     .withSubmittedAt(OffsetDateTime.now())
+    .withApArea(ApAreaEntityFactory().withName(AREA_NAME).produce())
     .produce()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
@@ -81,12 +81,25 @@ class Cas1PlacementApplicationEmailServiceTest {
       .withAllocatedToUser(assessor)
       .produce()
 
+    placementApplication.placementDates = mutableListOf(
+      PlacementDateEntityFactory()
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
+        .withPlacementApplication(placementApplication)
+        .produce(),
+    )
+
     service.placementApplicationSubmitted(placementApplication)
 
     mockEmailNotificationService.assertEmailRequestCount(1)
 
     val personalisation = mapOf(
+      "applicationUrl" to "http://frontend/applications/${application.id}",
       "crn" to TestConstants.CRN,
+      "applicationArea" to AREA_NAME,
+      "startDate" to "2020-03-12",
+      "endDate" to "2020-03-22",
+      "additionalDatesSet" to "no",
     )
 
     mockEmailNotificationService.assertEmailRequested(
@@ -141,12 +154,25 @@ class Cas1PlacementApplicationEmailServiceTest {
       .withAllocatedToUser(assessor)
       .produce()
 
+    placementApplication.placementDates = mutableListOf(
+      PlacementDateEntityFactory()
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
+        .withPlacementApplication(placementApplication)
+        .produce(),
+    )
+
     service.placementApplicationAllocated(placementApplication)
 
     mockEmailNotificationService.assertEmailRequestCount(1)
 
     val personalisation = mapOf(
+      "applicationUrl" to "http://frontend/applications/${application.id}",
       "crn" to TestConstants.CRN,
+      "applicationArea" to AREA_NAME,
+      "startDate" to "2020-03-12",
+      "endDate" to "2020-03-22",
+      "additionalDatesSet" to "no",
     )
 
     mockEmailNotificationService.assertEmailRequested(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -130,7 +130,7 @@ class Cas1PlacementRequestEmailServiceTest {
   }
 
   @Test
-  fun `placementRequestWithdrawn does send email to applicant if placement request not linked to placement application `() {
+  fun `placementRequestWithdrawn sends email to applicant if placement request not linked to placement application `() {
     val application = createApplication(
       applicantEmail = APPLICANT_EMAIL,
     )
@@ -150,7 +150,7 @@ class Cas1PlacementRequestEmailServiceTest {
     mockEmailNotificationService.assertEmailRequestCount(1)
     mockEmailNotificationService.assertEmailRequested(
       APPLICANT_EMAIL,
-      notifyConfig.templates.matchRequestWithdrawn,
+      notifyConfig.templates.placementRequestWithdrawn,
       mapOf(
         "applicationUrl" to "http://frontend/applications/${application.id}",
         "crn" to TestConstants.CRN,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.APPLICANT_EMAIL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.AREA_NAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.CRU_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockEmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -24,6 +25,7 @@ class Cas1PlacementRequestEmailServiceTest {
 
   private object TestConstants {
     const val APPLICANT_EMAIL = "application@test.com"
+    const val AREA_NAME = "theAreaName"
     const val CRN = "CRN123"
     const val CRU_EMAIL = "cruEmail@test.com"
   }
@@ -77,6 +79,9 @@ class Cas1PlacementRequestEmailServiceTest {
       mapOf(
         "applicationUrl" to "http://frontend/applications/${application.id}",
         "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to placementRequest.expectedArrival.toString(),
+        "endDate" to placementRequest.expectedDeparture().toString(),
       ),
     )
   }
@@ -149,6 +154,9 @@ class Cas1PlacementRequestEmailServiceTest {
       mapOf(
         "applicationUrl" to "http://frontend/applications/${application.id}",
         "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to placementRequest.expectedArrival.toString(),
+        "endDate" to placementRequest.expectedDeparture().toString(),
       ),
     )
   }
@@ -168,6 +176,7 @@ class Cas1PlacementRequestEmailServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .withApArea(
         ApAreaEntityFactory()
+          .withName(AREA_NAME)
           .withEmailAddress(apAreaEmail)
           .produce(),
       )


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-392 and https://dsdmoj.atlassian.net/browse/APS-398

This PR makes miscellaneous changes to emails related to new withdrawl functionality

* Add additional personalisation to the request for placement withdrawal emails
* Add additional personalisation to the match request withdrawal emails
* Send a separate email for each arrival date defined for placement applications on submission (because these are split into multiple entities at this point)
* Send a placement request withdrawn email to applicant if the match request representing the original application dates is withdrawn