### PR TITLE
Withdrawal Tree toString improvement

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -152,7 +152,7 @@ data class WithdrawableTreeNode(
   }
 
   private fun exemptFromCascadeDescription() = if (status.exemptFromCascade) {
-    "EXEMPT FROM CASCADE"
+    "EXEMPT FROM CASCADE (AD-HOC BOOKING)"
   } else {
     ""
   }


### PR DESCRIPTION
Because Ad Bookings are the only use case for ‘exemptFromCascade’ when withdrawing, explicitly state this when rendering the withdrawal tree