### PR TITLE
[CAS-244] - Update occupancy rate calculation in Occupancy Report based on Bedspace end date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportRow.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
 
+import java.time.LocalDate
+
 data class BedUtilisationReportRow(
   val probationRegion: String?,
   val pdu: String?,
@@ -16,7 +18,9 @@ data class BedUtilisationReportRow(
   val effectiveTurnaroundDays: Int,
   val voidDays: Int,
   val totalBookedDays: Int,
-  val totalDaysInTheMonth: Int,
+  val bedspaceStartDate: LocalDate,
+  val bedspaceEndDate: LocalDate?,
+  val bedspaceOnlineDays: Int,
   val occupancyRate: Double,
   val uniquePropertyRef: String,
   val uniqueBedspaceRef: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -1079,6 +1079,9 @@ class ReportsTest : IntegrationTestBase() {
             withRoom(room)
           }
 
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
           GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
           bookingEntityFactory.produceAndPersist {
@@ -1138,6 +1141,9 @@ class ReportsTest : IntegrationTestBase() {
           val bed = bedEntityFactory.produceAndPersist {
             withRoom(room)
           }
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
 
           GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 


### PR DESCRIPTION
This PR [CAS-244](https://dsdmoj.atlassian.net/browse/CAS-244) is to change the calculation of occupancy rate in Occupancy Report based on Bedspace start and end date. This will include:

1. The Occupancy Rate in the Occupancy Report will be calculated as follows:
occupancy percentage = bookedDaysActiveAndClosed / bedspaceOnlineDays
2. Add new columns to the report:
- bedspaceStartDate - set to the Creation Date of the Bedspace
- bedspaceEndDate - set if it not null
- bedspaceOnlineDays this will be calculated as the number of days between these dates:
      - bedspaceStartDate or report start date - whichever is LATER
      - bedspaceEndDate or report end date - whichever is EARLIER
4. Remove the column totalDaysInTheMonth








[CAS-244]: https://dsdmoj.atlassian.net/browse/CAS-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ