### PR TITLE
Add appeal data to application and placement reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/allocations/rules/AppealedAssessmentRule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/allocations/rules/AppealedAssessmentRule.kt
@@ -35,7 +35,8 @@ class AppealedAssessmentRule(
   }
 
   private fun allocateToArbitrator(application: ApplicationEntity): UserAllocatorRuleOutcome {
-    return when (val appeal = appealRepository.findByApplication(application)) {
+    val appeal = appealRepository.findByApplication(application).maxByOrNull { it.createdAt }
+    return when (appeal) {
       null -> UserAllocatorRuleOutcome.Skip
       else -> UserAllocatorRuleOutcome.AllocateToUser(appeal.createdBy.deliusUsername)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
@@ -13,7 +13,7 @@ import javax.persistence.Table
 
 @Repository
 interface AppealRepository : JpaRepository<AppealEntity, UUID> {
-  fun findByApplication(application: ApplicationEntity): AppealEntity?
+  fun findByApplication(application: ApplicationEntity): List<AppealEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
@@ -14,6 +14,7 @@ import javax.persistence.Table
 @Repository
 interface AppealRepository : JpaRepository<AppealEntity, UUID> {
   fun findByApplication(application: ApplicationEntity): List<AppealEntity>
+  fun findAllByAssessmentId(assessmentId: UUID): List<AppealEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -174,6 +174,8 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
 
   fun findByApplication_IdAndReallocatedAtNull(applicationId: UUID): AssessmentEntity?
 
+  fun findAllByApplicationId(applicationId: UUID): List<AssessmentEntity>
+
   @Query(
     """
     SELECT

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ApplicationReportGenerator.kt
@@ -17,7 +17,7 @@ class ApplicationReportGenerator : ReportGenerator<ApplicationEntityReportRow, A
         lastAllocatedToAssessorDate = this.getLastAllocatedToAssessorDate()?.toLocalDateTime()?.toLocalDate(),
         applicationAssessedDate = this.getApplicationAssessedDate()?.toLocalDate(),
         assessorCru = this.getAssessorCru(),
-        assessmentDecision = this.getAssessmentDecision(),
+        assessmentDecision = this.deriveAssessmentDecision(),
         assessmentDecisionRationale = this.getAssessmentDecisionRationale(),
         agreeWithShortNoticeReason = this.getAgreeWithShortNoticeReason(),
         reasonForLateApplication = this.getReasonForLateApplication(),
@@ -52,8 +52,17 @@ class ApplicationReportGenerator : ReportGenerator<ApplicationEntityReportRow, A
         hasNotArrived = this.getHasNotArrived(),
         notArrivedReason = this.getNotArrivedReason(),
         paroleDecisionDate = this.getParoleDecisionDate()?.toLocalDate(),
+        assessmentAppealCount = this.getAssessmentAppealCount(),
+        lastAssessmentAppealedDecision = this.getLastAssessmentAppealedDecision(),
+        lastAssessmentAppealedDate = this.getLastAssessmentAppealedDate()?.toLocalDate(),
+        assessmentAppealedFromStatus = this.getAssessmentAppealedFromStatus(),
         type = this.getType(),
       ),
     )
+  }
+
+  private fun ApplicationEntityReportRow.deriveAssessmentDecision() = when (this.getAssessmentAppealCount()) {
+    0, null -> this.getAssessmentDecision()
+    else -> this.getLastAssessmentAppealedDecision()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/PlacementApplicationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/PlacementApplicationReportGenerator.kt
@@ -24,7 +24,7 @@ class PlacementApplicationReportGenerator :
         applicationSubmittedAt = this.getApplicationSubmittedAt()?.toLocalDateTime()?.toLocalDate(),
         applicationAssessedDate = this.getApplicationAssessedDate()?.toLocalDate(),
         assessorCru = this.getAssessorCru(),
-        assessmentDecision = this.getAssessmentDecision(),
+        assessmentDecision = this.deriveAssessmentDecision(),
         assessmentDecisionRationale = this.getAssessmentDecisionRationale(),
         ageInYears = this.getAgeInYears()?.toInt(),
         gender = this.getGender(),
@@ -55,7 +55,16 @@ class PlacementApplicationReportGenerator :
         notArrivedReason = this.getNotArrivedReason(),
         placementRequestType = this.getPlacementRequestType(),
         paroleDecisionDate = this.getParoleDecisionDate()?.toLocalDate(),
+        assessmentAppealCount = this.getAssessmentAppealCount(),
+        lastAssessmentAppealedDecision = this.getLastAssessmentAppealedDecision(),
+        lastAssessmentAppealedDate = this.getLastAssessmentAppealedDate()?.toLocalDate(),
+        assessmentAppealedFromStatus = this.getAssessmentAppealedFromStatus(),
       ),
     )
+  }
+
+  private fun PlacementApplicationEntityReportRow.deriveAssessmentDecision() = when (this.getAssessmentAppealCount()) {
+    0, null -> this.getAssessmentDecision()
+    else -> this.getLastAssessmentAppealedDecision()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/ApplicationReportRow.kt
@@ -43,5 +43,9 @@ data class ApplicationReportRow(
   val hasNotArrived: Boolean?,
   val notArrivedReason: String?,
   val paroleDecisionDate: LocalDate?,
+  val assessmentAppealCount: Int?,
+  val lastAssessmentAppealedDecision: String?,
+  val lastAssessmentAppealedDate: LocalDate?,
+  val assessmentAppealedFromStatus: String?,
   val type: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/PlacementApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/PlacementApplicationReportRow.kt
@@ -44,4 +44,8 @@ data class PlacementApplicationReportRow(
   val notArrivedReason: String?,
   val placementRequestType: String?,
   val paroleDecisionDate: LocalDate?,
+  val assessmentAppealCount: Int?,
+  val lastAssessmentAppealedDecision: String?,
+  val lastAssessmentAppealedDate: LocalDate?,
+  val assessmentAppealedFromStatus: String?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/allocations/rules/AppealedAssessmentRuleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/allocations/rules/AppealedAssessmentRuleTest.kt
@@ -87,7 +87,7 @@ class AppealedAssessmentRuleTest {
     @Test
     fun `Returns Skip with when no appeal is found for the assessment`() {
       val (assessment, _) = createAssessmentAndAppeal(true, OffsetDateTime.now())
-      every { mockAppealRepository.findByApplication(assessment.application) } returns null
+      every { mockAppealRepository.findByApplication(assessment.application) } returns listOf()
 
       val result = appealedAssessmentRule.evaluateAssessment(assessment)
 
@@ -126,7 +126,7 @@ class AppealedAssessmentRuleTest {
         .withCreatedBy(appealUser)
         .produce()
 
-      every { mockAppealRepository.findByApplication(application) } returns appeal
+      every { mockAppealRepository.findByApplication(application) } returns listOf(appeal)
 
       return Pair(assessment, appeal)
     }


### PR DESCRIPTION
> See [APS-241 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-241).

This PR introduces several new columns regarding appeals to the application and placement application reports.

The new columns are as follows:

| Column name | Type | Description |
| --- | --- | --- |
| `assessmentAppealCount` | `int` | This will show the amount of appeals that have been made against this application and assessment |
| `lastAssessmentAppealedDecision` | `String` | This will show the appeal decision of the latest appeal record (Upheld or Rejected) |
| `lastAssessmentAppealedDate` | `Date` | This will show the date of the last appeal |
| `assessmentAppealedFromStatus` | `String` | This will store and show the original assessment decision so that it’s possible to see why things are being appealed |

In addition, the following columns have been updated:

| Column name | Type | Description |
| --- | --- | --- |
| `assessmentDecision` | `String` | This column now shows the decision recorded on the assessment only if no appeals have been made. Otherwise, it shows the decision of the latest appeal. |