### PR TITLE
(APS-459) Hide archived beds in bed summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -66,7 +66,7 @@ const val bedSummaryQuery =
   query =
   """
     $bedSummaryQuery
-    where r.premises_id = cast(?1 as UUID)
+    where r.premises_id = cast(?1 as UUID) and (b.end_date is null or b.end_date > CURRENT_DATE)
   """,
   resultSetMapping = "DomainBedSummaryMapping",
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -34,7 +34,7 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
           JOIN b.room r
         WHERE 
             r.premises = p 
-            AND b.endDate IS NULL OR b.endDate >= CURRENT_DATE
+            AND b.endDate IS NULL OR b.endDate > CURRENT_DATE
     )
     """
   }
@@ -82,7 +82,7 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
         ) 
         FROM ApprovedPremisesEntity p 
         LEFT JOIN p.rooms r 
-        LEFT JOIN r.beds b on (b.endDate IS NULL OR b.endDate >= CURRENT_DATE) 
+        LEFT JOIN r.beds b on (b.endDate IS NULL OR b.endDate > CURRENT_DATE) 
         LEFT JOIN p.probationRegion region
         LEFT JOIN region.apArea apArea
         WHERE(cast(:probationRegionId as text) IS NULL OR region.id = :probationRegionId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -83,6 +83,15 @@ class BedSummaryQueryTest : IntegrationTestBase() {
       )
     }
 
+    bedEntityFactory.produceAndPersist {
+      withRoom(
+        roomEntityFactory.produceAndPersist {
+          withPremises(premises)
+        },
+      )
+      withEndDate { LocalDate.now().minusDays(7) }
+    }
+
     bookingEntityFactory.produceAndPersist {
       withPremises(premises)
       withBed(bedWithBooking)


### PR DESCRIPTION
When returning the bed summary, only list the “live” beds (i.e do not have an `endDate` or have an `endDate` of later than the current date)