### PR TITLE
Model entities in an in-memory tree to determine what needs withdrawing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -136,6 +136,7 @@ class PlacementApplicationsController(
       withdrawalContext = WithdrawalContext(
         userService.getUserForRequest(),
         WithdrawableEntityType.PlacementApplication,
+        id,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -203,6 +203,7 @@ class PlacementRequestsController(
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          id,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -539,6 +539,7 @@ class PremisesController(
         withdrawalContext = WithdrawalContext(
           triggeringUser = user,
           triggeringEntityType = WithdrawableEntityType.Booking,
+          triggeringEntityId = booking.id,
         ),
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -132,6 +132,8 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
 
   fun findAllByCrn(crn: String): List<BookingEntity>
 
+  fun findAllByApplicationAndPlacementRequestIsNull(application: ApplicationEntity): List<BookingEntity>
+
   fun findAllByApplication(application: ApplicationEntity): List<BookingEntity>
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
@@ -45,6 +45,7 @@ class ApprovedPremisesBookingCancelSeedJob(
       withdrawalContext = WithdrawalContext(
         triggeringUser = null,
         triggeringEntityType = WithdrawableEntityType.Booking,
+        triggeringEntityId = booking.id,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
@@ -245,6 +245,7 @@ class ApprovedPremisesBookingSeedJob(
           withdrawalContext = WithdrawalContext(
             triggeringUser = null,
             triggeringEntityType = WithdrawableEntityType.Booking,
+            triggeringEntityId = createdBooking.id,
           ),
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -599,7 +599,14 @@ class ApplicationService(
           assessmentService.updateCas1AssessmentWithdrawn(it.id)
         }
 
-        withdrawableService.withdrawAllForApplication(application, user)
+        withdrawableService.withdrawApplicationDescendants(
+          application,
+          WithdrawalContext(
+            user,
+            WithdrawableEntityType.Application,
+            application.id,
+          ),
+        )
 
         return@validated success(Unit)
       },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -609,6 +609,13 @@ class ApplicationService(
   fun isWithdrawableForUser(user: UserEntity, application: ApplicationEntity) =
     userAccessService.userMayWithdrawApplication(user, application)
 
+  fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = !application.isWithdrawn,
+      userMayDirectlyWithdraw = isWithdrawableForUser(user, application),
+    )
+  }
+
   fun sendEmailApplicationWithdrawn(user: UserEntity, application: ApplicationEntity, premisesName: String?) {
     user.email?.let { email ->
       emailNotificationService.sendEmail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1143,7 +1143,18 @@ class BookingService(
       booking.isInCancellableStateCas1() && userAccessService.userMayCancelBooking(user, booking)
     }
 
-  fun getAllForApplication(applicationEntity: ApplicationEntity) = bookingRepository.findAllByApplication(applicationEntity)
+  fun getWithdrawableState(booking: BookingEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = booking.isInCancellableStateCas1(),
+      userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
+    )
+  }
+
+  fun getAllAdhocForApplication(applicationEntity: ApplicationEntity) =
+    bookingRepository.findAllByApplicationAndPlacementRequestIsNull(applicationEntity)
+
+  fun getAllForApplication(applicationEntity: ApplicationEntity) =
+    bookingRepository.findAllByApplication(applicationEntity)
 
   @Transactional
   fun createCas1Cancellation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -65,8 +65,10 @@ class PlacementApplicationService(
   @PostConstruct
   fun init() {
     if (!useNewWithdrawalLogic) {
-      log.warn("Old withdrawal logic is being used. This will add multiple dates to the same placement application " +
-        "on submission which limits potential withdrawal options. This behaviour is deprecated.")
+      log.warn(
+        "Old withdrawal logic is being used. This will add multiple dates to the same placement application " +
+          "on submission which limits potential withdrawal options. This behaviour is deprecated.",
+      )
     }
   }
 
@@ -198,6 +200,13 @@ class PlacementApplicationService(
     placementApplicationRepository
       .findByApplication(application)
       .filter { it.isInWithdrawableState() && userAccessService.userMayWithdrawPlacementApplication(user, it) }
+
+  fun getWithdrawableState(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = placementApplication.isInWithdrawableState(),
+      userMayDirectlyWithdraw = userAccessService.userMayWithdrawPlacementApplication(user, placementApplication),
+    )
+  }
 
   @Transactional
   fun withdrawPlacementApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -348,7 +348,7 @@ class PlacementRequestService(
     cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest)
     cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext)
 
-    withdrawableService.withdrawDescendants(placementRequest, withdrawalContext)
+    withdrawableService.withdrawPlacementRequestDescendants(placementRequest, withdrawalContext)
 
     return AuthorisableActionResult.Success(toPlacementRequestAndCancellations(placementRequest))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -307,6 +307,13 @@ class PlacementRequestService(
           userAccessService.userMayWithdrawPlacementRequest(user, it)
       }
 
+  fun getWithdrawableState(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableState {
+    return WithdrawableState(
+      withdrawable = placementRequest.isInWithdrawableState(),
+      userMayDirectlyWithdraw = placementRequest.isForApplicationsArrivalDate() && userAccessService.userMayWithdrawPlacementRequest(user, placementRequest),
+    )
+  }
+
   @Transactional
   fun withdrawPlacementRequest(
     placementRequestId: UUID,
@@ -481,5 +488,4 @@ class PlacementRequestService(
     val placementRequest: PlacementRequestEntity,
     val cancellations: List<CancellationEntity>,
   )
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -52,6 +52,7 @@ class WithdrawableService(
     val withdrawalContext = WithdrawalContext(
       user,
       WithdrawableEntityType.Application,
+      application.id,
     )
 
     val placementRequests = application.placementRequests
@@ -124,6 +125,7 @@ class WithdrawableService(
 data class WithdrawalContext(
   val triggeringUser: UserEntity?,
   val triggeringEntityType: WithdrawableEntityType,
+  val triggeringEntityId: UUID,
 )
 
 data class WithdrawableEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableService.kt
@@ -3,8 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Lazy
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -17,6 +20,7 @@ class WithdrawableService(
   // Added Lazy annotations here to prevent circular dependency issues
   @Lazy private val placementRequestService: PlacementRequestService,
   @Lazy private val bookingService: BookingService,
+  private val bookingRepository: BookingRepository,
   @Lazy private val placementApplicationService: PlacementApplicationService,
   private val withdrawableTreeBuilder: WithdrawableTreeBuilder,
 ) {
@@ -43,6 +47,62 @@ class WithdrawableService(
         )
       }
       .toSet()
+  }
+
+  fun withdrawDescendants(
+    placementRequest: PlacementRequestEntity,
+    context: WithdrawalContext,
+  ) {
+    withdrawDescendantsOfRootNode(
+      withdrawableTreeBuilder.treeForPlacementReq(placementRequest, context.triggeringUser!!),
+      context,
+    )
+  }
+
+  private fun withdrawDescendantsOfRootNode(
+    rootNode: WithdrawableTreeNode,
+    withdrawalContext: WithdrawalContext,
+  ) {
+    if (log.isDebugEnabled) {
+      log.debug("Tree for withdrawing descendants is $rootNode")
+    }
+
+    rootNode.collectDescendants().forEach {
+      if (it.status.withdrawable) {
+        withdraw(it, withdrawalContext)
+      }
+    }
+  }
+
+  private fun withdraw(
+    node: WithdrawableTreeNode,
+    context: WithdrawalContext,
+  ) {
+    when (node.entityType) {
+      WithdrawableEntityType.Application -> Unit
+      WithdrawableEntityType.PlacementRequest -> Unit
+      WithdrawableEntityType.PlacementApplication -> Unit
+      WithdrawableEntityType.Booking -> {
+        val booking = bookingRepository.findByIdOrNull(node.entityId)!!
+
+        val bookingCancellationResult = bookingService.createCas1Cancellation(
+          booking = booking,
+          cancelledAt = LocalDate.now(),
+          userProvidedReason = null,
+          notes = "Automatically withdrawn as ${context.triggeringEntityType.label} was withdrawn",
+          withdrawalContext = context,
+        )
+
+        when (bookingCancellationResult) {
+          is ValidatableActionResult.Success -> Unit
+          else -> log.error(
+            "Failed to automatically withdraw booking ${booking.id} " +
+              "when withdrawing ${context.triggeringEntityType.label} ${context.triggeringEntityId} " +
+              "with message ${extractMessage(bookingCancellationResult)}",
+          )
+        }
+      }
+    }
   }
 
   fun withdrawAllForApplication(
@@ -123,6 +183,12 @@ class WithdrawableService(
 }
 
 data class WithdrawalContext(
+  /**
+   * Ideally this would not be nullable, but we have seed jobs that cancel bookings
+   * that don't have an associated user. This would be an issue if seed jobs cancel
+   * any elements that can cascade withdrawals, as we assume the user is provided
+   * in these cases
+   */
   val triggeringUser: UserEntity?,
   val triggeringEntityType: WithdrawableEntityType,
   val triggeringEntityId: UUID,
@@ -134,11 +200,15 @@ data class WithdrawableEntity(
   val dates: List<WithdrawableDatePeriod>,
 )
 
-enum class WithdrawableEntityType {
-  Application,
-  PlacementRequest,
-  PlacementApplication,
-  Booking,
+enum class WithdrawableEntityType(val label: String) {
+  Application("Application"),
+
+  /**
+   * See [PlacementRequestEntity.isForApplicationsArrivalDate] for why we label this as Request for Placement
+   */
+  PlacementRequest("Request for Placement"),
+  PlacementApplication("Request for Placement"),
+  Booking("Placement"),
 }
 
 data class WithdrawableState(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
@@ -63,7 +63,7 @@ class WithdrawableTreeBuilder(
     )
   }
 
-  private fun treeForPlacementReq(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableTreeNode {
+  fun treeForPlacementReq(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableTreeNode {
     val children = listOfNotNull(
       placementRequest.booking?.let {
         treeForBooking(it, user)
@@ -101,7 +101,7 @@ data class WithdrawableTreeNode(
     return listOf(this) + collectDescendants()
   }
 
-  private fun collectDescendants(): List<WithdrawableTreeNode> {
+  fun collectDescendants(): List<WithdrawableTreeNode> {
     val result = mutableListOf<WithdrawableTreeNode>()
     children.forEach {
       result.add(it)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
@@ -1,0 +1,124 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.util.UUID
+
+/**
+ * The tree can have the following edges:
+ *
+ * > Application
+ * ---> Request for Placement
+ * ------> Match Request
+ * ---------> Placement
+ * ---> Match Request (For initial application dates)
+ * ------> Placement
+ * ---> Placement (For adhoc placements)
+ **/
+@Component
+class WithdrawableTreeBuilder(
+  @Lazy private val placementRequestService: PlacementRequestService,
+  @Lazy private val bookingService: BookingService,
+  @Lazy private val placementApplicationService: PlacementApplicationService,
+  @Lazy private val applicationService: ApplicationService,
+) {
+  fun treeForApp(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableTreeNode {
+    val children = mutableListOf<WithdrawableTreeNode>()
+
+    placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)?.let {
+      children.add(treeForPlacementReq(it, user))
+    }
+
+    placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(application.id).forEach {
+      children.add(treeForPlacementApp(it, user))
+    }
+
+    bookingService.getAllAdhocForApplication(application).forEach {
+      children.add(treeForBooking(it, user))
+    }
+
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.Application,
+      entityId = application.id,
+      status = applicationService.getWithdrawableState(application, user),
+      dates = emptyList(),
+      children = children,
+    )
+  }
+
+  private fun treeForPlacementApp(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableTreeNode {
+    val children = placementApplication.placementRequests.map { treeForPlacementReq(it, user) }
+
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.PlacementApplication,
+      entityId = placementApplication.id,
+      status = placementApplicationService.getWithdrawableState(placementApplication, user),
+      dates = placementApplication.placementDates.map { WithdrawableDatePeriod(it.expectedArrival, it.expectedDeparture()) },
+      children = children,
+    )
+  }
+
+  private fun treeForPlacementReq(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableTreeNode {
+    val children = listOfNotNull(
+      placementRequest.booking?.let {
+        treeForBooking(it, user)
+      },
+    )
+
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.PlacementRequest,
+      entityId = placementRequest.id,
+      status = placementRequestService.getWithdrawableState(placementRequest, user),
+      dates = listOf(WithdrawableDatePeriod(placementRequest.expectedArrival, placementRequest.expectedDeparture())),
+      children = children,
+    )
+  }
+
+  private fun treeForBooking(booking: BookingEntity, user: UserEntity): WithdrawableTreeNode {
+    return WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.Booking,
+      entityId = booking.id,
+      status = bookingService.getWithdrawableState(booking, user),
+      dates = listOf(WithdrawableDatePeriod(booking.arrivalDate, booking.departureDate)),
+      children = emptyList(),
+    )
+  }
+}
+
+data class WithdrawableTreeNode(
+  val entityType: WithdrawableEntityType,
+  val entityId: UUID,
+  val status: WithdrawableState,
+  val dates: List<WithdrawableDatePeriod> = emptyList(),
+  val children: List<WithdrawableTreeNode> = emptyList(),
+) {
+  fun flatten(): List<WithdrawableTreeNode> {
+    return listOf(this) + collectDescendants()
+  }
+
+  private fun collectDescendants(): List<WithdrawableTreeNode> {
+    val result = mutableListOf<WithdrawableTreeNode>()
+    children.forEach {
+      result.add(it)
+      result.addAll(it.collectDescendants())
+    }
+    return result
+  }
+
+  override fun toString(): String {
+    return "\n\n${render(0)}\n"
+  }
+
+  @SuppressWarnings("MagicNumber")
+  private fun render(depth: Int): String {
+    val padding = "  " + if (depth > 0) { "-".repeat(3 * depth) + "> " } else { "" }
+    val abbreviatedId = entityId.toString().substring(0, 3)
+    return padding + "$entityType($abbreviatedId), withdrawable:${status.withdrawable}\n" +
+      children.joinToString(separator = "") { it.render(depth + 1) }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WithdrawableTreeBuilder.kt
@@ -51,7 +51,7 @@ class WithdrawableTreeBuilder(
     )
   }
 
-  private fun treeForPlacementApp(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableTreeNode {
+  fun treeForPlacementApp(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableTreeNode {
     val children = placementApplication.placementRequests.map { treeForPlacementReq(it, user) }
 
     return WithdrawableTreeNode(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -20,6 +20,10 @@ class CancellationEntityFactory : Factory<CancellationEntity> {
   private var booking: Yielded<BookingEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
 
+  fun withDefaults() = apply {
+    withReason(CancellationReasonEntityFactory().produce())
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -95,7 +95,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
@@ -2315,8 +2317,7 @@ class ApplicationServiceTest {
       every { mockDomainEventTransformer.toWithdrawnBy(user) } returns domainEventWithdrawnBy
       every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
       every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
-
-      every { mockWithdrawableService.withdrawAllForApplication(application, user) } returns Unit
+      every { mockWithdrawableService.withdrawApplicationDescendants(application, any()) } returns Unit
 
       val authorisableActionResult = applicationService.withdrawApprovedPremisesApplication(
         application.id,
@@ -2362,7 +2363,10 @@ class ApplicationServiceTest {
       }
 
       verify(exactly = 1) {
-        mockWithdrawableService.withdrawAllForApplication(application, user)
+        mockWithdrawableService.withdrawApplicationDescendants(
+          application,
+          WithdrawalContext(user, WithdrawableEntityType.Application, application.id),
+        )
       }
     }
 
@@ -2385,7 +2389,7 @@ class ApplicationServiceTest {
       every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
       every { mockEmailNotificationService.sendEmail(any(), any(), any()) } just Runs
 
-      every { mockWithdrawableService.withdrawAllForApplication(application, user) } returns Unit
+      every { mockWithdrawableService.withdrawApplicationDescendants(application, any()) } returns Unit
 
       val authorisableActionResult =
         applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", "Some other reason")
@@ -2429,7 +2433,10 @@ class ApplicationServiceTest {
       }
 
       verify(exactly = 1) {
-        mockWithdrawableService.withdrawAllForApplication(application, user)
+        mockWithdrawableService.withdrawApplicationDescendants(
+          application,
+          WithdrawalContext(user, WithdrawableEntityType.Application, application.id),
+        )
       }
     }
 
@@ -2452,7 +2459,7 @@ class ApplicationServiceTest {
       val domainEventWithdrawnBy = WithdrawnByFactory().produce()
       every { mockDomainEventTransformer.toWithdrawnBy(user) } returns domainEventWithdrawnBy
       every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
-      every { mockWithdrawableService.withdrawAllForApplication(application, user) } returns Unit
+      every { mockWithdrawableService.withdrawApplicationDescendants(application, any()) } returns Unit
 
       applicationService.withdrawApprovedPremisesApplication(
         application.id,
@@ -2495,7 +2502,10 @@ class ApplicationServiceTest {
       }
 
       verify(exactly = 1) {
-        mockWithdrawableService.withdrawAllForApplication(application, user)
+        mockWithdrawableService.withdrawApplicationDescendants(
+          application,
+          WithdrawalContext(user, WithdrawableEntityType.Application, application.id),
+        )
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2145,6 +2145,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2176,6 +2177,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2200,6 +2202,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2231,6 +2234,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2258,6 +2262,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2319,6 +2324,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2406,6 +2412,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2454,6 +2461,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2535,6 +2543,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2621,6 +2630,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2674,6 +2684,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           triggeringEntity,
+          bookingEntity.id,
         ),
       )
 
@@ -2765,6 +2776,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2846,6 +2858,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Booking,
+          bookingEntity.id,
         ),
       )
 
@@ -2898,6 +2911,7 @@ class BookingServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          bookingEntity.id,
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -818,6 +818,7 @@ class PlacementApplicationServiceTest {
       val withdrawalContext = WithdrawalContext(
         user,
         WithdrawableEntityType.PlacementApplication,
+        placementApplication.id,
       )
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
@@ -868,6 +869,7 @@ class PlacementApplicationServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          placementApplication.id,
         ),
       )
 
@@ -906,6 +908,7 @@ class PlacementApplicationServiceTest {
           withdrawalContext = WithdrawalContext(
             user,
             triggeringEntity,
+            placementApplication.id,
           ),
         )
       }.hasMessage("Internal Server Error: Withdrawing a ${triggeringEntity.name} should not cascade to PlacementApplications")
@@ -943,6 +946,7 @@ class PlacementApplicationServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementApplication.id,
         ),
       )
 
@@ -955,6 +959,7 @@ class PlacementApplicationServiceTest {
           WithdrawalContext(
             user,
             WithdrawableEntityType.PlacementApplication,
+            placementApplication.id,
           ),
         )
       }
@@ -966,6 +971,7 @@ class PlacementApplicationServiceTest {
           WithdrawalContext(
             user,
             WithdrawableEntityType.PlacementApplication,
+            placementApplication.id,
           ),
         )
       }
@@ -1004,6 +1010,7 @@ class PlacementApplicationServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementApplication.id,
         ),
       )
 
@@ -1062,6 +1069,7 @@ class PlacementApplicationServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementApplication.id,
         ),
       )
 
@@ -1088,6 +1096,7 @@ class PlacementApplicationServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementApplication.id,
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -781,6 +781,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -807,6 +808,7 @@ class PlacementRequestServiceTest {
       val withdrawalContext = WithdrawalContext(
         user,
         WithdrawableEntityType.PlacementRequest,
+        placementRequestId,
       )
 
       val result = placementRequestService.withdrawPlacementRequest(
@@ -864,6 +866,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -908,6 +911,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -944,6 +948,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          placementRequestId,
         ),
       )
 
@@ -968,6 +973,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           triggeringEntity,
+          placementRequestId,
         ),
       )
 
@@ -1019,6 +1025,7 @@ class PlacementRequestServiceTest {
           WithdrawalContext(
             user,
             triggeringEntity,
+            placementRequestId,
           ),
         )
       }.hasMessage("Internal Server Error: Withdrawing a ${triggeringEntity.name} should not cascade to PlacementRequests")
@@ -1038,6 +1045,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -1073,6 +1081,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -1097,6 +1106,7 @@ class PlacementRequestServiceTest {
           withdrawalContext = WithdrawalContext(
             user,
             WithdrawableEntityType.PlacementRequest,
+            placementRequestId,
           ),
         )
       }
@@ -1134,6 +1144,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -1169,6 +1180,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 
@@ -1194,6 +1206,7 @@ class PlacementRequestServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementRequest,
+          placementRequestId,
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -64,7 +64,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CruService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -804,7 +803,7 @@ class PlacementRequestServiceTest {
         applicationService.updateApprovedPremisesApplicationStatus(application.id, PENDING_PLACEMENT_REQUEST)
       } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-      every { withdrawalService.withdrawDescendants(any(), any()) } returns Unit
+      every { withdrawalService.withdrawPlacementRequestDescendants(any(), any()) } returns Unit
 
       val withdrawalContext = WithdrawalContext(
         user,
@@ -832,7 +831,7 @@ class PlacementRequestServiceTest {
 
       verify { cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest) }
       verify { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext) }
-      verify { withdrawalService.withdrawDescendants(placementRequest, withdrawalContext) }
+      verify { withdrawalService.withdrawPlacementRequestDescendants(placementRequest, withdrawalContext) }
     }
 
     @Test
@@ -843,7 +842,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
+      every { withdrawalService.withdrawPlacementRequestDescendants(any(), any()) } returns Unit
 
       val withdrawnPlacementRequest = createValidPlacementRequest(application, user)
       withdrawnPlacementRequest.isWithdrawn = true
@@ -889,7 +888,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
+      every { withdrawalService.withdrawPlacementRequestDescendants(any(), any()) } returns Unit
 
       val withdrawnPlacementRequest = createValidPlacementRequest(application, user)
       withdrawnPlacementRequest.isWithdrawn = true
@@ -930,7 +929,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
+      every { withdrawalService.withdrawPlacementRequestDescendants(any(), any()) } returns Unit
 
       val withdrawnPlacementRequest = createValidPlacementRequest(application, user)
       withdrawnPlacementRequest.isWithdrawn = true
@@ -968,7 +967,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
+      every { withdrawalService.withdrawPlacementRequestDescendants(any(), any()) } returns Unit
 
       val providedReason = PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
       val result = placementRequestService.withdrawPlacementRequest(
@@ -1088,7 +1087,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
+      every { withdrawalService.withdrawPlacementRequestDescendants(any(), any()) } returns Unit
 
       val result = placementRequestService.withdrawPlacementRequest(
         placementRequestId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.NullSource
-import org.slf4j.Logger
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -73,6 +72,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableEntityType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
@@ -93,12 +93,12 @@ class PlacementRequestServiceTest {
   private val placementDateRepository = mockk<PlacementDateRepository>()
   private val cancellationRepository = mockk<CancellationRepository>()
   private val userAllocator = mockk<UserAllocator>()
-  private val bookingService = mockk<BookingService>()
   private val userAccessService = mockk<UserAccessService>()
   private val applicationService = mockk<ApplicationService>()
   private val cas1PlacementRequestEmailService = mockk<Cas1PlacementRequestEmailService>()
   private val cas1PlacementRequestDomainEventService = mockk<Cas1PlacementRequestDomainEventService>()
   private val taskDeadlineServiceMock = mockk<TaskDeadlineService>()
+  private val withdrawalService = mockk<WithdrawableService>()
 
   private val placementRequestService = PlacementRequestService(
     placementRequestRepository,
@@ -111,13 +111,13 @@ class PlacementRequestServiceTest {
     placementDateRepository,
     cancellationRepository,
     userAllocator,
-    bookingService,
     userAccessService,
     applicationService,
     cas1PlacementRequestEmailService,
     cas1PlacementRequestDomainEventService,
     "http://frontend/applications/#id",
     taskDeadlineServiceMock,
+    withdrawalService,
   )
 
   private val previousUser = UserEntityFactory()
@@ -791,7 +791,7 @@ class PlacementRequestServiceTest {
     @ParameterizedTest
     @EnumSource(PlacementRequestWithdrawalReason::class)
     @NullSource
-    fun `withdrawPlacementRequest returns Success and saves withdrawn PlacementRequest, triggering emails and domain events`(
+    fun `withdrawPlacementRequest returns Success and saves withdrawn PlacementRequest, triggering emails and domain events and cascades`(
       reason: PlacementRequestWithdrawalReason?,
     ) {
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
@@ -804,6 +804,7 @@ class PlacementRequestServiceTest {
         applicationService.updateApprovedPremisesApplicationStatus(application.id, PENDING_PLACEMENT_REQUEST)
       } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
+      every { withdrawalService.withdrawDescendants(any(), any()) } returns Unit
 
       val withdrawalContext = WithdrawalContext(
         user,
@@ -831,8 +832,7 @@ class PlacementRequestServiceTest {
 
       verify { cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest) }
       verify { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext) }
-
-      verify { bookingService wasNot Called }
+      verify { withdrawalService.withdrawDescendants(placementRequest, withdrawalContext) }
     }
 
     @Test
@@ -843,6 +843,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
+      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
 
       val withdrawnPlacementRequest = createValidPlacementRequest(application, user)
       withdrawnPlacementRequest.isWithdrawn = true
@@ -888,6 +889,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
+      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
 
       val withdrawnPlacementRequest = createValidPlacementRequest(application, user)
       withdrawnPlacementRequest.isWithdrawn = true
@@ -928,6 +930,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
+      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
 
       val withdrawnPlacementRequest = createValidPlacementRequest(application, user)
       withdrawnPlacementRequest.isWithdrawn = true
@@ -965,6 +968,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
+      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
 
       val providedReason = PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST
       val result = placementRequestService.withdrawPlacementRequest(
@@ -1052,121 +1056,6 @@ class PlacementRequestServiceTest {
       assertThat(result is AuthorisableActionResult.Success).isTrue
 
       verify { placementRequestRepository.save(any()) wasNot called }
-      verify { bookingService wasNot Called }
-    }
-
-    @Test
-    fun `withdrawPlacementRequest cascades to booking if defined`() {
-      val reason = PlacementRequestWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST
-      val booking = BookingEntityFactory().withDefaultPremises().produce()
-      placementRequest.booking = booking
-
-      every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
-      every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
-      every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequest)
-      every {
-        applicationService.updateApprovedPremisesApplicationStatus(application.id, PENDING_PLACEMENT_REQUEST)
-      } returns Unit
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
-      every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
-      every {
-        bookingService.createCas1Cancellation(any(), any(), any(), any(), any())
-      } returns mockk<ValidatableActionResult.Success<CancellationEntity>>()
-      every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-
-      val result = placementRequestService.withdrawPlacementRequest(
-        placementRequestId,
-        reason,
-        WithdrawalContext(
-          user,
-          WithdrawableEntityType.PlacementRequest,
-          placementRequestId,
-        ),
-      )
-
-      assertThat(result is AuthorisableActionResult.Success).isTrue
-
-      verify {
-        placementRequestRepository.save(
-          match {
-            it.id == placementRequestId &&
-              it.isWithdrawn &&
-              it.withdrawalReason == reason
-          },
-        )
-      }
-
-      verify {
-        bookingService.createCas1Cancellation(
-          booking = booking,
-          cancelledAt = LocalDate.now(),
-          userProvidedReason = null,
-          notes = "Automatically withdrawn as placement request was withdrawn",
-          withdrawalContext = WithdrawalContext(
-            user,
-            WithdrawableEntityType.PlacementRequest,
-            placementRequestId,
-          ),
-        )
-      }
-    }
-
-    @Test
-    fun `withdrawPlacementRequest cascades to booking if defined and logs error if fails`() {
-      val logger = mockk<Logger>()
-      placementRequestService.log = logger
-
-      val reason = PlacementRequestWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST
-
-      val booking = BookingEntityFactory().withDefaultPremises().produce()
-      placementRequest.booking = booking
-
-      every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
-      every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
-      every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequest)
-      every {
-        applicationService.updateApprovedPremisesApplicationStatus(application.id, PENDING_PLACEMENT_REQUEST)
-      } returns Unit
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
-      every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
-      every {
-        bookingService.createCas1Cancellation(any(), any(), any(), any(), any())
-      } returns ValidatableActionResult.GeneralValidationError("booking cancellation didn't work!")
-      every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
-
-      every { logger.error(any<String>()) } returns Unit
-
-      val result = placementRequestService.withdrawPlacementRequest(
-        placementRequestId,
-        reason,
-        WithdrawalContext(
-          user,
-          WithdrawableEntityType.PlacementRequest,
-          placementRequestId,
-        ),
-      )
-
-      assertThat(result is AuthorisableActionResult.Success).isTrue
-
-      verify {
-        placementRequestRepository.save(
-          match {
-            it.id == placementRequestId &&
-              it.isWithdrawn &&
-              it.withdrawalReason == reason
-          },
-        )
-      }
-
-      verify {
-        logger.error(
-          "Failed to automatically withdraw booking ${booking.id} when " +
-            "withdrawing placement request $placementRequestId with message " +
-            "booking cancellation didn't work!",
-        )
-      }
     }
 
     @Test
@@ -1199,6 +1088,7 @@ class PlacementRequestServiceTest {
       every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
+      every { withdrawalService.withdrawDescendants(any(),any()) } returns Unit
 
       val result = placementRequestService.withdrawPlacementRequest(
         placementRequestId,
@@ -1221,8 +1111,6 @@ class PlacementRequestServiceTest {
           },
         )
       }
-
-      verify { bookingService wasNot Called }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WithdrawableServiceTest.kt
@@ -235,6 +235,7 @@ class WithdrawableServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          any(),
         ),
       )
     } returns mockk<AuthorisableActionResult<PlacementRequestService.PlacementRequestAndCancellations>>()
@@ -246,6 +247,7 @@ class WithdrawableServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          any(),
         ),
       )
     } returns mockk<AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>>>()
@@ -259,6 +261,7 @@ class WithdrawableServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          any(),
         ),
       )
     } returns mockk<ValidatableActionResult.Success<CancellationEntity>>()
@@ -273,6 +276,7 @@ class WithdrawableServiceTest {
           WithdrawalContext(
             user,
             WithdrawableEntityType.Application,
+            any(),
           ),
         )
       }
@@ -286,6 +290,7 @@ class WithdrawableServiceTest {
           WithdrawalContext(
             user,
             WithdrawableEntityType.Application,
+            any(),
           ),
         )
       }
@@ -301,6 +306,7 @@ class WithdrawableServiceTest {
           WithdrawalContext(
             user,
             WithdrawableEntityType.Application,
+            any(),
           ),
         )
       }
@@ -332,6 +338,7 @@ class WithdrawableServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          any(),
         ),
       )
     } returns AuthorisableActionResult.Unauthorised()
@@ -343,6 +350,7 @@ class WithdrawableServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          any(),
         ),
       )
     } returns AuthorisableActionResult.Unauthorised()
@@ -356,6 +364,7 @@ class WithdrawableServiceTest {
         WithdrawalContext(
           user,
           WithdrawableEntityType.Application,
+          any(),
         ),
       )
     } returns ValidatableActionResult.GeneralValidationError("oh dear")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -81,6 +81,7 @@ class Cas1PlacementApplicationDomainEventServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementApplication.id,
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
@@ -83,6 +83,7 @@ class Cas1PlacementRequestDomainEventServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementRequest.id,
         ),
       )
 
@@ -156,6 +157,7 @@ class Cas1PlacementRequestDomainEventServiceTest {
         withdrawalContext = WithdrawalContext(
           user,
           WithdrawableEntityType.PlacementApplication,
+          placementRequest.id,
         ),
       )
 


### PR DESCRIPTION
We have a requirement to be able to block entities from being withdrawn if they relate a booking that has arrivals. For example, given the following tree of entities:

```
application
  -> placement application 1
      -> placement request 1
          -> booking with no arrival
  -> placement app 2
      -> placement request 2
          -> booking with arrival
```

We should not be able to withdraw the application, placement application 2, placement request 2 and the booking with arrival.

To enable such behaviour we need to move towards a tree representation of an application’s entities when making decisions about what is and isn’t withdrawable.

Building and using the tree has other benefits, such as:

* Reducing code duplication (especially for cascading) and making withdrawals more consistent across all entity types
* Making it easier to comprehend what will and will not be withdrawn by rendering the tree structure using the toString() function
* Making the approach to withdrawals more flexible for future changes to behaviour

This PR introduces a service to build this tree, use the tree to provide a list of withdrawables for a given user, and updates all entity-specific withdrawal functions to delegate to the withdrawal service to use this tree to manager withdrawals

We can also render the tree using toString() method, which is output at DEBUG level everytime a withdrawal is triggered:

```
  Application(295), withdrawable:true
  ---> PlacementRequest(3b4), withdrawable:true
  ------> Booking(a67), withdrawable:false
  ---> PlacementApplication(580), withdrawable:true
  ------> PlacementRequest(d28), withdrawable:true
  ---------> Booking(9fd), withdrawable:true
  ------> PlacementRequest(e07), withdrawable:true
  ---> PlacementApplication(56f), withdrawable:true
  ---> Booking(c00), withdrawable:true
  ---> Booking(836), withdrawable:false
```