### PR TITLE
Allow many ‘initial’ match requests to be returned

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -502,12 +502,10 @@ class ApplicationsController(
       throw ForbiddenProblem()
     }
 
-    val initialPlacementRequest = if (includeInitialRequestForPlacement == true) {
-      listOfNotNull(
-        placementRequestService.getPlacementRequestForInitialApplicationDates(applicationId)?.let {
-          placementApplicationTransformer.transformPlacementRequestJpaToApi(it)
-        },
-      )
+    val initialPlacementRequests = if (includeInitialRequestForPlacement == true) {
+      placementRequestService.getPlacementRequestForInitialApplicationDates(applicationId).map {
+        placementApplicationTransformer.transformPlacementRequestJpaToApi(it)
+      }
     } else { emptyList() }
 
     val placementApplicationEntities =
@@ -516,7 +514,7 @@ class ApplicationsController(
       placementApplicationTransformer.transformJpaToApi(it)
     }
 
-    return ResponseEntity.ok(initialPlacementRequest.plus(additionalPlacementRequests))
+    return ResponseEntity.ok(initialPlacementRequests.plus(additionalPlacementRequests))
   }
 
   override fun applicationsApplicationIdWithdrawablesGet(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -338,10 +338,19 @@ class PlacementRequestService(
     return CasResult.Success(toPlacementRequestAndCancellations(placementRequest))
   }
 
+  /**
+   * Whilst this should always return 0 or 1 requests, due to legacy application
+   * data inconsistencies there are a small number of applications that will return multiple
+   * placement requests.
+   *
+   * We know that only one of these placement requests relate to the initial application dates,
+   * and the rest relate to placement_applications, but we have no programmatic way of 'fixing'
+   * this link for those placement requests.
+   */
   fun getPlacementRequestForInitialApplicationDates(applicationId: UUID) =
     placementRequestRepository.findByApplication_id(applicationId)
       .filter { it.isForApplicationsArrivalDate() }
-      .firstOrNull { !it.isReallocated() }
+      .filter { !it.isReallocated() }
 
   private fun updateApplicationStatusOnWithdrawal(
     placementRequest: PlacementRequestEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -37,7 +37,7 @@ class WithdrawableTreeBuilder(
   fun treeForApp(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableTreeNode {
     val children = mutableListOf<WithdrawableTreeNode>()
 
-    placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)?.let {
+    placementRequestService.getPlacementRequestForInitialApplicationDates(application.id).forEach {
       children.add(treeForPlacementReq(it, user))
     }
 


### PR DESCRIPTION
Whilst there should only ever be 0 or 1 placement requests returned when requesting getPlacementRequestForInitialApplicationDates, due to data inconsistencies there are a small number of applications that will return multiple placement requests.

We know that only one of these placement requests relate to the initial application dates, and the rest relate to placement_applications, but we have no programmatic way of 'fixing' this link for those placement requests.