### PR TITLE
[APS-473] Add support for Mental Health Approved Premises when updating or submitting an application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -259,6 +259,7 @@ class ApplicationsController(
           isPipeApplication = body.isPipeApplication,
           isEmergencyApplication = body.isEmergencyApplication,
           isEsapApplication = body.isEsapApplication,
+          apType = body.apType,
           releaseType = body.releaseType?.name,
           arrivalDate = body.arrivalDate,
           isInapplicable = body.isInapplicable,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntityReportRow.kt
@@ -30,13 +30,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
       submission_event.data -> 'eventDetails' ->> 'mappa' as mappa,
       submission_event.data -> 'eventDetails' ->> 'offenceId' as offenceId,
       submission_event.data -> 'eventDetails' -> 'personReference' ->> 'noms' as noms,
-      (
-        CASE
-          WHEN apa.is_pipe_application THEN 'pipe'
-          WHEN apa.is_esap_application THEN 'esap'
-          ELSE 'normal'
-        END
-      ) as premisesType,
+      lower(apa.ap_type) as premisesType,
       application.data -> 'basic-information' -> 'sentence-type' ->> 'sentenceType' as sentenceType,
       submission_event.data -> 'eventDetails' ->> 'releaseType' as releaseType,
       cast(submission_event.data -> 'eventDetails' ->> 'submittedAt' as date) as applicationSubmissionDate,
@@ -119,13 +113,7 @@ interface ApplicationEntityReportRowRepository : JpaRepository<ApplicationEntity
       submission_event.data -> 'eventDetails' ->> 'mappa' as mappa,
       submission_event.data -> 'eventDetails' ->> 'offenceId' as offenceId,
       submission_event.data -> 'eventDetails' -> 'personReference' ->> 'noms' as noms,
-      (
-        CASE
-          WHEN apa.is_pipe_application THEN 'pipe'
-          WHEN apa.is_esap_application THEN 'esap'
-          ELSE 'normal'
-        END
-      ) as premisesType,
+      lower(apa.ap_type) as premisesType,
       application.data -> 'basic-information' -> 'sentence-type' ->> 'sentenceType' as sentenceType,
       submission_event.data -> 'eventDetails' ->> 'releaseType' as releaseType,
       cast(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -181,8 +181,8 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
     """
     SELECT
       apa.risk_ratings -> 'tier' -> 'value' ->> 'level' as tier,
-      apa.is_esap_application as isEsapApplication,
-      apa.is_pipe_application as isPipeApplication,
+      (apa.ap_type = 'ESAP') as isEsapApplication,
+      (apa.ap_type = 'PIPE') as isPipeApplication,
       assessment.decision as decision,
       application.submitted_at as applicationSubmittedAt,
       assessment.submitted_at as assessmentSubmittedAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntityReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntityReportRow.kt
@@ -33,13 +33,7 @@ interface PlacementApplicationEntityReportRowRepository : JpaRepository<Placemen
         submission_event.data -> 'eventDetails' ->> 'mappa' as mappa,
         submission_event.data -> 'eventDetails' ->> 'offenceId' as offenceId,
         submission_event.data -> 'eventDetails' -> 'personReference' ->> 'noms' as noms,
-        (
-          CASE
-            WHEN apa.is_pipe_application THEN 'pipe'
-            WHEN apa.is_esap_application THEN 'esap'
-            ELSE 'normal'
-          END
-        ) as premisesType,
+        lower(apa.ap_type) as premisesType,
         application.data -> 'basic-information' -> 'sentence-type' ->> 'sentenceType' as sentenceType,
         submission_event.data -> 'eventDetails' ->> 'releaseType' as releaseType,
         submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'ldu' ->> 'name' as referralLdu,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -21,9 +21,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
       (
         CASE
           WHEN :requiredQualification = 'womens' THEN apa.is_womens_application = true
-          WHEN :requiredQualification = 'pipe' THEN apa.is_pipe_application = true
+          WHEN :requiredQualification = 'pipe' THEN apa.ap_type = 'PIPE'
           WHEN :requiredQualification = 'emergency' THEN (apa.notice_type = 'emergency' OR apa.notice_type = 'shortNotice')
-          WHEN :requiredQualification = 'esap' THEN apa.is_esap_application = true
+          WHEN :requiredQualification = 'esap' THEN apa.ap_type = 'ESAP'
           ELSE true
         END
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesType.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+enum class ApprovedPremisesType {
+  NORMAL,
+  PIPE,
+  ESAP,
+  RFAP,
+  MHAP_ST_JOSEPHS,
+  MHAP_ELLIOTT_HOUSE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesType.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+
 enum class ApprovedPremisesType {
   NORMAL,
   PIPE,
@@ -7,4 +9,13 @@ enum class ApprovedPremisesType {
   RFAP,
   MHAP_ST_JOSEPHS,
   MHAP_ELLIOTT_HOUSE,
+}
+
+fun ApType.asApprovedPremisesType() = when (this) {
+  ApType.normal -> ApprovedPremisesType.NORMAL
+  ApType.pipe -> ApprovedPremisesType.PIPE
+  ApType.esap -> ApprovedPremisesType.ESAP
+  ApType.rfap -> ApprovedPremisesType.RFAP
+  ApType.mhapStJosephs -> ApprovedPremisesType.MHAP_ST_JOSEPHS
+  ApType.mhapElliottHouse -> ApprovedPremisesType.MHAP_ELLIOTT_HOUSE
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -322,9 +323,8 @@ class ApplicationService(
       createdAt = OffsetDateTime.now(),
       submittedAt = null,
       isWomensApplication = null,
-      isPipeApplication = null,
       isEmergencyApplication = null,
-      isEsapApplication = null,
+      apType = ApprovedPremisesType.NORMAL,
       convictionId = convictionId!!,
       eventNumber = deliusEventNumber!!,
       offenceId = offenceId!!,
@@ -528,9 +528,12 @@ class ApplicationService(
     application.apply {
       this.isInapplicable = updateFields.isInapplicable
       this.isWomensApplication = updateFields.isWomensApplication
-      this.isPipeApplication = updateFields.isPipeApplication
       this.isEmergencyApplication = updateFields.isEmergencyApplication
-      this.isEsapApplication = updateFields.isEsapApplication
+      this.apType = when {
+        updateFields.isPipeApplication == true -> ApprovedPremisesType.PIPE
+        updateFields.isEsapApplication == true -> ApprovedPremisesType.ESAP
+        else -> ApprovedPremisesType.NORMAL
+      }
       this.releaseType = updateFields.releaseType
       this.arrivalDate = if (updateFields.arrivalDate !== null) {
         OffsetDateTime.of(updateFields.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC)
@@ -777,9 +780,12 @@ class ApplicationService(
 
     application.apply {
       isWomensApplication = submitApplication.isWomensApplication
-      isPipeApplication = submitApplication.isPipeApplication
       this.isEmergencyApplication = isEmergencyApplication
-      this.isEsapApplication = isEsapApplication
+      apType = when {
+        submitApplication.isPipeApplication == true -> ApprovedPremisesType.PIPE
+        submitApplication.isEsapApplication == true -> ApprovedPremisesType.ESAP
+        else -> ApprovedPremisesType.NORMAL
+      }
       submittedAt = OffsetDateTime.now()
       document = serializedTranslatedDocument
       releaseType = submitApplication.releaseType.toString()

--- a/src/main/resources/db/migration/all/20240321120638__make_ap_type_column_on_approved_premises_applications_table.sql
+++ b/src/main/resources/db/migration/all/20240321120638__make_ap_type_column_on_approved_premises_applications_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN ap_type TEXT NOT NULL DEFAULT 'NORMAL';

--- a/src/main/resources/db/migration/all/20240321120711__migrate_pipe_and_esap_applications_to_ap_type_column_on_approved_premises_applications_table.sql
+++ b/src/main/resources/db/migration/all/20240321120711__migrate_pipe_and_esap_applications_to_ap_type_column_on_approved_premises_applications_table.sql
@@ -1,0 +1,9 @@
+UPDATE approved_premises_applications
+SET ap_type = 'PIPE'
+WHERE is_pipe_application = true;
+
+UPDATE approved_premises_applications
+SET ap_type = 'ESAP'
+WHERE is_esap_application = true;
+
+ALTER TABLE approved_premises_applications ALTER COLUMN ap_type DROP DEFAULT;

--- a/src/main/resources/db/migration/all/20240321120835__remove_is_pipe_application_and_is_esap_application_columns_from_approved_premises_applications_table.sql
+++ b/src/main/resources/db/migration/all/20240321120835__remove_is_pipe_application_and_is_esap_application_columns_from_approved_premises_applications_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE approved_premises_applications DROP COLUMN is_pipe_application;
+ALTER TABLE approved_premises_applications DROP COLUMN is_esap_application;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1608,6 +1608,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             arrivalDate:
               type: string
               format: date-time
@@ -2143,6 +2145,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -2184,6 +2188,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -2207,10 +2213,6 @@ components:
             noticeType:
               $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
-            - isPipeApplication
-            - isWomensApplication
-            - isEmergencyApplication
-            - isEsapApplication
             - targetLocation
             - releaseType
             - sentenceType

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3774,6 +3774,8 @@ components:
       enum:
         - isPIPE
         - isESAP
+        - isMHAPStJosephs
+        - isMHAPElliottHouse
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - hasBrailleSignage
@@ -3805,6 +3807,8 @@ components:
         - pipe
         - esap
         - rfap
+        - mhapStJosephs
+        - mhapElliottHouse
     BedSearchParameters:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8271,6 +8271,8 @@ components:
       enum:
         - isPIPE
         - isESAP
+        - isMHAPStJosephs
+        - isMHAPElliottHouse
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - hasBrailleSignage
@@ -8302,6 +8304,8 @@ components:
         - pipe
         - esap
         - rfap
+        - mhapStJosephs
+        - mhapElliottHouse
     BedSearchParameters:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6105,6 +6105,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             arrivalDate:
               type: string
               format: date-time
@@ -6640,6 +6642,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -6681,6 +6685,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -6704,10 +6710,6 @@ components:
             noticeType:
               $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
-            - isPipeApplication
-            - isWomensApplication
-            - isEmergencyApplication
-            - isEsapApplication
             - targetLocation
             - releaseType
             - sentenceType

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2154,6 +2154,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             arrivalDate:
               type: string
               format: date-time
@@ -2689,6 +2691,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -2730,6 +2734,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -2753,10 +2759,6 @@ components:
             noticeType:
               $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
-            - isPipeApplication
-            - isWomensApplication
-            - isEmergencyApplication
-            - isEsapApplication
             - targetLocation
             - releaseType
             - sentenceType

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4320,6 +4320,8 @@ components:
       enum:
         - isPIPE
         - isESAP
+        - isMHAPStJosephs
+        - isMHAPElliottHouse
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - hasBrailleSignage
@@ -4351,6 +4353,8 @@ components:
         - pipe
         - esap
         - rfap
+        - mhapStJosephs
+        - mhapElliottHouse
     BedSearchParameters:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3822,6 +3822,8 @@ components:
       enum:
         - isPIPE
         - isESAP
+        - isMHAPStJosephs
+        - isMHAPElliottHouse
         - isSemiSpecialistMentalHealth
         - isRecoveryFocussed
         - hasBrailleSignage
@@ -3853,6 +3855,8 @@ components:
         - pipe
         - esap
         - rfap
+        - mhapStJosephs
+        - mhapElliottHouse
     BedSearchParameters:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1656,6 +1656,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             arrivalDate:
               type: string
               format: date-time
@@ -2191,6 +2193,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -2232,6 +2236,8 @@ components:
               type: boolean
             isEsapApplication:
               type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
             targetLocation:
               type: string
             releaseType:
@@ -2255,10 +2261,6 @@ components:
             noticeType:
               $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
-            - isPipeApplication
-            - isWomensApplication
-            - isEmergencyApplication
-            - isEsapApplication
             - targetLocation
             - releaseType
             - sentenceType

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
@@ -32,9 +33,8 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
   private var isWomensApplication: Yielded<Boolean?> = { null }
-  private var isPipeApplication: Yielded<Boolean?> = { null }
   private var isEmergencyApplication: Yielded<Boolean?> = { null }
-  private var isEsapApplication: Yielded<Boolean?> = { null }
+  private var apType: Yielded<ApprovedPremisesType> = { ApprovedPremisesType.NORMAL }
   private var convictionId: Yielded<Long> = { randomInt(0, 1000).toLong() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var offenceId: Yielded<String> = { randomStringMultiCaseWithNumbers(5) }
@@ -104,10 +104,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isWomensApplication = { isWomensApplication }
   }
 
-  fun withIsPipeApplication(isPipeApplication: Boolean) = apply {
-    this.isPipeApplication = { isPipeApplication }
-  }
-
   fun withConvictionId(convictionId: Long) = apply {
     this.convictionId = { convictionId }
   }
@@ -172,8 +168,8 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.isEmergencyApplication = { isEmergencyApplication }
   }
 
-  fun withIsEsapApplication(isEsapApplication: Boolean?) = apply {
-    this.isEsapApplication = { isEsapApplication }
+  fun withApType(apType: ApprovedPremisesType) = apply {
+    this.apType = { apType }
   }
 
   fun withName(name: String) = apply {
@@ -222,9 +218,8 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
     isWomensApplication = this.isWomensApplication(),
-    isPipeApplication = this.isPipeApplication(),
     isEmergencyApplication = this.isEmergencyApplication(),
-    isEsapApplication = this.isEsapApplication(),
+    apType = this.apType(),
     convictionId = this.convictionId(),
     eventNumber = this.eventNumber(),
     offenceId = this.offenceId(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import java.time.OffsetDateTime
 
 class ApplicationSummaryQueryTest : IntegrationTestBase() {
@@ -26,7 +27,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(differentUser)
             withApplicationSchema(applicationSchema)
-            withIsPipeApplication(true)
+            withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
             withReleaseType("rotl")
             withSubmittedAt(null)
@@ -36,7 +37,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(user)
             withApplicationSchema(applicationSchema)
-            withIsPipeApplication(true)
+            withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
             withReleaseType("rotl")
             withSubmittedAt(null)
@@ -48,7 +49,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(user)
             withApplicationSchema(applicationSchema)
-            withIsPipeApplication(true)
+            withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
             withReleaseType("rotl")
             withIsWithdrawn(true)
@@ -67,7 +68,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(user)
             withApplicationSchema(applicationSchema)
-            withIsPipeApplication(true)
+            withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
             withReleaseType("rotl")
             withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -507,7 +507,7 @@ class ApplicationTest : IntegrationTestBase() {
                 ),
                 createdAt = application.createdAt.toInstant(),
                 isWomensApplication = null,
-                isPipeApplication = null,
+                isPipeApplication = false,
                 isEmergencyApplication = null,
                 isEsapApplication = null,
                 arrivalDate = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -85,11 +87,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
       risksFactory.produce(),
     )
     withApArea(apArea)
-    if (requiredQualification !== null) {
-      withIsPipeApplication(requiredQualification == UserQualification.PIPE)
-      withIsEsapApplication(requiredQualification == UserQualification.ESAP)
-      withIsWomensApplication(requiredQualification == UserQualification.WOMENS)
-    }
+    applyQualification(requiredQualification)
     withNoticeType(noticeType)
   }
 
@@ -148,6 +146,15 @@ fun IntegrationTestBase.`Given a Placement Request`(
   }
 
   return Pair(placementRequest, application)
+}
+
+private fun ApprovedPremisesApplicationEntityFactory.applyQualification(requiredQualification: UserQualification?) {
+  when (requiredQualification) {
+    UserQualification.PIPE -> withApType(ApprovedPremisesType.PIPE)
+    UserQualification.ESAP -> withApType(ApprovedPremisesType.ESAP)
+    UserQualification.WOMENS -> withIsWomensApplication(true)
+    else -> { }
+  }
 }
 
 @Suppress(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.OffsetDateTime
@@ -52,10 +53,11 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     if (name !== null) {
       withName(name)
     }
-    if (requiredQualification !== null) {
-      withIsPipeApplication(requiredQualification == UserQualification.PIPE)
-      withIsEsapApplication(requiredQualification == UserQualification.ESAP)
-      withIsWomensApplication(requiredQualification == UserQualification.WOMENS)
+    when (requiredQualification) {
+      UserQualification.PIPE -> withApType(ApprovedPremisesType.PIPE)
+      UserQualification.ESAP -> withApType(ApprovedPremisesType.ESAP)
+      UserQualification.WOMENS -> withIsWomensApplication(true)
+      else -> { }
     }
     withNoticeType(noticeType)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/allocations/rules/EsapAssessmentRuleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/allocations/rules/EsapAssessmentRuleTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import java.time.OffsetDateTime
 
 class EsapAssessmentRuleTest {
@@ -38,7 +39,7 @@ class EsapAssessmentRuleTest {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(createdByUser)
         .withSubmittedAt(OffsetDateTime.now())
-        .withIsEsapApplication(true)
+        .withApType(ApprovedPremisesType.ESAP)
         .produce()
 
       val assessment = ApprovedPremisesAssessmentEntityFactory()
@@ -94,7 +95,7 @@ class EsapAssessmentRuleTest {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(createdByUser)
         .withSubmittedAt(null)
-        .withIsEsapApplication(true)
+        .withApType(ApprovedPremisesType.ESAP)
         .produce()
 
       val assessment = ApprovedPremisesAssessmentEntityFactory()
@@ -122,7 +123,7 @@ class EsapAssessmentRuleTest {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(createdByUser)
         .withSubmittedAt(OffsetDateTime.now())
-        .withIsEsapApplication(false)
+        .withApType(ApprovedPremisesType.NORMAL)
         .produce()
 
       val assessment = ApprovedPremisesAssessmentEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -66,6 +66,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -1863,7 +1864,7 @@ class AssessmentServiceTest {
           }
           .produce(),
       )
-      .withIsPipeApplication(true)
+      .withApType(ApprovedPremisesType.PIPE)
       .produce()
 
     val previousAssessment = ApprovedPremisesAssessmentEntityFactory()
@@ -1923,7 +1924,7 @@ class AssessmentServiceTest {
           }
           .produce(),
       )
-      .withIsPipeApplication(true)
+      .withApType(ApprovedPremisesType.PIPE)
       .produce()
 
     val previousAssessment = ApprovedPremisesAssessmentEntityFactory()
@@ -2468,7 +2469,7 @@ class AssessmentServiceTest {
             }
             .produce(),
         )
-        .withIsPipeApplication(true)
+        .withApType(ApprovedPremisesType.PIPE)
         .withNoticeType(timelinessCategory)
         .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayCountService
 import java.time.LocalDate
@@ -195,7 +196,13 @@ class TaskDeadlineServiceTest {
       ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(user)
         .withNoticeType(noticeType)
-        .withIsEsapApplication(isEsap)
+        .apply {
+          if (isEsap) {
+            withApType(ApprovedPremisesType.ESAP)
+          } else {
+            withApType(ApprovedPremisesType.NORMAL)
+          }
+        }
         .produce(),
     )
 


### PR DESCRIPTION
> See [APS-473 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-473).

This PR adds support for Mental Health Approved Premises (MHAP) within CAS1 applications. There are two ways to specify that an application is MHAP when updating or submitting an application:
- Setting `isMhapApplication` to `true`
- Setting `apType` to `"mhap"`

Using the `apType` enum is preferred for future usage, but `isMhapApplication` has been introduced for backwards compatibility by analogy with the current usage of `isPipeApplication` and `isEsapApplication`. Only one method can be used; for example, setting both `isMhapApplication` to `true` and `apType` to `"mhap"` will return a validation error. This is to avoid having to decide precedence or assign arbitrarily when the values disagree. If `apType` is used, all three of `isPipeApplication`, `isEsapApplication`, and `isMhapApplication` must be `null`; likewise, if any of those three are non-null, `apType` must be `null`.

Internally, the `approved_premises_applications` table has been remodelled to remove the `is_pipe_application` and `is_esap_application` in favour of an `ap_type` column, allowing for greater flexibility in adding new AP types in future.