### PR TITLE
Remove use of mockkStatic for test stability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/WorkingDayCountService.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 @Service
 class WorkingDayCountService(
   private val govUKBankHolidaysApiClient: GovUKBankHolidaysApiClient,
+  private val timeService: TimeService,
 ) {
 
   val bankHolidays: List<LocalDate> by lazy {
@@ -26,7 +27,7 @@ class WorkingDayCountService(
   }
 
   fun getCompleteWorkingDaysFromNowUntil(to: LocalDate): Int {
-    return LocalDate.now().getDaysUntilExclusiveEnd(to).filter { it.isWorkingDay(bankHolidays) }.size
+    return timeService.nowAsLocalDate().getDaysUntilExclusiveEnd(to).filter { it.isWorkingDay(bankHolidays) }.size
   }
 
   fun addWorkingDays(date: LocalDate, count: Int): LocalDate {


### PR DESCRIPTION
We suspect that the introduction of mockkStatisc was causing test instability issues in circle. This change uses the TimeService in WorkingDayCountService to retrieve the current LocalDate, which can then be mocked in the unit test without mockkStatic