### PR TITLE
Cas2 115 extend status updates report with status details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/ApplicationStatusUpdatesReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/ApplicationStatusUpdatesReportRow.kt
@@ -8,4 +8,5 @@ class ApplicationStatusUpdatesReportRow(
   val newStatus: String,
   val updatedAt: String,
   val updatedBy: String,
+  val statusDetails: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/ApplicationStatusUpdatesReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/ApplicationStatusUpdatesReportRow.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2
 
+@Suppress("LongParameterList")
 class ApplicationStatusUpdatesReportRow(
   val eventId: String,
   val applicationId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -62,6 +62,7 @@ class ReportsService(
         newStatus = row.getNewStatus(),
         updatedBy = row.getUpdatedBy(),
         updatedAt = row.getUpdatedAt(),
+        statusDetails = row.getStatusDetails(),
       )
     }
 


### PR DESCRIPTION
Reference these JIRA tickets for information: [CAS2-115](https://dsdmoj.atlassian.net/browse/CAS2-115) and [CAS2-114](https://dsdmoj.atlassian.net/browse/CAS2-114)

**Introduction**

The JSON structure of the data field in the domain events table for a record with an event type `CAS2_APPLICATION_STATUS_UPDATED` is as follows:

```JSON
{
   "eventType":"applications.cas2.application.status-updated",
   "eventDetails":{
      "applicationId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
      "applicationUrl":"http://localhost:3000/applications/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
      "personReference":{
         "noms":"XXXXXXX",
         "crn":"XXXXXXX"
      },
      "newStatus":{
         "name":"moreInfoRequested",
         "label":"More information requested",
         "description":"The prison offender manager (POM) must provide information requested for the application to progress.",
         "statusDetails":[
            {
               "name":"personalInformation",
               "label":"Personal information"
            },
            {
               "name":"healthNeeds",
               "label":"Health needs"
            },
            {
               "name":"other",
               "label":"Other"
            }
         ]
      },
      "updatedBy":{
         "username":"CAS2_ASSESSOR_USER",
         "name":"CAS2 Assessor",
         "email":"assessor@example.com",
         "origin":"XXXXX"
      },
      "updatedAt":"2024-02-03T16:28:54Z"
   },
   "id":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "timestamp":"2024-02-03T16:28:54Z",
   "eventType":"applications.cas2.application.status-updated"
}
```

The requirement is to add an additional column in the 'Application Status Updated' Excel report which contains the secondary detail information for each status update, these are included in the `statusDetail` element and need to be incuded in the Excel report, specifically the `name` values.

There may be zero, one or more details for each status update, and they should be pipe delimited and therefore the SQL query to generate the report needs to be modified to extract the value of `name` for each element within the `statusDetails` array.  Due to the JSON structure, the array needs to be unnested using `json_array_elements` and aggregated using `string_agg`.

**SQL Query Logic**

To illustrate the logic a simplified example is used to show how the query is built up.  There is also a corresponding [db-fiddle example](https://www.db-fiddle.com/f/gkd4jrYihKQjRaZnMJw3S9/6).

Start with a SQL table and insert an `id` and some JSON `data` where the first record contains no details; the second record contains one detail; and the third contains three:

```SQL
create table events (
  id INT PRIMARY KEY NOT NULL,
  data JSON
);

insert into events (id, data) values

(1, '{"status":{"name":"place withdrawn","statusDetails":[]}}'),

(2, '{"status":{"name":"placeOffered","statusDetails":[{"name": "awaiting confirmation"}]}}'),

(3, '{"status":{"name":"informationRequired","statusDetails":[{"name": "personalInformation"}, {"name": "healthNeeds"}, {"name": "other"}]}}');
```

**Query 1: Select all data from events**

```SQL
select id, data from events;
```

Results:

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/4be4ddbc-42ae-4fdc-9b97-4cecb0429850)

**Query 2: Select id and details using LATERAL join**

```SQL
select id, details from events, lateral json_array_elements(events.data -> 'status' -> 'statusDetails') as details;
```

`LATERAL` with `json_array_elements` expands the statusDetails array elements, creates new rows for each element and joins it back with the id.  More information on Postgres LATERAL can be found [here](https://www.postgresql.org/docs/current/queries-table-expressions.html#QUERIES-LATERAL).  The `lateral` keyword can be omitted from this query since it is being used with a set function but has been left for clarity.

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/41d00ea1-e7f8-4296-8146-70e0fbe16813)

**Query 3: Select the values of all 'name' keys for each row**

```SQL
select id, elements ->> 'name' from events, lateral json_array_elements(events.data -> 'status' -> 'statusDetails') as elements;
```

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/83476ea7-a979-4741-bebd-a9630ffeab30)

**Query 4: Aggregate the name values, delimit by '|' and group them by id**

```SQL
select id, string_agg(elements ->> 'name', '|') as statusDetails from events, lateral json_array_elements(events.data -> 'status' -> 'statusDetails') as elements group by id;
```

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/db540da7-9b14-474d-96e5-85f048467de3)

**Query 5: use a left join so all rows are returned from events, regardless of whether they have details or not**

This means that we include rows where statusDetails is null.  `left join lateral` requires `on true`.

```SQL
select id, string_agg(elements ->> 'name', '|') as statusDetails from events left join lateral json_array_elements(events.data -> 'status' -> 'statusDetails') as elements on true group by id;
```

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/873884be-9ef2-485b-beb9-7cfdfbac53d7)

**Query 6: use COALESCE to return a blank string for null statusDetails**

```SQL
select id, coalesce(string_agg(elements ->> 'name', '|'), '') as statusDetails from events left join lateral json_array_elements(events.data -> 'status' -> 'statusDetails') as elements on true group by id;
```

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/e9b88b7e-65d5-44fd-a0af-07249a84983d)

[CAS2-115]: https://dsdmoj.atlassian.net/browse/CAS2-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAS2-114]: https://dsdmoj.atlassian.net/browse/CAS2-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ