### PR TITLE
Feature/aps 445 bookings with arrivals blocks withdrawals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -132,6 +132,8 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
 
   fun findAllByCrn(crn: String): List<BookingEntity>
 
+  fun findAllByApplicationAndPlacementRequestIsNull(application: ApplicationEntity): List<BookingEntity>
+
   fun findAllByApplication(application: ApplicationEntity): List<BookingEntity>
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -609,6 +609,13 @@ class ApplicationService(
   fun isWithdrawableForUser(user: UserEntity, application: ApplicationEntity) =
     userAccessService.userMayWithdrawApplication(user, application)
 
+  fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = !application.isWithdrawn,
+      userMayDirectlyWithdraw = isWithdrawableForUser(user, application),
+    )
+  }
+
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {
     user.email?.let { email ->
       emailNotificationService.sendEmail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1143,7 +1143,18 @@ class BookingService(
       booking.isInCancellableStateCas1() && userAccessService.userMayCancelBooking(user, booking)
     }
 
-  fun getAllForApplication(applicationEntity: ApplicationEntity) = bookingRepository.findAllByApplication(applicationEntity)
+  fun getWithdrawableState(booking: BookingEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = booking.isInCancellableStateCas1(),
+      userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
+    )
+  }
+
+  fun getAllAdhocForApplication(applicationEntity: ApplicationEntity) =
+    bookingRepository.findAllByApplicationAndPlacementRequestIsNull(applicationEntity)
+
+  fun getAllForApplication(applicationEntity: ApplicationEntity) =
+    bookingRepository.findAllByApplication(applicationEntity)
 
   @Transactional
   fun createCas1Cancellation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -65,8 +65,10 @@ class PlacementApplicationService(
   @PostConstruct
   fun init() {
     if (!useNewWithdrawalLogic) {
-      log.warn("Old withdrawal logic is being used. This will add multiple dates to the same placement application " +
-        "on submission which limits potential withdrawal options. This behaviour is deprecated.")
+      log.warn(
+        "Old withdrawal logic is being used. This will add multiple dates to the same placement application " +
+          "on submission which limits potential withdrawal options. This behaviour is deprecated.",
+      )
     }
   }
 
@@ -198,6 +200,13 @@ class PlacementApplicationService(
     placementApplicationRepository
       .findByApplication(application)
       .filter { it.isInWithdrawableState() && userAccessService.userMayWithdrawPlacementApplication(user, it) }
+
+  fun getWithdrawableState(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = placementApplication.isInWithdrawableState(),
+      userMayDirectlyWithdraw = userAccessService.userMayWithdrawPlacementApplication(user, placementApplication),
+    )
+  }
 
   @Transactional
   fun withdrawPlacementApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -307,6 +307,13 @@ class PlacementRequestService(
           userAccessService.userMayWithdrawPlacementRequest(user, it)
       }
 
+  fun getWithdrawableState(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = placementRequest.isInWithdrawableState(),
+      userMayDirectlyWithdraw = placementRequest.isForApplicationsArrivalDate() && userAccessService.userMayWithdrawPlacementRequest(user, placementRequest),
+    )
+  }
+
   @Transactional
   fun withdrawPlacementRequest(
     placementRequestId: UUID,
@@ -481,5 +488,4 @@ class PlacementRequestService(
     val placementRequest: PlacementRequestEntity,
     val cancellations: List<CancellationEntity>,
   )
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -6,11 +6,11 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Withdrawables
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.extractMessage
 import java.time.LocalDate
+import java.util.UUID
 
 @Service
 class WithdrawableService(
@@ -18,31 +18,37 @@ class WithdrawableService(
   @Lazy private val placementRequestService: PlacementRequestService,
   @Lazy private val bookingService: BookingService,
   @Lazy private val placementApplicationService: PlacementApplicationService,
-  @Lazy private val applicationService: ApplicationService,
+  private val withdrawableTreeBuilder: WithdrawableTreeBuilder,
 ) {
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
   fun allWithdrawables(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
-  ): Withdrawables {
-    val placementRequests = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
-    val bookings = bookingService.getCancelleableCas1BookingsForUser(user, application)
-    val placementApplications = placementApplicationService.getWithdrawablePlacementApplicationsForUser(user, application)
+  ): Set<WithdrawableEntity> {
+    val rootNode = withdrawableTreeBuilder.treeForApp(application, user)
 
-    return Withdrawables(
-      applicationService.isWithdrawableForUser(user, application),
-      placementRequests = placementRequests,
-      bookings = bookings,
-      placementApplications = placementApplications,
-    )
+    if (log.isDebugEnabled) {
+      log.debug("Withdrawables tree is $rootNode")
+    }
+
+    return rootNode.flatten()
+      .filter { it.status.withdrawable }
+      .filter { it.status.userMayDirectlyWithdraw }
+      .map {
+        WithdrawableEntity(
+          it.entityType,
+          it.entityId,
+          it.dates,
+        )
+      }
+      .toSet()
   }
 
   fun withdrawAllForApplication(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
   ) {
-
     val withdrawalContext = WithdrawalContext(
       user,
       WithdrawableEntityType.Application,
@@ -93,13 +99,13 @@ class WithdrawableService(
     val now = LocalDate.now()
     val bookings = bookingService.getAllForApplication(application)
     bookings.forEach { booking ->
-      if(booking.isInCancellableStateCas1()) {
+      if (booking.isInCancellableStateCas1()) {
         val bookingCancellationResult = bookingService.createCas1Cancellation(
           booking = booking,
           cancelledAt = now,
           userProvidedReason = null,
           notes = "Automatically withdrawn as placement request was withdrawn",
-          withdrawalContext = withdrawalContext
+          withdrawalContext = withdrawalContext,
         )
 
         when (bookingCancellationResult) {
@@ -120,9 +126,25 @@ data class WithdrawalContext(
   val triggeringEntityType: WithdrawableEntityType,
 )
 
+data class WithdrawableEntity(
+  val type: WithdrawableEntityType,
+  val id: UUID,
+  val dates: List<WithdrawableDatePeriod>,
+)
+
 enum class WithdrawableEntityType {
   Application,
   PlacementRequest,
   PlacementApplication,
   Booking,
 }
+
+data class WithdrawableState(
+  val withdrawable: Boolean,
+  val userMayDirectlyWithdraw: Boolean,
+)
+
+data class WithdrawableDatePeriod(
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
@@ -1,0 +1,124 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.util.UUID
+
+/**
+ * The tree can have the following edges:
+ *
+ * > Application
+ * ---> Request for Placement
+ * ------> Match Request
+ * ---------> Placement
+ * ---> Match Request (For initial application dates)
+ * ------> Placement
+ * ---> Placement (For adhoc placements)
+ **/
+@Component
+class WithdrawableTreeBuilder(
+  @Lazy private val placementRequestService: PlacementRequestService,
+  @Lazy private val bookingService: BookingService,
+  @Lazy private val placementApplicationService: PlacementApplicationService,
+  @Lazy private val applicationService: ApplicationService,
+) {
+  fun treeForApp(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableTreeNode {
+    val children = mutableListOf<WithdrawableTreeNode>()
+
+    placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)?.let {
+      children.add(treeForPlacementReq(it, user))
+    }
+
+    placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(application.id).forEach {
+      children.add(treeForPlacementApp(it, user))
+    }
+
+    bookingService.getAllAdhocForApplication(application).forEach {
+      children.add(treeForBooking(it, user))
+    }
+
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.Application,
+      entityId = application.id,
+      status = applicationService.getWithdrawableState(application, user),
+      dates = emptyList(),
+      children = children,
+    )
+  }
+
+  private fun treeForPlacementApp(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableTreeNode {
+    val children = placementApplication.placementRequests.map { treeForPlacementReq(it, user) }
+
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.PlacementApplication,
+      entityId = placementApplication.id,
+      status = placementApplicationService.getWithdrawableState(placementApplication, user),
+      dates = placementApplication.placementDates.map { WithdrawableDatePeriod(it.expectedArrival, it.expectedDeparture()) },
+      children = children,
+    )
+  }
+
+  private fun treeForPlacementReq(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableTreeNode {
+    val children = listOfNotNull(
+      placementRequest.booking?.let {
+        treeForBooking(it, user)
+      },
+    )
+
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.PlacementRequest,
+      entityId = placementRequest.id,
+      status = placementRequestService.getWithdrawableState(placementRequest, user),
+      dates = listOf(WithdrawableDatePeriod(placementRequest.expectedArrival, placementRequest.expectedDeparture())),
+      children = children,
+    )
+  }
+
+  private fun treeForBooking(booking: BookingEntity, user: UserEntity): WithdrawableTreeNode {
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.Booking,
+      entityId = booking.id,
+      status = bookingService.getWithdrawableState(booking, user),
+      dates = listOf(WithdrawableDatePeriod(booking.arrivalDate, booking.departureDate)),
+      children = emptyList(),
+    )
+  }
+}
+
+data class WithdrawableTreeNode(
+  val entityType: WithdrawableEntityType,
+  val entityId: UUID,
+  val status: WithdrawableState,
+  val dates: List<WithdrawableDatePeriod> = emptyList(),
+  val children: List<WithdrawableTreeNode> = emptyList(),
+) {
+  fun flatten(): List<WithdrawableTreeNode> {
+    return listOf(this) + collectDescendants()
+  }
+
+  private fun collectDescendants(): List<WithdrawableTreeNode> {
+    val result = mutableListOf<WithdrawableTreeNode>()
+    children.forEach {
+      result.add(it)
+      result.addAll(it.collectDescendants())
+    }
+    return result
+  }
+
+  override fun toString(): String {
+    return "\n\n${render(0)}\n"
+  }
+
+  @SuppressWarnings("MagicNumber")
+  private fun render(depth: Int): String {
+    val padding = "  " + if (depth > 0) { "-".repeat(3 * depth) + "> " } else { "" }
+    val abbreviatedId = entityId.toString().substring(0, 3)
+    return padding + "$entityType($abbreviatedId), withdrawable:${status.withdrawable}\n" +
+      children.joinToString(separator = "") { it.render(depth + 1) }
+  }
+}


### PR DESCRIPTION
We have a requirement to be able to block entities from being withdrawn if they relate a booking that has arrivals. For example, given the following tree of entities:

```
application
  -> placement application 1
      -> placement request 1
          -> booking with no arrival
  -> placement app 2
      -> placement request 2
          -> booking with arrival
```

We should not be able to withdraw the application, placement application 2, placement request 2 and the booking with arrival.

To enable such behaviour we need to move towards a tree repsentation of an application’s entities when making decisions about what is and isn’t withdrawable. This commit is the first part of the change, add logic to build the tree  and using that to determine which entities are directly withdrawable by the given user. The existing integration tests provide us good regression for this functionality.

Subsequent commits will use this tree to plan and execute withdrawal cascading, at which point we can introduce the concept of entities blocking the withdrawal of ancestors in the tree.

Using the tree has other benefits, such as:

* Reducing code duplication (especially for cascading) and making withdrawals more consistent across all entity types
* Making it easier to comprehend what will and will not be withdrawn by rendering the tree structure using the toString() function
* Making the approach to withdrawals more flexible for future changes to behaviour