### PR TITLE
Handle missing CRNs returned from bulk endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Primary
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -103,11 +105,28 @@ class ApDeliusContextApiOffenderDetailsDataSource(
   override fun getOffenderDetailSummaries(crns: List<String>): Map<String, ClientResult<OffenderDetailSummary>> {
     return when (val clientResult = apDeliusContextApiClient.getSummariesForCrns(crns)) {
       is ClientResult.Success -> {
-        clientResult.body.cases
-          .associateBy(
-            keySelector = { it.crn },
-            valueTransform = { clientResult.copyWithBody(body = it.asOffenderDetailSummary()) },
-          )
+        val crnToAccessResult = clientResult.body.cases.associateBy(
+          keySelector = { it.crn },
+          valueTransform = { it },
+        )
+
+        crns.associateBy(
+          keySelector = { it },
+          valueTransform = { crn ->
+            val access = crnToAccessResult[crn]
+
+            if (access != null) {
+              clientResult.copyWithBody(body = access.asOffenderDetailSummary())
+            } else {
+              ClientResult.Failure.StatusCode(
+                method = HttpMethod.GET,
+                path = "/probation-cases/summaries",
+                status = HttpStatus.NOT_FOUND,
+                body = null,
+              )
+            }
+          },
+        )
       }
       else -> return crns.associateWith { clientResult as ClientResult<OffenderDetailSummary> }
     }
@@ -127,11 +146,28 @@ class ApDeliusContextApiOffenderDetailsDataSource(
   ): Map<String, ClientResult<UserOffenderAccess>> {
     return when (val clientResult = apDeliusContextApiClient.getUserAccessForCrns(deliusUsername, crns)) {
       is ClientResult.Success -> {
-        clientResult.body.access
-          .associateBy(
-            keySelector = { it.crn },
-            valueTransform = { clientResult.copyWithBody(body = it.asUserOffenderAccess()) },
-          )
+        val crnToAccessResult = clientResult.body.access.associateBy(
+          keySelector = { it.crn },
+          valueTransform = { it },
+        )
+
+        crns.associateBy(
+          keySelector = { it },
+          valueTransform = { crn ->
+            val access = crnToAccessResult[crn]
+
+            if (access != null) {
+              clientResult.copyWithBody(body = access.asUserOffenderAccess())
+            } else {
+              ClientResult.Failure.StatusCode(
+                method = HttpMethod.GET,
+                path = "/users/access?username=$deliusUsername",
+                status = HttpStatus.NOT_FOUND,
+                body = null,
+              )
+            }
+          },
+        )
       }
       else -> crns.associateWith { clientResult as ClientResult<UserOffenderAccess> }
     }


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-509

/probation-cases/summaries and /users/access will not return a CRN if information isn’t found for that CRN.

Before this commit, the code was (implicitly) assuming that if a CRN wasn’t found, a 404 would be returned.

This commit changes the logic calling these two endpoints to return an individual ‘Not Found’ status code for any CRN not included in the result.

The code isn’t ideal as we need to include the method/path when building the not found responses, which the OffenderDetailsDataSource shouldn’t really need to know. Ideally we would refactor this code to stop returning such a complex response hierarchy from the updated functions.