### PR TITLE
(APS-450) Return distinct domain events in timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -227,7 +227,7 @@ class DomainEventService(
     )
 
   fun getAllDomainEventsForApplication(applicationId: UUID) =
-    domainEventRepository.findAllTimelineEventsByApplicationId(applicationId)
+    domainEventRepository.findAllTimelineEventsByApplicationId(applicationId).distinctBy { it.id }
 
   private fun saveAndEmit(
     domainEvent: DomainEvent<*>,


### PR DESCRIPTION
We’ve noticed when making multiple appeals, the timeline shows multiple events because we’re carrying out multiple JOINs on the query. I’ve gone through a number of permutations of using the `DISTINCT` operator, but nothing seems to work as we expect, so I’ve opted for calling `distinctBy` in the service method, which seems to do the trick. As the number of events is unlikely to get unmanageable, we’re not asking the system to do too much extra work (either on the application or database side)