### PR TITLE
(APS-338) Allow sorting tasks by person and allocated user

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -32,6 +32,9 @@
     <ID>TooManyFunctions:Dates.kt$uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Dates.kt</ID>
     <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest$fun</ID>
     <ID>UnusedPrivateProperty:MigrationJobService.kt$MigrationJobService$@Value("\${migration-job.throttle-enabled}") private val throttle: Boolean</ID>
+    <ID>CyclomaticComplexMethod:TasksTest.kt$TasksTest.GetAllReallocatableTest$@ParameterizedTest @CsvSource(value = ["createdAt,asc", "createdAt,desc", "dueAt,asc", "dueAt,desc", "person,asc", "person,desc", "allocatedTo,asc", "allocatedTo,desc"]) fun `Get all reallocatable tasks returns 200 when no type retains original sort order`(sortBy: String, sortDirection: String)</ID>
+    <ID>ThrowsCount:TasksTest.kt$TasksTest.GetAllReallocatableTest$@ParameterizedTest @CsvSource(value = ["createdAt,asc", "createdAt,desc", "dueAt,asc", "dueAt,desc", "person,asc", "person,desc", "allocatedTo,asc", "allocatedTo,desc"]) fun `Get all reallocatable tasks returns 200 when no type retains original sort order`(sortBy: String, sortDirection: String)</ID>
+    <ID>TooGenericExceptionThrown:TasksTest.kt$TasksTest.GetAllReallocatableTest$throw RuntimeException("Unexpected sortField $sortBy")</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -21,11 +21,14 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         cast(assessment.id as TEXT) AS id,
         assessment.created_at AS created_at,
         assessment.due_at AS due_at,
-        'ASSESSMENT' AS type
+        'ASSESSMENT' AS type,
+        application.name as person,
+        u.name as allocated_to
       FROM
         assessments assessment
         INNER JOIN approved_premises_applications application ON assessment.application_id = application.id
         LEFT JOIN ap_areas area ON area.id = application.ap_area_id
+        LEFT JOIN users u ON u.id = assessment.allocated_to_user_id
       WHERE
         'ASSESSMENT' in :taskTypes AND
         assessment.is_withdrawn IS NOT TRUE
@@ -51,11 +54,14 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         cast(placement_application.id as TEXT) AS id,
         placement_application.created_at AS created_at,
         placement_application.due_at AS due_at,
-        'PLACEMENT_APPLICATION' AS type
+        'PLACEMENT_APPLICATION' AS type,
+        application.name as person,
+        u.name as allocated_to
       from
         placement_applications placement_application
         INNER JOIN approved_premises_applications application ON placement_application.application_id = application.id
         LEFT JOIN ap_areas area ON area.id = application.ap_area_id
+        LEFT JOIN users u ON u.id = placement_application.allocated_to_user_id
       WHERE
         'PLACEMENT_APPLICATION' in :taskTypes AND
         placement_application.submitted_at IS NOT NULL
@@ -81,12 +87,15 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         cast(placement_request.id as TEXT) AS id,
         placement_request.created_at AS created_at,
         placement_request.due_at AS due_at,
-        'PLACEMENT_REQUEST' AS type
+        'PLACEMENT_REQUEST' AS type,
+        application.name as person,
+        u.name as allocated_to
       FROM
         placement_requests placement_request
         INNER JOIN approved_premises_applications application ON placement_request.application_id = application.id
         LEFT JOIN booking_not_mades booking_not_made ON booking_not_made.placement_request_id = placement_request.id
         LEFT JOIN ap_areas area ON area.id = application.ap_area_id
+        LEFT JOIN users u ON u.id = placement_request.allocated_to_user_id
       WHERE
         'PLACEMENT_REQUEST' IN :taskTypes AND
         placement_request.booking_id IS NULL
@@ -177,6 +186,8 @@ data class Task(
   val createdAt: LocalDateTime,
   @Enumerated(EnumType.STRING)
   val type: TaskEntityType,
+  val person: String,
+  val allocatedTo: String?,
 )
 
 enum class TaskEntityType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -106,6 +106,8 @@ class TaskService(
         when (pageCriteria.sortBy) {
           TaskSortField.createdAt -> "created_at"
           TaskSortField.dueAt -> "due_at"
+          TaskSortField.allocatedTo -> "allocated_to"
+          TaskSortField.person -> "person"
         },
       ),
     )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -299,6 +299,8 @@ components:
       enum:
         - createdAt
         - dueAt
+        - person
+        - allocatedTo
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4874,6 +4874,8 @@ components:
       enum:
         - createdAt
         - dueAt
+        - person
+        - allocatedTo
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -852,6 +852,8 @@ components:
       enum:
         - createdAt
         - dueAt
+        - person
+        - allocatedTo
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -347,6 +347,8 @@ components:
       enum:
         - createdAt
         - dueAt
+        - person
+        - allocatedTo
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -25,6 +25,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
   apArea: ApAreaEntity? = null,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
+  name: String? = null,
 ): PlacementApplicationEntity {
   val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
@@ -45,6 +46,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
       }
     },
     apArea = apArea,
+    name = name,
   )
 
   return placementApplicationFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -26,6 +26,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   isWithdrawn: Boolean = false,
   apArea: ApAreaEntity? = null,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
+  name: String? = null,
 ): Pair<AssessmentEntity, ApprovedPremisesApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
@@ -44,6 +45,9 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withReleaseType("licence")
     withIsWithdrawn(isWithdrawn)
     withApArea(apArea)
+    if (name !== null) {
+      withName(name)
+    }
   }
 
   val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
@@ -81,6 +85,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   data: String? = "{ \"some\": \"data\"}",
   decision: AssessmentDecision? = null,
   submittedAt: OffsetDateTime? = null,
+  dueAt: OffsetDateTime? = null,
   block: (assessment: AssessmentEntity, application: ApprovedPremisesApplicationEntity) -> Unit,
 ) {
   val (assessment, application) = `Given an Assessment for Approved Premises`(
@@ -91,6 +96,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     data,
     decision,
     submittedAt,
+    dueAt,
   )
 
   block(assessment, application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -311,9 +311,33 @@ class TaskServiceTest {
     val placementApplications = List(4) { generatePlacementApplication() }
     val placementRequests = List(4) { generatePlacementRequest() }
 
-    val assessmentTasks = assessments.map { Task(it.id, it.createdAt.toLocalDateTime(), TaskEntityType.ASSESSMENT) }
-    val placementApplicationTasks = placementApplications.map { Task(it.id, it.createdAt.toLocalDateTime(), TaskEntityType.PLACEMENT_APPLICATION) }
-    val placementRequestTasks = placementRequests.map { Task(it.id, it.createdAt.toLocalDateTime(), TaskEntityType.PLACEMENT_REQUEST) }
+    val assessmentTasks = assessments.map {
+      Task(
+        it.id,
+        it.createdAt.toLocalDateTime(),
+        TaskEntityType.ASSESSMENT,
+        (it.application as ApprovedPremisesApplicationEntity).name,
+        it.allocatedToUser?.name,
+      )
+    }
+    val placementApplicationTasks = placementApplications.map {
+      Task(
+        it.id,
+        it.createdAt.toLocalDateTime(),
+        TaskEntityType.PLACEMENT_APPLICATION,
+        it.application.name,
+        it.allocatedToUser?.name,
+      )
+    }
+    val placementRequestTasks = placementRequests.map {
+      Task(
+        it.id,
+        it.createdAt.toLocalDateTime(),
+        TaskEntityType.PLACEMENT_REQUEST,
+        it.application.name,
+        it.allocatedToUser?.name,
+      )
+    }
 
     val tasks = listOf(
       assessmentTasks,


### PR DESCRIPTION
This adds two new fields to sort by:

- `person` to sort by the offender’s name; and
- `allocatedTo` to sort by the allocated user’s name