### PR TITLE
(APS-455) Fix off by one error in emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.GovUKBankHolidaysApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilExclusiveEnd
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNextWorkingDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWorkingDay
@@ -22,6 +23,10 @@ class WorkingDayCountService(
 
   fun getWorkingDaysCount(from: LocalDate, to: LocalDate): Int {
     return from.getDaysUntilInclusive(to).filter { it.isWorkingDay(bankHolidays) }.size
+  }
+
+  fun getCompleteWorkingDaysFromNowUntil(to: LocalDate): Int {
+    return LocalDate.now().getDaysUntilExclusiveEnd(to).filter { it.isWorkingDay(bankHolidays) }.size
   }
 
   fun addWorkingDays(date: LocalDate, count: Int): LocalDate {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
@@ -79,7 +79,7 @@ class Cas1AssessmentEmailService(
     }
 
     return STANDARD_DEADLINE_COPY.format(
-      workingDayCountService.getWorkingDaysCount(LocalDate.now(), deadline.toLocalDate()).toString(),
+      workingDayCountService.getCompleteWorkingDaysFromNowUntil(deadline.toLocalDate()).toString(),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentEmailServiceTest.kt
@@ -79,7 +79,7 @@ class Cas1AssessmentEmailServiceTest {
 
     @Test
     fun `assessmentAllocated sends an email to a user if they have an email address and an emergency assessment with a deadline of next working day`() {
-      every { mockWorkingDayCountService.getWorkingDaysCount(any(), any()) } returns 2
+      every { mockWorkingDayCountService.getCompleteWorkingDaysFromNowUntil(any()) } returns 2
       val deadline = OffsetDateTime.now().plusDays(2)
 
       service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, deadline, true)
@@ -96,7 +96,7 @@ class Cas1AssessmentEmailServiceTest {
 
     @Test
     fun `assessmentAllocated sends an email to a user if they have an email address and a standard deadline`() {
-      every { mockWorkingDayCountService.getWorkingDaysCount(any(), any()) } returns 10
+      every { mockWorkingDayCountService.getCompleteWorkingDaysFromNowUntil(any()) } returns 10
       val deadline = OffsetDateTime.now().plusDays(10)
 
       service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, deadline, false)


### PR DESCRIPTION
The email notifications when people were allocated assessments were off by one, because we were counting the number of working days including today when stating how many days they have to complete the assessment (inclusive), instead of the difference in working days between the due date and today's date (exclusive).

This adds a new `getDifferenceInWorkingDays` function and uses it in the email service to let the user know how many TOTAL working days they have to complete an assessment.