### PR TITLE
Remove CAS1 User Details from App Update API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -262,9 +262,6 @@ class ApplicationsController(
           releaseType = body.releaseType?.name,
           arrivalDate = body.arrivalDate,
           isInapplicable = body.isInapplicable,
-          applicantUserDetails = body.applicantUserDetails,
-          caseManagerIsNotApplicant = body.caseManagerIsNotApplicant,
-          caseManagerUserDetails = body.caseManagerUserDetails,
         ),
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -484,9 +484,6 @@ class ApplicationService(
     val arrivalDate: LocalDate?,
     val data: String,
     val isInapplicable: Boolean?,
-    val applicantUserDetails: Cas1ApplicationUserDetails?,
-    val caseManagerIsNotApplicant: Boolean?,
-    val caseManagerUserDetails: Cas1ApplicationUserDetails?,
   )
 
   @Transactional
@@ -534,9 +531,6 @@ class ApplicationService(
         null
       }
       this.data = updateFields.data
-      this.applicantUserDetails = upsertCas1ApplicationUserDetails(this.applicantUserDetails, updateFields.applicantUserDetails)
-      this.caseManagerIsNotApplicant = updateFields.caseManagerIsNotApplicant
-      this.caseManagerUserDetails = upsertCas1ApplicationUserDetails(this.caseManagerUserDetails, updateFields.caseManagerUserDetails)
     }
 
     val savedApplication = applicationRepository.save(application)

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2139,12 +2139,6 @@ components:
             arrivalDate:
               type: string
               format: date
-            applicantUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
-            caseManagerIsNotApplicant:
-              type: boolean
-            caseManagerUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6714,12 +6714,6 @@ components:
             arrivalDate:
               type: string
               format: date
-            applicantUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
-            caseManagerIsNotApplicant:
-              type: boolean
-            caseManagerUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2692,12 +2692,6 @@ components:
             arrivalDate:
               type: string
               format: date
-            applicantUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
-            caseManagerIsNotApplicant:
-              type: boolean
-            caseManagerUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2187,12 +2187,6 @@ components:
             arrivalDate:
               type: string
               format: date
-            applicantUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
-            caseManagerIsNotApplicant:
-              type: boolean
-            caseManagerUserDetails:
-              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
     UpdateTemporaryAccommodationApplication:
       allOf:
         - $ref: '#/components/schemas/UpdateApplication'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1960,17 +1960,6 @@ class ApplicationTest : IntegrationTestBase() {
                   isWomensApplication = false,
                   isPipeApplication = true,
                   type = UpdateApplicationType.CAS1,
-                  applicantUserDetails = Cas1ApplicationUserDetails(
-                    "applicantName",
-                    "applicantEmail",
-                    "applicationTelephone",
-                  ),
-                  caseManagerIsNotApplicant = false,
-                  caseManagerUserDetails = Cas1ApplicationUserDetails(
-                    "cmName",
-                    "cmEmail",
-                    "cmTelephone",
-                  ),
                 ),
               )
               .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -943,9 +943,6 @@ class ApplicationServiceTest {
             arrivalDate = null,
             data = "{}",
             isInapplicable = null,
-            applicantUserDetails = null,
-            caseManagerIsNotApplicant = null,
-            caseManagerUserDetails = null,
           ),
         ) is AuthorisableActionResult.NotFound,
       ).isTrue
@@ -976,9 +973,6 @@ class ApplicationServiceTest {
             arrivalDate = null,
             data = "{}",
             isInapplicable = null,
-            applicantUserDetails = null,
-            caseManagerIsNotApplicant = null,
-            caseManagerUserDetails = null,
           ),
         ) is AuthorisableActionResult.Unauthorised,
       ).isTrue
@@ -1003,9 +997,6 @@ class ApplicationServiceTest {
           arrivalDate = null,
           data = "{}",
           isInapplicable = null,
-          applicantUserDetails = null,
-          caseManagerIsNotApplicant = null,
-          caseManagerUserDetails = null,
         ),
       )
 
@@ -1037,9 +1028,6 @@ class ApplicationServiceTest {
           arrivalDate = null,
           data = "{}",
           isInapplicable = null,
-          applicantUserDetails = null,
-          caseManagerIsNotApplicant = null,
-          caseManagerUserDetails = null,
         ),
       )
 
@@ -1081,9 +1069,6 @@ class ApplicationServiceTest {
           arrivalDate = LocalDate.parse("2023-04-17"),
           data = updatedData,
           isInapplicable = false,
-          applicantUserDetails = Cas1ApplicationUserDetails("applicantName", "applicantEmail", "applicantPhone"),
-          caseManagerIsNotApplicant = true,
-          caseManagerUserDetails = Cas1ApplicationUserDetails("caseManagerName", "caseManagerEmail", "caseManagerPhone"),
         ),
       )
 
@@ -1101,99 +1086,9 @@ class ApplicationServiceTest {
       assertThat(approvedPremisesApplication.releaseType).isEqualTo("rotl")
       assertThat(approvedPremisesApplication.isInapplicable).isEqualTo(false)
       assertThat(approvedPremisesApplication.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T00:00:00Z"))
-      assertThat(approvedPremisesApplication.applicantUserDetails).isEqualTo(theApplicantUserDetailsEntity)
-      assertThat(approvedPremisesApplication.caseManagerIsNotApplicant).isEqualTo(true)
-      assertThat(approvedPremisesApplication.caseManagerUserDetails).isEqualTo(theCaseManagerUserDetailsEntity)
-    }
-
-    @Test
-    fun `updateApprovedPremisesApplication updates existing application user details`() {
-      setupMocksForSuccess()
-
-      val existingApplicantUserDetails = Cas1ApplicationUserDetailsEntity(UUID.randomUUID(), "oldApplicantEmail", "oldApplicantName", "oldApplicantPhone")
-      val existingCaseManagerUserDetails = Cas1ApplicationUserDetailsEntity(UUID.randomUUID(), "oldApplicantEmail", "oldApplicantName", "oldApplicantPhone")
-
-      val theUpdatedApplicantUserDetailsEntity = Cas1ApplicationUserDetailsEntityFactory().produce()
-      every {
-        mockCas1ApplicationUserDetailsRepository.save(
-          match {
-            it.id == existingApplicantUserDetails.id &&
-              it.name == "applicantName" &&
-              it.email == "applicantEmail" &&
-              it.telephoneNumber == "applicantPhone"
-          },
-        )
-      } returns theUpdatedApplicantUserDetailsEntity
-
-      val theUpdatedCaseManagerUserDetailsEntity = Cas1ApplicationUserDetailsEntityFactory().produce()
-      every {
-        mockCas1ApplicationUserDetailsRepository.save(
-          match {
-            it.id == existingCaseManagerUserDetails.id &&
-              it.name == "caseManagerName" &&
-              it.email == "caseManagerEmail" &&
-              it.telephoneNumber == "caseManagerPhone"
-          },
-        )
-      } returns theUpdatedCaseManagerUserDetailsEntity
-
-      application.applicantUserDetails = existingApplicantUserDetails
-      application.caseManagerUserDetails = existingCaseManagerUserDetails
-
-      val result = applicationService.updateApprovedPremisesApplication(
-        applicationId = applicationId,
-        Cas1ApplicationUpdateFields(
-          isWomensApplication = false,
-          isPipeApplication = true,
-          isEmergencyApplication = false,
-          isEsapApplication = false,
-          releaseType = "rotl",
-          arrivalDate = LocalDate.parse("2023-04-17"),
-          data = updatedData,
-          isInapplicable = false,
-          applicantUserDetails = Cas1ApplicationUserDetails("applicantName", "applicantEmail", "applicantPhone"),
-          caseManagerIsNotApplicant = true,
-          caseManagerUserDetails = Cas1ApplicationUserDetails("caseManagerName", "caseManagerEmail", "caseManagerPhone"),
-        ),
-      )
-
-      result as AuthorisableActionResult.Success
-      val validatableActionResult = result.entity as ValidatableActionResult.Success
-      val approvedPremisesApplication = validatableActionResult.entity as ApprovedPremisesApplicationEntity
-
-      assertThat(approvedPremisesApplication.applicantUserDetails).isEqualTo(theUpdatedApplicantUserDetailsEntity)
-      assertThat(approvedPremisesApplication.caseManagerIsNotApplicant).isEqualTo(true)
-      assertThat(approvedPremisesApplication.caseManagerUserDetails).isEqualTo(theUpdatedCaseManagerUserDetailsEntity)
-    }
-
-    @Test
-    fun `updateApprovedPremisesApplication removes existing case manager user details if subsequently nulled`() {
-      setupMocksForSuccess()
-
-      val existingCaseManagerUserDetails = Cas1ApplicationUserDetailsEntity(UUID.randomUUID(), "oldApplicantEmail", "oldApplicantName", "oldApplicantPhone")
-
-      every { mockCas1ApplicationUserDetailsRepository.delete(existingCaseManagerUserDetails) } returns Unit
-
-      application.caseManagerUserDetails = existingCaseManagerUserDetails
-
-      applicationService.updateApprovedPremisesApplication(
-        applicationId = applicationId,
-        Cas1ApplicationUpdateFields(
-          isWomensApplication = false,
-          isPipeApplication = true,
-          isEmergencyApplication = false,
-          isEsapApplication = false,
-          releaseType = "rotl",
-          arrivalDate = LocalDate.parse("2023-04-17"),
-          data = updatedData,
-          isInapplicable = false,
-          applicantUserDetails = null,
-          caseManagerIsNotApplicant = false,
-          caseManagerUserDetails = null,
-        ),
-      )
-
-      verify { mockCas1ApplicationUserDetailsRepository.delete(existingCaseManagerUserDetails) }
+      assertThat(approvedPremisesApplication.applicantUserDetails).isNull()
+      assertThat(approvedPremisesApplication.caseManagerIsNotApplicant).isNull()
+      assertThat(approvedPremisesApplication.caseManagerUserDetails).isNull()
     }
 
     private fun setupMocksForSuccess() {


### PR DESCRIPTION
These details are only used once an application is submitted, so capturing them before submission doesn’t add any value