### PR TITLE
Optionally include 'initial' request for placement when returning placement applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -25,6 +25,8 @@ import javax.persistence.Table
 @Suppress("FunctionNaming")
 @Repository
 interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUID> {
+  fun findByApplication_id(applicationId: UUID): List<PlacementRequestEntity>
+
   fun findByApplication(application: ApprovedPremisesApplicationEntity): List<PlacementRequestEntity>
 
   @Query(
@@ -179,7 +181,7 @@ data class PlacementRequestEntity(
 
   fun hasActiveBooking() = booking != null && booking?.cancellations.isNullOrEmpty()
 
-  fun expectedDeparture() = expectedArrival.plusDays(duration.toLong())
+  fun expectedDeparture(): LocalDate = expectedArrival.plusDays(duration.toLong())
 
   fun isReallocated() = reallocatedAt != null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -369,6 +369,11 @@ class PlacementRequestService(
     return AuthorisableActionResult.Success(Unit)
   }
 
+  fun getPlacementRequestForInitialApplicationDates(applicationId: UUID) =
+    placementRequestRepository.findByApplication_id(applicationId)
+      .filter { it.isForApplicationsArrivalDate() }
+      .firstOrNull { it.isActive() }
+
   private fun updateApplicationStatusOnWithdrawal(
     placementRequest: PlacementRequestEntity,
     isUserRequestedWithdrawal: Boolean,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -8,22 +8,28 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 
 @Component
 class PlacementApplicationTransformer(
   private val objectMapper: ObjectMapper,
+  private val jsonSchemaService: JsonSchemaService,
+  private val placementRequestTransformer: PlacementRequestTransformer,
 ) {
   fun transformJpaToApi(jpa: PlacementApplicationEntity): PlacementApplication {
-    val latestAssessment = jpa.application.getLatestAssessment()!!
+    val assessment = jpa.application.getLatestAssessment()!!
+    val application = jpa.application
 
     return PlacementApplication(
       id = jpa.id,
-      applicationId = jpa.application.id,
-      applicationCompletedAt = jpa.application.submittedAt!!.toInstant(),
-      assessmentId = latestAssessment.id,
-      assessmentCompletedAt = latestAssessment.submittedAt!!.toInstant(),
+      applicationId = application.id,
+      applicationCompletedAt = application.submittedAt!!.toInstant(),
+      assessmentId = assessment.id,
+      assessmentCompletedAt = assessment.submittedAt!!.toInstant(),
       createdByUserId = jpa.createdByUser.id,
       schemaVersion = jpa.schemaVersion.id,
       createdAt = jpa.createdAt.toInstant(),
@@ -35,6 +41,30 @@ class PlacementApplicationTransformer(
       isWithdrawn = jpa.isWithdrawn(),
       withdrawalReason = getWithdrawalReason(jpa.withdrawalReason),
       type = PlacementApplicationType.additional,
+    )
+  }
+
+  fun transformPlacementRequestJpaToApi(jpa: PlacementRequestEntity): PlacementApplication {
+    val application = jpa.application
+    val assessment = jpa.assessment
+
+    return PlacementApplication(
+      id = jpa.id,
+      applicationId = application.id,
+      applicationCompletedAt = application.submittedAt!!.toInstant(),
+      assessmentId = assessment.id,
+      assessmentCompletedAt = assessment.submittedAt!!.toInstant(),
+      createdByUserId = application.createdByUser.id,
+      schemaVersion = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java).id,
+      createdAt = jpa.createdAt.toInstant(),
+      data = "{}",
+      document = "{}",
+      outdatedSchema = false,
+      submittedAt = application.submittedAt?.toInstant(),
+      canBeWithdrawn = jpa.isInWithdrawableState(),
+      isWithdrawn = jpa.isWithdrawn,
+      withdrawalReason = placementRequestTransformer.getWithdrawalReason(jpa.withdrawalReason),
+      type = PlacementApplicationType.initial,
     )
   }
 
@@ -56,7 +86,7 @@ class PlacementApplicationTransformer(
     PlacementApplicationWithdrawalReason.NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION -> WithdrawPlacementRequestReason.noCapacityDueToPlacementPrioritisation
     PlacementApplicationWithdrawalReason.NO_CAPACITY -> WithdrawPlacementRequestReason.noCapacity
     PlacementApplicationWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST -> WithdrawPlacementRequestReason.errorInPlacementRequest
-    PlacementApplicationWithdrawalReason.RELATED_APPLICATION_WITHDRAWN -> WithdrawPlacementRequestReason.relatedPlacementApplicationWithdrawn
+    PlacementApplicationWithdrawalReason.RELATED_APPLICATION_WITHDRAWN -> WithdrawPlacementRequestReason.relatedApplicationWithdrawn
     null -> null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
@@ -33,6 +34,7 @@ class PlacementApplicationTransformer(
       canBeWithdrawn = jpa.isInWithdrawableState(),
       isWithdrawn = jpa.isWithdrawn(),
       withdrawalReason = getWithdrawalReason(jpa.withdrawalReason),
+      type = PlacementApplicationType.additional,
     )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -535,6 +535,15 @@ components:
           - RelatedApplicationWithdrawn
           - RelatedPlacementRequestWithdrawn
           - RelatedPlacementApplicationWithdrawn
+    PlacementApplicationType:
+      type: string
+      description: |
+        'Initial' means that the request for placement was created for the arrival date included on the original application. 
+        'Additional' means the request for placement was created after the application had been authorised
+        A given application should only have, at most, one request for placement of type 'Initial'
+      enum:
+        - Initial
+        - Additional
     Booking:
       allOf:
         - $ref: '#/components/schemas/BookingBody'
@@ -3463,6 +3472,7 @@ components:
           properties:
             id:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field provides a PlacementRequest ID.
               format: uuid
             createdByUserId:
               type: string
@@ -3480,6 +3490,7 @@ components:
               format: date-time
             assessmentId:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field shouldn't be used.
               format: uuid
             assessmentCompletedAt:
               type: string
@@ -3497,6 +3508,8 @@ components:
               type: boolean
             withdrawalReason:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+            type:
+              $ref: '#/components/schemas/PlacementApplicationType'
           required:
             - id
             - createdByUserId
@@ -3508,6 +3521,7 @@ components:
             - applicationCompletedAt
             - canBeWithdrawn
             - isWithdrawn
+            - type
     NewPlacementApplication:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -539,8 +539,8 @@ components:
       type: string
       description: |
         'Initial' means that the request for placement was created for the arrival date included on the original application. 
-        'Additional' means the request for placement was created after the application had been authorised
-        A given application should only have, at most, one request for placement of type 'Initial'
+        'Additional' means the request for placement was created after the application had been assessed as suitable.
+        A given application should only have, at most, one request for placement of type 'Initial'.
       enum:
         - Initial
         - Additional

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2032,6 +2032,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: includeInitialRequestForPlacement
+          in: query
+          description: If true, will return a PlacementApplication of type 'Initial' representing the placement requests as part of the original application submission (i.e. when arrival date is known).
+          required: false
+          schema:
+            type: boolean
         - name: X-Service-Name
           in: header
           required: true

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2034,6 +2034,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: includeInitialRequestForPlacement
+          in: query
+          description: If true, will return a PlacementApplication of type 'Initial' representing the placement requests as part of the original application submission (i.e. when arrival date is known).
+          required: false
+          schema:
+            type: boolean
         - name: X-Service-Name
           in: header
           required: true

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5092,6 +5092,15 @@ components:
           - RelatedApplicationWithdrawn
           - RelatedPlacementRequestWithdrawn
           - RelatedPlacementApplicationWithdrawn
+    PlacementApplicationType:
+      type: string
+      description: |
+        'Initial' means that the request for placement was created for the arrival date included on the original application. 
+        'Additional' means the request for placement was created after the application had been authorised.
+        A given application should only have, at most, one request for placement of type 'Initial'
+      enum:
+        - Initial
+        - Additional
     Booking:
       allOf:
         - $ref: '#/components/schemas/BookingBody'
@@ -8020,6 +8029,7 @@ components:
           properties:
             id:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field provides a PlacementRequest ID.
               format: uuid
             createdByUserId:
               type: string
@@ -8037,6 +8047,7 @@ components:
               format: date-time
             assessmentId:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field shouldn't be used.
               format: uuid
             assessmentCompletedAt:
               type: string
@@ -8054,6 +8065,8 @@ components:
               type: boolean
             withdrawalReason:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+            type:
+              $ref: '#/components/schemas/PlacementApplicationType'
           required:
             - id
             - createdByUserId
@@ -8065,6 +8078,7 @@ components:
             - applicationCompletedAt
             - canBeWithdrawn
             - isWithdrawn
+            - type
     NewPlacementApplication:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5102,8 +5102,8 @@ components:
       type: string
       description: |
         'Initial' means that the request for placement was created for the arrival date included on the original application. 
-        'Additional' means the request for placement was created after the application had been authorised.
-        A given application should only have, at most, one request for placement of type 'Initial'
+        'Additional' means the request for placement was created after the application had been assessed as suitable.
+        A given application should only have, at most, one request for placement of type 'Initial'.
       enum:
         - Initial
         - Additional

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1022,8 +1022,8 @@ components:
       type: string
       description: |
         'Initial' means that the request for placement was created for the arrival date included on the original application. 
-        'Additional' means the request for placement was created after the application had been authorised.
-        A given application should only have, at most, one request for placement of type 'Initial'
+        'Additional' means the request for placement was created after the application had been assessed as suitable.
+        A given application should only have, at most, one request for placement of type 'Initial'.
       enum:
         - Initial
         - Additional

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1018,6 +1018,15 @@ components:
           - RelatedApplicationWithdrawn
           - RelatedPlacementRequestWithdrawn
           - RelatedPlacementApplicationWithdrawn
+    PlacementApplicationType:
+      type: string
+      description: |
+        'Initial' means that the request for placement was created for the arrival date included on the original application. 
+        'Additional' means the request for placement was created after the application had been authorised.
+        A given application should only have, at most, one request for placement of type 'Initial'
+      enum:
+        - Initial
+        - Additional
     Booking:
       allOf:
         - $ref: '#/components/schemas/BookingBody'
@@ -3946,6 +3955,7 @@ components:
           properties:
             id:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field provides a PlacementRequest ID.
               format: uuid
             createdByUserId:
               type: string
@@ -3963,6 +3973,7 @@ components:
               format: date-time
             assessmentId:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field shouldn't be used.
               format: uuid
             assessmentCompletedAt:
               type: string
@@ -3980,6 +3991,8 @@ components:
               type: boolean
             withdrawalReason:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+            type:
+              $ref: '#/components/schemas/PlacementApplicationType'
           required:
             - id
             - createdByUserId
@@ -3991,6 +4004,7 @@ components:
             - applicationCompletedAt
             - canBeWithdrawn
             - isWithdrawn
+            - type
     NewPlacementApplication:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -583,6 +583,15 @@ components:
           - RelatedApplicationWithdrawn
           - RelatedPlacementRequestWithdrawn
           - RelatedPlacementApplicationWithdrawn
+    PlacementApplicationType:
+      type: string
+      description: |
+        'Initial' means that the request for placement was created for the arrival date included on the original application. 
+        'Additional' means the request for placement was created after the application had been authorised.
+        A given application should only have, at most, one request for placement of type 'Initial'
+      enum:
+        - Initial
+        - Additional
     Booking:
       allOf:
         - $ref: '#/components/schemas/BookingBody'
@@ -3511,6 +3520,7 @@ components:
           properties:
             id:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field provides a PlacementRequest ID.
               format: uuid
             createdByUserId:
               type: string
@@ -3528,6 +3538,7 @@ components:
               format: date-time
             assessmentId:
               type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field shouldn't be used.
               format: uuid
             assessmentCompletedAt:
               type: string
@@ -3545,6 +3556,8 @@ components:
               type: boolean
             withdrawalReason:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+            type:
+              $ref: '#/components/schemas/PlacementApplicationType'
           required:
             - id
             - createdByUserId
@@ -3556,6 +3569,7 @@ components:
             - applicationCompletedAt
             - canBeWithdrawn
             - isWithdrawn
+            - type
     NewPlacementApplication:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -587,8 +587,8 @@ components:
       type: string
       description: |
         'Initial' means that the request for placement was created for the arrival date included on the original application. 
-        'Additional' means the request for placement was created after the application had been authorised.
-        A given application should only have, at most, one request for placement of type 'Initial'
+        'Additional' means the request for placement was created after the application had been assessed as suitable.
+        A given application should only have, at most, one request for placement of type 'Initial'.
       enum:
         - Initial
         - Additional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1121,71 +1121,65 @@ class ApplicationTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Get placement applications returns 403 Forbidden if incorrect XServiceName`() {
-    `Given a User` { user, jwt ->
+  @Nested
+  inner class GetPlacementApplications {
 
-      `Given a Placement Application`(
-        createdByUser = user,
-        schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        },
-      ) { placementApplicationEntity ->
+    @Test
+    fun `Get placement applications returns 403 Forbidden if incorrect XServiceName`() {
+      `Given a User` { user, jwt ->
 
-        val applicationId = placementApplicationEntity.application.id
-
-        webTestClient.get()
-          .uri("/applications/$applicationId/placement-applications")
-          .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-          .exchange()
-          .expectStatus()
-          .isForbidden
-      }
-    }
-  }
-
-  @Test
-  fun `Get placement applications without JWT returns 401`() {
-    `Given a User` { user, _ ->
-
-      `Given a Placement Application`(
-        createdByUser = user,
-        schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        },
-      ) { placementApplicationEntity ->
-
-        val applicationId = placementApplicationEntity.application.id
-        webTestClient.get()
-          .uri("/applications/$applicationId/placement-applications")
-          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-          .exchange()
-          .expectStatus()
-          .isUnauthorized
-      }
-    }
-  }
-
-  @ParameterizedTest
-  @NullSource
-  @EnumSource(value = PlacementApplicationDecision::class, names = ["WITHDRAWN_BY_PP"], mode = EnumSource.Mode.EXCLUDE)
-  fun `Get placement applications returns the transformed objects`(decision: PlacementApplicationDecision?) {
-    `Given a User` { user, jwt ->
-      `Given a Placement Application`(
-        createdByUser = user,
-        schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        },
-        decision = decision,
-        submittedAt = OffsetDateTime.now(),
-      ) { _ ->
         `Given a Placement Application`(
           createdByUser = user,
           schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           },
-          reallocated = true,
+        ) { placementApplicationEntity ->
+
+          val applicationId = placementApplicationEntity.application.id
+
+          webTestClient.get()
+            .uri("/applications/$applicationId/placement-applications")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+        }
+      }
+    }
+
+    @Test
+    fun `Get placement applications without JWT returns 401`() {
+      `Given a User` { user, _ ->
+
+        `Given a Placement Application`(
+          createdByUser = user,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+        ) { placementApplicationEntity ->
+
+          val applicationId = placementApplicationEntity.application.id
+          webTestClient.get()
+            .uri("/applications/$applicationId/placement-applications")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+        }
+      }
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EnumSource(value = PlacementApplicationDecision::class, names = ["WITHDRAWN_BY_PP"], mode = EnumSource.Mode.EXCLUDE)
+    fun `Get placement applications returns the transformed objects`(decision: PlacementApplicationDecision?) {
+      `Given a User` { user, jwt ->
+        `Given a Placement Application`(
+          createdByUser = user,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
           decision = decision,
           submittedAt = OffsetDateTime.now(),
         ) { _ ->
@@ -1194,95 +1188,106 @@ class ApplicationTest : IntegrationTestBase() {
             schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
               withPermissiveSchema()
             },
+            reallocated = true,
             decision = decision,
             submittedAt = OffsetDateTime.now(),
-          ) { placementApplicationEntity ->
+          ) { _ ->
+            `Given a Placement Application`(
+              createdByUser = user,
+              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withPermissiveSchema()
+              },
+              decision = decision,
+              submittedAt = OffsetDateTime.now(),
+            ) { placementApplicationEntity ->
 
-            val applicationId = placementApplicationEntity.application.id
-            val rawResult = webTestClient.get()
-              .uri("/applications/$applicationId/placement-applications")
-              .header("Authorization", "Bearer $jwt")
-              .header("X-Service-Name", ServiceName.approvedPremises.value)
-              .exchange()
-              .expectStatus()
-              .isOk
-              .returnResult<String>()
-              .responseBody
-              .blockFirst()
+              val applicationId = placementApplicationEntity.application.id
+              val rawResult = webTestClient.get()
+                .uri("/applications/$applicationId/placement-applications")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .returnResult<String>()
+                .responseBody
+                .blockFirst()
 
-            val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
+              val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
 
-            assertThat(body.size).isEqualTo(1)
-            assertThat(body[0].id).isEqualTo(placementApplicationEntity.id)
-            assertThat(body[0].applicationId).isEqualTo(placementApplicationEntity.application.id)
-            assertThat(body[0].createdByUserId).isEqualTo(placementApplicationEntity.createdByUser.id)
-            assertThat(body[0].schemaVersion).isEqualTo(placementApplicationEntity.schemaVersion.id)
-            assertThat(body[0].createdAt).isEqualTo(placementApplicationEntity.createdAt.toInstant())
-            assertThat(body[0].submittedAt).isCloseTo(
-              placementApplicationEntity.submittedAt!!.toInstant(),
-              within(1, ChronoUnit.SECONDS),
-            )
+              assertThat(body.size).isEqualTo(1)
+              assertThat(body[0].id).isEqualTo(placementApplicationEntity.id)
+              assertThat(body[0].applicationId).isEqualTo(placementApplicationEntity.application.id)
+              assertThat(body[0].createdByUserId).isEqualTo(placementApplicationEntity.createdByUser.id)
+              assertThat(body[0].schemaVersion).isEqualTo(placementApplicationEntity.schemaVersion.id)
+              assertThat(body[0].createdAt).isEqualTo(placementApplicationEntity.createdAt.toInstant())
+              assertThat(body[0].submittedAt).isCloseTo(
+                placementApplicationEntity.submittedAt!!.toInstant(),
+                within(1, ChronoUnit.SECONDS),
+              )
+            }
           }
         }
       }
     }
-  }
 
-  @Test
-  fun `Get placement applications does not return withdrawn placement applications`() {
-    `Given a User` { user, jwt ->
-      `Given a Placement Application`(
-        createdByUser = user,
-        schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        },
-        decision = PlacementApplicationDecision.WITHDRAWN_BY_PP,
-      ) { placementApplicationEntity ->
-        val applicationId = placementApplicationEntity.application.id
-        val rawResult = webTestClient.get()
-          .uri("/applications/$applicationId/placement-applications")
-          .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
-          .exchange()
-          .expectStatus()
-          .isOk
-          .returnResult<String>()
-          .responseBody
-          .blockFirst()
+    @Test
+    fun `Get placement applications does not return withdrawn placement applications`() {
+      `Given a User` { user, jwt ->
+        `Given a Placement Application`(
+          createdByUser = user,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+          decision = PlacementApplicationDecision.WITHDRAWN_BY_PP,
+        ) { placementApplicationEntity ->
+          val applicationId = placementApplicationEntity.application.id
+          val rawResult = webTestClient.get()
+            .uri("/applications/$applicationId/placement-applications")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.approvedPremises.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .returnResult<String>()
+            .responseBody
+            .blockFirst()
 
-        val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
-        assertThat(body.size).isEqualTo(0)
+          val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
+          assertThat(body.size).isEqualTo(0)
+        }
       }
     }
-  }
 
-  @Test
-  fun `Get placement applications does not return unsubmitted placement applications`() {
-    `Given a User` { user, jwt ->
-      `Given a Placement Application`(
-        createdByUser = user,
-        schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-          withPermissiveSchema()
-        },
-        decision = PlacementApplicationDecision.WITHDRAWN_BY_PP,
-        submittedAt = null,
-      ) { placementApplicationEntity ->
-        val applicationId = placementApplicationEntity.application.id
-        val rawResult = webTestClient.get()
-          .uri("/applications/$applicationId/placement-applications")
-          .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
-          .exchange()
-          .expectStatus()
-          .isOk
-          .returnResult<String>()
-          .responseBody
-          .blockFirst()
+    @Test
+    fun `Get placement applications does not return unsubmitted placement applications`() {
+      `Given a User` { user, jwt ->
+        `Given a Placement Application`(
+          createdByUser = user,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+          decision = PlacementApplicationDecision.WITHDRAWN_BY_PP,
+          submittedAt = null,
+        ) { placementApplicationEntity ->
+          val applicationId = placementApplicationEntity.application.id
+          val rawResult = webTestClient.get()
+            .uri("/applications/$applicationId/placement-applications")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.approvedPremises.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .returnResult<String>()
+            .responseBody
+            .blockFirst()
 
-        val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
-        assertThat(body.size).isEqualTo(0)
+          val body = objectMapper.readValue(rawResult, object : TypeReference<List<PlacementApplication>>() {})
+          assertThat(body.size).isEqualTo(0)
+        }
       }
     }
+
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -19,15 +19,22 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -38,7 +45,15 @@ class PlacementApplicationTransformerTest {
     registerModule(JavaTimeModule())
     registerKotlinModule()
   }
-  private val placementApplicationTransformer = PlacementApplicationTransformer(objectMapper)
+
+  private val jsonSchemaService = mockk<JsonSchemaService>()
+  private val placementRequestTransformer = mockk<PlacementRequestTransformer>()
+
+  private val placementApplicationTransformer = PlacementApplicationTransformer(
+    objectMapper,
+    jsonSchemaService,
+    placementRequestTransformer,
+  )
 
   private var user = UserEntityFactory()
     .withYieldedProbationRegion {
@@ -206,5 +221,78 @@ class PlacementApplicationTransformerTest {
     }
 
     assertThat(result.withdrawalReason).isEqualTo(WithdrawPlacementRequestReason.errorInPlacementRequest)
+  }
+
+  @Test
+  fun `transformPlacementRequestJpaToApi converts correctly`() {
+    val placementRequest = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(
+        PlacementRequirementsEntityFactory()
+          .withApplication(application)
+          .withAssessment(assessment)
+          .produce(),
+      )
+      .produce()
+
+    val schemaId = UUID.randomUUID()
+    every {
+      jsonSchemaService.getNewestSchema<ApprovedPremisesPlacementApplicationJsonSchemaEntity>(any())
+    } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().withId(schemaId).produce()
+
+    every { placementRequestTransformer.getWithdrawalReason(null) } returns null
+
+    val result = placementApplicationTransformer.transformPlacementRequestJpaToApi(placementRequest)
+
+    assertThat(result.id).isEqualTo(placementRequest.id)
+    assertThat(result.applicationId).isEqualTo(application.id)
+    assertThat(result.applicationCompletedAt).isEqualTo(application.submittedAt!!.toInstant())
+    assertThat(result.assessmentId).isEqualTo(assessment.id)
+    assertThat(result.assessmentCompletedAt).isEqualTo(assessment.submittedAt!!.toInstant())
+    assertThat(result.createdByUserId).isEqualTo(application.createdByUser.id)
+    assertThat(result.schemaVersion).isEqualTo(schemaId)
+    assertThat(result.createdAt).isEqualTo(placementRequest.createdAt.toInstant())
+    assertThat(result.data).isEqualTo("{}")
+    assertThat(result.document).isEqualTo("{}")
+    assertThat(result.outdatedSchema).isEqualTo(false)
+    assertThat(result.submittedAt).isEqualTo(application.submittedAt?.toInstant())
+    assertThat(result.canBeWithdrawn).isEqualTo(true)
+    assertThat(result.isWithdrawn).isEqualTo(false)
+    assertThat(result.withdrawalReason).isNull()
+    assertThat(result.type).isEqualTo(PlacementApplicationType.initial)
+  }
+
+  @Test
+  fun `transformPlacementRequestJpaToApi converts correctly for withdrawn request`() {
+    val placementRequest = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(
+        PlacementRequirementsEntityFactory()
+          .withApplication(application)
+          .withAssessment(assessment)
+          .produce(),
+      )
+      .withIsWithdrawn(true)
+      .withWithdrawalReason(PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
+      .produce()
+
+    val schemaId = UUID.randomUUID()
+    every {
+      jsonSchemaService.getNewestSchema<ApprovedPremisesPlacementApplicationJsonSchemaEntity>(any())
+    } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().withId(schemaId).produce()
+
+    every {
+      placementRequestTransformer.getWithdrawalReason(PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
+    } returns WithdrawPlacementRequestReason.duplicatePlacementRequest
+
+    val result = placementApplicationTransformer.transformPlacementRequestJpaToApi(placementRequest)
+
+    assertThat(result.id).isEqualTo(placementRequest.id)
+    assertThat(result.canBeWithdrawn).isEqualTo(false)
+    assertThat(result.isWithdrawn).isEqualTo(true)
+    assertThat(result.withdrawalReason).isEqualTo(WithdrawPlacementRequestReason.duplicatePlacementRequest)
+    assertThat(result.type).isEqualTo(PlacementApplicationType.initial)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.NullSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
@@ -93,6 +94,7 @@ class PlacementApplicationTransformerTest {
     assertThat(result.canBeWithdrawn).isEqualTo(true)
     assertThat(result.isWithdrawn).isEqualTo(false)
     assertThat(result.withdrawalReason).isNull()
+    assertThat(result.type).isEqualTo(PlacementApplicationType.additional)
   }
 
   @Test


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-395

The /applications/{id}/placement-applications endpoint has been enhanced to add an optional query param ‘includeInitialRequestForPlacement’, which is null/false by default. If set to true, an additional PlacementApplication of type ‘initial’ will be returned representing the request for placement implicit in the application submission (i.e. the one based upon the original applications’ arrival date).

This is actually modelled as a PlacementRequest in the database, so certain elements of this specific PlacementApplication should be used with care, specifically the ‘id’ field, which actually corresponds to a PlacementRequest ID. For more information on this approach, see the documentation on PlacementRequestEntity#isForApplicationsArrivalDate