### PR TITLE
Add route for getting an Assessment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -60,6 +60,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(HttpMethod.PUT, "/cas2/assessments/**", hasRole("CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2/assessments/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("POM", "CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentService.kt
@@ -42,4 +42,11 @@ class AssessmentService(
       ValidatableActionResult.Success(savedAssessment),
     )
   }
+
+  fun getAssessment(assessmentId: UUID): AuthorisableActionResult<Cas2AssessmentEntity> {
+    val assessmentEntity = assessmentRepository.findByIdOrNull(assessmentId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    return AuthorisableActionResult.Success(assessmentEntity)
+  }
 }

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -167,6 +167,37 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Gets a single CAS2 assessment by its ID
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2Assessment'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid assessmentId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /submissions:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -169,6 +169,37 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+    get:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Gets a single CAS2 assessment by its ID
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2Assessment'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid assessmentId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /submissions:
     get:
       tags:


### PR DESCRIPTION
[Jira ticket CAS2-255](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-255)

**Not to be merged until https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1542 is merged** (although they could probably be merged independently, this branch contains some changes/refactorings introduced in that branch).

We're [now](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1514) creating an Assessment when a CAS2 Application is created.

This PR adds a route (`/assessments/{assessmentId}`) accessible to Assessors and Admins to allow API consumers to fetch one of these Assessments. Although an Assessment belongs to an Application, we've kept the endpoint separate (i.e. not including a reference to the Application ID) to keep it consistent with the approach outlined in [this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1542) to make it easier for us to refactor this in future.