### PR TITLE
(APS-459) Allow beds to be archived

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -220,7 +220,7 @@ class PremisesController(
     return ResponseEntity.ok(
       premisesWithRoomCounts.map {
         val premises = it.getPremises()
-        val totalBeds = it.getRoomCount()
+        val totalBeds = it.getBedCount()
         val availableBedsForToday = premisesService.getAvailabilityForRange(premises, LocalDate.now(), LocalDate.now().plusDays(1))
           .values.first().getFreeCapacity(totalBeds)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -39,13 +39,13 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
     """
   }
 
-  @Query("SELECT p as premises, $BED_COUNT_QUERY as roomCount  FROM PremisesEntity p")
-  fun findAllWithRoomCount(): List<PremisesWithRoomCount>
+  @Query("SELECT p as premises, $BED_COUNT_QUERY as bedCount FROM PremisesEntity p")
+  fun findAllWithBedCount(): List<PremisesWithBedCount>
 
   @Query(
-    "SELECT p as premises, $BED_COUNT_QUERY as roomCount FROM PremisesEntity p WHERE p.probationRegion.id = :probationRegionId",
+    "SELECT p as premises, $BED_COUNT_QUERY as bedCount FROM PremisesEntity p WHERE p.probationRegion.id = :probationRegionId",
   )
-  fun findAllByProbationRegion(probationRegionId: UUID): List<PremisesWithRoomCount>
+  fun findAllByProbationRegion(probationRegionId: UUID): List<PremisesWithBedCount>
 
   @Query(
     """
@@ -92,19 +92,19 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
   )
   fun findAllApprovedPremisesSummary(probationRegionId: UUID?, apAreaId: UUID?): List<ApprovedPremisesSummary>
 
-  @Query("SELECT p as premises, $BED_COUNT_QUERY as roomCount FROM PremisesEntity p WHERE TYPE(p) = :type")
-  fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesWithRoomCount>
+  @Query("SELECT p as premises, $BED_COUNT_QUERY as bedCount FROM PremisesEntity p WHERE TYPE(p) = :type")
+  fun <T : PremisesEntity> findAllByType(type: Class<T>): List<PremisesWithBedCount>
 
   @Query(
     """
         SELECT 
           p as premises, 
-          $BED_COUNT_QUERY as roomCount 
+          $BED_COUNT_QUERY as bedCount 
         FROM PremisesEntity p 
         WHERE p.probationRegion.id = :probationRegionId AND TYPE(p) = :type
     """,
   )
-  fun <T : PremisesEntity> findAllByProbationRegionAndType(probationRegionId: UUID, type: Class<T>): List<PremisesWithRoomCount>
+  fun <T : PremisesEntity> findAllByProbationRegionAndType(probationRegionId: UUID, type: Class<T>): List<PremisesWithBedCount>
 
   @Query("SELECT COUNT(p) = 0 FROM PremisesEntity p WHERE name = :name AND TYPE(p) = :type")
   fun <T : PremisesEntity> nameIsUniqueForType(name: String, type: Class<T>): Boolean
@@ -324,7 +324,7 @@ interface BookingSummary {
   fun getStatus(): BookingStatus
 }
 
-interface PremisesWithRoomCount {
+interface PremisesWithBedCount {
   fun getPremises(): PremisesEntity
-  fun getRoomCount(): Int
+  fun getBedCount(): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesWithRoomCount
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesWithBedCount
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
@@ -57,7 +57,7 @@ class PremisesService(
     ServiceName.temporaryAccommodation to TemporaryAccommodationPremisesEntity::class.java,
   )
 
-  fun getAllPremises(): List<PremisesWithRoomCount> = premisesRepository.findAllWithRoomCount()
+  fun getAllPremises(): List<PremisesWithBedCount> = premisesRepository.findAllWithBedCount()
 
   fun getAllTemporaryAccommodationPremisesSummaries(regionId: UUID): List<TemporaryAccommodationPremisesSummary> {
     return premisesRepository.findAllTemporaryAccommodationSummary(regionId)
@@ -67,16 +67,16 @@ class PremisesService(
     return premisesRepository.findAllApprovedPremisesSummary(probationRegionId, apAreaId)
   }
 
-  fun getAllPremisesInRegion(probationRegionId: UUID): List<PremisesWithRoomCount> = premisesRepository.findAllByProbationRegion(probationRegionId)
+  fun getAllPremisesInRegion(probationRegionId: UUID): List<PremisesWithBedCount> = premisesRepository.findAllByProbationRegion(probationRegionId)
 
-  fun getAllPremisesForService(service: ServiceName): List<PremisesWithRoomCount> = serviceNameToEntityType[service]?.let {
+  fun getAllPremisesForService(service: ServiceName): List<PremisesWithBedCount> = serviceNameToEntityType[service]?.let {
     premisesRepository.findAllByType(it)
   } ?: listOf()
 
   fun getAllPremisesInRegionForService(
     probationRegionId: UUID,
     service: ServiceName,
-  ): List<PremisesWithRoomCount> = serviceNameToEntityType[service]?.let {
+  ): List<PremisesWithBedCount> = serviceNameToEntityType[service]?.let {
     premisesRepository.findAllByProbationRegionAndType(probationRegionId, it)
   } ?: listOf()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import java.time.LocalDate
 import java.util.UUID
 class PremisesSummaryTest : IntegrationTestBase() {
   @Test
@@ -108,6 +109,18 @@ class PremisesSummaryTest : IntegrationTestBase() {
         withYieldedRoom { room }
       }
 
+      // Removed beds
+      bedEntityFactory.produceAndPersistMultiple(2) {
+        withYieldedRoom { room }
+        withEndDate { LocalDate.now().minusDays(5) }
+      }
+
+      // Bed scheduled for removal
+      bedEntityFactory.produceAndPersist {
+        withYieldedRoom { room }
+        withEndDate { LocalDate.now().plusDays(5) }
+      }
+
       webTestClient.get()
         .uri("/premises/summary")
         .header("Authorization", "Bearer $jwt")
@@ -122,7 +135,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
         .jsonPath("$[0].postcode").isEqualTo("NW1 6XE")
         .jsonPath("$[0].status").isEqualTo("active")
         .jsonPath("$[0].apCode").isEqualTo("APCODE")
-        .jsonPath("$[0].bedCount").isEqualTo(5)
+        .jsonPath("$[0].bedCount").isEqualTo(6)
         .jsonPath("$[0].probationRegion").isEqualTo(probationRegion.name)
         .jsonPath("$[0].apArea").isEqualTo(apArea.name)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberT
 import java.time.LocalDate
 import java.util.UUID
 import java.util.stream.Stream
+import kotlin.random.Random
 
 class PremisesTest : IntegrationTestBase() {
   @Autowired
@@ -1176,7 +1177,10 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS3")
-      }.onEach { addRoomsAndBeds(it, roomCount = 4, bedsPerRoom = 5) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 4, bedsPerRoom = 5)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val premises = cas1Premises + cas3Premises
 
@@ -1206,7 +1210,10 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS1")
-      }.onEach { addRoomsAndBeds(it, roomCount = 5, bedsPerRoom = 4) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 5, bedsPerRoom = 4)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       // Add some extra premises for the other service that shouldn't be returned
       temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
@@ -1215,7 +1222,10 @@ class PremisesTest : IntegrationTestBase() {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
         withService("CAS3")
-      }.onEach { addRoomsAndBeds(it, roomCount = 6, bedsPerRoom = 4) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 6, bedsPerRoom = 4)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val expectedJson = objectMapper.writeValueAsString(
         premises.map {
@@ -1281,13 +1291,19 @@ class PremisesTest : IntegrationTestBase() {
             withProbationRegion(region)
           }
         }
-      }.onEach { addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 10) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 10)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val cas1Premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { region }
         withService("CAS1")
-      }.onEach { addRoomsAndBeds(it, roomCount = 2, 10) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 2, 10)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       // Add some extra premises in both services for other regions that shouldn't be returned
       val otherRegion = probationRegionEntityFactory.produceAndPersist {
@@ -1305,13 +1321,19 @@ class PremisesTest : IntegrationTestBase() {
             withProbationRegion(otherRegion)
           }
         }
-      }.onEach { addRoomsAndBeds(it, roomCount = 2, 10) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 2, 10)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { otherRegion }
         withService("CAS1")
-      }.onEach { addRoomsAndBeds(it, roomCount = 1, 20) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 1, 20)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val expectedPremises = cas1Premises + cas3Premises
 
@@ -1345,14 +1367,20 @@ class PremisesTest : IntegrationTestBase() {
             withProbationRegion(user.probationRegion)
           }
         }
-      }.onEach { addRoomsAndBeds(it, roomCount = 20, 1) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 20, 1)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       // Add some extra premises in the same region but in Approved Premises that shouldn't be returned
       approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(user.probationRegion)
         withService("CAS1")
-      }.onEach { addRoomsAndBeds(it, roomCount = 5, 4) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 5, 4)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       // Add some extra premises in both services for other regions that shouldn't be returned
       val otherProbationRegion = probationRegionEntityFactory.produceAndPersist {
@@ -1370,13 +1398,19 @@ class PremisesTest : IntegrationTestBase() {
             withProbationRegion(otherProbationRegion)
           }
         }
-      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 4, 5)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withProbationRegion(otherProbationRegion)
         withService("CAS1")
-      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 4, 5)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val expectedJson = objectMapper.writeValueAsString(
         premises.map {
@@ -1405,7 +1439,10 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 4, 5)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val premisesToGet = premises[2]
       val expectedJson = objectMapper.writeValueAsString(premisesTransformer.transformJpaToApi(premises[2], 20, 20))
@@ -1429,7 +1466,10 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-      }.onEach { addRoomsAndBeds(it, roomCount = 4, 5) }
+      }.onEach {
+        addRoomsAndBeds(it, roomCount = 4, 5)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       val keyWorker = ContextStaffMemberFactory().produce()
       premises.forEach {
@@ -1543,6 +1583,7 @@ class PremisesTest : IntegrationTestBase() {
       }
 
       val rooms = addRoomsAndBeds(premises, roomCount = 4, 5)
+      addRoomsAndBeds(premises, roomCount = 1, bedsPerRoom = 1, isActive = false)
 
       val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
         withNomsNumber("26")
@@ -1676,6 +1717,7 @@ class PremisesTest : IntegrationTestBase() {
 
       val totalBeds = 20
       val rooms = addRoomsAndBeds(premises, roomCount = 4, 5)
+      addRoomsAndBeds(premises, roomCount = 1, bedsPerRoom = 1, isActive = false)
 
       val startDate = LocalDate.now()
 
@@ -2123,7 +2165,10 @@ class PremisesTest : IntegrationTestBase() {
         withYieldedProbationRegion {
           probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
         }
-      }.also { addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 5) }
+      }.also {
+        addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 5)
+        addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
+      }
 
       webTestClient.get()
         .uri("/premises/${premises.id}")
@@ -3637,12 +3682,15 @@ class PremisesTest : IntegrationTestBase() {
     )
   }
 
-  fun addRoomsAndBeds(premises: PremisesEntity, roomCount: Int, bedsPerRoom: Int): List<RoomEntity> {
+  fun addRoomsAndBeds(premises: PremisesEntity, roomCount: Int, bedsPerRoom: Int, isActive: Boolean = true): List<RoomEntity> {
     return roomEntityFactory.produceAndPersistMultiple(roomCount) {
       withYieldedPremises { premises }
     }.onEach {
       bedEntityFactory.produceAndPersistMultiple(bedsPerRoom) {
         withYieldedRoom { it }
+        if (!isActive) {
+          withEndDate { LocalDate.now().minusDays(Random.nextLong(1, 10)) }
+        }
       }
     }.map {
       roomTestRepository.getReferenceById(it.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WorkingDayCountServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/WorkingDayCountServiceTest.kt
@@ -27,7 +27,7 @@ class WorkingDayCountServiceTest {
   private val mockGovUKBankHolidaysApiClient = mockk<GovUKBankHolidaysApiClient>()
   private val mockTimeService = mockk<TimeService>()
 
-  private val workingDayCountService = WorkingDayCountService(mockGovUKBankHolidaysApiClient,mockTimeService)
+  private val workingDayCountService = WorkingDayCountService(mockGovUKBankHolidaysApiClient, mockTimeService)
 
   private val emptyBankHolidays = ClientResult.Success(
     HttpStatus.OK,


### PR DESCRIPTION
This updates the `bedCount`s where they are used to only include beds that either do not have an `endDate` or have an `endDate` of later than the current date.