### PR TITLE
Only submitted placement requests are withdrawable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -116,7 +116,7 @@ data class PlacementApplicationEntity(
 
   fun isActive() = !isReallocated() && !isWithdrawn()
 
-  fun isInWithdrawableState() = isActive()
+  fun isInWithdrawableState() = isSubmitted() && isActive()
 
   fun isSubmitted() = submittedAt != null
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1161,6 +1161,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
       `Given a User` { user, jwt ->
         `Given a Placement Application`(
           createdByUser = user,
+          submittedAt = OffsetDateTime.now(),
           schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -709,6 +709,7 @@ class PlacementApplicationServiceTest {
         .withAllocatedToUser(allocatedTo)
         .withDecision(null)
         .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
         .produce()
 
       val withdrawalContext = WithdrawalContext(
@@ -749,6 +750,7 @@ class PlacementApplicationServiceTest {
         .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
         .withDecision(null)
         .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
         .produce()
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
@@ -787,6 +789,7 @@ class PlacementApplicationServiceTest {
         .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
         .withDecision(null)
         .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
         .produce()
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
@@ -812,6 +815,7 @@ class PlacementApplicationServiceTest {
         .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
         .withDecision(null)
         .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
         .produce()
 
       val placementRequest1 = createValidPlacementRequest(application, user)
@@ -874,6 +878,7 @@ class PlacementApplicationServiceTest {
         .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
         .withDecision(null)
         .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.now())
         .produce()
 
       val placementRequest1 = createValidPlacementRequest(application, user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawalContext
+import java.time.OffsetDateTime
 
 class WithdrawableServiceTest {
   private val mockPlacementRequestService = mockk<PlacementRequestService>()
@@ -80,6 +81,7 @@ class WithdrawableServiceTest {
   val placementApplications = PlacementApplicationEntityFactory()
     .withCreatedByUser(user)
     .withApplication(application)
+    .withSubmittedAt(OffsetDateTime.now())
     .produceMany()
     .take(2)
     .toList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -120,10 +120,10 @@ class PlacementApplicationTransformerTest {
     assertThat(result.createdAt).isEqualTo(placementApplication.createdAt.toInstant())
     assertThat(result.data).isNull()
     assertThat(result.document).isNull()
-    assertThat(result.outdatedSchema).isEqualTo(true)
+    assertThat(result.outdatedSchema).isTrue
     assertThat(result.submittedAt).isNull()
-    assertThat(result.canBeWithdrawn).isEqualTo(true)
-    assertThat(result.isWithdrawn).isEqualTo(false)
+    assertThat(result.canBeWithdrawn).isFalse
+    assertThat(result.isWithdrawn).isFalse
     assertThat(result.withdrawalReason).isNull()
     assertThat(result.type).isEqualTo(PlacementApplicationType.additional)
 


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-432

Previously we were returning unsubmitted placement requests. Because these don’t neccessarily have dates associated with them, an error occurred when rendering the withdrawable on the UI. We should not be returning unsubmitted placement apps as they are not surfaced anywhere else on the UI once the user navigates away from the creation forms.