### PR TITLE
placement.adhoc backfill now supports true & false

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -197,8 +197,8 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   fun findActiveOverlappingBookingByBed(bedId: UUID, date: LocalDate): List<BookingEntity>
 
   @Modifying
-  @Query("UPDATE BookingEntity b set b.adhoc = true where b.id = :bookingId")
-  fun updateBookingAsAdhoc(bookingId: UUID): Int
+  @Query("UPDATE BookingEntity b set b.adhoc = :adhoc where b.id = :bookingId")
+  fun updateBookingAdhocStatus(bookingId: UUID, adhoc: Boolean): Int
 }
 
 @EntityListeners(BookingListener::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingAdhocPropertySeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingAdhocPropertySeedJob.kt
@@ -12,26 +12,30 @@ class Cas1BookingAdhocPropertySeedJob(
   id = UUID.randomUUID(),
   fileName = fileName,
   requiredHeaders = setOf(
-    "adhoc_booking_id",
+    "booking_id",
+    "is_adhoc",
   ),
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun deserializeRow(columns: Map<String, String>) = Cas1BookingAdhocPropertySeedCsvRow(
-    adhocBookingId = columns["adhoc_booking_id"]!!.trim(),
+    bookingId = columns["booking_id"]!!.trim(),
+    isAdhoc = columns["is_adhoc"]!!.trim().equals("true", ignoreCase = true),
   )
 
   override fun processRow(row: Cas1BookingAdhocPropertySeedCsvRow) {
-    val bookingId = row.adhocBookingId
+    val bookingId = row.bookingId
+    val isAdhoc = row.isAdhoc
 
-    if (bookingRepository.updateBookingAsAdhoc(UUID.fromString(bookingId)) == 0) {
+    if (bookingRepository.updateBookingAdhocStatus(UUID.fromString(bookingId), isAdhoc) == 0) {
       error("Could not find booking with id $bookingId")
     }
 
-    log.info("Update booking $bookingId to indicate it's adhoc")
+    log.info("Update booking $bookingId adhoc status to $isAdhoc")
   }
 }
 
 data class Cas1BookingAdhocPropertySeedCsvRow(
-  val adhocBookingId: String,
+  val bookingId: String,
+  val isAdhoc: Boolean,
 )


### PR DESCRIPTION
Previously the adhoc backfill job would only set the adhoc field to false. The job now takes a spreadsheet that can be used to set the value to either true or false, allowing us to selectively populate this field for large datasets