### PR TITLE
[CAS-229]-CAS3-reports-Configure and generate based on configured number of months

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -112,3 +112,6 @@ generic-prometheus-alerts:
 
 env_details:
   production_env: false
+
+cas3-report:
+  end-date-override: 3

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -133,3 +133,6 @@ generic-prometheus-alerts:
 
 env_details:
   production_env: false
+
+cas3-report:
+  end-date-override: 3

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.temporaryAccommodation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
@@ -18,6 +19,7 @@ class BedUtilisationReportGenerator(
   private val bookingRepository: BookingRepository,
   private val lostBedsRepository: LostBedsRepository,
   private val workingDayCountService: WorkingDayCountService,
+  private val cas3EndDateOverride: Int,
 ) : ReportGenerator<BedEntity, BedUtilisationReportRow, BedUtilisationReportProperties>(BedUtilisationReportRow::class) {
   override fun filter(properties: BedUtilisationReportProperties): (BedEntity) -> Boolean = {
     checkServiceType(properties.serviceName, it.room.premises) &&
@@ -26,7 +28,11 @@ class BedUtilisationReportGenerator(
 
   override val convert: BedEntity.(properties: BedUtilisationReportProperties) -> List<BedUtilisationReportRow> = { properties ->
     val startOfMonth = LocalDate.of(properties.year, properties.month, 1)
-    val endOfMonth = LocalDate.of(properties.year, properties.month, startOfMonth.month.length(startOfMonth.isLeapYear))
+    val endOfMonth = if (properties.serviceName == temporaryAccommodation && cas3EndDateOverride != 0) {
+      startOfMonth.plusMonths(cas3EndDateOverride.toLong())
+    } else {
+      LocalDate.of(properties.year, properties.month, startOfMonth.month.length(startOfMonth.isLeapYear))
+    }
 
     var bookedDaysActiveAndClosed = 0
     var confirmedDays = 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/ReportService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3
 
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.jetbrains.kotlinx.dataframe.io.writeExcel
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.TransitionalAccommodationReferralReportGenerator
@@ -18,13 +19,19 @@ class ReportService(
   private val offenderService: OffenderService,
   private val userService: UserService,
   private val transitionalAccommodationReferralReportRowRepository: TransitionalAccommodationReferralReportRepository,
+  @Value("\${cas3-report.end-date-override:0}") private val endDateOverride: Int,
 ) {
   fun createCas3ApplicationReferralsReport(
     properties: TransitionalAccommodationReferralReportProperties,
     outputStream: OutputStream,
   ) {
     val fromDate = LocalDate.of(properties.year, properties.month, 1)
-    val toDate = LocalDate.of(properties.year, properties.month, fromDate.month.length(fromDate.isLeapYear))
+    var toDate = LocalDate.of(properties.year, properties.month, fromDate.month.length(fromDate.isLeapYear))
+
+    if (endDateOverride != 0) {
+      toDate = fromDate.plusMonths((endDateOverride).toLong())
+    }
+
     val referralsInScope = transitionalAccommodationReferralReportRowRepository.findAllReferrals(
       fromDate,
       toDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -851,6 +851,7 @@ class ReportsTest : IntegrationTestBase() {
           realBookingRepository,
           realLostBedsRepository,
           realWorkingDayCountService,
+          0,
         )
           .createReport(listOf(bed), BedUsageReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
 
@@ -958,6 +959,7 @@ class ReportsTest : IntegrationTestBase() {
           realBookingRepository,
           realLostBedsRepository,
           realWorkingDayCountService,
+          0,
         )
           .createReport(listOf(bed), BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, 2023, 4))
 


### PR DESCRIPTION
Refer [CAS-195](https://dsdmoj.atlassian.net/browse/CAS-195) for more information.

This PR is to run the CAS3 reports for 3 months instead of 1 month to see the performance of the report(testing purpose only).

This change is just for testing purpose to make sure the service performance is acceptable and work without any issue before we change the service to search based on `startDate` and `endate` instead of searching only for 1 month.

[CAS-195]: https://dsdmoj.atlassian.net/browse/CAS-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ