### PR TITLE
Capture triggering user in domain events and show on Timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
@@ -26,6 +27,8 @@ import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
@@ -76,6 +79,7 @@ data class DomainEventEntity(
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   val data: String,
   val service: String,
+  val triggeredByUserId: UUID?,
 ) {
   final inline fun <reified T> toDomainEvent(objectMapper: ObjectMapper): DomainEvent<T> {
     val data = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -36,21 +36,22 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
   @Query(
     """
-      SELECT 
-        cast(d.id as TEXT), 
-        d.type, 
-        d.occurred_at as occurredAt,
-        cast(d.application_id as TEXT) as applicationId,
-        cast(d.assessment_id as TEXT) as assessmentId,
-        cast(d.booking_id as TEXT) as bookingId,
-        cast(b.premises_id as TEXT) as premisesId,
-        cast(a.id as TEXT) as appealId
-      FROM domain_events d 
-      LEFT OUTER JOIN bookings b ON b.id = d.booking_id
-      LEFT OUTER JOIN appeals a ON d.application_id = a.application_id
-      WHERE d.application_id = :applicationId
-    """,
-    nativeQuery = true,
+     SELECT 
+        d.id as id,
+        d.type as type, 
+        d.occurredAt as occurredAt,
+        d.applicationId as applicationId,
+        d.assessmentId as assessmentId,
+        d.bookingId as bookingId,
+        b.premises.id as premisesId,
+        a.id as appealId,
+        u as triggeredByUser
+      FROM DomainEventEntity d 
+      LEFT OUTER JOIN BookingEntity b ON b.id = d.bookingId
+      LEFT OUTER JOIN AppealEntity a ON a.application.id = d.applicationId 
+      LEFT OUTER JOIN UserEntity u ON u.id = d.triggeredByUserId
+      WHERE d.applicationId = :applicationId
+    """
   )
   fun findAllTimelineEventsByApplicationId(applicationId: UUID): List<DomainEventSummary>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
@@ -1,16 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import java.sql.Timestamp
+import java.time.OffsetDateTime
 import java.util.UUID
 
 interface DomainEventSummary {
   val id: String
   val type: DomainEventType
-  val occurredAt: Timestamp
+  val occurredAt: OffsetDateTime
   val applicationId: UUID?
   val assessmentId: UUID?
   val bookingId: UUID?
   val premisesId: UUID?
   val appealId: UUID?
+  val triggeredByUser: UserEntity?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -37,6 +37,7 @@ class DomainEventService(
   private val objectMapper: ObjectMapper,
   private val domainEventRepository: DomainEventRepository,
   val domainEventWorker: ConfiguredDomainEventWorker,
+  private val userService: UserService,
   @Value("\${domain-events.cas1.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
   @Value("\${url-templates.api.cas1.application-submitted-event-detail}") private val applicationSubmittedDetailUrlTemplate: String,
   @Value("\${url-templates.api.cas1.application-assessed-event-detail}") private val applicationAssessedDetailUrlTemplate: String,
@@ -250,6 +251,7 @@ class DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS1",
+        triggeredByUserId = userService.getUserForRequestOrNull()?.id,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingTopicException
 import java.time.OffsetDateTime
@@ -107,6 +108,7 @@ class DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS2",
+        triggeredByUserId = null,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingTopicException
 import java.time.OffsetDateTime
@@ -231,6 +232,7 @@ class DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS3",
+        triggeredByUserId = null,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
@@ -18,6 +19,7 @@ class ApplicationTimelineTransformer(
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-appeal}") private val appealUrlTemplate: UrlTemplate,
   private val domainEventDescriber: DomainEventDescriber,
+  private val userTransformer: UserTransformer,
 ) {
 
   fun transformDomainEventSummaryToTimelineEvent(domainEventSummary: DomainEventSummary): TimelineEvent {
@@ -29,6 +31,7 @@ class ApplicationTimelineTransformer(
       occurredAt = domainEventSummary.occurredAt.toInstant(),
       associatedUrls = associatedUrls,
       content = domainEventDescriber.getDescription(domainEventSummary),
+      createdBy = domainEventSummary.triggeredByUser?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) }
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -50,7 +50,7 @@ class UserTransformer(
       isActive = jpa.isActive,
       qualifications = jpa.qualifications.map(::transformQualificationToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
-      service = ServiceName.approvedPremises.value,
+      service = "CAS1",
       apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
     )
     ServiceName.temporaryAccommodation -> TemporaryAccommodationUser(

--- a/src/main/resources/db/migration/all/20240313090552__add_triggered_by_user_to_domain_event.sql
+++ b/src/main/resources/db/migration/all/20240313090552__add_triggered_by_user_to_domain_event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events ADD triggered_by_user_id UUID null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -6,6 +6,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -23,6 +24,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var data: Yielded<String> = { "{}" }
   private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS3")) }
+  private var triggeredByUserId: Yielded<UUID?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -85,5 +87,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     createdAt = this.createdAt(),
     data = this.data(),
     service = this.service(),
+    triggeredByUserId = this.triggeredByUserId(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -94,7 +94,7 @@ class ProfileTest : IntegrationTestBase() {
               telephoneNumber = telephoneNumber,
               roles = listOf(ApprovedPremisesUserRole.assessor),
               qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
-              service = ServiceName.approvedPremises.value,
+              service = "CAS1",
               isActive = true,
               apArea = ApArea(region.apArea.id, region.apArea.identifier, region.apArea.name),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -193,7 +193,7 @@ class UsersTest : IntegrationTestBase() {
             telephoneNumber = telephoneNumber,
             roles = emptyList(),
             qualifications = emptyList(),
-            service = ServiceName.approvedPremises.value,
+            service = "CAS1",
             isActive = true,
             apArea = ApArea(region.apArea.id, region.apArea.identifier, region.apArea.name),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -30,12 +30,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonDep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonNotArrivedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -322,23 +324,25 @@ class DomainEventDescriberTest {
 data class DomainEventSummaryImpl(
   override val id: String,
   override val type: DomainEventType,
-  override val occurredAt: Timestamp,
+  override val occurredAt: OffsetDateTime,
   override val applicationId: UUID?,
   override val assessmentId: UUID?,
   override val bookingId: UUID?,
   override val premisesId: UUID?,
   override val appealId: UUID?,
+  override val triggeredByUser: UserEntity?,
 ) : DomainEventSummary {
   companion object {
     fun ofType(type: DomainEventType) = DomainEventSummaryImpl(
       id = UUID.randomUUID().toString(),
       type = type,
-      occurredAt = Timestamp.from(Instant.now()),
+      occurredAt = OffsetDateTime.now(),
       applicationId = null,
       assessmentId = null,
       bookingId = null,
       premisesId = null,
       appealId = null,
+      triggeredByUser = null,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
@@ -31,6 +31,7 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@SuppressWarnings("CyclomaticComplexMethod")
 class DomainEventServiceTest {
   private val domainEventRepositoryMock = mockk<DomainEventRepository>()
   private val hmppsQueueServiceMock = mockk<HmppsQueueService>()
@@ -139,7 +140,8 @@ class DomainEventServiceTest {
                 it.type == DomainEventType.CAS2_APPLICATION_SUBMITTED &&
                 it.crn == domainEventToSave.crn &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-                it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+                it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+                it.triggeredByUserId == null
             },
           )
         }
@@ -201,7 +203,8 @@ class DomainEventServiceTest {
                 it.type == DomainEventType.CAS2_APPLICATION_SUBMITTED &&
                 it.crn == domainEventToSave.crn &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-                it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+                it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+                it.triggeredByUserId == null
             },
           )
         }
@@ -255,7 +258,8 @@ class DomainEventServiceTest {
                 it.type == DomainEventType.CAS2_APPLICATION_SUBMITTED &&
                 it.crn == domainEventToSave.crn &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-                it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+                it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+                it.triggeredByUserId == null
             },
           )
         }
@@ -310,7 +314,8 @@ class DomainEventServiceTest {
                 it.type == DomainEventType.CAS2_APPLICATION_STATUS_UPDATED &&
                 it.crn == domainEventToSave.crn &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-                it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+                it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+                it.triggeredByUserId == null
             },
           )
         }
@@ -377,7 +382,8 @@ class DomainEventServiceTest {
                 it.type == DomainEventType.CAS2_APPLICATION_STATUS_UPDATED &&
                 it.crn == domainEventToSave.crn &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-                it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+                it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+                it.triggeredByUserId == null
             },
           )
         }
@@ -426,7 +432,8 @@ class DomainEventServiceTest {
                 it.type == DomainEventType.CAS2_APPLICATION_STATUS_UPDATED &&
                 it.crn == domainEventToSave.crn &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-                it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+                it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+                it.triggeredByUserId == null
             },
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
@@ -53,6 +53,7 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@SuppressWarnings("CyclomaticComplexMethod")
 class DomainEventServiceTest {
   private val domainEventRepositoryMock = mockk<DomainEventRepository>()
   private val domainEventBuilderMock = mockk<DomainEventBuilder>()
@@ -72,29 +73,15 @@ class DomainEventServiceTest {
     }
     .produce()
 
-  private val domainEventService = DomainEventService(
-    objectMapper = objectMapper,
-    domainEventRepository = domainEventRepositoryMock,
-    domainEventBuilder = domainEventBuilderMock,
-    hmppsQueueService = hmppsQueueServiceMock,
-    emitDomainEventsEnabled = EventType.entries,
-    bookingCancelledDetailUrlTemplate = "http://api/events/cas3/booking-cancelled/#eventId",
-    bookingCancelledUpdatedDetailUrlTemplate = "http://api/events/cas3/booking-cancelled-updated/#eventId",
-    bookingConfirmedDetailUrlTemplate = "http://api/events/cas3/booking-confirmed/#eventId",
-    bookingProvisionallyMadeDetailUrlTemplate = "http://api/events/cas3/booking-provisionally-made/#eventId",
-    personArrivedDetailUrlTemplate = "http://api/events/cas3/person-arrived/#eventId",
-    personDepartedDetailUrlTemplate = "http://api/events/cas3/person-departed/#eventId",
-    referralSubmittedDetailUrlTemplate = "http://api/events/cas3/referral-submitted/#eventId",
-    personDepartureUpdatedDetailUrlTemplate = "http://api/events/cas3/person-departure-updated/#eventId",
-    personArrivedUpdatedDetailUrlTemplate = "http://api/events/cas3/person-arrived-updated/#eventId",
-  )
+  private val domainEventService = buildService(emitDomainEventsEnabled = EventType.entries)
+  private val domainEventServiceEmittingDisabled = buildService(emitDomainEventsEnabled = listOf())
 
-  private val domainEventServiceEmittingDisabled = DomainEventService(
+  private fun buildService(emitDomainEventsEnabled: List<EventType>) = DomainEventService(
     objectMapper = objectMapper,
     domainEventRepository = domainEventRepositoryMock,
     domainEventBuilder = domainEventBuilderMock,
     hmppsQueueService = hmppsQueueServiceMock,
-    emitDomainEventsEnabled = listOf(),
+    emitDomainEventsEnabled = emitDomainEventsEnabled,
     bookingCancelledDetailUrlTemplate = "http://api/events/cas3/booking-cancelled/#eventId",
     bookingCancelledUpdatedDetailUrlTemplate = "http://api/events/cas3/booking-cancelled-updated/#eventId",
     bookingConfirmedDetailUrlTemplate = "http://api/events/cas3/booking-confirmed/#eventId",
@@ -347,7 +334,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -480,7 +468,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CONFIRMED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -545,7 +534,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CONFIRMED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -598,7 +588,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CONFIRMED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -733,7 +724,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -800,7 +792,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -855,7 +848,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -988,7 +982,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_ARRIVED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1053,7 +1048,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_ARRIVED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1106,7 +1102,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_ARRIVED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1202,7 +1199,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1267,7 +1265,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1320,7 +1319,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1427,7 +1427,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_REFERRAL_SUBMITTED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1503,7 +1504,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_REFERRAL_SUBMITTED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1567,7 +1569,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_REFERRAL_SUBMITTED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1601,7 +1604,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1649,7 +1653,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1683,7 +1688,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1770,7 +1776,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1805,7 +1812,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1853,7 +1861,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1899,7 +1908,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -1933,7 +1943,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -2012,7 +2023,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_ARRIVED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -2060,7 +2072,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_ARRIVED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }
@@ -2091,7 +2104,8 @@ class DomainEventServiceTest {
             it.type == DomainEventType.CAS3_PERSON_ARRIVED_UPDATED &&
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data)
+            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
+            it.triggeredByUserId == null
         },
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -23,6 +23,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.WOMENS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MATCHER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_WORKFLOW_MANAGER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REFERRER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
@@ -74,20 +76,20 @@ class UserTransformerTest {
   @Test
   fun `Should successfully transfer user entity with role CAS1_MATCHER to matcher`() {
     val result =
-      userTransformer.transformJpaToApi(buildUserEntity(UserRole.CAS1_MATCHER), approvedPremises) as ApprovedPremisesUser
+      userTransformer.transformJpaToApi(buildUserEntity(CAS1_MATCHER), approvedPremises) as ApprovedPremisesUser
 
     assertThat(result.roles).contains(matcher)
-    assertThat(result.service).isEqualTo(approvedPremises.value)
+    assertThat(result.service).isEqualTo("CAS1")
     verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
   }
 
   @Test
   fun `should return distinct roles for Approved Premises`() {
-    val user = buildUserEntity(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
+    val user = buildUserEntity(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_WORKFLOW_MANAGER)
     user.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
 
     val result =
@@ -104,11 +106,11 @@ class UserTransformerTest {
 
   @Test
   fun `should return distinct roles for Temporary Accommodation`() {
-    val user = buildUserEntity(UserRole.CAS3_REFERRER)
-    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
-    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
-    user.addRoleForUnitTest(UserRole.CAS3_REFERRER)
-    user.addRoleForUnitTest(UserRole.CAS3_REPORTER)
+    val user = buildUserEntity(CAS3_REFERRER)
+    user.addRoleForUnitTest(CAS3_REFERRER)
+    user.addRoleForUnitTest(CAS3_REFERRER)
+    user.addRoleForUnitTest(CAS3_REFERRER)
+    user.addRoleForUnitTest(CAS3_REPORTER)
 
     val result =
       userTransformer.transformJpaToApi(user, temporaryAccommodation) as TemporaryAccommodationUser
@@ -123,11 +125,11 @@ class UserTransformerTest {
 
   @Test
   fun `transformJpaToAPIUserWithWorkload should return distinct roles`() {
-    val user = buildUserEntity(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_MATCHER)
-    user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)
+    val user = buildUserEntity(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_MATCHER)
+    user.addRoleForUnitTest(CAS1_WORKFLOW_MANAGER)
 
     val workload = UserWorkload(
       0,
@@ -148,7 +150,7 @@ class UserTransformerTest {
 
   @Test
   fun `transformJpaToAPIUserWithWorkload should return AP area`() {
-    val user = buildUserEntity(UserRole.CAS1_MATCHER)
+    val user = buildUserEntity(CAS1_MATCHER)
 
     val workload = UserWorkload(
       0,


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-490

This PR adds 'triggering_user_id' to the common domain_events table and automatically populates it with the calling user's user id. For consistency with other entries in the table, no FK constraint is defined against the user, and a left join is used when retrieving the user to be included in timeline entries, as shown below:

<img width="1120" alt="Screenshot 2024-03-13 at 19 43 16" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/ab554fb2-8c71-45b3-bb55-1362cc64e547">