### PR TITLE
Update CAS2 seed data

### DIFF
--- a/src/main/resources/db/seed/local+dev+test/cas2_application_data/data_A1234AI.json
+++ b/src/main/resources/db/seed/local+dev+test/cas2_application_data/data_A1234AI.json
@@ -13,8 +13,23 @@
       "consentDate-day": "1"
     }
   },
+  "hdc-licence-dates": {
+    "hdc-licence-dates": {
+      "hdcEligibilityDate": "2024-02-28",
+      "hdcEligibilityDate-year": "2024",
+      "hdcEligibilityDate-month": "2",
+      "hdcEligibilityDate-day": "22",
+      "conditionalReleaseDate": "2024-02-22",
+      "conditionalReleaseDate-year": "2024",
+      "conditionalReleaseDate-month": "2",
+      "conditionalReleaseDate-day": "28"
+    }
+  },
   "referrer-details": {
-    "confirm-details": { "name": "Roger Smith", "email": "rsmith@justice.example.com" },
+    "confirm-details": {
+      "name": "Roger Smith",
+      "email": "rsmith@justice.example.com"
+    },
     "job-title": { "jobTitle": "POM" },
     "contact-number": { "telephone": "07777 777 777" }
   },
@@ -333,17 +348,7 @@
     ],
     "offence-history": {}
   },
-  "hdc-licence-and-cpp-details": {
-    "hdc-licence-dates": {
-      "hdcEligibilityDate": "2024-02-28",
-      "hdcEligibilityDate-year": "2024",
-      "hdcEligibilityDate-month": "2",
-      "hdcEligibilityDate-day": "28",
-      "conditionalReleaseDate": "2024-02-22",
-      "conditionalReleaseDate-year": "2024",
-      "conditionalReleaseDate-month": "2",
-      "conditionalReleaseDate-day": "22"
-    },
+  "cpp-details-and-hdc-licence-conditions": {
     "cpp-details": {
       "name": "Roger Smith",
       "probationRegion": "Leeds",

--- a/src/main/resources/db/seed/local+dev+test/cas2_application_data/document_A1234AI.json
+++ b/src/main/resources/db/seed/local+dev+test/cas2_application_data/document_A1234AI.json
@@ -26,6 +26,19 @@
           ]
         },
         {
+          "title": "Add HDC licence dates",
+          "questionsAndAnswers": [
+            {
+              "question": "HDC eligibility date",
+              "answer": "22 February 2024"
+            },
+            {
+              "question": "Conditional release date",
+              "answer": "28 February 2024"
+            }
+          ]
+        },
+        {
           "title": "Add your details",
           "questionsAndAnswers": [
             {
@@ -522,16 +535,8 @@
           ]
         },
         {
-          "title": "Add HDC licence and CPP details",
+          "title": "Add CPP details and HDC licence conditions",
           "questionsAndAnswers": [
-            {
-              "question": "HDC eligibility date",
-              "answer": "28 February 2024"
-            },
-            {
-              "question": "Conditional release date",
-              "answer": "22 February 2024"
-            },
             {
               "question": "Who is Aadland Bertrand's Community Probation Practitioner (CPP)?",
               "answer": "Roger Smith\r\nLeeds\r\ncpp@justice.example.com\r\n01234 777 099"


### PR DESCRIPTION
Updates CAS2 seed data after changing the application schema to move HDC dates into their own task at the top of the task list.