### PR TITLE
[CAS-166]-CAS3-Bedspace search to include booking departure date 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -122,7 +122,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     "SELECT b FROM BookingEntity b WHERE (b.bed, b.departureDate) IN (" +
       "  SELECT b2.bed, MAX(b2.departureDate)" +
       "  FROM BookingEntity b2 " +
-      "  WHERE b2.departureDate < :date " +
+      "  WHERE b2.departureDate <= :date " +
       "  AND b2.bed.id IN :bedIds " +
       "  AND SIZE(b2.cancellations) = 0 " +
       "  GROUP BY b2.bed " +


### PR DESCRIPTION
Refer [CAS-166](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-166) for more information.

There is an issue with the search showing results when the bedspace is not available, but this is not about the turnaround time.

A bedspace is booked from 21/2 to 26/2 with turnaround ending on 28/2.

It is showing an overlap on the 26/2 - but this property only has 1 bedspace so this bedspace should NOT be shown.

Note that the property does NOT come in the search for any of the dates in the range 21/2 until 28/2 except the 26/2 - which is the end date of the booking - so there is some bug with the way that the end date is being used in the search.

`Fix': Include the departureDate when querying to find existing booking which are closest to new search start date.

[CAS-166]: https://dsdmoj.atlassian.net/browse/CAS-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ