### PR TITLE
Add migration job to add missing links between placement_applications and placement_requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -157,7 +157,7 @@ data class PlacementRequestEntity(
 
   @OneToOne
   @JoinColumn(name = "placement_application_id")
-  val placementApplication: PlacementApplicationEntity?,
+  var placementApplication: PlacementApplicationEntity?,
 
   val createdAt: OffsetDateTime,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
@@ -1,0 +1,157 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import java.util.UUID
+import javax.persistence.EntityManager
+
+/**
+ * This job creates links between placement_applications and their corresponding placement_requests
+ *
+ * As of November 2023 this link was populated when a placement_applications was accepted, so this backfill
+ * should only apply to placement_applications accepted before November 2023
+ *
+ * We establish the link by finding pairs of placement_requests and placement_applications on an application
+ * that hav the same arrival date and duration
+ *
+ * Whilst this approach should 'fix' the link for most placement_applications, if a placement_application
+ * has already been withdrawn there is no way to determine if it was ACCEPTED before the withdrawal occurred so these
+ * can't be considered. This is because when withdrawing the placement_application.decision value is updated to
+ * WITHDRAWN/WITHDRAWN_BY_PP overwriting 'ACCEPTED' (if set). This will result in an error being logged for the particular
+ * application
+ */
+class Cas1FixPlacementApplicationLinksJob(
+  private val placementApplicationRepository: PlacementApplicationRepository,
+  private val applicationRepository: ApplicationRepository,
+  private val placementRequestRepository: PlacementRequestRepository,
+  private val entityManager: EntityManager,
+  private val transactionTemplate: TransactionTemplate,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+  var log: Logger = LoggerFactory.getLogger(this::class.java)
+
+  override fun process() {
+    val applicationIds = placementApplicationRepository.findApplicationsThatHaveAnAcceptedPlacementApplicationWithoutACorrespondingPlacementRequest()
+
+    log.info("Fixing PlacementApplication to PlacementRequest relationships for ${applicationIds.size} applications")
+
+    applicationIds.forEach { applicationId ->
+      transactionTemplate.executeWithoutResult {
+        try {
+          updateApplication(UUID.fromString(applicationId))
+        } catch (e: IllegalStateException) {
+          log.error(e.message)
+        }
+      }
+    }
+    entityManager.clear()
+  }
+
+  @SuppressWarnings("ReturnCount")
+  fun updateApplication(applicationId: UUID) {
+    log.info("Fixing PlacementApplication to PlacementRequest relationships for Application $applicationId")
+
+    val application = applicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity
+
+    val unlinkedPlacementRequests = application.placementRequests
+      .filter { !it.isReallocated() }
+      .filter { it.placementApplication == null }
+      .toMutableList()
+
+    val placementAppsAndDate = placementApplicationRepository.findByApplication(application)
+      .filter { it.isAccepted() }
+      .flatMap { placementApp ->
+        placementApp.placementDates.map {
+          PlacementAppAndDate(
+            placementApplication = placementApp,
+            date = it,
+            placementRequest = null,
+          )
+        }
+      }
+
+    val placementAppsWithDecisionMadeDateSet = placementAppsAndDate
+      // we only started capturing decisionMadeAt in Dec 2023
+      .filter { it.placementApplication.decisionMadeAt != null }
+
+    if (placementAppsWithDecisionMadeDateSet.isNotEmpty()) {
+      log.error(
+        "We should not be considering PlacementApplications with a non-null decisionMadeAt, because this was " +
+          "only set for decisions made after linking PlacementApplications to PlacementRequests was automatically " +
+          "managed in code. Placement applications are ${placementAppsWithDecisionMadeDateSet.map { describe(it) }}",
+      )
+      return
+    }
+
+    log.info("We have ${placementAppsAndDate.size} PlacementApplications to match for application $applicationId")
+
+    placementAppsAndDate.forEach { placementAppAndDate ->
+      val matchingPlacementRequests = unlinkedPlacementRequests.filter { placementRequest ->
+        placementRequest.expectedArrival == placementAppAndDate.date.expectedArrival &&
+          placementRequest.duration == placementAppAndDate.date.duration
+      }
+
+      if (matchingPlacementRequests.isEmpty()) {
+        log.error("No placement request found for placement app ${describe(placementAppAndDate)} for application $applicationId")
+        return
+      } else if (matchingPlacementRequests.size > 1) {
+        log.error("More than one potential placement request found for placement app ${describe(placementAppAndDate)} for application $applicationId")
+        return
+      } else {
+        val placementRequest = matchingPlacementRequests.first()
+        placementAppAndDate.placementRequest = placementRequest
+        unlinkedPlacementRequests.remove(placementRequest)
+      }
+    }
+
+    val applicationArrivalDate = application.arrivalDate?.toLocalDate()
+    if (applicationArrivalDate != null) {
+      if (unlinkedPlacementRequests.size != 1) {
+        log.error(
+          "Application ${application.id} has an arrival date set on the initial application," +
+            " but after matching to placement apps, no placement requests remain that represents this date",
+        )
+        return
+      } else {
+        val remainingPlacementRequestDate = unlinkedPlacementRequests[0].expectedArrival
+        if (applicationArrivalDate != remainingPlacementRequestDate) {
+          log.error(
+            "Application ${application.id} has an arrival date set on the initial application, but after matching to placement apps," +
+              " the only remaining placement request doesn't have the expected arrival date " +
+              "(expected $applicationArrivalDate was $remainingPlacementRequestDate)",
+          )
+          return
+        }
+      }
+    } else if (unlinkedPlacementRequests.isNotEmpty()) {
+      log.error("Application ${application.id} does not have an arrival date set on the initial application, yet there are unmatched placement requests.")
+      return
+    }
+
+    placementAppsAndDate.forEach { placementAppAndDate ->
+      val placementApp = placementAppAndDate.placementApplication
+      val placementRequest = placementAppAndDate.placementRequest!!
+      placementRequest.placementApplication = placementApp
+      log.info("Linked PlacementRequest ${placementRequest.id} to PlacementApplication ${placementAppAndDate.placementApplication.id}")
+      placementRequestRepository.save(placementRequest)
+    }
+  }
+
+  private fun describe(placementApp: PlacementAppAndDate) =
+    "${placementApp.placementApplication.id} for date ${placementApp.date.expectedArrival} and duration ${placementApp.date.duration}"
+
+  data class PlacementAppAndDate(
+    val placementApplication: PlacementApplicationEntity,
+    val date: PlacementDateEntity,
+    var placementRequest: PlacementRequestEntity?,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepositor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJobApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.BookingStatusMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
@@ -85,6 +86,14 @@ class MigrationJobService(
           applicationContext.getBean(Cas1ApplicationUserDetailsRepository::class.java),
           applicationContext.getBean(EntityManager::class.java),
           pageSize,
+          transactionTemplate,
+        )
+
+        MigrationJobType.cas1FixPlacementAppLinks -> Cas1FixPlacementApplicationLinksJob(
+          applicationContext.getBean(PlacementApplicationRepository::class.java),
+          applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(PlacementRequestRepository::class.java),
+          applicationContext.getBean(EntityManager::class.java),
           transactionTemplate,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -346,6 +346,11 @@ class PlacementRequestService(
    * We know that only one of these placement requests relate to the initial application dates,
    * and the rest relate to placement_applications, but we have no programmatic way of 'fixing'
    * this link for those placement requests.
+   *
+   * Note: this is only an issue when the placement applications are withdrawn, so any incorrect
+   * placement requests returned here will appear as withdrawn to the user
+   *
+   * See [Cas1FixPlacementApplicationLinksJob] for more information.
    */
   fun getPlacementRequestForInitialApplicationDates(applicationId: UUID) =
     placementRequestRepository.findByApplication_id(applicationId)

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3496,6 +3496,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
+        - update_cas1_fix_placement_app_links
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7993,6 +7993,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
+        - update_cas1_fix_placement_app_links
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4049,6 +4049,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
+        - update_cas1_fix_placement_app_links
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3544,6 +3544,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
+        - update_cas1_fix_placement_app_links
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrateCas1FixPlacementApplicationLinksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrateCas1FixPlacementApplicationLinksTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class MigrateCas1FixPlacementApplicationLinksTest : MigrationJobTestBase() {
+
+  @Nested
+  inner class QueryTest {
+
+    @Test
+    fun `Repo query only returns relevant applications`() {
+      `Given a User` { user, _ ->
+
+        `Given a Placement Application`(
+          crn = "placementAppWithoutDecision",
+          createdByUser = user,
+          decision = null,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+        )
+
+        val placementAppAlreadyLinkedToPlacementRequest = `Given a Placement Application`(
+          crn = "placementAppAlreadyLinkedToPlacementRequest",
+          createdByUser = user,
+          decision = PlacementApplicationDecision.ACCEPTED,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+        )
+        `Given a Placement Request`(
+          crn = placementAppAlreadyLinkedToPlacementRequest.application.crn,
+          placementRequestAllocatedTo = user,
+          assessmentAllocatedTo = user,
+          createdByUser = user,
+          placementApplication = placementAppAlreadyLinkedToPlacementRequest,
+        )
+
+        val placementAppNotLinkedToPlacementRequest = `Given a Placement Application`(
+          crn = "placementAppNotLinkedToPlacementRequest",
+          createdByUser = user,
+          decision = PlacementApplicationDecision.ACCEPTED,
+          schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+        )
+
+        val result =
+          placementApplicationRepository.findApplicationsThatHaveAnAcceptedPlacementApplicationWithoutACorrespondingPlacementRequest()
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).isEqualTo(placementAppNotLinkedToPlacementRequest.application.id.toString())
+      }
+    }
+  }
+
+  @Nested
+  inner class MigrationTest {
+
+    @Test
+    fun `Backfill adds placement request to placement application link`() {
+      `Given a User` { user, _ ->
+        val (_, application) = `Given a Placement Request`(
+          placementRequestAllocatedTo = user,
+          assessmentAllocatedTo = user,
+          createdByUser = user,
+          expectedArrival = LocalDate.of(2024, 5, 6),
+          duration = 7,
+        )
+
+        val placementApplication = placementApplicationFactory.produceAndPersist {
+          withApplication(application)
+          withCreatedByUser(user)
+          withSchemaVersion(
+            approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withPermissiveSchema()
+            },
+          )
+          withSubmittedAt(OffsetDateTime.now())
+          withDecision(PlacementApplicationDecision.ACCEPTED)
+        }
+        placementDateFactory.produceAndPersist {
+          withPlacementApplication(placementApplication)
+          withExpectedArrival(LocalDate.of(2024, 5, 6))
+          withDuration(7)
+        }
+
+        migrationJobService.runMigrationJob(MigrationJobType.cas1FixPlacementAppLinks)
+
+        val updatedPlacementRequests = placementRequestRepository.findByApplication_id(application.id)
+        assertThat(updatedPlacementRequests).hasSize(1)
+        assertThat(updatedPlacementRequests[0].placementApplication!!.id).isEqualTo(placementApplication.id)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -81,19 +81,19 @@ fun IntegrationTestBase.`Given a Placement Application`(
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
-) {
-  block(
-    `Given a Placement Application`(
-      assessmentDecision = assessmentDecision,
-      createdByUser = createdByUser,
-      schema = schema,
-      crn = crn,
-      allocatedToUser = allocatedToUser,
-      submittedAt = submittedAt,
-      decision = decision,
-      reallocated = reallocated,
-      placementType = placementType,
-      dueAt = dueAt,
-    ),
+): PlacementApplicationEntity {
+  val placementApplication = `Given a Placement Application`(
+    assessmentDecision = assessmentDecision,
+    createdByUser = createdByUser,
+    schema = schema,
+    crn = crn,
+    allocatedToUser = allocatedToUser,
+    submittedAt = submittedAt,
+    decision = decision,
+    reallocated = reallocated,
+    placementType = placementType,
+    dueAt = dueAt,
   )
+  block(placementApplication)
+  return placementApplication
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
@@ -44,7 +45,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   assessmentSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
   placementApplication: PlacementApplicationEntity? = null,
   requiredQualification: UserQualification? = null,
-): Pair<PlacementRequestEntity, ApplicationEntity> {
+): Pair<PlacementRequestEntity, ApprovedPremisesApplicationEntity> {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
     withPermissiveSchema()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
@@ -1,0 +1,445 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.migration
+
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.Logger
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.ACCEPTED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import javax.persistence.EntityManager
+import kotlin.math.log
+
+class Cas1FixPlacementApplicationLinksJobTest {
+
+  private val placementApplicationRepository = mockk<PlacementApplicationRepository>()
+  private val applicationRepository = mockk<ApplicationRepository>()
+  private val placementRequestRepository = mockk<PlacementRequestRepository>()
+  private val entityManager = mockk<EntityManager>()
+  private val transactionTemplate = mockk<TransactionTemplate>()
+
+  private val service = Cas1FixPlacementApplicationLinksJob(
+    placementApplicationRepository,
+    applicationRepository,
+    placementRequestRepository,
+    entityManager,
+    transactionTemplate,
+  )
+
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withApArea(
+      ApAreaEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  private val createdByUser = UserEntityFactory()
+    .withProbationRegion(probationRegion)
+    .produce()
+
+  private val applicationWithNoArrivalDate = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(createdByUser)
+    .withArrivalDate(null)
+    .produce()
+
+  private val applicationWithArrivalDate = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(createdByUser)
+    .withArrivalDate(OffsetDateTime.now())
+    .produce()
+
+  private val assessment = ApprovedPremisesAssessmentEntityFactory()
+    .withApplication(applicationWithNoArrivalDate)
+    .produce()
+
+  val placementRequirements = PlacementRequirementsEntityFactory()
+    .withApplication(applicationWithNoArrivalDate)
+    .withAssessment(assessment)
+    .produce()
+
+  val logger = mockk<Logger>()
+
+  @BeforeEach
+  fun setupLogger() {
+    service.log = logger
+    every { logger.debug(any()) } returns Unit
+    every { logger.info(any()) } returns Unit
+    every { logger.error(any()) } returns Unit
+  }
+
+  @Test
+  fun `nothing to do`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns emptyList()
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify { placementRequestRepository wasNot Called }
+  }
+
+  @Test
+  fun `match placement app with single date to single placement request`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementAppWithSingleDate1 = placementApp()
+    addDates(placementAppWithSingleDate1, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementAppWithSingleDate1)
+    every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest1.id &&
+            it.placementApplication == placementAppWithSingleDate1
+        },
+      )
+    }
+
+    assertNoErrorsLogged()
+  }
+
+  @Test
+  fun `match placement app with single date to single placement request when application has initial date set`() {
+    every { applicationRepository.findByIdOrNull(applicationWithArrivalDate.id) } returns applicationWithArrivalDate
+
+    val placementApp = placementApp(application = applicationWithArrivalDate)
+    addDates(placementApp, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10, application = applicationWithArrivalDate)
+    applicationWithArrivalDate.placementRequests.add(placementRequest1)
+    val placementRequest2 = placementRequestForDates(applicationWithArrivalDate.arrivalDate!!.toLocalDate(), 10, application = applicationWithArrivalDate)
+    applicationWithArrivalDate.placementRequests.add(placementRequest2)
+
+    every { placementApplicationRepository.findByApplication(applicationWithArrivalDate) } returns listOf(placementApp)
+    every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
+
+    service.updateApplication(applicationWithArrivalDate.id)
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest1.id &&
+            it.placementApplication == placementApp
+        },
+      )
+    }
+
+    assertNoErrorsLogged()
+  }
+
+  @Test
+  fun `match multiple placement apps with single date to placement requests`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementAppWithSingleDate1 = placementApp()
+    addDates(placementAppWithSingleDate1, LocalDate.of(2020, 1, 2), 10)
+
+    val placementAppWithSingleDate2 = placementApp()
+    addDates(placementAppWithSingleDate2, LocalDate.of(2020, 2, 3), 20)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    val placementRequest2 = placementRequestForDates(LocalDate.of(2020, 2, 3), 20)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest2)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementAppWithSingleDate1, placementAppWithSingleDate2)
+    every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest1.id &&
+            it.placementApplication == placementAppWithSingleDate1
+        },
+      )
+    }
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest2.id &&
+            it.placementApplication == placementAppWithSingleDate2
+        },
+      )
+    }
+
+    assertNoErrorsLogged()
+  }
+
+  @Test
+  fun `match single placement apps with multiple dates to placement requests`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementAppWithMultipleDate1 = placementApp()
+    addDates(placementAppWithMultipleDate1, LocalDate.of(2020, 1, 2), 10)
+    addDates(placementAppWithMultipleDate1, LocalDate.of(2020, 2, 3), 20)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    val placementRequest2 = placementRequestForDates(LocalDate.of(2020, 2, 3), 20)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest2)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementAppWithMultipleDate1)
+    every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest1.id &&
+            it.placementApplication == placementAppWithMultipleDate1
+        },
+      )
+    }
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest2.id &&
+            it.placementApplication == placementAppWithMultipleDate1
+        },
+      )
+    }
+
+    assertNoErrorsLogged()
+  }
+
+  @Test
+  fun `match placement app with single date to single placement request, ignore placement apps that aren't accepted`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementAppWithSingleDate1 = placementApp()
+    addDates(placementAppWithSingleDate1, LocalDate.of(2020, 1, 2), 10)
+
+    val placementAppWithoutDecisionIsIgnored = placementApp(decision = null)
+    addDates(placementAppWithoutDecisionIsIgnored, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementAppWithSingleDate1, placementAppWithoutDecisionIsIgnored)
+    every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      placementRequestRepository.save(
+        match {
+          it.id == placementRequest1.id &&
+            it.placementApplication == placementAppWithSingleDate1
+        },
+      )
+    }
+
+    assertNoErrorsLogged()
+  }
+
+  @Test
+  fun `error if placement application has a decision date, because any application with this populated should already be correctly linked to placement requests`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementAppWithDecisionDate = placementApp(decisionDate = OffsetDateTime.now())
+    addDates(placementAppWithDecisionDate, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementAppWithDecisionDate)
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+    verify {
+      logger.error(
+        "We should not be considering PlacementApplications with a non-null decisionMadeAt, because this was only set for " +
+          "decisions made after linking PlacementApplications to PlacementRequests was automatically managed in code. " +
+          "Placement applications are [${placementAppWithDecisionDate.id} for date 2020-01-02 and duration 10]",
+      )
+    }
+  }
+
+  @Test
+  fun `error if no corresponding placement request found`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementApp = placementApp()
+    addDates(placementApp, LocalDate.of(2020, 1, 2), 10)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementApp)
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      logger.error(
+        "No placement request found for placement app ${placementApp.id} for date 2020-01-02 and " +
+          "duration 10 for application ${applicationWithNoArrivalDate.id}",
+      )
+    }
+  }
+
+  @Test
+  fun `error if multiple potential placement requests found`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementApp = placementApp()
+    addDates(placementApp, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    val placementRequest2 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest2)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementApp)
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      logger.error(
+        "More than one potential placement request found for placement app ${placementApp.id} for " +
+          "date 2020-01-02 and duration 10 for application ${applicationWithNoArrivalDate.id}",
+      )
+    }
+  }
+
+  @Test
+  fun `error if application has no initial date and unmatched placement requests exist`() {
+    every { applicationRepository.findByIdOrNull(applicationWithNoArrivalDate.id) } returns applicationWithNoArrivalDate
+
+    val placementApp = placementApp()
+    addDates(placementApp, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest1)
+
+    val placementRequest2 = placementRequestForDates(LocalDate.of(2020, 2, 3), 20)
+    applicationWithNoArrivalDate.placementRequests.add(placementRequest2)
+
+    every { placementApplicationRepository.findByApplication(applicationWithNoArrivalDate) } returns listOf(placementApp)
+
+    service.updateApplication(applicationWithNoArrivalDate.id)
+
+    verify {
+      logger.error(
+        "Application ${applicationWithNoArrivalDate.id} does not have an arrival date set on the initial application, " +
+          "yet there are unmatched placement requests.",
+      )
+    }
+  }
+
+  @Test
+  fun `error if application has an initial date and no unmatched placement requests exist after mapping`() {
+    every { applicationRepository.findByIdOrNull(applicationWithArrivalDate.id) } returns applicationWithArrivalDate
+
+    val placementApp = placementApp(application = applicationWithArrivalDate)
+    addDates(placementApp, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10, application = applicationWithArrivalDate)
+    applicationWithArrivalDate.placementRequests.add(placementRequest1)
+
+    every { placementApplicationRepository.findByApplication(applicationWithArrivalDate) } returns listOf(placementApp)
+
+    service.updateApplication(applicationWithArrivalDate.id)
+
+    verify {
+      logger.error(
+        "Application ${applicationWithArrivalDate.id} has an arrival date set on the initial application, " +
+          "but after matching to placement apps, no placement requests remain that represents this date",
+      )
+    }
+  }
+
+  @Test
+  fun `error if application has an initial date and remaining placement request has different start date`() {
+    every { applicationRepository.findByIdOrNull(applicationWithArrivalDate.id) } returns applicationWithArrivalDate
+
+    val placementApp = placementApp(application = applicationWithArrivalDate)
+    addDates(placementApp, LocalDate.of(2020, 1, 2), 10)
+
+    val placementRequest1 = placementRequestForDates(LocalDate.of(2020, 1, 2), 10, application = applicationWithArrivalDate)
+    applicationWithArrivalDate.placementRequests.add(placementRequest1)
+    val placementRequest2 = placementRequestForDates(applicationWithArrivalDate.arrivalDate!!.toLocalDate().minusMonths(1), 10, application = applicationWithArrivalDate)
+    applicationWithArrivalDate.placementRequests.add(placementRequest2)
+
+    every { placementApplicationRepository.findByApplication(applicationWithArrivalDate) } returns listOf(placementApp)
+
+    service.updateApplication(applicationWithArrivalDate.id)
+
+    verify {
+      logger.error(
+        "Application ${applicationWithArrivalDate.id} has an arrival date set on the initial application, " +
+          "but after matching to placement apps, the only remaining placement request doesn't have the " +
+          "expected arrival date (expected 2024-03-18 was 2024-02-18)",
+      )
+    }
+  }
+
+  private fun assertNoErrorsLogged() {
+    verify(exactly = 0) { logger.error(any()) }
+  }
+
+  private fun placementApp(
+    application: ApprovedPremisesApplicationEntity = applicationWithNoArrivalDate,
+    decision: PlacementApplicationDecision? = ACCEPTED,
+    decisionDate: OffsetDateTime? = null,
+  ) =
+    PlacementApplicationEntityFactory()
+      .withDefaults()
+      .withApplication(application)
+      .withDecision(decision)
+      .withDecisionMadeAt(decisionDate)
+      .produce()
+
+  private fun placementRequestForDates(
+    start: LocalDate,
+    duration: Int,
+    application: ApprovedPremisesApplicationEntity = applicationWithNoArrivalDate,
+  ) = PlacementRequestEntityFactory()
+    .withPlacementRequirements(placementRequirements)
+    .withApplication(application)
+    .withAssessment(assessment)
+    .withPlacementApplication(null)
+    .withExpectedArrival(start)
+    .withDuration(duration)
+    .produce()
+
+  private fun addDates(placementApp: PlacementApplicationEntity, start: LocalDate, duration: Int) {
+    placementApp.placementDates.add(
+      PlacementDateEntityFactory()
+        .withPlacementApplication(placementApp)
+        .withExpectedArrival(start)
+        .withDuration(duration)
+        .produce(),
+    )
+  }
+}


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-438

Placement Applications accepted before November were not linked to their corresponding Placement Requests. This relationship is impotant to:

1. Differentiate the placement request created for the initial application dates from those created for additional request for placements (placement_application)
2. Allow withdrawals to correctly cascade from placement_applications to their corresponding placement_requests and bookings