### PR TITLE
(APS-455) Add dueAt to assessment summaries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -50,6 +50,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
            a.allocated_to_user_id is not null as allocated,
            ap.crn as crn,
            apa.name as personName,
+           a.due_at as dueAt,
            CASE
              WHEN (a.decision is not null) THEN 'COMPLETED'
              WHEN (open_acn.id IS NOT NULL) THEN 'AWAITING_RESPONSE'
@@ -370,6 +371,7 @@ interface DomainAssessmentSummary {
   val decision: String?
   val crn: String
   val status: DomainAssessmentSummaryStatus?
+  val dueAt: Timestamp?
 }
 
 enum class DomainAssessmentSummaryStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -91,6 +91,7 @@ class AssessmentTransformer(
         decision = transformDomainSummaryDecisionToApi(ase.decision),
         risks = ase.riskRatings?.let { risksTransformer.transformDomainToApi(objectMapper.readValue<PersonRisks>(it), ase.crn) },
         person = personTransformer.transformModelToPersonApi(personInfo),
+        dueAt = ase.dueAt!!.toInstant(),
       )
       "temporary-accommodation" -> TemporaryAccommodationAssessmentSummary(
         type = "CAS3",

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2516,8 +2516,12 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            dueAt:
+              type: string
+              format: date-time
           required:
             - status
+            - dueAt
     TemporaryAccommodationAssessmentSummary:
       allOf:
         - $ref: '#/components/schemas/AssessmentSummary'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7091,8 +7091,12 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            dueAt:
+              type: string
+              format: date-time
           required:
             - status
+            - dueAt
     TemporaryAccommodationAssessmentSummary:
       allOf:
         - $ref: '#/components/schemas/AssessmentSummary'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3038,8 +3038,12 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            dueAt:
+              type: string
+              format: date-time
           required:
             - status
+            - dueAt
     TemporaryAccommodationAssessmentSummary:
       allOf:
         - $ref: '#/components/schemas/AssessmentSummary'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2564,8 +2564,12 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            dueAt:
+              type: string
+              format: date-time
           required:
             - status
+            - dueAt
     TemporaryAccommodationAssessmentSummary:
       allOf:
         - $ref: '#/components/schemas/AssessmentSummary'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2397,6 +2397,7 @@ class AssessmentTest : IntegrationTestBase() {
         crn = assessment.application.crn,
         allocated = assessment.allocatedToUser != null,
         status = status,
+        dueAt = assessment.dueAt?.toTimestamp(),
       )
   }
 
@@ -2413,5 +2414,6 @@ class AssessmentTest : IntegrationTestBase() {
     override val decision: String?,
     override val crn: String,
     override val status: DomainAssessmentSummaryStatus?,
+    override val dueAt: Timestamp?,
   ) : DomainAssessmentSummary
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -364,6 +364,7 @@ class AssessmentTransformerTest {
       crn = randomStringMultiCaseWithNumbers(6),
       allocated = true,
       status = null,
+      dueAt = null,
     )
 
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
@@ -395,6 +396,7 @@ class AssessmentTransformerTest {
       crn = randomStringMultiCaseWithNumbers(6),
       allocated = true,
       status = DomainAssessmentSummaryStatus.AWAITING_RESPONSE,
+      dueAt = Timestamp.from(Instant.now()),
     )
 
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
@@ -424,5 +426,6 @@ class AssessmentTransformerTest {
     override val decision: String?,
     override val crn: String,
     override val status: DomainAssessmentSummaryStatus?,
+    override val dueAt: Timestamp?,
   ) : DomainAssessmentSummary
 }


### PR DESCRIPTION
We’re currently returing the default 10 days for all assessments in the frontend which isn’t correct