### PR TITLE
Allow Assessor to update assessment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -59,6 +59,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
+        authorize(HttpMethod.PUT, "/cas2/assessments/**", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("POM", "CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/AssessmentsController.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.AssessmentsCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
+
+@Service("Cas2AssessmentsController")
+class AssessmentsController(
+  private val assessmentService: AssessmentService,
+  private val assessmentsTransformer: AssessmentsTransformer,
+) : AssessmentsCas2Delegate {
+
+  override fun assessmentsAssessmentIdPut(
+    assessmentId: java.util.UUID,
+    updateCas2Assessment: UpdateCas2Assessment,
+  ):
+    ResponseEntity<Cas2Assessment> {
+    val assessmentResult = assessmentService.updateAssessment(assessmentId, updateCas2Assessment)
+    val validationResult = when (assessmentResult) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(assessmentId, "Assessment")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> assessmentResult.entity
+    }
+
+    val updatedAssessment = when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.Success -> validationResult.entity
+    }
+
+    return ResponseEntity.ok(
+      assessmentsTransformer.transformJpaToApiRepresentation(updatedAssessment),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentService.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
@@ -22,4 +26,20 @@ class AssessmentService(
         application = cas2ApplicationEntity,
       ),
     )
+
+  fun updateAssessment(assessmentId: UUID, newAssessment: UpdateCas2Assessment): AuthorisableActionResult<ValidatableActionResult<Cas2AssessmentEntity>> {
+    val assessmentEntity = assessmentRepository.findByIdOrNull(assessmentId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    assessmentEntity.apply {
+      this.nacroReferralId = newAssessment.nacroReferralId
+      this.assessorName = newAssessment.assessorName
+    }
+
+    val savedAssessment = assessmentRepository.save(assessmentEntity)
+
+    return AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(savedAssessment),
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/AssessmentsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/AssessmentsTransformer.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
+
+@Component("Cas2AssessmentsTransformer")
+class AssessmentsTransformer {
+  fun transformJpaToApiRepresentation(
+    jpaAssessment: Cas2AssessmentEntity,
+  ): Cas2Assessment {
+    return Cas2Assessment(
+      jpaAssessment.id,
+      jpaAssessment.nacroReferralId,
+      jpaAssessment.assessorName,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
@@ -20,6 +19,7 @@ class SubmissionsTransformer(
   private val nomisUserTransformer: NomisUserTransformer,
   private val statusUpdateTransformer: StatusUpdateTransformer,
   private val timelineEventsTransformer: TimelineEventsTransformer,
+  private val assessmentsTransformer: AssessmentsTransformer,
 ) {
 
   fun transformJpaToApiRepresentation(
@@ -41,7 +41,7 @@ class SubmissionsTransformer(
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       telephoneNumber = jpa.telephoneNumber,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
-      assessment = Cas2Assessment(nacroReferralId = jpa.assessment?.nacroReferralId, assessorName = jpa.assessment?.assessorName),
+      assessment = assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!),
     )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2453,10 +2453,25 @@ components:
     Cas2Assessment:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         nacroReferralId:
           type: string
         assessorName:
           type: string
+      required:
+        - id
+    UpdateCas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+      required:
+        - nacroReferralId
+        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -128,6 +128,45 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /assessments/{assessmentId}:
+    put:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Updates a single CAS2 assessment by its ID
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information to update the assessment with
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/UpdateCas2Assessment'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2Assessment'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid assessmentId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /submissions:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7028,10 +7028,25 @@ components:
     Cas2Assessment:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         nacroReferralId:
           type: string
         assessorName:
           type: string
+      required:
+        - id
+    UpdateCas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+      required:
+        - nacroReferralId
+        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -130,6 +130,45 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /assessments/{assessmentId}:
+    put:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Updates a single CAS2 assessment by its ID
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information to update the assessment with
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateCas2Assessment'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2Assessment'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid assessmentId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /submissions:
     get:
       tags:
@@ -2936,10 +2975,25 @@ components:
     Cas2Assessment:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         nacroReferralId:
           type: string
         assessorName:
           type: string
+      required:
+        - id
+    UpdateCas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+      required:
+        - nacroReferralId
+        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2501,10 +2501,25 @@ components:
     Cas2Assessment:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         nacroReferralId:
           type: string
         assessorName:
           type: string
+      required:
+        - id
+    UpdateCas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+      required:
+        - nacroReferralId
+        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2AssessmentEntityFactory.kt
@@ -15,8 +15,8 @@ class Cas2AssessmentEntityFactory : Factory<Cas2AssessmentEntity> {
       .withCreatedByUser(NomisUserEntityFactory().produce())
       .produce()
   }
-  private var nacroReferralId: Yielded<String?> = { null }
-  private var assessorName: Yielded<String?> = { null }
+  private var nacroReferralId: String? = null
+  private var assessorName: String? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -27,18 +27,18 @@ class Cas2AssessmentEntityFactory : Factory<Cas2AssessmentEntity> {
   }
 
   fun withNacroReferralId(id: String) = apply {
-    this.nacroReferralId = { id }
+    this.nacroReferralId = id
   }
 
   fun withAssessorName(name: String) = apply {
-    this.assessorName = { name }
+    this.assessorName = name
   }
 
   override fun produce(): Cas2AssessmentEntity = Cas2AssessmentEntity(
     id = this.id(),
     createdAt = this.createdAt(),
     application = this.application(),
-    nacroReferralId = this.nacroReferralId(),
-    assessorName = this.assessorName(),
+    nacroReferralId = this.nacroReferralId,
+    assessorName = this.assessorName,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2AssessmentTest.kt
@@ -1,0 +1,144 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2AssessmentTest : IntegrationTestBase() {
+
+  @SpykBean
+  lateinit var realAssessmentRepository: Cas2AssessmentRepository
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realAssessmentRepository)
+  }
+
+  @Nested
+  inner class MissingJwt {
+    @Test
+    fun `updating an assessment without JWT returns 401`() {
+      webTestClient.put()
+        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+  }
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `updating an assessment is forbidden to external users who are not Assessors`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "auth",
+        roles = listOf("ROLE_CAS2_ADMIN"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class ControlsOnInternalUsers {
+    @Test
+    fun `updating an application is forbidden to nomis users`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_POM"),
+      )
+
+      webTestClient.put()
+        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class PutToUpdate {
+    @Test
+    fun `assessors update assessment returns 200`() {
+      val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+      `Given a CAS2 User` { referrer, _ ->
+        `Given a CAS2 Assessor` { assessor, jwt ->
+          val submittedApplication = createSubmittedApplication(applicationId, referrer)
+
+          // with an assessment
+          val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+            withApplication(submittedApplication)
+            withNacroReferralId("someID")
+            withAssessorName("some name")
+          }
+
+          val updatedNacroReferralId = "123N"
+          val updatedAssessorName = "Anne Assessor"
+
+          val rawResponseBody = webTestClient.put()
+            .uri("/cas2/assessments/${assessment.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.cas2.value)
+            .bodyValue(
+              UpdateCas2Assessment(
+                nacroReferralId = updatedNacroReferralId,
+                assessorName = updatedAssessorName,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .returnResult<String>()
+            .responseBody
+            .blockFirst()
+
+          val responseBody =
+            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2Assessment>() {})
+
+          Assertions.assertThat(responseBody.nacroReferralId).isEqualTo(updatedNacroReferralId)
+          Assertions.assertThat(responseBody.assessorName).isEqualTo(updatedAssessorName)
+        }
+      }
+    }
+
+    private fun createSubmittedApplication(applicationId: UUID, referrer: NomisUserEntity): Cas2ApplicationEntity {
+      val applicationSchema =
+        cas2ApplicationJsonSchemaEntityFactory.produceAndPersist()
+
+      return cas2ApplicationEntityFactory.produceAndPersist {
+        withId(applicationId)
+        withCreatedByUser(referrer)
+        withApplicationSchema(applicationSchema)
+        withSubmittedAt(OffsetDateTime.now())
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentServiceTest.kt
@@ -7,10 +7,14 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.times
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -52,6 +56,81 @@ class AssessmentServiceTest {
           match { it.application == application },
         )
       }
+    }
+  }
+
+  @Nested
+  inner class UpdateAssessment {
+
+    @Test
+    fun `saves and returns entity from db`() {
+      val assessmentId = UUID.randomUUID()
+      val application = Cas2ApplicationEntityFactory()
+        .withCreatedByUser(
+          NomisUserEntityFactory()
+            .produce(),
+        ).produce()
+      val assessEntity = Cas2AssessmentEntity(
+        id = assessmentId,
+        application = application,
+        createdAt = OffsetDateTime.now(),
+      )
+
+      val newAssessmentData = UpdateCas2Assessment(
+        nacroReferralId = "1234OH",
+        assessorName = "Anne Assessor",
+      )
+
+      every { mockAssessmentRepository.save(any()) } answers
+        {
+          assessEntity
+        }
+
+      every { mockAssessmentRepository.findByIdOrNull(assessmentId) } answers
+        {
+          assessEntity
+        }
+
+      val result = assessmentService.updateAssessment(
+        assessmentId = assessmentId,
+        newAssessment = newAssessmentData,
+      )
+      Assertions.assertThat(result).isEqualTo(
+        AuthorisableActionResult.Success(
+          ValidatableActionResult.Success(assessEntity),
+        ),
+      )
+
+      verify(exactly = 1) {
+        mockAssessmentRepository.save(
+          match {
+            it.id == assessEntity.id &&
+              it.nacroReferralId == newAssessmentData.nacroReferralId &&
+              it.assessorName == newAssessmentData.assessorName
+          },
+        )
+      }
+    }
+
+    @Test
+    fun `returns NotFound if entity is not found`() {
+      val assessmentId = UUID.randomUUID()
+      val newAssessmentData = UpdateCas2Assessment(
+        nacroReferralId = "1234OH",
+        assessorName = "Anne Assessor",
+      )
+
+      every { mockAssessmentRepository.findByIdOrNull(assessmentId) } answers
+        {
+          null
+        }
+
+      val result = assessmentService.updateAssessment(
+        assessmentId = assessmentId,
+        newAssessment = newAssessmentData,
+      )
+
+      Assertions.assertThat(result is AuthorisableActionResult.NotFound).isTrue
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/AssessmentsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/AssessmentsTransformerTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas2
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
+
+class AssessmentsTransformerTest {
+  private val assessmentEntity = Cas2AssessmentEntityFactory().produce()
+
+  private val assessmentsTransformer = AssessmentsTransformer()
+
+  @Test
+  fun `transforms an assessment entity`() {
+    val transformation = assessmentsTransformer.transformJpaToApiRepresentation(assessmentEntity)
+
+    Assertions.assertThat(transformation).isEqualTo(
+      Cas2Assessment(
+        assessmentEntity.id,
+        assessmentEntity.nacroReferralId,
+        assessmentEntity.assessorName,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
DO NOT MERGE until this PR has been merged: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1542 

This is the step [following this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1524 ) and that to be merged first, once it is then this PR can be pointed at `main` branch 

https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-254 

This allows Assessors to update an Assessment by a PUT request to `cas2/assessments/{id}` with these string fields:

- nacroReferralId
- assessorName 

Although an Assessment belongs to an Application, I've taken the choice here to make the end point only `assessments` and not e.g. `applications/{applicationId}/assessments` because of the work we hope to do to refactor assessments described in this PR https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1514 but interested in any feedback.