### PR TITLE
Enable AP Delius Context API as the offender data source for production

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -79,8 +79,8 @@ generic-service:
     ARRIVED-DEPARTED-DOMAIN-EVENTS-DISABLED: true
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
-    DATA-SOURCES_OFFENDER-DETAILS: community_api
-    DATA-SOURCES_OFFENDER-RISKS: community_api
+    DATA-SOURCES_OFFENDER-DETAILS: ap_delius_context_api
+    DATA-SOURCES_OFFENDER-RISKS: ap_delius_context_api
 
     PAGINATION_CAS3_BOOKING-SEARCH-PAGE-SIZE: 100
 


### PR DESCRIPTION
This PR updates the configuration to switch the data source for offender details and offender risks to the AP Delius Context API in the production environment.

Following the deployment of this change to `test` (#1513) as well as `dev` and `preprod` (#1404), we now have confidence that this change will work as expected and deliver some performance improvements.

This change still needs to be enabled locally (through WireMock and/or [ap-tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools)), but this doesn't prevent deployment to production.

See the PRs below for more context about this configuration change:
- #1200
- #1220 
- #1257 
- #1298 
- #1317 
- #1354 
- #1404 
- #1513 