### PR TITLE
revert use of delius_context_api for offender info (do not merge)

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -79,9 +79,8 @@ generic-service:
     ARRIVED-DEPARTED-DOMAIN-EVENTS-DISABLED: true
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
-    DATA-SOURCES_OFFENDER-DETAILS: ap_delius_context_api
-    DATA-SOURCES_OFFENDER-RISKS: ap_delius_context_api
-
+    DATA-SOURCES_OFFENDER-DETAILS: community_api
+    DATA-SOURCES_OFFENDER-RISKS: community_api
 
     USER-ALLOCATIONS_RULES_LEGACY-ALLOCATOR_ENABLED: false
     USER-ALLOCATIONS_RULES_LEGACY-ALLOCATOR_PRIORITY: -1


### PR DESCRIPTION
An issue has been found with this integration, causing an exception in production, as detailed on APS-509.

This commit reverts back to the non-bulk endpoint whilst the issue is being resolved, if we decide reversion is required in the meantime