### PR TITLE
Email the Assessors when a Referrer leaves a note

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -43,6 +43,7 @@ class NotifyTemplates {
   val placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
   val cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
   val cas2NoteAddedForReferrer = "debe17a2-9f79-4d26-88a0-690dd73e2a5b"
+  val cas2NoteAddedForAssessor = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1"
   val appealSuccess = "ae21f3ae-3a4a-4df8-a1b8-2640ea80d101"
   val appealReject = "32c9c282-198d-4d43-960e-89c97f1bcf81"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
@@ -54,10 +54,25 @@ class EmailNotificationService(
       log.error("Unable to send template $templateId to user $recipientEmailAddress", notificationClientException)
     }
   }
+
+  override fun sendCas2Email(
+    recipientEmailAddress: String,
+    templateId: String,
+    personalisation: Map<String, *>,
+  ) {
+    sendEmail(
+      recipientEmailAddress,
+      templateId,
+      personalisation,
+      notifyConfig.emailAddresses.cas2ReplyToId,
+    )
+  }
 }
 
 interface EmailNotifier {
   fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>, replyToEmailId: String? = null)
+
+  fun sendCas2Email(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>)
 }
 
 data class EmailRequest(val email: String, val templateId: String, val personalisation: Map<String, *>, val replyToEmailId: String? = null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockEmailNotificationService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockEmailNotificationService.kt
@@ -18,7 +18,7 @@ class MockEmailNotificationService : EmailNotifier {
   }
 
   override fun sendCas2Email(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>) {
-    requestedEmails.add(EmailRequest(recipientEmailAddress, templateId, personalisation))
+    requestedEmails.add(EmailRequest(recipientEmailAddress, templateId, personalisation, replyToEmailId = "cbe00c2d-387b-4283-9b9c-13c8b7a61444"))
   }
 
   fun assertNoEmailsRequested() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockEmailNotificationService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockEmailNotificationService.kt
@@ -17,6 +17,10 @@ class MockEmailNotificationService : EmailNotifier {
     requestedEmails.add(EmailRequest(recipientEmailAddress, templateId, personalisation))
   }
 
+  override fun sendCas2Email(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>) {
+    requestedEmails.add(EmailRequest(recipientEmailAddress, templateId, personalisation))
+  }
+
   fun assertNoEmailsRequested() {
     assertEmailRequestCount(0)
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -203,6 +203,8 @@ user-allocations:
 
 notify:
   send-placement-request-notifications: true
+  emailaddresses:
+    cas2assessors: "assessors@example.com"
 
 feature-flags:
   cas1-use-new-withdrawal-logic: true


### PR DESCRIPTION
[CAS2-10 Jira ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-10)

> As an assessor
> I want to know when a note has been added to a referral I have reviewed
> So that I can review it in a timely manner to progress the referral

This PR adds functionality for sending an email to Assessors when a Referrer leaves a note on an Application.

It also adds some helper functions, such as one for pre-filling the `reply-to` email ID for the CAS2 team so we no longer need to manually pass it in everywhere that function is called.