### PR TITLE
`INNER JOIN` approved_premises_applications when listing tasks

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -35,6 +35,7 @@
     <ID>CyclomaticComplexMethod:TasksTest.kt$TasksTest.GetAllReallocatableTest$@ParameterizedTest @CsvSource(value = ["createdAt,asc", "createdAt,desc", "dueAt,asc", "dueAt,desc", "person,asc", "person,desc", "allocatedTo,asc", "allocatedTo,desc"]) fun `Get all reallocatable tasks returns 200 when no type retains original sort order`(sortBy: String, sortDirection: String)</ID>
     <ID>ThrowsCount:TasksTest.kt$TasksTest.GetAllReallocatableTest$@ParameterizedTest @CsvSource(value = ["createdAt,asc", "createdAt,desc", "dueAt,asc", "dueAt,desc", "person,asc", "person,desc", "allocatedTo,asc", "allocatedTo,desc"]) fun `Get all reallocatable tasks returns 200 when no type retains original sort order`(sortBy: String, sortDirection: String)</ID>
     <ID>TooGenericExceptionThrown:TasksTest.kt$TasksTest.GetAllReallocatableTest$throw RuntimeException("Unexpected sortField $sortBy")</ID>
+    <ID>LongParameterList:GivenAnAssessment.kt$( allocatedToUser: UserEntity?, createdByUser: UserEntity, crn: String = randomStringMultiCaseWithNumbers(8), reallocated: Boolean = false, data: String? = "{ \"some\": \"data\"}", createdAt: OffsetDateTime? = null, block: ((assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit)? = null, )</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -49,7 +49,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
       FROM
         assessments assessment
         INNER JOIN applications application ON assessment.application_id = application.id
-        LEFT JOIN approved_premises_applications apa ON application.id = apa.id
+        INNER JOIN approved_premises_applications apa ON application.id = apa.id
         LEFT JOIN ap_areas area ON area.id = apa.ap_area_id
         LEFT JOIN users u ON u.id = assessment.allocated_to_user_id
       WHERE
@@ -87,7 +87,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
       from
         placement_applications placement_application
         INNER JOIN applications application ON placement_application.application_id = application.id
-        LEFT JOIN approved_premises_applications apa ON application.id = apa.id
+        INNER JOIN approved_premises_applications apa ON application.id = apa.id
         LEFT JOIN ap_areas area ON area.id = apa.ap_area_id
         LEFT JOIN users u ON u.id = placement_application.allocated_to_user_id
       WHERE
@@ -125,7 +125,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
       FROM
         placement_requests placement_request
         INNER JOIN applications application ON placement_request.application_id = application.id
-        LEFT JOIN approved_premises_applications apa ON application.id = apa.id
+        INNER JOIN approved_premises_applications apa ON application.id = apa.id
         LEFT JOIN booking_not_mades booking_not_made ON booking_not_made.placement_request_id = placement_request.id
         LEFT JOIN ap_areas area ON area.id = apa.ap_area_id
         LEFT JOIN users u ON u.id = placement_request.allocated_to_user_id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -612,6 +612,11 @@ class TasksTest : IntegrationTestBase() {
                 ),
               )
 
+              `Given an Assessment for Temporary Accommodation`(
+                createdByUser = otherUser,
+                allocatedToUser = null,
+              )
+
               repeat(counts[TaskType.assessment]!!["allocated"]!!) {
                 `Given an Assessment for Approved Premises`(
                   allocatedToUser = otherUser,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -111,7 +111,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
 }
 
 fun IntegrationTestBase.`Given an Assessment for Temporary Accommodation`(
-  allocatedToUser: UserEntity,
+  allocatedToUser: UserEntity?,
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   reallocated: Boolean = false,
@@ -137,7 +137,9 @@ fun IntegrationTestBase.`Given an Assessment for Temporary Accommodation`(
   }
 
   val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
-    withAllocatedToUser(allocatedToUser)
+    if (allocatedToUser != null) {
+      withAllocatedToUser(allocatedToUser)
+    }
     withApplication(application)
     withAssessmentSchema(assessmentSchema)
     withData(data)


### PR DESCRIPTION
We’ve been getting an error in certain circumstances when querying for tasks. My suspicion is that doing a `LEFT JOIN` instead of an `INNER JOIN` is causing non-AP assessments to be included. I’ve created a temporary accommodation Assessment in some of the task lisiting tests to prove this theory and it seems to ring true.