### PR TITLE
Update CAS2 seed data to match questions

### DIFF
--- a/src/main/resources/db/seed/local+dev+test/cas2_application_data/data_A1234AI.json
+++ b/src/main/resources/db/seed/local+dev+test/cas2_application_data/data_A1234AI.json
@@ -300,7 +300,7 @@
   },
   "offending-history": {
     "any-previous-convictions": {
-      "hasAnyPreviousConvictions": "yes"
+      "hasAnyPreviousConvictions": "yesRelevantRisk"
     },
     "offence-history-data": [
       {

--- a/src/main/resources/db/seed/local+dev+test/cas2_application_data/document_A1234AI.json
+++ b/src/main/resources/db/seed/local+dev+test/cas2_application_data/document_A1234AI.json
@@ -505,7 +505,7 @@
           "questionsAndAnswers": [
             {
               "question": "Does Aadland Bertrand have any previous convictions?",
-              "answer": "Yes"
+              "answer": "Yes, and there is relevant risk"
             },
             {
               "question": "Historical offence 1",


### PR DESCRIPTION
We recently updated an offence history question[1]. This commit updates the seed data to match.

[1]
https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/786cbbe8a7c0a326859172972cd89471a708fa9b/server/form-pages/utils/questions.ts#L814