### PR TITLE
Adhoc bookings are exempt from cascade withdrawals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1135,6 +1135,14 @@ class BookingService(
       withdrawable = booking.isInCancellableStateCas1(),
       userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
       blockAncestorWithdrawals = booking.hasArrivals(),
+      /**
+       * Several legacy adhoc bookings are linked to potentially unrelated placement requests.
+       * This behaviour was removed in commit 2d96a4d37567fde3f91a7a9172b459a91fb30625
+       *
+       * To avoid such adhoc bookings being unintentionally withdrawn when (unrelated) ancestor
+       * elements are withdrawn, we mark them as exempt from cascade
+       */
+      exemptFromCascade = booking.adhoc == true,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -233,6 +233,13 @@ data class WithdrawableState(
    * placement and application
    */
   val blockAncestorWithdrawals: Boolean = false,
+  /**
+   * If true, this entity will not be automatically withdrawn if an
+   * ancestor entity is withdrawn. For example, adhoc bookings linked
+   * to an application are not automatically withdrawn if the application
+   * is withdrawn
+   */
+  val exemptFromCascade: Boolean = false,
 )
 
 data class WithdrawableDatePeriod(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeOperations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeOperations.kt
@@ -26,7 +26,10 @@ class Cas1WithdrawableTreeOperations(
     withdrawalContext: WithdrawalContext,
   ) {
     rootNode.collectDescendants().forEach { descendant ->
-      if (descendant.status.withdrawable && !descendant.isBlocked()) {
+      if (descendant.status.withdrawable &&
+        !descendant.status.exemptFromCascade &&
+        !descendant.isBlocked()
+      ) {
         withdraw(descendant, withdrawalContext)
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -52,6 +52,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
   private var status: Yielded<BookingStatus?> = { null }
+  private var adhoc: Yielded<Boolean?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -196,6 +197,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.status = { departed }
   }
 
+  fun withAdhoc(adhoc: Boolean?) = apply {
+    this.adhoc = { adhoc }
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),
@@ -221,5 +226,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     nomsNumber = this.nomsNumber(),
     placementRequest = this.placementRequest(),
     status = this.status.invoke(),
+    adhoc = this.adhoc(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -6676,6 +6676,34 @@ class BookingServiceTest {
 
       assertThat(result.blockAncestorWithdrawals).isEqualTo(true)
     }
+
+    @Test
+    fun `getWithdrawableState exempt from cascde if adhoc booking`() {
+      val booking = BookingEntityFactory()
+        .withPremises(premises)
+        .withAdhoc(true)
+        .produce()
+
+      every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
+
+      val result = bookingService.getWithdrawableState(booking, user)
+
+      assertThat(result.exemptFromCascade).isEqualTo(true)
+    }
+
+    @Test
+    fun `getWithdrawableState not exempt from cascde if not adhoc booking`() {
+      val booking = BookingEntityFactory()
+        .withPremises(premises)
+        .withAdhoc(false)
+        .produce()
+
+      every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
+
+      val result = bookingService.getWithdrawableState(booking, user)
+
+      assertThat(result.exemptFromCascade).isEqualTo(false)
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
@@ -215,6 +215,146 @@ class Cas1WithdrawableTreeOperationsTest {
   }
 
   @Test
+  fun `withdrawDescendantsOfRootNode ignores nodes exempt from cascade`() {
+    val placementApplication = PlacementApplicationEntityFactory()
+      .withApplication(application)
+      .withCreatedByUser(user)
+      .produce()
+
+    val placementRequestWithdrawable = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withPlacementApplication(placementApplication)
+      .produce()
+
+    val placementRequestExempt = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withPlacementApplication(placementApplication)
+      .produce()
+
+    val bookingWithdrawable = BookingEntityFactory().withPremises(approvedPremises).produce()
+    val bookingExempt = BookingEntityFactory().withPremises(approvedPremises).produce()
+
+    val adhocBookingWithdrawable = BookingEntityFactory().withPremises(approvedPremises).produce()
+    val adhocBookingExempt = BookingEntityFactory().withPremises(approvedPremises).produce()
+
+    val tree = WithdrawableTreeNode(
+      entityType = WithdrawableEntityType.Application,
+      entityId = application.id,
+      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      children = listOf(
+        WithdrawableTreeNode(
+          entityType = WithdrawableEntityType.PlacementApplication,
+          entityId = placementApplication.id,
+          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          children = listOf(
+            WithdrawableTreeNode(
+              entityType = WithdrawableEntityType.PlacementRequest,
+              entityId = placementRequestWithdrawable.id,
+              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              children = listOf(
+                WithdrawableTreeNode(
+                  entityType = WithdrawableEntityType.Booking,
+                  entityId = bookingWithdrawable.id,
+                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+                ),
+                WithdrawableTreeNode(
+                  entityType = WithdrawableEntityType.Booking,
+                  entityId = bookingExempt.id,
+                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, exemptFromCascade = true),
+                ),
+              ),
+            ),
+            WithdrawableTreeNode(
+              entityType = WithdrawableEntityType.PlacementRequest,
+              entityId = placementRequestExempt.id,
+              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, exemptFromCascade = true),
+            ),
+          ),
+        ),
+        WithdrawableTreeNode(
+          entityType = WithdrawableEntityType.Booking,
+          entityId = adhocBookingWithdrawable.id,
+          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+        ),
+        WithdrawableTreeNode(
+          entityType = WithdrawableEntityType.Booking,
+          entityId = adhocBookingExempt.id,
+          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, exemptFromCascade = true),
+        ),
+      ),
+    )
+
+    val context = WithdrawalContext(
+      triggeringUser = user,
+      triggeringEntityType = WithdrawableEntityType.Application,
+      triggeringEntityId = application.id,
+    )
+
+    every {
+      mockPlacementApplicationService.withdrawPlacementApplication(any(), any(), any())
+    } returns mockk<CasResult<PlacementApplicationEntity>>()
+
+    every {
+      mockPlacementRequestService.withdrawPlacementRequest(any(), any(), any())
+    } returns CasResult.Success(mockk<PlacementRequestService.PlacementRequestAndCancellations>())
+
+    every {
+      mockBookingService.createCas1Cancellation(any(), any(), null, any(), any(), any())
+    } returns mockk<CasResult.Success<CancellationEntity>>()
+
+    every { mockBookingRepository.findByIdOrNull(bookingWithdrawable.id) } returns bookingWithdrawable
+    every { mockBookingRepository.findByIdOrNull(adhocBookingWithdrawable.id) } returns adhocBookingWithdrawable
+
+    service.withdrawDescendantsOfRootNode(tree, context)
+
+    verify {
+      mockPlacementApplicationService.withdrawPlacementApplication(
+        placementApplication.id,
+        null,
+        context,
+      )
+    }
+
+    verify {
+      mockPlacementRequestService.withdrawPlacementRequest(
+        placementRequestWithdrawable.id,
+        null,
+        context,
+      )
+    }
+
+    verify {
+      mockBookingService.createCas1Cancellation(
+        bookingWithdrawable,
+        any(),
+        null,
+        "Automatically withdrawn as Application was withdrawn",
+        null,
+        context,
+      )
+    }
+
+    verify {
+      mockBookingService.createCas1Cancellation(
+        adhocBookingWithdrawable,
+        any(),
+        null,
+        "Automatically withdrawn as Application was withdrawn",
+        null,
+        context,
+      )
+    }
+
+    confirmVerified(mockPlacementApplicationService)
+    confirmVerified(mockPlacementRequestService)
+    confirmVerified(mockBookingService)
+  }
+
+  @Test
   fun `withdrawDescendantsOfRootNode ignores nodes that are blocking, or ancestors of blocking`() {
     val placementApplicationWithdrawable = PlacementApplicationEntityFactory()
       .withApplication(application)


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-475

Several legacy adhoc bookings are linked to potentially unrelated placement requests. This behaviour was removed in commit 2d96a4d37567fde3f91a7a9172b459a91fb30625.  To avoid such adhoc placements being unintentionally withdrawn when (unrelated) ancestor elements are withdrawn, we mark them as exempt from cascade.

Exempting such makes sense in the general context because when creating an adhoc booking the user doesn’t explicitly link it to an application, it is automatically assigned to an application with the required CRN (if such an applciation exists). Therefore, it’s unexpected for an adhoc to be withdrawn automatically if an application withdraws the application.

The withdrawal tree toString has been updated to highlight when placements are exempt from cascade. The simple example below shows a booking with a single adhoc booking

```
2024-03-14 08:11:21.614 DEBUG 6138 --- [io-8080-exec-10] u.g.j.d.h.a.s.cas1.WithdrawableService   : Tree for withdrawing Application with id 15b5300d-c7d0-4e5d-8849-f94d5a42966f is 

  Application(15b), withdrawable:Y, mayDirectlyWithdraw:Y,  
  ---> Booking(498), withdrawable:Y, mayDirectlyWithdraw:Y,  EXEMPT FROM CASCADE
```