### PR TITLE
(To Discard) Capture Case Manager Information as First Class Properties and Backfill

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AppealService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -254,14 +255,16 @@ class ApplicationsController(
     val applicationResult = when (body) {
       is UpdateApprovedPremisesApplication -> applicationService.updateApprovedPremisesApplication(
         applicationId = applicationId,
-        data = serializedData,
-        isWomensApplication = body.isWomensApplication,
-        isPipeApplication = body.isPipeApplication,
-        isEmergencyApplication = body.isEmergencyApplication,
-        isEsapApplication = body.isEsapApplication,
-        releaseType = body.releaseType?.name,
-        arrivalDate = body.arrivalDate,
-        isInapplicable = body.isInapplicable,
+        Cas1ApplicationUpdateFields(
+          data = serializedData,
+          isWomensApplication = body.isWomensApplication,
+          isPipeApplication = body.isPipeApplication,
+          isEmergencyApplication = body.isEmergencyApplication,
+          isEsapApplication = body.isEsapApplication,
+          releaseType = body.releaseType?.name,
+          arrivalDate = body.arrivalDate,
+          isInapplicable = body.isInapplicable,
+        ),
       )
 
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -264,6 +264,9 @@ class ApplicationsController(
           releaseType = body.releaseType?.name,
           arrivalDate = body.arrivalDate,
           isInapplicable = body.isInapplicable,
+          caseManagerName = body.caseManager?.name,
+          caseManagerEmail = body.caseManager?.email,
+          caseManagerTelephoneNumber = body.caseManager?.telephoneNumber,
         ),
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -316,6 +316,9 @@ class ApprovedPremisesApplicationEntity(
   @ManyToOne
   @JoinColumn(name = "ap_area_id")
   var apArea: ApAreaEntity?,
+  var caseManagerName: String?,
+  var caseManagerEmail: String?,
+  var caseManagerTelephoneNumber: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Region
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Team
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CaseManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
@@ -346,6 +347,9 @@ class ApplicationService(
       situation = null,
       inmateInOutStatusOnSubmission = null,
       apArea = null,
+      caseManagerName = null,
+      caseManagerEmail = null,
+      caseManagerTelephoneNumber = null,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -474,16 +474,20 @@ class ApplicationService(
     )
   }
 
+  data class Cas1ApplicationUpdateFields(
+    val isWomensApplication: Boolean?,
+    val isPipeApplication: Boolean?,
+    val isEmergencyApplication: Boolean?,
+    val isEsapApplication: Boolean?,
+    val releaseType: String?,
+    val arrivalDate: LocalDate?,
+    val data: String,
+    val isInapplicable: Boolean?,
+  )
+
   fun updateApprovedPremisesApplication(
     applicationId: UUID,
-    isWomensApplication: Boolean?,
-    isPipeApplication: Boolean?,
-    isEmergencyApplication: Boolean?,
-    isEsapApplication: Boolean?,
-    releaseType: String?,
-    arrivalDate: LocalDate?,
-    data: String,
-    isInapplicable: Boolean?,
+    updateFields: Cas1ApplicationUpdateFields,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()
@@ -513,18 +517,18 @@ class ApplicationService(
     }
 
     application.apply {
-      this.isInapplicable = isInapplicable
-      this.isWomensApplication = isWomensApplication
-      this.isPipeApplication = isPipeApplication
-      this.isEmergencyApplication = isEmergencyApplication
-      this.isEsapApplication = isEsapApplication
-      this.releaseType = releaseType
-      this.arrivalDate = if (arrivalDate !== null) {
-        OffsetDateTime.of(arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC)
+      this.isInapplicable = updateFields.isInapplicable
+      this.isWomensApplication = updateFields.isWomensApplication
+      this.isPipeApplication = updateFields.isPipeApplication
+      this.isEmergencyApplication = updateFields.isEmergencyApplication
+      this.isEsapApplication = updateFields.isEsapApplication
+      this.releaseType = updateFields.releaseType
+      this.arrivalDate = if (updateFields.arrivalDate !== null) {
+        OffsetDateTime.of(updateFields.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC)
       } else {
         null
       }
-      this.data = data
+      this.data = updateFields.data
     }
 
     val savedApplication = applicationRepository.save(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Region
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Team
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CaseManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
@@ -487,6 +486,9 @@ class ApplicationService(
     val arrivalDate: LocalDate?,
     val data: String,
     val isInapplicable: Boolean?,
+    val caseManagerName: String? = null,
+    val caseManagerEmail: String? = null,
+    val caseManagerTelephoneNumber: String? = null,
   )
 
   fun updateApprovedPremisesApplication(
@@ -533,6 +535,9 @@ class ApplicationService(
         null
       }
       this.data = updateFields.data
+      this.caseManagerName = updateFields.caseManagerName
+      this.caseManagerEmail = updateFields.caseManagerEmail
+      this.caseManagerTelephoneNumber = updateFields.caseManagerTelephoneNumber
     }
 
     val savedApplication = applicationRepository.save(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CaseManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
@@ -93,6 +94,7 @@ class ApplicationsTransformer(
         ),
         type = "CAS1",
         apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) },
+        caseManager = toCaseManager(jpa),
       )
 
       is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
@@ -120,6 +122,17 @@ class ApplicationsTransformer(
       )
 
       else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
+    }
+  }
+
+  fun toCaseManager(application: ApprovedPremisesApplicationEntity): CaseManager? {
+    val name = application.caseManagerName
+    val email = application.caseManagerEmail
+    val telephoneNumber = application.caseManagerTelephoneNumber
+    return if (name != null && email != null && telephoneNumber != null) {
+      CaseManager(name,email,telephoneNumber)
+    } else {
+      return null
     }
   }
 

--- a/src/main/resources/db/migration/all/20240301092808__cas1_add_case_manager_to_application.sql
+++ b/src/main/resources/db/migration/all/20240301092808__cas1_add_case_manager_to_application.sql
@@ -1,0 +1,4 @@
+ALTER TABLE approved_premises_applications
+    ADD case_manager_name text null,
+ADD case_manager_email text null,
+ADD case_manager_telephone_number text null;

--- a/src/main/resources/db/migration/all/20240301102609__cas1_backfill_case_manager.sql
+++ b/src/main/resources/db/migration/all/20240301102609__cas1_backfill_case_manager.sql
@@ -1,0 +1,10 @@
+update approved_premises_applications apa set
+    case_manager_name = cast(a.data -> 'basic-information' -> 'case-manager-information' ->> 'name' as text),
+    case_manager_email = cast(a.data -> 'basic-information' -> 'case-manager-information' ->> 'emailAddress' as text),
+    case_manager_telephone_number  = cast(a.data -> 'basic-information' -> 'case-manager-information' ->> 'phoneNumber' as text)
+from applications a
+where
+    a.id = apa.id AND
+    cast(a.data -> 'basic-information' -> 'case-manager-information' ->> 'name' as text) is not null AND
+    cast(a.data -> 'basic-information' -> 'case-manager-information' ->> 'emailAddress' as text) is not null AND
+    cast(a.data -> 'basic-information' -> 'case-manager-information' ->> 'phoneNumber' as text) is not null

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2132,6 +2132,21 @@ components:
             arrivalDate:
               type: string
               format: date
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
+    CaseManager:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+      required:
+        - name
+        - email
+        - telephoneNumber
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1638,6 +1638,8 @@ components:
               $ref: '#/components/schemas/PersonStatus'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6707,6 +6707,21 @@ components:
             arrivalDate:
               type: string
               format: date
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
+    CaseManager:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+      required:
+        - name
+        - email
+        - telephoneNumber
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6213,6 +6213,8 @@ components:
               $ref: '#/components/schemas/PersonStatus'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2615,6 +2615,21 @@ components:
             arrivalDate:
               type: string
               format: date
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
+    CaseManager:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+      required:
+        - name
+        - email
+        - telephoneNumber
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2121,6 +2121,8 @@ components:
               $ref: '#/components/schemas/PersonStatus'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2180,6 +2180,21 @@ components:
             arrivalDate:
               type: string
               format: date
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
+    CaseManager:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+      required:
+        - name
+        - email
+        - telephoneNumber
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1686,6 +1686,8 @@ components:
               $ref: '#/components/schemas/PersonStatus'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            caseManager:
+              $ref: '#/components/schemas/CaseManager'
           required:
             - createdByUserId
             - schemaVersion

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -53,6 +53,9 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var status: Yielded<ApprovedPremisesApplicationStatus> = { ApprovedPremisesApplicationStatus.STARTED }
   private var inmateInOutStatusOnSubmission: Yielded<String?> = { null }
   private var apArea: Yielded<ApAreaEntity?> = { null }
+  private var caseManagerName: Yielded<String?> = { null }
+  private var caseManagerEmail: Yielded<String?> = { null }
+  private var caseManagerTelephoneNumber: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -225,5 +228,8 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     situation = this.situation(),
     inmateInOutStatusOnSubmission = this.inmateInOutStatusOnSubmission(),
     apArea = this.apArea(),
+    caseManagerName = this.caseManagerName(),
+    caseManagerEmail = this.caseManagerEmail(),
+    caseManagerTelephoneNumber = this.caseManagerTelephoneNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -193,6 +193,18 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.apArea = { apArea }
   }
 
+  fun withCaseManagerName(name: String?) = apply {
+    this.caseManagerName = { name }
+  }
+
+  fun withCaseManagerEmail(email: String?) = apply {
+    this.caseManagerEmail = { email }
+  }
+
+  fun withCaseManagerTelephoneNumber(telephoneNumber: String?) = apply {
+    this.caseManagerTelephoneNumber = { telephoneNumber }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1976,7 +1976,6 @@ class ApplicationTest : IntegrationTestBase() {
         }
       }
     }
-
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -666,6 +666,9 @@ class ApplicationTest : IntegrationTestBase() {
           }
           """,
           )
+          withCaseManagerName("theCaseManagerName")
+          withCaseManagerEmail("theCaseManagerEmail")
+          withCaseManagerTelephoneNumber("theCaseManagerTelephoneNo")
         }
 
         CommunityAPI_mockOffenderUserAccessCall(
@@ -693,7 +696,10 @@ class ApplicationTest : IntegrationTestBase() {
             applicationEntity.createdByUser.id == it.createdByUserId &&
             applicationEntity.submittedAt?.toInstant() == it.submittedAt &&
             serializableToJsonNode(applicationEntity.data) == serializableToJsonNode(it.data) &&
-            newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema
+            newestJsonSchema.id == it.schemaVersion && !it.outdatedSchema &&
+            applicationEntity.caseManagerName == it.caseManager?.name &&
+            applicationEntity.caseManagerEmail == it.caseManager?.email &&
+            applicationEntity.caseManagerTelephoneNumber == it.caseManager?.telephoneNumber
         }
       }
     }
@@ -3381,7 +3387,7 @@ class ApplicationTest : IntegrationTestBase() {
             )
           }
 
-          val applicationEntity = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          approvedPremisesApplicationEntityFactory.produceAndPersist {
             withApplicationSchema(newestJsonSchema)
             withId(applicationId1)
             withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1138,6 +1138,9 @@ class ApplicationServiceTest {
         arrivalDate = LocalDate.parse("2023-04-17"),
         data = updatedData,
         isInapplicable = false,
+        caseManagerName = "theCaseManagerName",
+        caseManagerEmail = "theCaseManagerEmail",
+        caseManagerTelephoneNumber = "theCaseManagerPhoneNo",
       ),
     )
 
@@ -1155,6 +1158,9 @@ class ApplicationServiceTest {
     assertThat(approvedPremisesApplication.releaseType).isEqualTo("rotl")
     assertThat(approvedPremisesApplication.isInapplicable).isEqualTo(false)
     assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T00:00:00Z"))
+    assertThat(approvedPremisesApplication.caseManagerName).isEqualTo("theCaseManagerName")
+    assertThat(approvedPremisesApplication.caseManagerEmail).isEqualTo("theCaseManagerEmail")
+    assertThat(approvedPremisesApplication.caseManagerTelephoneNumber).isEqualTo("theCaseManagerPhoneNo")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -85,6 +85,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateD
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApprovedPremisesApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -926,14 +927,16 @@ class ApplicationServiceTest {
     assertThat(
       applicationService.updateApprovedPremisesApplication(
         applicationId = applicationId,
-        isWomensApplication = false,
-        isPipeApplication = null,
-        isEmergencyApplication = false,
-        isEsapApplication = false,
-        releaseType = null,
-        arrivalDate = null,
-        data = "{}",
-        isInapplicable = null,
+        Cas1ApplicationUpdateFields(
+          isWomensApplication = false,
+          isPipeApplication = null,
+          isEmergencyApplication = false,
+          isEsapApplication = false,
+          releaseType = null,
+          arrivalDate = null,
+          data = "{}",
+          isInapplicable = null,
+        ),
       ) is AuthorisableActionResult.NotFound,
     ).isTrue
   }
@@ -970,14 +973,16 @@ class ApplicationServiceTest {
     assertThat(
       applicationService.updateApprovedPremisesApplication(
         applicationId = applicationId,
-        isWomensApplication = false,
-        isPipeApplication = null,
-        isEmergencyApplication = false,
-        isEsapApplication = false,
-        releaseType = null,
-        arrivalDate = null,
-        data = "{}",
-        isInapplicable = null,
+        Cas1ApplicationUpdateFields(
+          isWomensApplication = false,
+          isPipeApplication = null,
+          isEmergencyApplication = false,
+          isEsapApplication = false,
+          releaseType = null,
+          arrivalDate = null,
+          data = "{}",
+          isInapplicable = null,
+        ),
       ) is AuthorisableActionResult.Unauthorised,
     ).isTrue
   }
@@ -1011,14 +1016,16 @@ class ApplicationServiceTest {
 
     val result = applicationService.updateApprovedPremisesApplication(
       applicationId = applicationId,
-      isWomensApplication = false,
-      isPipeApplication = null,
-      isEmergencyApplication = false,
-      isEsapApplication = false,
-      releaseType = null,
-      arrivalDate = null,
-      data = "{}",
-      isInapplicable = null,
+      Cas1ApplicationUpdateFields(
+        isWomensApplication = false,
+        isPipeApplication = null,
+        isEmergencyApplication = false,
+        isEsapApplication = false,
+        releaseType = null,
+        arrivalDate = null,
+        data = "{}",
+        isInapplicable = null,
+      ),
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1062,14 +1069,16 @@ class ApplicationServiceTest {
 
     val result = applicationService.updateApprovedPremisesApplication(
       applicationId = applicationId,
-      isWomensApplication = false,
-      isPipeApplication = null,
-      isEmergencyApplication = false,
-      isEsapApplication = false,
-      releaseType = null,
-      arrivalDate = null,
-      data = "{}",
-      isInapplicable = null,
+      Cas1ApplicationUpdateFields(
+        isWomensApplication = false,
+        isPipeApplication = null,
+        isEmergencyApplication = false,
+        isEsapApplication = false,
+        releaseType = null,
+        arrivalDate = null,
+        data = "{}",
+        isInapplicable = null,
+      ),
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1120,14 +1129,16 @@ class ApplicationServiceTest {
 
     val result = applicationService.updateApprovedPremisesApplication(
       applicationId = applicationId,
-      isWomensApplication = false,
-      isPipeApplication = true,
-      isEmergencyApplication = false,
-      isEsapApplication = false,
-      releaseType = "rotl",
-      arrivalDate = LocalDate.parse("2023-04-17"),
-      data = updatedData,
-      isInapplicable = false,
+      Cas1ApplicationUpdateFields(
+        isWomensApplication = false,
+        isPipeApplication = true,
+        isEmergencyApplication = false,
+        isEsapApplication = false,
+        releaseType = "rotl",
+        arrivalDate = LocalDate.parse("2023-04-17"),
+        data = updatedData,
+        isInapplicable = false,
+      ),
     )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -110,7 +110,13 @@ class ApplicationsTransformerTest {
   fun `transformJpaToApi transforms an Approved Premises application correctly`(args: Pair<ApiApprovedPremisesApplicationStatus, ApprovedPremisesApplicationStatus>) {
     val (apiStatus, jpaStatus) = args
 
-    val application = approvedPremisesApplicationFactory.withStatus(jpaStatus).withApArea(null).produce()
+    val application = approvedPremisesApplicationFactory
+      .withStatus(jpaStatus)
+      .withApArea(null)
+      .withCaseManagerName("caseManagerName")
+      .withCaseManagerEmail("caseManagerEmail")
+      .withCaseManagerTelephoneNumber("caseManagerTelephoneNumber")
+      .produce()
 
     val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
 
@@ -118,6 +124,9 @@ class ApplicationsTransformerTest {
     assertThat(result.createdByUserId).isEqualTo(user.id)
     assertThat(result.status).isEqualTo(apiStatus)
     assertThat(result.apArea).isNull()
+    assertThat(result.caseManager?.name).isEqualTo("caseManagerName")
+    assertThat(result.caseManager?.email).isEqualTo("caseManagerEmail")
+    assertThat(result.caseManager?.telephoneNumber).isEqualTo("caseManagerTelephoneNumber")
   }
 
   @Test
@@ -133,6 +142,24 @@ class ApplicationsTransformerTest {
 
     assertThat(result.apArea).isEqualTo(mockApArea)
     verify { mockApAreaTransformer.transformJpaToApi(apArea) }
+  }
+
+  @Test
+  fun `transformJpaToApi doesnt return case manager if not defined`() {
+    val apArea = ApAreaEntityFactory().produce()
+    val application = approvedPremisesApplicationFactory
+      .withCaseManagerName(null)
+      .withCaseManagerEmail(null)
+      .withCaseManagerTelephoneNumber(null)
+      .produce()
+
+    val mockApArea = mockk<ApArea>()
+
+    every { mockApAreaTransformer.transformJpaToApi(apArea) } returns mockApArea
+
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as ApprovedPremisesApplication
+
+    assertThat(result.caseManager).isNull()
   }
 
   @Test


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-446

* Add case manager information as first class properties on cas1 app entity
* Allow the UI to set these values when doing an application update via PUT
* Return these fields when returning applications
* Added SQL to backfill fields from information captured in data json