### PR TITLE
Return initial placement request even if withdrawn

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -372,7 +372,7 @@ class PlacementRequestService(
   fun getPlacementRequestForInitialApplicationDates(applicationId: UUID) =
     placementRequestRepository.findByApplication_id(applicationId)
       .filter { it.isForApplicationsArrivalDate() }
-      .firstOrNull { it.isActive() }
+      .firstOrNull { !it.isReallocated() }
 
   private fun updateApplicationStatusOnWithdrawal(
     placementRequest: PlacementRequestEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1233,7 +1233,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get placement applications returns initial request for placement alongside other placement apps if requested()`() {
+    fun `Get placement applications returns initial request for placement alongside other placement apps if requested, even if withdrawn`() {
       `Given a User` { user, jwt ->
         `Given a Placement Application`(
           createdByUser = user,
@@ -1247,7 +1247,7 @@ class ApplicationTest : IntegrationTestBase() {
           val application = placementApplicationEntity.application
 
           val placementRequestEntity = placementRequestFactory.produceAndPersist {
-            val assessment = application.assessments.get(0)
+            val assessment = application.assessments[0]
 
             val placementRequirements = placementRequirementsFactory.produceAndPersist {
               withApplication(application)
@@ -1265,6 +1265,8 @@ class ApplicationTest : IntegrationTestBase() {
             withApplication(application)
             withAssessment(assessment)
             withPlacementRequirements(placementRequirements)
+            withReallocatedAt(null)
+            withIsWithdrawn(true)
           }
 
           val applicationId = placementApplicationEntity.application.id


### PR DESCRIPTION
When /applications/{id}/placement-applications returns a list of placement requests it includes a representation of the original request made when the application was assessed, by using the corresponding match request as a proxy. This should be returned even if the corresponding match request has been withdrawn, allowing users to see it in its withdrawn state