### PR TITLE
Withdraw adhoc bookings when application withdrawn

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
@@ -1141,6 +1142,8 @@ class BookingService(
     bookingRepository.findAllByApplication(application).filter { booking ->
       booking.isInCancellableStateCas1() && userAccessService.userMayCancelBooking(user, booking)
     }
+
+  fun getAllForApplication(applicationEntity: ApplicationEntity) = bookingRepository.findAllByApplication(applicationEntity)
 
   @Transactional
   fun createCas1Cancellation(


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-439

Whilst adhoc bookings were already being returned in the list of withdrawable elements (integration tests have been updated to prove this), before this commit when withdrawing an application this wasn’t cascaded to applicable bookings.

This commit ensures withdrawals cascade to any adhoc bookings (i.e. bookings not linked to a placement_request). Integration tests have been updated to assert on this, and also better assert on email personalisation values to differentiate between emails actually sent (i.e. differentiate between two ‘booking withdrawn’ emails for different bookings)