### PR TITLE
Make CAS2 Assessment update fields nullable

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2482,9 +2482,6 @@ components:
           type: string
         assessorName:
           type: string
-      required:
-        - nacroReferralId
-        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7057,9 +7057,6 @@ components:
           type: string
         assessorName:
           type: string
-      required:
-        - nacroReferralId
-        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3035,9 +3035,6 @@ components:
           type: string
         assessorName:
           type: string
-      required:
-        - nacroReferralId
-        - assessorName
     AssessmentSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2530,9 +2530,6 @@ components:
           type: string
         assessorName:
           type: string
-      required:
-        - nacroReferralId
-        - assessorName
     AssessmentSummary:
       type: object
       properties:


### PR DESCRIPTION
The frontend updates the Assessment via a form like so

![Screenshot 2024-03-08 at 11 33 51](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/56e55979-c213-4761-a9af-78e6fd5bd8ae)

We originally thought that the frontend could send an empty string back for any fields not entered in the form, but the restClient strips out empty fields.

Because either of these fields could be `null`, we do not need to require that they both be sent by the frontend.
Because it's a PUT request, the API will still update both values sent, even if they are `null`

```
    assessmentEntity.apply {
      this.nacroReferralId = newAssessment.nacroReferralId
      this.assessorName = newAssessment.assessorName
    }
 ```
 
 I don't think this needs any further testing IMO, as we would be testing the workings of the OpenAPI typing, and that Kotlin can assign `null` to things, but open to changing it if anyone feels strongly. 