### PR TITLE
[CAS-228] booking search by crn

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
@@ -48,11 +48,12 @@ class BookingsController(
     sortOrder: SortOrder?,
     sortField: BookingSearchSortField?,
     page: Int?,
+    crn: String?,
   ): ResponseEntity<BookingSearchResults> {
     val sortOrder = sortOrder ?: SortOrder.ascending
     val sortField = sortField ?: BookingSearchSortField.bookingCreatedAt
 
-    val (results, metadata) = bookingSearchService.findBookings(xServiceName, status, sortOrder, sortField, page)
+    val (results, metadata) = bookingSearchService.findBookings(xServiceName, status, sortOrder, sortField, page, crn)
 
     return ResponseEntity.ok()
       .headers(metadata?.toHeaders())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -163,6 +163,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       WHERE b.service = :serviceName
       AND (:status is null or b.status = :#{#status?.toString()})
       AND (Cast(:probationRegionId as varchar) is null or p.probation_region_id = :probationRegionId)
+      AND (:crn is null OR b.crn = :crn)
     """,
     nativeQuery = true,
   )
@@ -170,6 +171,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     serviceName: String,
     status: BookingStatus?,
     probationRegionId: UUID?,
+    crn: String?,
     pageable: Pageable?,
   ): Page<BookingSearchResult>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
@@ -35,6 +35,7 @@ class BookingSearchService(
     sortOrder: SortOrder,
     sortField: BookingSearchSortField,
     page: Int?,
+    crn: String?,
   ): Pair<List<BookingSearchResultDto>, PaginationMetadata?> {
     val user = userService.getUserForRequest()
     val probationRegionId = when (serviceName) {
@@ -49,6 +50,7 @@ class BookingSearchService(
       serviceName.value,
       status,
       probationRegionId,
+      crn,
       buildPage(sortOrder, sortField, page, pageSize),
     )
     var results = removeRestrictedAndUpdatePersonNameFromOffenderDetail(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2397,6 +2397,12 @@ paths:
           description: Filters the bookings to those relevant to the specified service.
           schema:
             $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: crn
+          in: query
+          description: If provided, return only results for the given CRN
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2399,6 +2399,12 @@ paths:
           description: Filters the bookings to those relevant to the specified service.
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: crn
+          in: query
+          description: If provided, return only results for the given CRN
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: successful operation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -2806,7 +2806,6 @@ class BookingTest : IntegrationTestBase() {
       }
     }
 
-
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
     fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(
@@ -2843,7 +2842,6 @@ class BookingTest : IntegrationTestBase() {
           .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
       }
     }
-
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingSearchServiceTest.kt
@@ -65,7 +65,7 @@ class BookingSearchServiceTest {
       }
       .produce()
 
-    every { mockBookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(
       crns.map { TestBookingSearchResult().withPersonCrn(it) },
     )
 
@@ -78,6 +78,7 @@ class BookingSearchServiceTest {
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
       1,
+      null,
     )
 
     assertThat(results).hasSize(3)
@@ -98,7 +99,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(
       listOf(
         TestBookingSearchResult()
           .withPersonCrn("crn1")
@@ -124,6 +125,7 @@ class BookingSearchServiceTest {
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
       1,
+      null,
     )
     assertThat(results).hasSize(2)
     assertThat(results).matches { result ->
@@ -131,7 +133,7 @@ class BookingSearchServiceTest {
     }
     assertThat(metadata).isNotNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), any())
+      mockBookingRepository.findBookings(any(), any(), any(), any(), any())
     }
   }
 
@@ -146,7 +148,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(
       listOf(
         TestBookingSearchResult()
           .withPersonCrn("crn1")
@@ -178,6 +180,7 @@ class BookingSearchServiceTest {
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
       1,
+      null,
     )
 
     assertThat(results).hasSize(3)
@@ -187,7 +190,7 @@ class BookingSearchServiceTest {
     assertThat(results.last().personName).isNull()
     assertThat(metaData).isNotNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), any())
+      mockBookingRepository.findBookings(any(), any(), any(), any(), any())
     }
   }
 
@@ -208,7 +211,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), pageable) } returns PageImpl(
       listOf(
         TestBookingSearchResult().withPersonCrn("crn1"),
         TestBookingSearchResult().withPersonCrn("crn2"),
@@ -228,6 +231,7 @@ class BookingSearchServiceTest {
       sortOrder,
       BookingSearchSortField.personName,
       1,
+      null,
     )
 
     assertThat(results).hasSize(3)
@@ -239,7 +243,7 @@ class BookingSearchServiceTest {
     }
     assertThat(metaData).isNotNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), pageable)
+      mockBookingRepository.findBookings(any(), any(), any(), any(), pageable)
     }
   }
 
@@ -260,7 +264,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), pageable) } returns PageImpl(
       listOf(
         TestBookingSearchResult().withPersonCrn("crn1"),
         TestBookingSearchResult().withPersonCrn("crn2"),
@@ -280,6 +284,7 @@ class BookingSearchServiceTest {
       sortOrder,
       BookingSearchSortField.personName,
       1,
+      null,
     )
 
     assertThat(results).hasSize(3)
@@ -291,7 +296,7 @@ class BookingSearchServiceTest {
     }
     assertThat(metaData).isNotNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), pageable)
+      mockBookingRepository.findBookings(any(), any(), any(), any(), pageable)
     }
   }
 
@@ -312,7 +317,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), pageable) } returns PageImpl(
       listOf(
         TestBookingSearchResult().withPersonCrn("crn1"),
         TestBookingSearchResult().withPersonCrn("crn2"),
@@ -332,6 +337,7 @@ class BookingSearchServiceTest {
       sortOrder,
       BookingSearchSortField.personName,
       null,
+      null,
     )
 
     assertThat(results).hasSize(3)
@@ -343,7 +349,7 @@ class BookingSearchServiceTest {
     }
     assertThat(metaData).isNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), pageable)
+      mockBookingRepository.findBookings(any(), any(), any(), any(), pageable)
     }
   }
 
@@ -364,7 +370,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), pageable) } returns PageImpl(
       listOf(
         TestBookingSearchResult().withPersonCrn("crn1"),
         TestBookingSearchResult().withPersonCrn("crn2"),
@@ -384,12 +390,13 @@ class BookingSearchServiceTest {
       sortOrder,
       BookingSearchSortField.personCrn,
       2,
+      null,
     )
 
     assertThat(results).hasSize(3)
     assertThat(metaData).isNotNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), pageable)
+      mockBookingRepository.findBookings(any(), any(), any(), any(), pageable)
     }
   }
 
@@ -404,7 +411,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(emptyList())
     every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any(), any()) } returns emptyList()
 
     val (results, metaData) = bookingSearchService.findBookings(
@@ -413,12 +420,13 @@ class BookingSearchServiceTest {
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
       1,
+      null,
     )
 
     assertThat(results).hasSize(0)
     assertThat(metaData).isNotNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), any())
+      mockBookingRepository.findBookings(any(), any(), any(), any(), any())
     }
   }
 
@@ -433,7 +441,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(emptyList())
     every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any(), any()) } returns emptyList()
 
     val (results, metaData) = bookingSearchService.findBookings(
@@ -442,12 +450,13 @@ class BookingSearchServiceTest {
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
       null,
+      "S448160",
     )
 
     assertThat(results).hasSize(0)
     assertThat(metaData).isNull()
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), any())
+      mockBookingRepository.findBookings(any(), any(), any(), any(), any())
     }
   }
 
@@ -462,7 +471,7 @@ class BookingSearchServiceTest {
           .produce()
       }
       .produce()
-    every { mockBookingRepository.findBookings(any(), any(), any(), any()) }.throws(
+    every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) }.throws(
       DataRetrievalFailureException(
         "some-exception",
       ),
@@ -475,10 +484,11 @@ class BookingSearchServiceTest {
         SortOrder.ascending,
         BookingSearchSortField.bookingCreatedAt,
         1,
+        null,
       )
     }
     verify(exactly = 1) {
-      mockBookingRepository.findBookings(any(), any(), any(), any())
+      mockBookingRepository.findBookings(any(), any(), any(), any(), any())
     }
     verify(exactly = 0) {
       mockOffenderService.getOffenderByCrn(any(), any())


### PR DESCRIPTION
Refer [CAS-228](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-228) for more information.

This PR is to support crn based booking search.
The changes are:
1. Added optional query parameter `crn` into booking search api `bookings/search`
2. Changed the service and DB query to include `crn` in the search if its available

[CAS-228]: https://dsdmoj.atlassian.net/browse/CAS-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ