### PR TITLE
Withdrawal Tree Spike to enable blocking withdrawl

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -540,17 +540,17 @@ class ApplicationsController(
       throw RuntimeException("Unsupported Application type: ${application::class.qualifiedName}")
     }
 
-    val withdrawables = withdrawableService.allWithdrawables(application, user)
-
-    val allWithdrawables =
-      if (withdrawables.application) {
-        listOf(applicationsTransformer.transformToWithdrawable(application))
-      } else {
-        emptyList()
-      } +
-        withdrawables.placementApplications.map { placementApplicationTransformer.transformToWithdrawable(it) } +
-        withdrawables.placementRequests.map { placementRequestTransformer.transformToWithdrawable(it) } +
-        withdrawables.bookings.map { bookingTransformer.transformToWithdrawable(it) }
+    val allWithdrawables = withdrawableService.allWithdrawablesNew(application, user)
+//
+//    val allWithdrawables =
+//      if (withdrawables.application) {
+//        listOf(applicationsTransformer.transformToWithdrawable(application))
+//      } else {
+//        emptyList()
+//      } +
+//        withdrawables.placementApplications.map { placementApplicationTransformer.transformToWithdrawable(it) } +
+//        withdrawables.placementRequests.map { placementRequestTransformer.transformToWithdrawable(it) } +
+//        withdrawables.bookings.map { bookingTransformer.transformToWithdrawable(it) }
 
     return ResponseEntity.ok(allWithdrawables)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -251,6 +251,8 @@ data class BookingEntity(
 
   fun isInCancellableStateCas1() = !isCancelled && arrivals.isEmpty()
 
+  fun hasArrivals() = arrivals.isNotEmpty()
+
   fun isActive() = !isCancelled
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -599,12 +599,26 @@ class ApplicationService(
           assessmentService.updateCas1AssessmentWithdrawn(it.id)
         }
 
-        withdrawableService.withdrawAllForApplication(application, user)
+        withdrawableService.cascadeWithdrawalApplication(
+          application,
+          user,
+          WithdrawalContext(user, WithdrawableEntityType.Application)
+        )
+
+        //withdrawableService.withdrawAllForApplication(application, user)
 
         return@validated success(Unit)
       },
     )
   }
+
+  fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = !application.isWithdrawn,
+      userMayDirectlyWithdraw = isWithdrawableForUser(user, application),
+    )
+  }
+
 
   fun isWithdrawableForUser(user: UserEntity, application: ApplicationEntity) =
     userAccessService.userMayWithdrawApplication(user, application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -66,6 +66,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
@@ -1135,6 +1137,14 @@ class BookingService(
     }
 
     return success(nonArrivalEntity)
+  }
+
+  fun getWithdrawableState(booking: BookingEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = booking.isInCancellableStateCas1(),
+      userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
+      blocking = booking.isActive() && booking.hasArrivals()
+    )
   }
 
   fun getCancelleableCas1BookingsForUser(user: UserEntity, application: ApprovedPremisesApplicationEntity): List<BookingEntity> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -4,10 +4,20 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Withdrawables
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.extractMessage
+import java.time.LocalDate
+import java.util.UUID
 
 @Service
 class WithdrawableService(
@@ -23,6 +33,7 @@ class WithdrawableService(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
   ): Withdrawables {
+
     val placementRequests = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
     val bookings = bookingService.getCancelleableCas1BookingsForUser(user, application)
     val placementApplications = placementApplicationService.getWithdrawablePlacementApplicationsForUser(user, application)
@@ -33,6 +44,36 @@ class WithdrawableService(
       bookings = bookings,
       placementApplications = placementApplications,
     )
+  }
+
+  fun allWithdrawablesNew(
+    application: ApprovedPremisesApplicationEntity,
+    user: UserEntity,
+  ): List<Withdrawable> {
+
+    val rootNode = treeForApp(application, user)
+
+    log.info("Tree is $rootNode")
+
+    val allNodes = listOf(rootNode) + rootNode.collectDescendants()
+
+    return allNodes
+      .filter { it.status.withdrawable }
+      .filter { it.status.userMayDirectlyWithdraw }
+      .map {
+        Withdrawable(
+          it.id,
+          toType(it.type),
+          it.dates,
+        )
+      }
+  }
+
+  fun toType(entityType: WithdrawableEntityType): WithdrawableType = when(entityType) {
+    WithdrawableEntityType.Application -> WithdrawableType.application
+    WithdrawableEntityType.PlacementRequest -> WithdrawableType.placementRequest
+    WithdrawableEntityType.PlacementApplication -> WithdrawableType.placementApplication
+    WithdrawableEntityType.Booking -> WithdrawableType.booking
   }
 
   fun withdrawAllForApplication(
@@ -87,6 +128,200 @@ class WithdrawableService(
       }
     }
   }
+
+  fun cascadeWithdrawalApplication(application: ApprovedPremisesApplicationEntity,
+                                   // TOOD: this is on context but nullable?
+                                   user: UserEntity,
+                                   context: WithdrawalContext) {
+    withdrawDescendants(
+      treeForApp(application, user),
+      context
+    )
+  }
+
+  fun cascadePlacementApplication(placementApplication: PlacementApplicationEntity,
+                                  context: WithdrawalContext) {
+    withdrawDescendants(
+      // TODO: need to figure out this nullable context issue. Maybe handle it being null
+      // (don't populate withdrawable for user?)
+      treeForPlacementApp(placementApplication,context.triggeringUser!!),
+      context
+    )
+  }
+
+  fun cascadePlacementRequest(placementRequest: PlacementRequestEntity,
+                                  context: WithdrawalContext) {
+    withdrawDescendants(
+      // TODO: need to figure out this nullable context issue. Maybe handle it being null
+      // (don't populate withdrawable for user?)
+      treeForPlacementReq(placementRequest,context.triggeringUser!!),
+      context
+    )
+  }
+
+  private fun withdrawDescendants(rootNode: WithdrawalTreeNode,
+                                  withdrawalContext: WithdrawalContext) {
+    log.info("Tree is $rootNode")
+
+    rootNode.collectDescendants().forEach {
+      if(it.status.withdrawable) {
+        withdraw(it, withdrawalContext)
+      }
+    }
+  }
+
+  private fun withdraw(node: WithdrawalTreeNode,
+                       context: WithdrawalContext) {
+
+      when(node.type) {
+        WithdrawableEntityType.Application -> Unit
+        WithdrawableEntityType.PlacementRequest -> {
+
+          val result = placementRequestService.withdrawPlacementRequest(
+            placementRequestId = node.id,
+            userProvidedReason = null,
+            context,
+          )
+
+          when (result) {
+            is AuthorisableActionResult.Success -> Unit
+            else -> log.error(
+              "Failed to automatically withdraw placement application ${node.id} " +
+                // TODO: for id add trigger entity id into context
+                "when withdrawing ${context.triggeringEntityType} with id TODO " +
+                "with error type ${result::class}",
+            )
+          }
+
+        }
+        WithdrawableEntityType.PlacementApplication -> {
+
+          val result = placementApplicationService.withdrawPlacementApplication(
+            id = node.id,
+            userProvidedReason = null,
+            context,
+          )
+
+          when (result) {
+            is AuthorisableActionResult.Success -> Unit
+            else -> log.error(
+              "Failed to automatically withdraw placement application ${node.id} " +
+                // TODO: for id add trigger entity id into context
+                "when withdrawing ${context.triggeringEntityType} with id TODO " +
+                "with error type ${result::class}",
+            )
+          }
+
+        }
+        WithdrawableEntityType.Booking -> {
+
+          // TODO: hacky and gets person for no reason
+          val booking = (bookingService.getBooking(node.id) as AuthorisableActionResult.Success).entity.booking
+
+          val bookingCancellationResult = bookingService.createCas1Cancellation(
+            booking = booking,
+            cancelledAt = LocalDate.now(),
+            userProvidedReason = null,
+            // TODO: this isn't correct, could be adhoc booking from app?
+            // maybe could put triggering node in?
+            notes = "Automatically withdrawn as placement request was withdrawn",
+            withdrawalContext = context,
+          )
+
+          when (bookingCancellationResult) {
+            is ValidatableActionResult.Success -> Unit
+            else -> log.error(
+              "Failed to automatically withdraw booking ${booking.id} " +
+                // TODO: for id add trigger entity id into context
+                "when withdrawing ${context.triggeringEntityType} with id TODO " +
+                "with message ${extractMessage(bookingCancellationResult)}",
+            )
+          }
+
+
+        }
+      }
+
+  }
+
+  /*
+  A
+   -> PA
+      -> PR
+          -> B
+   -> PR
+      -> B
+   -> B
+   */
+
+  fun treeForApp(application: ApprovedPremisesApplicationEntity, user: UserEntity) : WithdrawalTreeNode {
+    // TODO: adhoc booking - once merged in other branch
+
+    var children = mutableListOf<WithdrawalTreeNode>()
+
+    val placementRequestForInitialApp = placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
+
+    placementRequestForInitialApp?.let {
+      children.add(treeForPlacementReq(it, user))
+    }
+
+    val placementApplications = placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(application.id)
+
+    children.addAll(
+      placementApplications.map {
+        treeForPlacementApp(it, user)
+      }
+    )
+
+    return WithdrawalTreeNode(
+      type = WithdrawableEntityType.Application,
+      id = application.id,
+      dates = emptyList(),
+      status = applicationService.getWithdrawableState(application, user),
+      children = children
+    )
+  }
+
+  fun treeForPlacementApp(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawalTreeNode {
+    val children = placementApplication.placementRequests.map {
+      treeForPlacementReq(it, user)
+    }
+
+    return WithdrawalTreeNode(
+      type = WithdrawableEntityType.PlacementApplication,
+      id = placementApplication.id,
+      dates = placementApplication.placementDates.map { DatePeriod(it.expectedArrival,it.expectedDeparture()) },
+      status = placementApplicationService.getWithdrawableState(placementApplication, user),
+      children = children
+    )
+  }
+
+  fun treeForPlacementReq(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawalTreeNode {
+    val children = listOfNotNull(
+      placementRequest.booking?.let {
+        treeForBooking(it, user)
+      }
+    )
+
+    return WithdrawalTreeNode(
+      type = WithdrawableEntityType.PlacementRequest,
+      id = placementRequest.id,
+      dates = listOf(DatePeriod(placementRequest.expectedArrival,placementRequest.expectedDeparture())),
+      status = placementRequestService.getWithdrawableState(placementRequest, user),
+      children = children
+    )
+  }
+
+  fun treeForBooking(booking: BookingEntity, user: UserEntity): WithdrawalTreeNode {
+    return WithdrawalTreeNode(
+      type = WithdrawableEntityType.Booking,
+      id = booking.id,
+      dates = listOf(DatePeriod(booking.arrivalDate,booking.departureDate)),
+      status = bookingService.getWithdrawableState(booking, user),
+      children = emptyList()
+    )
+  }
+
 }
 
 data class WithdrawalContext(
@@ -100,3 +335,45 @@ enum class WithdrawableEntityType {
   PlacementApplication,
   Booking,
 }
+
+data class WithdrawalTreeNode(
+  // TODO: rename entityType?
+  val type: WithdrawableEntityType,
+  // TODO: rename entityId?
+  val id: UUID,
+  val dates: List<DatePeriod>,
+  val status: WithdrawableState,
+  val children: List<WithdrawalTreeNode>,
+) {
+  fun collectDescendants(): List<WithdrawalTreeNode> {
+    val result = mutableListOf<WithdrawalTreeNode>()
+    children.forEach {
+      result.add(it)
+      result.addAll(it.collectDescendants())
+    }
+    return result
+  }
+
+  fun isBlocked(): Boolean =
+     status.blocking || children.any { it.isBlocked() }
+
+  override fun toString(): String {
+    return "\n\n" + render(0)
+  }
+
+  private fun render(depth: Int): String {
+    val padding = "".padStart(depth * 3)
+    return padding + "Node($type, withdrawable:${status.withdrawable}, blocking:${status.blocking}" +
+           if(children.isNotEmpty()) {
+             "\n" + children.joinToString(separator = "") { it.render(depth + 1) } + "$padding)\n"
+           } else {
+             ")\n"
+           }
+  }
+}
+
+data class WithdrawableState (
+  val withdrawable: Boolean,
+  val userMayDirectlyWithdraw: Boolean,
+  val blocking: Boolean = false,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -342,6 +342,8 @@ class WithdrawalTest : IntegrationTestBase() {
 
             val (application, _) = createApplicationAndAssessment(applicant, allocatedTo, offenderDetails)
 
+            // TODO: this fails beacause these are (not deliberately) adhoc bookings
+            // new branch shoudl make this more realistic, and it should start working
             val booking1expectedArrival = LocalDate.now().plusDays(1)
             val booking1expectedDeparture = LocalDate.now().plusDays(6)
             val booking1 = createBooking(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableEntityType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationEmailService
@@ -95,6 +96,7 @@ class PlacementApplicationServiceTest {
     sendPlacementRequestNotifications = true,
     taskDeadlineServiceMock,
     useNewWithdrawalLogic = useNewWithdrawalLogic,
+    withdrawableService = mockk<WithdrawableService>(),
   )
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -72,6 +72,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableEntityType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
@@ -117,6 +118,7 @@ class PlacementRequestServiceTest {
     cas1PlacementRequestDomainEventService,
     "http://frontend/applications/#id",
     taskDeadlineServiceMock,
+    withdrawableService = mockk<WithdrawableService>(),
   )
 
   private val previousUser = UserEntityFactory()


### PR DESCRIPTION
This spike rewrites withdrawal cascading to be centrally managed, using a tree strucutre of related entities to determine what needs withdrawing when cascading.

This approach will make it simple to block ancestor elements being withdrawn when bookings have arrivals. This method on WithdrawalTreeNode can be used for this purpose:

fun isBlocked(): Boolean = status.blocking || children.any { it.isBlocked() }

This recursively drills down the tree to see if any descendents are blocking (to be tested!)

The tree is also used to get the initial list of withdrawables

There are various TODOs to improve things. It would be good if the top level withdrawal request was orchestrated through the tree too but this may be awkward because each entity has a diffierent type used to define the withdrawal reason. BUT - if we didn’t do this i’m not sure how we’d check if the ‘top level’ entity being withdrawn is blocked or not (although the user shouldn’t be requesting this in the first place as it will be marked as blocked when returning withdrawables, but it would be nice to be consistent just-in-case they somehow manage it)