### PR TITLE
Seed Assessments on Submitted Applications for CAS2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
@@ -159,6 +160,7 @@ class SeedService(
           applicationContext.getBean(NomisUserRepository::class.java),
           applicationContext.getBean(ExternalUserRepository::class.java),
           applicationContext.getBean(Cas2StatusUpdateRepository::class.java),
+          applicationContext.getBean(Cas2AssessmentRepository::class.java),
           applicationContext.getBean(JsonSchemaService::class.java),
           applicationContext.getBean(Cas2PersistedApplicationStatusFinder::class.java),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
@@ -61,7 +61,7 @@ class SeedCas2ApplicationTest : SeedTestBase() {
   }
 
   @Test
-  fun `An IN_PROGRESS application has _data_ but no _document_`() {
+  fun `An IN_PROGRESS application has _data_ but no _document_ or Assessment`() {
     cas2ApplicationRepository.deleteAll()
 
     nomisUserEntityFactory.produceAndPersist {
@@ -98,10 +98,11 @@ class SeedCas2ApplicationTest : SeedTestBase() {
 
     assertThat(serializableToJsonNode(persistedApplication.data)).isNotEmpty()
     assertThat(serializableToJsonNode(persistedApplication.document)).isEmpty()
+    assertThat(persistedApplication.assessment).isNull()
   }
 
   @Test
-  fun `A SUBMITTED application has _data_ AND _document_`() {
+  fun `A SUBMITTED application has _data_ AND _document_ AND an Assessment`() {
     cas2ApplicationRepository.deleteAll()
 
     nomisUserEntityFactory.produceAndPersist {
@@ -139,6 +140,7 @@ class SeedCas2ApplicationTest : SeedTestBase() {
 
     assertThat(serializableToJsonNode(persistedApplication.data)).isNotEmpty()
     assertThat(serializableToJsonNode(persistedApplication.document)).isNotEmpty()
+    assertThat(persistedApplication.assessment).isNotNull()
   }
 
   @Test


### PR DESCRIPTION
~~DO NOT MERGE until we have tested the migration job we are currently testing has passed.~~ this can be merged now as we successfully ran the `update_cas2_applications_with_assessments` job in all environments and checked that all non-seeded submitted applications have assessments ☺️ 

we [previously introduced a function](https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/e479df3f5556005cafb15598aed944668b67353e) to create an Assessment when an Application is submitted. 

This commit ensures our seeded data matches what we would expect to see on real submitted applications.

I've used the `@SuppressWarnings("LongParameterList")` annotation because I don't see a way of reducing the parameters without making it less readable, any suggestions welcome!
