### PR TITLE
Use new Placement Request Submitted email template when splitting requests into 'one per date'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -37,6 +37,7 @@ class NotifyTemplates {
   val placementRequestDecisionAccepted = "dd6f7526-05ce-4951-ba98-a2e68962fb43"
   val placementRequestDecisionRejected = "b258a025-d1e8-47f2-833e-641d7c119ff5"
   val placementRequestSubmitted = "deb11bc6-d424-4370-bbe5-41f6a823d292"
+  val placementRequestSubmittedV2 = "e7e5b481-aca8-4930-bf4e-b3098834e840"
   val placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
   val cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
   val appealSuccess = "ae21f3ae-3a4a-4df8-a1b8-2640ea80d101"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
@@ -22,11 +22,17 @@ class Cas1PlacementApplicationEmailService(
       return
     }
 
+    val templateId = if(sendNewWithdrawalNotifications) {
+      notifyConfig.templates.placementRequestSubmittedV2
+    } else {
+      notifyConfig.templates.placementRequestSubmitted
+    }
+
     val createdByUser = placementApplication.createdByUser
     createdByUser.email?.let { email ->
       emailNotifier.sendEmail(
         recipientEmailAddress = email,
-        templateId = notifyConfig.templates.placementRequestSubmitted,
+        templateId = templateId,
         personalisation = getPersonalisation(placementApplication),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -723,7 +723,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             assertThat(createdPlacementDates[0].expectedArrival).isEqualTo(placementDates[0].expectedArrival)
 
             emailAsserter.assertEmailsRequestedCount(2)
-            emailAsserter.assertEmailRequested(placementApplicationEntity.createdByUser.email!!, notifyConfig.templates.placementRequestSubmitted)
+            emailAsserter.assertEmailRequested(placementApplicationEntity.createdByUser.email!!, notifyConfig.templates.placementRequestSubmittedV2)
             emailAsserter.assertEmailRequested(placementApplicationEntity.createdByUser.email!!, notifyConfig.templates.placementRequestAllocated)
           }
         }
@@ -814,11 +814,11 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             val templates = notifyConfig.templates
 
             emailAsserter.assertEmailsRequestedCount(6)
-            emailAsserter.assertEmailRequested(recipient, templates.placementRequestSubmitted, mapOf("startDate" to "2024-01-02"))
+            emailAsserter.assertEmailRequested(recipient, templates.placementRequestSubmittedV2, mapOf("startDate" to "2024-01-02"))
             emailAsserter.assertEmailRequested(recipient, templates.placementRequestAllocated, mapOf("startDate" to "2024-01-02"))
-            emailAsserter.assertEmailRequested(recipient, templates.placementRequestSubmitted, mapOf("startDate" to "2024-02-03"))
+            emailAsserter.assertEmailRequested(recipient, templates.placementRequestSubmittedV2, mapOf("startDate" to "2024-02-03"))
             emailAsserter.assertEmailRequested(recipient, templates.placementRequestAllocated, mapOf("startDate" to "2024-02-03"))
-            emailAsserter.assertEmailRequested(recipient, templates.placementRequestSubmitted, mapOf("startDate" to "2024-03-04"))
+            emailAsserter.assertEmailRequested(recipient, templates.placementRequestSubmittedV2, mapOf("startDate" to "2024-03-04"))
             emailAsserter.assertEmailRequested(recipient, templates.placementRequestAllocated, mapOf("startDate" to "2024-03-04"))
           }
         }


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-431

If using the new withdrawal logic that splits requests for placements into an entity per date, use the new email template, allowing us to include more information on the email without breaking emails currently being sent in live