### PR TITLE
Bookings with arrivals blocks ancestor withdrawals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -251,9 +251,11 @@ data class BookingEntity(
   val arrival: ArrivalEntity?
     get() = arrivals.maxByOrNull { it.createdAt }
 
-  fun isInCancellableStateCas1() = !isCancelled && arrivals.isEmpty()
+  fun isInCancellableStateCas1() = !isCancelled && !hasArrivals()
 
   fun isActive() = !isCancelled
+
+  fun hasArrivals() = arrivals.isNotEmpty()
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -631,13 +631,10 @@ class ApplicationService(
     return CasResult.Success(Unit)
   }
 
-  fun isWithdrawableForUser(user: UserEntity, application: ApplicationEntity) =
-    userAccessService.userMayWithdrawApplication(user, application)
-
   fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = !application.isWithdrawn,
-      userMayDirectlyWithdraw = isWithdrawableForUser(user, application),
+      userMayDirectlyWithdraw = userAccessService.userMayWithdrawApplication(user, application),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1142,15 +1142,11 @@ class BookingService(
     return success(nonArrivalEntity)
   }
 
-  fun getCancelleableCas1BookingsForUser(user: UserEntity, application: ApprovedPremisesApplicationEntity): List<BookingEntity> =
-    bookingRepository.findAllByApplication(application).filter { booking ->
-      booking.isInCancellableStateCas1() && userAccessService.userMayCancelBooking(user, booking)
-    }
-
   fun getWithdrawableState(booking: BookingEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = booking.isInCancellableStateCas1(),
       userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
+      blockAncestorWithdrawals = booking.hasArrivals(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -201,11 +201,6 @@ class PlacementApplicationService(
     )
   }
 
-  fun getWithdrawablePlacementApplicationsForUser(user: UserEntity, application: ApprovedPremisesApplicationEntity) =
-    placementApplicationRepository
-      .findByApplication(application)
-      .filter { it.isInWithdrawableState() && userAccessService.userMayWithdrawPlacementApplication(user, it) }
-
   fun getWithdrawableState(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = placementApplication.isInWithdrawableState(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
@@ -291,24 +290,6 @@ class PlacementRequestService(
       bookingNotMadeRepository.save(bookingNotMade),
     )
   }
-
-  /**
-   * This should return a maximum of one placement request, representing the dates known
-   * at the point of application submission.
-   *
-   * For more information on why we do this, see [PlacementRequestEntity.isForApplicationsArrivalDate]
-   */
-  fun getWithdrawablePlacementRequestsForUser(
-    user: UserEntity,
-    application: ApprovedPremisesApplicationEntity,
-  ): List<PlacementRequestEntity> =
-    placementRequestRepository
-      .findByApplication(application)
-      .filter {
-        it.isInWithdrawableState() &&
-          it.isForApplicationsArrivalDate() &&
-          userAccessService.userMayWithdrawPlacementRequest(user, it)
-      }
 
   fun getWithdrawableState(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -114,6 +114,8 @@ data class WithdrawableTreeNode(
     return result
   }
 
+  fun isBlocked(): Boolean = status.blockAncestorWithdrawals || children.any { it.isBlocked() }
+
   override fun toString(): String {
     return "\n\n${render(0)}\n"
   }
@@ -122,7 +124,15 @@ data class WithdrawableTreeNode(
   private fun render(depth: Int): String {
     val padding = "  " + if (depth > 0) { "-".repeat(3 * depth) + "> " } else { "" }
     val abbreviatedId = entityId.toString().substring(0, 3)
-    return padding + "$entityType($abbreviatedId), withdrawable:${status.withdrawable}, mayDirectlyWithdraw:${status.userMayDirectlyWithdraw}\n" +
+    return padding + "$entityType($abbreviatedId), withdrawable:${status.withdrawable}, mayDirectlyWithdraw:${status.userMayDirectlyWithdraw}, ${blockingDescription()}\n" +
       children.joinToString(separator = "") { it.render(depth + 1) }
+  }
+
+  private fun blockingDescription() = if (status.blockAncestorWithdrawals) {
+    "BLOCKING"
+  } else if (isBlocked()) {
+    "BLOCKED"
+  } else {
+    ""
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeOperations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeOperations.kt
@@ -25,9 +25,9 @@ class Cas1WithdrawableTreeOperations(
     rootNode: WithdrawableTreeNode,
     withdrawalContext: WithdrawalContext,
   ) {
-    rootNode.collectDescendants().forEach {
-      if (it.status.withdrawable) {
-        withdraw(it, withdrawalContext)
+    rootNode.collectDescendants().forEach { descendant ->
+      if (descendant.status.withdrawable && !descendant.isBlocked()) {
+        withdraw(descendant, withdrawalContext)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/notification/EmailNotificationAsserter.kt
@@ -31,19 +31,20 @@ class EmailNotificationAsserter {
     assertEmailsRequestedCount(0)
   }
 
-  fun assertEmailRequested(toEmailAddress: String, templateId: String, personalisation: Map<String,Any> = emptyMap()) {
+  fun assertEmailRequested(toEmailAddress: String, templateId: String, personalisation: Map<String, Any> = emptyMap()) {
     val anyMatch = requestedEmails.any {
       toEmailAddress == it.email &&
-      templateId == it.templateId &&
-      it.personalisation.entries.containsAll(personalisation.entries)
+        templateId == it.templateId &&
+        it.personalisation.entries.containsAll(personalisation.entries)
     }
 
     assertThat(anyMatch)
       .withFailMessage {
-        "Could not find email request. Provided email requests are $requestedEmails"
+        "Could not find email request for template $templateId to $toEmailAddress with personalisation $personalisation. Provided email requests are ${formatRequestedEmails()}"
       }.isTrue
-
   }
+
+  fun formatRequestedEmails() = "\n" + requestedEmails.map { "\n $it" }
 
   fun assertEmailsRequestedCount(expectedCount: Int) {
     assertThat(requestedEmails.size).isEqualTo(expectedCount)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -71,10 +71,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
 import java.time.LocalDate
@@ -574,106 +574,6 @@ class PlacementRequestServiceTest {
             data.failureDescription == "some notes"
         },
       )
-    }
-  }
-
-  @Nested
-  inner class GetWithdrawablePlacementRequestsForUser {
-
-    @Test
-    fun `getWithdrawablePlacementRequestsForUser doesn't return reallocated placement requests`() {
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
-        .produce()
-
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val placementRequestWithdrawable = createValidPlacementRequest(application, user)
-
-      val placementRequestReallocated = createValidPlacementRequest(application, user)
-      placementRequestReallocated.reallocatedAt = OffsetDateTime.now()
-
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestReallocated)
-      every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequestWithdrawable) } returns true
-
-      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
-
-      assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
-    }
-
-    @Test
-    fun `getWithdrawablePlacementRequestsForUser doesn't return withdrawn placement requests`() {
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
-        .produce()
-
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val placementRequestWithdrawable = createValidPlacementRequest(application, user)
-
-      val placementRequestWithdrawn = createValidPlacementRequest(application, user)
-      placementRequestWithdrawn.isWithdrawn = true
-
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithdrawable, placementRequestWithdrawn)
-      every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequestWithdrawable) } returns true
-
-      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
-
-      assertThat(result).isEqualTo(listOf(placementRequestWithdrawable))
-    }
-
-    @Test
-    fun `getWithdrawablePlacementRequestsForUser doesn't return placement requests not from original application dates`() {
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
-        .produce()
-
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val placementRequestNotWithdrawable = createValidPlacementRequest(
-        application,
-        user,
-        placementApplication = PlacementApplicationEntityFactory()
-          .withCreatedByUser(user)
-          .withApplication(application)
-          .produce(),
-      )
-
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestNotWithdrawable)
-
-      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
-
-      assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `getWithdrawablePlacementRequestsForUser returns placement requests with bookings`() {
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(UserEntityFactory().withUnitTestControlProbationRegion().produce())
-        .produce()
-
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val placementRequestWithoutBooking = createValidPlacementRequest(application, user)
-
-      val placementRequestWithBooking = createValidPlacementRequest(application, user)
-      placementRequestWithBooking.booking = BookingEntityFactory().withDefaultPremises().produce()
-
-      every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequestWithoutBooking, placementRequestWithBooking)
-      every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequestWithoutBooking) } returns true
-      every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequestWithBooking) } returns true
-
-      val result = placementRequestService.getWithdrawablePlacementRequestsForUser(user, application)
-
-      assertThat(result).isEqualTo(listOf(placementRequestWithoutBooking, placementRequestWithBooking))
     }
   }
 


### PR DESCRIPTION
If a booking has an arrival, any related entity (match request, request for placement, application) cannot be withdrawn and are marked as blocked. Such entities will not be returned in the withdrawable list, and any attempt to withdraw one of these entities will result in a 400 error.

As part of this commit the WithdrawalTest has been effectively rewritten as so many existing tests broke. This class should now be more concise and each test has a complete description of the entity tree.