### PR TITLE
Fix bug that would withdraw unrelated placements

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -104,7 +104,7 @@ generic-service:
     USER-ALLOCATIONS_RULES_EMERGENCY-ASSESSMENTS_ALLOCATE-TO-USERS_NAT: # TODO: Determine appropriate user
 
     NOTIFY_SEND-PLACEMENT-REQUEST-NOTIFICATIONS: true
-    FEATURE-FLAGS_CAS1-USE-NEW-WITHDRAWAL-LOGIC: true
+    FEATURE-FLAGS_CAS1-USE-NEW-WITHDRAWAL-LOGIC: false
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -133,7 +133,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   fun findAllByCrn(crn: String): List<BookingEntity>
 
   @Query(
-    "SELECT b From BookingEntity b WHERE b.adhoc IS TRUE or b.adhoc IS NULL",
+    "SELECT b From BookingEntity b WHERE b.application = :application AND (b.adhoc IS TRUE or b.adhoc IS NULL)",
   )
   fun findAllAdhocOrUnknownByApplication(application: ApplicationEntity): List<BookingEntity>
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -354,6 +354,7 @@ class WithdrawalTest : IntegrationTestBase() {
           `Given a User` { requestForPlacementAssessor, _ ->
             `Given an Offender` { offenderDetails, _ ->
               val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
+              val (otherApplication, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
               val placementApplication1 = createPlacementApplication(application, listOf(LocalDate.now() to 2))
               val placementRequest1 = createPlacementRequest(application) {
@@ -389,6 +390,21 @@ class WithdrawalTest : IntegrationTestBase() {
               val adhocBooking = createBooking(
                 application = application,
                 adhoc = true,
+                hasArrival = false,
+                startDate = LocalDate.now().plusDays(20),
+                endDate = LocalDate.now().plusDays(26),
+              )
+
+              createBooking(
+                application = otherApplication,
+                adhoc = true,
+                hasArrival = false,
+                startDate = LocalDate.now().plusDays(20),
+                endDate = LocalDate.now().plusDays(26),
+              )
+              createBooking(
+                application = otherApplication,
+                adhoc = null,
                 hasArrival = false,
                 startDate = LocalDate.now().plusDays(20),
                 endDate = LocalDate.now().plusDays(26),
@@ -484,7 +500,7 @@ class WithdrawalTest : IntegrationTestBase() {
             )
             addBookingToPlacementRequest(placementRequest3, booking2HasArrival)
 
-            val adhocBooking = createBooking(
+            createBooking(
               application = application,
               hasArrival = false,
               startDate = LocalDate.now().plusDays(20),
@@ -582,6 +598,7 @@ class WithdrawalTest : IntegrationTestBase() {
         `Given a User` { requestForPlacementAssessor, _ ->
           `Given an Offender` { offenderDetails, _ ->
             val (application, assessment) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
+            val (otherApplication, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
             val placementApplication1 = createPlacementApplication(application, listOf(LocalDate.now() to 2))
             val placementRequest1 = createPlacementRequest(application) {
@@ -626,6 +643,23 @@ class WithdrawalTest : IntegrationTestBase() {
               startDate = LocalDate.now().plusDays(1),
               endDate = LocalDate.now().plusDays(6),
               adhoc = null,
+            )
+
+            // regression test to ensure other application's
+            // bookings aren't affected
+            createBooking(
+              application = otherApplication,
+              adhoc = true,
+              hasArrival = false,
+              startDate = LocalDate.now().plusDays(20),
+              endDate = LocalDate.now().plusDays(26),
+            )
+            createBooking(
+              application = otherApplication,
+              adhoc = null,
+              hasArrival = false,
+              startDate = LocalDate.now().plusDays(20),
+              endDate = LocalDate.now().plusDays(26),
             )
 
             withdrawApplication(application, jwt)


### PR DESCRIPTION
The findAllAdhocOrUnknownByApplication was not filtering out bookings not related to the application.