### PR TITLE
If placement adhoc state unknown, treat as adhoc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1140,9 +1140,11 @@ class BookingService(
        * This behaviour was removed in commit 2d96a4d37567fde3f91a7a9172b459a91fb30625
        *
        * To avoid such adhoc bookings being unintentionally withdrawn when (unrelated) ancestor
-       * elements are withdrawn, we mark them as exempt from cascade
+       * elements are withdrawn, we mark them as exempt from cascade. We also treat bookings
+       * with an unknown state (i.e. ones we could not backfill) as adhoc to avoid non-adhoc
+       * bookings being inadvertently removed
        */
-      exemptFromCascade = booking.adhoc == true,
+      exemptFromCascade = booking.adhoc == null || booking.adhoc == true,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -152,7 +152,7 @@ data class WithdrawableTreeNode(
   }
 
   private fun exemptFromCascadeDescription() = if (status.exemptFromCascade) {
-    "EXEMPT FROM CASCADE"
+    "EXEMPT FROM CASCADE (AD-HOC BOOKING)"
   } else {
     ""
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -6678,10 +6678,24 @@ class BookingServiceTest {
     }
 
     @Test
-    fun `getWithdrawableState exempt from cascde if adhoc booking`() {
+    fun `getWithdrawableState exempt from cascade if adhoc booking`() {
       val booking = BookingEntityFactory()
         .withPremises(premises)
         .withAdhoc(true)
+        .produce()
+
+      every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
+
+      val result = bookingService.getWithdrawableState(booking, user)
+
+      assertThat(result.exemptFromCascade).isEqualTo(true)
+    }
+
+    @Test
+    fun `getWithdrawableState exempt from cascade if adhoc status not known`() {
+      val booking = BookingEntityFactory()
+        .withPremises(premises)
+        .withAdhoc(null)
         .produce()
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true


### PR DESCRIPTION
This is specifically for withdrawal logic. In this case the placement will be excluded from withdrawal cascading.

This is required because we can’t fully backfill the ‘adhoc’ boolean for existing placements, so we have to be cautious and treat them as adhoc placements.