### PR TITLE
[CAS-235] -  Add end_date column to beds table for Cas3 premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -844,7 +844,7 @@ class PremisesController(
     }
 
     val room = extractResultEntityOrThrow(
-      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristicIds),
+      roomService.createRoom(premises, newRoom.name, newRoom.notes, newRoom.characteristicIds, newRoom.bedEndDate),
     )
 
     return ResponseEntity(roomTransformer.transformJpaToApi(room), HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.util.UUID
 import javax.persistence.ColumnResult
 import javax.persistence.ConstructorResult
@@ -102,6 +103,7 @@ data class BedEntity(
   @ManyToOne
   @JoinColumn(name = "room_id")
   val room: RoomEntity,
+  var endDate: LocalDate?,
 ) {
 
   override fun toString() = "BedEntity: $id"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
@@ -145,6 +145,7 @@ class ApprovedPremisesRoomsSeedJob(
         name = "${row.roomNumber} - ${row.bedCount}",
         code = row.bedCode,
         room = room,
+        null,
       ),
     )
     log.info("New bed created: ${row.bedCode} (AP: ${row.apCode} | Room: ${room.code})")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationBedspaceSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/TemporaryAccommodationBedspaceSeedJob.kt
@@ -55,7 +55,7 @@ class TemporaryAccommodationBedspaceSeedJob(
   ) {
     log.info("Creating new Temporary Accommodation bedspace '${row.bedspaceName}' on premises '${row.premisesName}'")
 
-    roomService.createRoom(premises, row.bedspaceName, row.notes, characteristics.map { it.id })
+    roomService.createRoom(premises, row.bedspaceName, row.notes, characteristics.map { it.id }, null)
   }
 
   private fun updateExistingRoom(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.time.LocalDate
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -32,6 +33,7 @@ class RoomService(
     roomName: String,
     notes: String?,
     characteristicIds: List<UUID>,
+    bedEndDate: LocalDate?,
   ): ValidatableActionResult<RoomEntity> = validated {
     // RoomEntity needs to be created before the validation so that the CharacteristicService can match the
     // model and service scopes against it.
@@ -80,7 +82,7 @@ class RoomService(
     }
 
     if (automaticallyCreateBed) {
-      val bed = createBedInternal(room, "default-bed")
+      val bed = createBedInternal(room, "default-bed", bedEndDate)
       room.beds.add(bed)
     }
 
@@ -175,30 +177,17 @@ class RoomService(
     )
   }
 
-  fun createBed(
-    room: RoomEntity,
-    bedName: String,
-  ): ValidatableActionResult<BedEntity> = validated {
-    if (bedName.isEmpty()) {
-      "$.name" hasValidationError "empty"
-    }
-
-    if (validationErrors.any()) {
-      return fieldValidationError
-    }
-
-    return success(createBedInternal(room, bedName))
-  }
-
   private fun createBedInternal(
     room: RoomEntity,
     bedName: String,
+    bedEndDate: LocalDate?,
   ): BedEntity = bedRepository.save(
     BedEntity(
       id = UUID.randomUUID(),
       name = bedName,
       code = null,
       room = room,
+      endDate = bedEndDate,
     ),
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedTransformer.kt
@@ -10,5 +10,6 @@ class BedTransformer {
     id = jpa.id,
     name = jpa.name,
     code = jpa.code,
+    bedEndDate = jpa.endDate,
   )
 }

--- a/src/main/resources/db/migration/all/20240306145525__add_enddate_to_bed.sql
+++ b/src/main/resources/db/migration/all/20240306145525__add_enddate_to_bed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE beds ADD COLUMN end_date DATE NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2939,6 +2939,11 @@ components:
           items:
             type: string
             format: uuid
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -2992,6 +2997,11 @@ components:
         code:
           type: string
           example: NEABC04
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2939,11 +2939,11 @@ components:
           items:
             type: string
             format: uuid
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified.
+          description: End date of the bed availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -2997,11 +2997,11 @@ components:
         code:
           type: string
           example: NEABC04
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified
+          description: End date of the bed availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7514,6 +7514,11 @@ components:
           items:
             type: string
             format: uuid
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -7567,6 +7572,11 @@ components:
         code:
           type: string
           example: NEABC04
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7514,11 +7514,11 @@ components:
           items:
             type: string
             format: uuid
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified.
+          description: End date of the bed availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -7572,11 +7572,11 @@ components:
         code:
           type: string
           example: NEABC04
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified
+          description: End date of the bed availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3492,6 +3492,11 @@ components:
           items:
             type: string
             format: uuid
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -3545,6 +3550,11 @@ components:
         code:
           type: string
           example: NEABC04
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3492,11 +3492,11 @@ components:
           items:
             type: string
             format: uuid
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified.
+          description: End date of the bed availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -3550,11 +3550,11 @@ components:
         code:
           type: string
           example: NEABC04
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified
+          description: End date of the bed availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2987,11 +2987,11 @@ components:
           items:
             type: string
             format: uuid
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified.
+          description: End date of the bed availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -3045,11 +3045,11 @@ components:
         code:
           type: string
           example: NEABC04
-        endDate:
+        bedEndDate:
           type: string
           format: date
           example: 2024-03-30
-          description: End date of the room availability, open for availability if not specified
+          description: End date of the bed availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2987,6 +2987,11 @@ components:
           items:
             type: string
             format: uuid
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified.
       required:
         - name
         - characteristicIds
@@ -3040,6 +3045,11 @@ components:
         code:
           type: string
           example: NEABC04
+        endDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the room availability, open for availability if not specified
       required:
         - id
         - name

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Characteristi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
 import java.util.UUID
 
 class RoomEntityFactory : Factory<RoomEntity> {
@@ -63,6 +64,7 @@ class BedEntityFactory : Factory<BedEntity> {
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var code: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
   private var room: Yielded<RoomEntity>? = null
+  private var endDate: Yielded<LocalDate>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -83,11 +85,15 @@ class BedEntityFactory : Factory<BedEntity> {
   fun withYieldedRoom(room: Yielded<RoomEntity>) = apply {
     this.room = room
   }
+  fun withEndDate(endDate: Yielded<LocalDate>) = apply {
+    this.endDate = endDate
+  }
 
   override fun produce() = BedEntity(
     id = this.id(),
     name = this.name(),
     code = this.code(),
     room = this.room?.invoke() ?: throw java.lang.RuntimeException("Must provide a room"),
+    endDate = this.endDate?.invoke(),
   )
 }


### PR DESCRIPTION
Refer [CAS-235](https://dsdmoj.atlassian.net/browse/CAS-235) for more information

This PR is to add an `endDate` to the CAS3 beds table to indicate the availability of the particular room. Similar to archive property but using `endDate`.  

I have added optional `endDate` to to the API which creates room and change the service to store the endDate in the CAS3 specific 'beds` table. 

This PR contains below changes:
1. Modify existing POST API `/premises/{premisesID}/rooms` by adding optional `endDate`
2. Modify existing GET API `/premises/{id}/rooms` by adding optional `endDate`
3.  Modify existing GET API `/premises/{id}/rooms/{roomId}` by adding optional `endDate`
4. Change the service to store the endDate into `beds` table and retrieve the same.

Note:We will have separate story to modify and use this `endDate` in search and book process


[CAS-235]: https://dsdmoj.atlassian.net/browse/CAS-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ