### PR TITLE
Move `personName`, `crn` and `nomsNumber` to top level `Cas2SubmittedApplicationsSummaries`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -177,10 +177,12 @@ class SubmissionsController(
   ):
     Cas2SubmittedApplicationSummary {
     val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
+    val personName = offenderService.getOffenderNameOrPlaceholder(personInfo)
 
     return submissionsTransformer.transformJpaSummaryToApiRepresentation(
       application,
       personInfo,
+      personName,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -46,6 +46,7 @@ WHERE a.created_by_user_id = :userId
 SELECT
     CAST(a.id AS TEXT) as id,
     a.crn,
+    a.noms_number as nomsNumber,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
     a.submitted_at as submittedAt
@@ -134,6 +135,7 @@ data class Cas2ApplicationEntity(
 interface AppSummary {
   fun getId(): UUID
   fun getCrn(): String
+  fun getNomsNumber(): String
   fun getCreatedByUserId(): UUID
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -82,6 +82,16 @@ class OffenderService(
     }
   }
 
+  fun getOffenderNameOrPlaceholder(personInfoResult: PersonInfoResult.Success): String {
+    return when (personInfoResult) {
+      is PersonInfoResult.Success.Full ->
+        "${personInfoResult.offenderDetailSummary.firstName} " +
+          personInfoResult.offenderDetailSummary.surname
+
+      is PersonInfoResult.Success.Restricted -> "Unknown"
+    }
+  }
+
   private fun getInfoForPerson(crn: String): PersonInfoResult {
     var offenderResponse = offenderDetailsDataSource.getOffenderDetailSummary(crn)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -56,6 +56,8 @@ class SubmissionsTransformer(
       createdByUserId = jpaSummary.getCreatedByUserId(),
       createdAt = jpaSummary.getCreatedAt().toInstant(),
       submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
+      crn = jpaSummary.getCrn(),
+      nomsNumber = jpaSummary.getNomsNumber(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -49,10 +49,12 @@ class SubmissionsTransformer(
     jpaSummary: Cas2ApplicationSummary,
     personInfo:
       PersonInfoResult.Success,
+    personName: String,
   ): Cas2SubmittedApplicationSummary {
     return Cas2SubmittedApplicationSummary(
       id = jpaSummary.getId(),
       person = personTransformer.transformModelToPersonApi(personInfo),
+      personName = personName,
       createdByUserId = jpaSummary.getCreatedByUserId(),
       createdAt = jpaSummary.getCreatedAt().toInstant(),
       submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1962,6 +1962,10 @@ components:
           format: uuid
         person:
           $ref: '#/components/schemas/Person'
+        crn:
+          type: string
+        nomsNumber:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -1974,6 +1978,8 @@ components:
         - id
         - person
         - createdAt
+        - crn
+        - nomsNumber
     Cas2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1966,6 +1966,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        personName:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -1978,6 +1980,7 @@ components:
         - id
         - person
         - createdAt
+        - personName
         - crn
         - nomsNumber
     Cas2StatusUpdate:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6459,6 +6459,10 @@ components:
           format: uuid
         person:
           $ref: '#/components/schemas/Person'
+        crn:
+          type: string
+        nomsNumber:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -6471,6 +6475,8 @@ components:
         - id
         - person
         - createdAt
+        - crn
+        - nomsNumber
     Cas2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6463,6 +6463,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        personName:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -6475,6 +6477,7 @@ components:
         - id
         - person
         - createdAt
+        - personName
         - crn
         - nomsNumber
     Cas2StatusUpdate:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2519,6 +2519,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        personName:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -2531,6 +2533,7 @@ components:
         - id
         - person
         - createdAt
+        - personName
         - crn
         - nomsNumber
     Cas2StatusUpdate:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2515,6 +2515,10 @@ components:
           format: uuid
         person:
           $ref: '#/components/schemas/Person'
+        crn:
+          type: string
+        nomsNumber:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -2527,6 +2531,8 @@ components:
         - id
         - person
         - createdAt
+        - crn
+        - nomsNumber
     Cas2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2014,6 +2014,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        personName:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -2026,6 +2028,7 @@ components:
         - id
         - person
         - createdAt
+        - personName
         - crn
         - nomsNumber
     Cas2StatusUpdate:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2010,6 +2010,10 @@ components:
           format: uuid
         person:
           $ref: '#/components/schemas/Person'
+        crn:
+          type: string
+        nomsNumber:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -2022,6 +2026,8 @@ components:
         - id
         - person
         - createdAt
+        - crn
+        - nomsNumber
     Cas2StatusUpdate:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpd
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -209,6 +210,7 @@ class Cas2SubmissionTest(
                 withApplicationSchema(applicationSchema)
                 withCreatedByUser(user)
                 withCrn(offenderDetails.otherIds.crn)
+                withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
                 withSubmittedAt(OffsetDateTime.parse("2023-01-02T09:00:00+01:00"))
                 withData("{}")
               }
@@ -218,6 +220,7 @@ class Cas2SubmissionTest(
                 withApplicationSchema(applicationSchema)
                 withCreatedByUser(user)
                 withCrn(offenderDetails.otherIds.crn)
+                withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
                 withSubmittedAt(OffsetDateTime.parse("2023-01-01T09:00:00+01:00"))
                 withData("{}")
               }
@@ -227,6 +230,7 @@ class Cas2SubmissionTest(
                 withApplicationSchema(applicationSchema)
                 withCreatedByUser(user)
                 withCrn(offenderDetails.otherIds.crn)
+                withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
                 withSubmittedAt(OffsetDateTime.parse("2023-01-03T09:00:00+01:00"))
                 withData("{}")
               }
@@ -236,6 +240,7 @@ class Cas2SubmissionTest(
                 withApplicationSchema(applicationSchema)
                 withCreatedByUser(user)
                 withCrn(offenderDetails.otherIds.crn)
+                withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
                 withSubmittedAt(null)
                 withData("{}")
               }
@@ -261,29 +266,23 @@ class Cas2SubmissionTest(
                 object : TypeReference<List<Cas2SubmittedApplicationSummary>>() {},
               )
 
-            Assertions.assertThat(responseBody[0]).matches {
-              submittedcas2applicationentityFirst.id == it.id &&
-                submittedcas2applicationentityFirst.crn == it.person.crn &&
-                submittedcas2applicationentityFirst.createdAt.toInstant() == it.createdAt &&
-                submittedcas2applicationentityFirst.createdByUser.id == it.createdByUserId &&
-                submittedcas2applicationentityFirst.submittedAt?.toInstant() == it.submittedAt
-            }
+            assertApplicationResponseMatchesExpected(
+              responseBody[0],
+              submittedcas2applicationentityFirst,
+              offenderDetails,
+            )
 
-            Assertions.assertThat(responseBody[1]).matches {
-              submittedcas2applicationentitySecond.id == it.id &&
-                submittedcas2applicationentitySecond.crn == it.person.crn &&
-                submittedcas2applicationentitySecond.createdAt.toInstant() == it.createdAt &&
-                submittedcas2applicationentitySecond.createdByUser.id == it.createdByUserId &&
-                submittedcas2applicationentitySecond.submittedAt?.toInstant() == it.submittedAt
-            }
+            assertApplicationResponseMatchesExpected(
+              responseBody[1],
+              submittedcas2applicationentitySecond,
+              offenderDetails,
+            )
 
-            Assertions.assertThat(responseBody[2]).matches {
-              submittedcas2applicationentityThird.id == it.id &&
-                submittedcas2applicationentityThird.crn == it.person.crn &&
-                submittedcas2applicationentityThird.createdAt.toInstant() == it.createdAt &&
-                submittedcas2applicationentityThird.createdByUser.id == it.createdByUserId &&
-                submittedcas2applicationentityThird.submittedAt?.toInstant() == it.submittedAt
-            }
+            assertApplicationResponseMatchesExpected(
+              responseBody[2],
+              submittedcas2applicationentityThird,
+              offenderDetails,
+            )
 
             Assertions.assertThat(responseBody).noneMatch {
               inProgressCas2ApplicationEntity.id == it.id
@@ -291,6 +290,25 @@ class Cas2SubmissionTest(
           }
         }
       }
+    }
+
+    private fun assertApplicationResponseMatchesExpected(
+      response: Cas2SubmittedApplicationSummary,
+      expectedSubmittedApplication: Cas2ApplicationEntity,
+      offenderDetails: OffenderDetailSummary,
+    ) {
+      Assertions.assertThat(response).matches {
+        expectedSubmittedApplication.id == it.id &&
+          expectedSubmittedApplication.crn == it.person.crn &&
+          expectedSubmittedApplication.crn == it.crn &&
+          expectedSubmittedApplication.nomsNumber == it.nomsNumber &&
+          expectedSubmittedApplication.createdAt.toInstant() == it.createdAt &&
+          expectedSubmittedApplication.createdByUser.id == it.createdByUserId &&
+          expectedSubmittedApplication.submittedAt?.toInstant() == it.submittedAt
+      }
+
+      Assertions.assertThat(response.personName)
+        .isEqualTo("${offenderDetails.firstName} ${offenderDetails.surname}")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -89,6 +89,7 @@ class ApplicationServiceTest {
       val applicationSummary = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
         override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/OffenderServiceTest.kt
@@ -438,6 +438,32 @@ class OffenderServiceTest {
     }
   }
 
+  @Nested
+  inner class GetOffenderNameOrPlaceholder {
+    @Test
+    fun `returns Unknown when offender is PersonInfoResult-Restricted`() {
+      val personInfoResult = PersonInfoResult.Success.Restricted(crn = "RESTRICTED", nomsNumber = null)
+      val result = offenderService.getOffenderNameOrPlaceholder(personInfoResult)
+      assertThat(result).isEqualTo("Unknown")
+    }
+
+    @Test
+    fun `returns the person's full name when offender is PersonInfoResult-Full`() {
+      val offenderDetailSummary = OffenderDetailsSummaryFactory()
+        .withFirstName("ExampleFirst")
+        .withLastName("ExampleLast")
+        .produce()
+      val inmateDetail = InmateDetailFactory().produce()
+      val personInfoResult = PersonInfoResult.Success.Full(
+        crn = "FULL",
+        offenderDetailSummary,
+        inmateDetail,
+      )
+      val result = offenderService.getOffenderNameOrPlaceholder(personInfoResult)
+      assertThat(result).isEqualTo("ExampleFirst ExampleLast")
+    }
+  }
+
   private fun mock404RoSH(crn: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.NOT_FOUND, body = null)
 
   private fun mock500RoSH(crn: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.INTERNAL_SERVER_ERROR, body = null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -150,6 +150,7 @@ class ApplicationsTransformerTest {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
         override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
@@ -170,6 +171,7 @@ class ApplicationsTransformerTest {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
         override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
@@ -127,11 +129,29 @@ class SubmissionsTransformerTest {
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
       }
 
-      val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(applicationSummary, mockk())
+      val personInfo = mockk<PersonInfoResult.Success>()
+      val person = mockk<Person>()
 
-      assertThat(transformation.id).isEqualTo(applicationSummary.getId())
-      assertThat(transformation.crn).isEqualTo(applicationSummary.getCrn())
-      assertThat(transformation.nomsNumber).isEqualTo(applicationSummary.getNomsNumber())
+      every { mockPersonTransformer.transformModelToPersonApi(personInfo) } returns person
+
+      val expectedSubmittedApplicationSummary = Cas2SubmittedApplicationSummary(
+        id = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809"),
+        crn = "CRN123",
+        nomsNumber = "NOMS456",
+        createdByUserId = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f"),
+        createdAt = Instant.parse("2023-04-19T13:25:00+01:00"),
+        submittedAt = Instant.parse("2023-04-19T13:25:30+01:00"),
+        personName = "Example Offender",
+        person = person,
+      )
+
+      val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(
+        applicationSummary,
+        personInfo,
+        "Example Offender",
+      )
+
+      assertThat(transformation).isEqualTo(expectedSubmittedApplicationSummary)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -121,7 +120,8 @@ class SubmissionsTransformerTest {
     fun `transforms submitted summary application to API summary representation `() {
       val applicationSummary = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
-        override fun getCrn() = randomStringMultiCaseWithNumbers(6)
+        override fun getCrn() = "CRN123"
+        override fun getNomsNumber() = "NOMS456"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
@@ -130,6 +130,8 @@ class SubmissionsTransformerTest {
       val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(applicationSummary, mockk())
 
       assertThat(transformation.id).isEqualTo(applicationSummary.getId())
+      assertThat(transformation.crn).isEqualTo(applicationSummary.getCrn())
+      assertThat(transformation.nomsNumber).isEqualTo(applicationSummary.getNomsNumber())
     }
   }
 }


### PR DESCRIPTION
We have an 'assessor's dashboard' page on CAS2, which queries the `/submissions` endpoint to retrieve paged results of all submitted applications across all time.

![Screenshot 2024-03-15 at 15 28 03](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/75f493b9-4b70-408f-a412-9ca78d444bd2)

The response times for this are very slow https://dsdmoj.atlassian.net/browse/CAS2-318 

Part of the reason for this could be that we are making two calls to integration APIs in order to retrieve a `FullPerson` type.

1. Here when we get the `offenderSummary` 

https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/938a6dda5c012a3b80080ef109d80de6f63fdeee/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt#L86 

2. And then to get the `inmateDetail` 

https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/938a6dda5c012a3b80080ef109d80de6f63fdeee/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt#L101

There's three phases of work I suggest to resolve this:

### 1. remove the second API call to get inmate details (this PR)
For this dashboard, we only need the person's name from the integration APIs, which means that only the first call is needed. We already have the `nomsNumber` and `crn` on the Application Entity. 
Let's just return the person's name on the summary and not bother to return a full `Person` type. This should significantly reduce the response time as we'd go from 1 to 2 external API calls.
Cons: We might need to show inmate details on a dashboard in future, but that could be introduced again if needed, and maybe solved by phase 2.
This would be done in stages, in order not to break the UI.
A. (API) Introduce the top level fields
B. (FE) Use the new fields on the UI (PR here https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/583) 
c. (API) Remove the old `Person` field and extraneous API call.

### 2. use bulk search for CRNs (near-future work)
We use the `getOffenderDetailSummaries` on the `OffenderDetailsDataSource` to bulk search for the offender summaries, rather than making a call per CRN.

### 3. save offender/inmate details on the Application (far-future work)
The wider CAS teams are now agreeing to pull in offender data and save in our db, so [we do not have to make these integration calls](https://mojdt.slack.com/archives/C03K0HB0LBE/p1710429149171069).
This would mean we save the prisoner name when an application is created on the Application table, and remove the need for this API call altogether.