### PR TITLE
Run CAS1 e2es in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ jobs:
   cas1_e2e_tests:
     docker:
       - image: mcr.microsoft.com/playwright:v1.41.2-focal
+    parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:
@@ -244,8 +245,17 @@ jobs:
       - node/install-packages
       - run:
           name: E2E Check
-          command: |
-            npm run test
+          command: |            
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"
+            username="HMPPS_AUTH_USERNAME_$SHARD"
+            password="HMPPS_AUTH_PASSWORD_$SHARD"
+            email="HMPPS_AUTH_EMAIL_$SHARD"
+            name="HMPPS_AUTH_NAME_$SHARD"
+            HMPPS_AUTH_USERNAME="${!username}"
+            HMPPS_AUTH_PASSWORD="${!password}"
+            HMPPS_AUTH_EMAIL="${!email}"
+            HMPPS_AUTH_NAME="${!name}"
+            npm run test -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
       - store_artifacts:
           path: playwright-report
           destination: playwright-report
@@ -403,6 +413,7 @@ workflows:
       - cas1_e2e_tests:
           context:
             - hmpps-community-accommodation
+            - approved-premises-ui-e2e
           requires:
             - deploy_dev
       - cas2_e2e_tests:


### PR DESCRIPTION
This follows the instructions in:

https://playwright.dev/docs/ci#circleci

To avoid stamping on user’s permissions, we also have a user for each shard, with the login details stored as with a prefix (so `HMPPS_AUTH_USERNAME_1, HMPPS_AUTH_PASSWORD_1 etc etc), we then get the auth details for each shard in the setup process with a bit of Bash jiggery pokery and then run a selection of tests on each shard. This reduces the total runtime to around 3 minutes!