### PR TITLE
[CAS-240] - Update bedEndDate with business rule

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -882,11 +882,12 @@ class PremisesController(
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
     }
 
-    if (updateRoom.name != null && premises is TemporaryAccommodationPremisesEntity) {
-      validationResult = when (val renameRoomResult = roomService.renameRoom(premises, roomId, updateRoom.name)) {
-        is AuthorisableActionResult.NotFound -> throw NotFoundProblem(roomId, "Room")
-        is AuthorisableActionResult.Success -> renameRoomResult.entity
-        is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    if (premises is TemporaryAccommodationPremisesEntity) {
+      if (updateRoom.name != null) {
+        validationResult = extractEntityFromAuthorisableActionResult(roomService.renameRoom(premises, roomId, updateRoom.name))
+      }
+      if (updateRoom.bedEndDate != null) {
+        validationResult = extractEntityFromAuthorisableActionResult(roomService.updateBedEndDate(premises, roomId, updateRoom.bedEndDate))
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.ColumnResult
 import javax.persistence.ConstructorResult
@@ -104,6 +106,8 @@ data class BedEntity(
   @JoinColumn(name = "room_id")
   val room: RoomEntity,
   var endDate: LocalDate?,
+  @CreationTimestamp
+  var createdAt: OffsetDateTime,
 ) {
 
   override fun toString() = "BedEntity: $id"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -186,6 +186,15 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     nativeQuery = true,
   )
   fun findAllCas3bookingsWithNullStatus(pageable: Pageable?): Slice<BookingEntity>
+
+  @Query(
+    "SELECT b FROM BookingEntity b " +
+      "WHERE b.bed.id = :bedId " +
+      "AND NOT EXISTS (SELECT na FROM NonArrivalEntity na WHERE na.booking = b ) " +
+      "AND b.departureDate >= :date " +
+      "AND SIZE(b.cancellations) = 0 ",
+  )
+  fun findActiveOverlappingBookingByBed(bedId: UUID, date: LocalDate): List<BookingEntity>
 }
 
 @EntityListeners(BookingListener::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesRoomsSeedJob.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ApprovedPremisesRoomsSeedJob(
@@ -146,6 +147,7 @@ class ApprovedPremisesRoomsSeedJob(
         code = row.bedCode,
         room = room,
         null,
+        createdAt = OffsetDateTime.now(),
       ),
     )
     log.info("New bed created: ${row.bedCode} (AP: ${row.apCode} | Room: ${room.code})")

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2956,6 +2956,11 @@ components:
             format: uuid
         name:
           type: string
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
       required:
         - characteristicIds
     Room:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7531,6 +7531,11 @@ components:
             format: uuid
         name:
           type: string
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
       required:
         - characteristicIds
     Room:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3509,6 +3509,11 @@ components:
             format: uuid
         name:
           type: string
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
       required:
         - characteristicIds
     Room:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3004,6 +3004,11 @@ components:
             format: uuid
         name:
           type: string
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
       required:
         - characteristicIds
     Room:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class RoomEntityFactory : Factory<RoomEntity> {
@@ -65,6 +66,7 @@ class BedEntityFactory : Factory<BedEntity> {
   private var code: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
   private var room: Yielded<RoomEntity>? = null
   private var endDate: Yielded<LocalDate>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -89,11 +91,16 @@ class BedEntityFactory : Factory<BedEntity> {
     this.endDate = endDate
   }
 
+  fun withCreatedAt(createdAt: Yielded<OffsetDateTime>) = apply {
+    this.createdAt = createdAt
+  }
+
   override fun produce() = BedEntity(
     id = this.id(),
     name = this.name(),
     code = this.code(),
     room = this.room?.invoke() ?: throw java.lang.RuntimeException("Must provide a room"),
     endDate = this.endDate?.invoke(),
+    createdAt = this.createdAt(),
   )
 }


### PR DESCRIPTION
Refer [CAS-240](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1331?selectedIssue=CAS-240) for more information.

This PR is to update the bedEnddate if its not already existing for CAS3 bed. The below changes where added as part of this PR
1. Expose existing `created_at` DB column as JPA entity element to run business rule.
2. Add a Entity Query to find existing active bookings which are overlapping with given 'bedEndDate` to make sure we are not allowing to add `bedEndDate` if we have existing bookings.
3. Service change to allow update `bedEndDate` with below business rule.
          1. Don't allow add `bedEndDate` if already existing for the Bed.
          2. Don't allow to add `bedEndDate` if its before bed `creation date`
          3. Don't allow to add `bedEndDate` if any active existing booking for the room which overlapping with `bedEndDate`
5. OpenAPI change to include `bedEndDate` attribute into existing endpoint `/premises/{premisesId}/room/{roomId}

[CAS-240]: https://dsdmoj.atlassian.net/browse/CAS-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ