### PR TITLE
Check to ensure withdrawal is limited to same app

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -50,6 +50,7 @@ class Cas1WithdrawableTreeBuilder(
     }
 
     return WithdrawableTreeNode(
+      applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
       status = applicationService.getWithdrawableState(application, user),
@@ -62,6 +63,7 @@ class Cas1WithdrawableTreeBuilder(
     val children = placementApplication.placementRequests.map { treeForPlacementReq(it, user) }
 
     return WithdrawableTreeNode(
+      applicationId = placementApplication.application.id,
       entityType = WithdrawableEntityType.PlacementApplication,
       entityId = placementApplication.id,
       status = placementApplicationService.getWithdrawableState(placementApplication, user),
@@ -89,6 +91,7 @@ class Cas1WithdrawableTreeBuilder(
     }
 
     return WithdrawableTreeNode(
+      applicationId = placementRequest.application.id,
       entityType = WithdrawableEntityType.PlacementRequest,
       entityId = placementRequest.id,
       status = placementRequestService.getWithdrawableState(placementRequest, user),
@@ -99,6 +102,7 @@ class Cas1WithdrawableTreeBuilder(
 
   fun treeForBooking(booking: BookingEntity, user: UserEntity): WithdrawableTreeNode {
     return WithdrawableTreeNode(
+      applicationId = booking.application?.id,
       entityType = WithdrawableEntityType.Booking,
       entityId = booking.id,
       status = bookingService.getWithdrawableState(booking, user),
@@ -109,6 +113,7 @@ class Cas1WithdrawableTreeBuilder(
 }
 
 data class WithdrawableTreeNode(
+  val applicationId: UUID?,
   val entityType: WithdrawableEntityType,
   val entityId: UUID,
   val status: WithdrawableState,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
@@ -71,6 +71,7 @@ class Cas1WithdrawableServiceTest {
       cas1WithdrawableTreeBuilder.treeForApp(application, user)
     } returns
       WithdrawableTreeNode(
+        applicationId = application.id,
         entityType = WithdrawableEntityType.PlacementApplication,
         entityId = appId,
         status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -110,16 +111,19 @@ class Cas1WithdrawableServiceTest {
       cas1WithdrawableTreeBuilder.treeForApp(application, user)
     } returns
       WithdrawableTreeNode(
+        applicationId = application.id,
         entityType = WithdrawableEntityType.Application,
         entityId = appWithdrawableId,
         status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
         children = listOf(
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementRequest,
             entityId = placementRequest1WithdrawableId,
             status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
             children = listOf(
               WithdrawableTreeNode(
+                applicationId = application.id,
                 entityType = WithdrawableEntityType.Booking,
                 entityId = placementWithdrawableId,
                 status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -127,16 +131,19 @@ class Cas1WithdrawableServiceTest {
             ),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementRequest,
             entityId = placementRequestWithdrawableButNotPermittedId,
             status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementApplication1WithdrawableId,
             status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
             children = listOf(
               WithdrawableTreeNode(
+                applicationId = application.id,
                 entityType = WithdrawableEntityType.PlacementRequest,
                 entityId = placementRequest2WithdrawableId,
                 status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -144,11 +151,13 @@ class Cas1WithdrawableServiceTest {
             ),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementApplication2NotWithdrawableId,
             status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.Booking,
             entityId = placementNotWithdrawableId,
             status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -181,16 +190,19 @@ class Cas1WithdrawableServiceTest {
       cas1WithdrawableTreeBuilder.treeForApp(application, user)
     } returns
       WithdrawableTreeNode(
+        applicationId = application.id,
         entityType = WithdrawableEntityType.Application,
         entityId = appWithdrawableButBlockedId,
         status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
         children = listOf(
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementRequest,
             entityId = placementRequest1WithdrawableButBlockedId,
             status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
             children = listOf(
               WithdrawableTreeNode(
+                applicationId = application.id,
                 entityType = WithdrawableEntityType.Booking,
                 entityId = placementWithdrawableButBlockingId,
                 status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockAncestorWithdrawals = true),
@@ -198,16 +210,19 @@ class Cas1WithdrawableServiceTest {
             ),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementRequest,
             entityId = placementRequestWithdrawableButNotPermittedId,
             status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementApplication1WithdrawableId,
             status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
             children = listOf(
               WithdrawableTreeNode(
+                applicationId = application.id,
                 entityType = WithdrawableEntityType.PlacementRequest,
                 entityId = placementRequest2WithdrawableId,
                 status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockAncestorWithdrawals = false),
@@ -215,11 +230,13 @@ class Cas1WithdrawableServiceTest {
             ),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementApplication2NotWithdrawableId,
             status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
           ),
           WithdrawableTreeNode(
+            applicationId = application.id,
             entityType = WithdrawableEntityType.Booking,
             entityId = placementNotWithdrawableId,
             status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -245,6 +262,7 @@ class Cas1WithdrawableServiceTest {
       every { applicationService.getApplication(application.id) } returns application
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Application,
         application.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -302,6 +320,7 @@ class Cas1WithdrawableServiceTest {
       every { applicationService.getApplication(application.id) } returns application
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Application,
         application.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
@@ -319,6 +338,7 @@ class Cas1WithdrawableServiceTest {
       every { applicationService.getApplication(application.id) } returns application
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Application,
         application.id,
         WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -337,11 +357,13 @@ class Cas1WithdrawableServiceTest {
       every { applicationService.getApplication(application.id) } returns application
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Application,
         application.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
         children = listOf(
           WithdrawableTreeNode(
+            applicationId = application.id,
             WithdrawableEntityType.Booking,
             UUID.randomUUID(),
             WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockAncestorWithdrawals = true),
@@ -383,6 +405,7 @@ class Cas1WithdrawableServiceTest {
       every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementRequest,
         placementRequest.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -427,6 +450,7 @@ class Cas1WithdrawableServiceTest {
       every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementRequest,
         placementRequest.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
@@ -444,6 +468,7 @@ class Cas1WithdrawableServiceTest {
       every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementRequest,
         placementRequest.id,
         WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -462,11 +487,13 @@ class Cas1WithdrawableServiceTest {
       every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementRequest,
         placementRequest.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
         children = listOf(
           WithdrawableTreeNode(
+            applicationId = application.id,
             WithdrawableEntityType.Booking,
             UUID.randomUUID(),
             WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockAncestorWithdrawals = true),
@@ -499,6 +526,7 @@ class Cas1WithdrawableServiceTest {
       every { placementApplicationService.getApplicationOrNull(placementApplication.id) } returns placementApplication
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementApplication,
         placementApplication.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -538,6 +566,7 @@ class Cas1WithdrawableServiceTest {
       every { placementApplicationService.getApplicationOrNull(placementApplication.id) } returns placementApplication
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementApplication,
         placementApplication.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
@@ -555,6 +584,7 @@ class Cas1WithdrawableServiceTest {
       every { placementApplicationService.getApplicationOrNull(placementApplication.id) } returns placementApplication
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementApplication,
         placementApplication.id,
         WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -573,11 +603,13 @@ class Cas1WithdrawableServiceTest {
       every { placementApplicationService.getApplicationOrNull(placementApplication.id) } returns placementApplication
 
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.PlacementApplication,
         placementApplication.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
         children = listOf(
           WithdrawableTreeNode(
+            applicationId = application.id,
             WithdrawableEntityType.PlacementApplication,
             placementApplication.id,
             WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockAncestorWithdrawals = true),
@@ -610,6 +642,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun success() {
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Booking,
         booking.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -650,6 +683,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `fails if user may not directly withdraw()`() {
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Booking,
         booking.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
@@ -665,6 +699,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `fails if not withdrawable()`() {
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Booking,
         booking.id,
         WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -681,6 +716,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `fails if blocked()`() {
       val tree = WithdrawableTreeNode(
+        applicationId = application.id,
         WithdrawableEntityType.Booking,
         booking.id,
         WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockAncestorWithdrawals = true),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
@@ -4,6 +4,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.slf4j.Logger
 import org.springframework.data.repository.findByIdOrNull
@@ -30,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Withdrawabl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableTreeNode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import java.util.UUID
 
 class Cas1WithdrawableTreeOperationsTest {
   private val mockPlacementRequestService = mockk<PlacementRequestService>()
@@ -51,6 +53,7 @@ class Cas1WithdrawableTreeOperationsTest {
   val user = UserEntityFactory().withProbationRegion(probationRegion).produce()
 
   val application = ApprovedPremisesApplicationEntityFactory()
+    .withId(UUID.fromString("fb724580-d6df-4e0e-92bb-54573f396202"))
     .withCreatedByUser(user)
     .produce()
 
@@ -102,26 +105,31 @@ class Cas1WithdrawableTreeOperationsTest {
     val adhocBookingNotWithdrawable = BookingEntityFactory().withPremises(approvedPremises).produce()
 
     val tree = WithdrawableTreeNode(
+      applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
       status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplication.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
               status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
+                  applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawable.id,
                   status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
                 ),
                 WithdrawableTreeNode(
+                  applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
                   status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
@@ -129,6 +137,7 @@ class Cas1WithdrawableTreeOperationsTest {
               ),
             ),
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
               status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -136,11 +145,13 @@ class Cas1WithdrawableTreeOperationsTest {
           ),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawable.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingNotWithdrawable.id,
           status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
@@ -254,16 +265,19 @@ class Cas1WithdrawableTreeOperationsTest {
     val adhocBookingWithdrawableButBlocked = BookingEntityFactory().withPremises(approvedPremises).produce()
 
     val tree = WithdrawableTreeNode(
+      applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
       status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplicationWithdrawable.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
               status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
@@ -271,21 +285,25 @@ class Cas1WithdrawableTreeOperationsTest {
           ),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplicationWithdrawableButBlocked.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawableButBlocked.id,
               status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
+                  applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawableButBlocking.id,
                   status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockAncestorWithdrawals = true),
                 ),
                 WithdrawableTreeNode(
+                  applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
                   status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false, blockAncestorWithdrawals = false),
@@ -293,6 +311,7 @@ class Cas1WithdrawableTreeOperationsTest {
               ),
             ),
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
               status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -300,11 +319,13 @@ class Cas1WithdrawableTreeOperationsTest {
           ),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawable.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockAncestorWithdrawals = false),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawableButBlocked.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockAncestorWithdrawals = true),
@@ -402,26 +423,31 @@ class Cas1WithdrawableTreeOperationsTest {
     val adhocBookingNotWithdrawable = BookingEntityFactory().withPremises(approvedPremises).produce()
 
     val tree = WithdrawableTreeNode(
+      applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
       status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplication.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
               status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
+                  applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawable.id,
                   status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
                 ),
                 WithdrawableTreeNode(
+                  applicationId = UUID.randomUUID(),
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
                   status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
@@ -429,6 +455,7 @@ class Cas1WithdrawableTreeOperationsTest {
               ),
             ),
             WithdrawableTreeNode(
+              applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
               status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
@@ -436,11 +463,13 @@ class Cas1WithdrawableTreeOperationsTest {
           ),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawable.id,
           status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
         ),
         WithdrawableTreeNode(
+          applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingNotWithdrawable.id,
           status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
@@ -502,5 +531,113 @@ class Cas1WithdrawableTreeOperationsTest {
           "with message oh dear",
       )
     }
+  }
+
+  @Test
+  fun `withdrawDescendantsOfRootNode throws exception if any nodes don't belong to same application as root node`() {
+    val otherApplicationId = UUID.fromString("4071072a-3d52-4904-b5bd-32b6420b105a")
+
+    val placementApplicationOtherApp = PlacementApplicationEntityFactory()
+      .withId(UUID.fromString("db8c102a-4062-4f8e-ab0f-d5f8953f447c"))
+      .withApplication(application)
+      .withCreatedByUser(user)
+      .produce()
+
+    val placementRequestWithdrawable = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withPlacementApplication(placementApplicationOtherApp)
+      .produce()
+
+    val placementRequestNotWithdrawable = PlacementRequestEntityFactory()
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withPlacementRequirements(placementRequirements)
+      .withPlacementApplication(placementApplicationOtherApp)
+      .produce()
+
+    val bookingWithdrawableOtherApp = BookingEntityFactory()
+      .withId(UUID.fromString("843de779-0b23-4517-8dea-f749596e0666"))
+      .withPremises(approvedPremises)
+      .produce()
+    val bookingNotWithdrawable = BookingEntityFactory().withPremises(approvedPremises).produce()
+
+    val adhocBookingWithdrawableOtherApp = BookingEntityFactory()
+      .withId(UUID.fromString("3a159ffe-d22e-4a04-9432-c7df4f836098"))
+      .withPremises(approvedPremises)
+      .produce()
+    val adhocBookingNotWithdrawable = BookingEntityFactory().withPremises(approvedPremises).produce()
+
+    val tree = WithdrawableTreeNode(
+      applicationId = application.id,
+      entityType = WithdrawableEntityType.Application,
+      entityId = application.id,
+      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      children = listOf(
+        WithdrawableTreeNode(
+          applicationId = otherApplicationId,
+          entityType = WithdrawableEntityType.PlacementApplication,
+          entityId = placementApplicationOtherApp.id,
+          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          children = listOf(
+            WithdrawableTreeNode(
+              applicationId = application.id,
+              entityType = WithdrawableEntityType.PlacementRequest,
+              entityId = placementRequestWithdrawable.id,
+              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              children = listOf(
+                WithdrawableTreeNode(
+                  applicationId = otherApplicationId,
+                  entityType = WithdrawableEntityType.Booking,
+                  entityId = bookingWithdrawableOtherApp.id,
+                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+                ),
+                WithdrawableTreeNode(
+                  applicationId = otherApplicationId,
+                  entityType = WithdrawableEntityType.Booking,
+                  entityId = bookingNotWithdrawable.id,
+                  status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+                ),
+              ),
+            ),
+            WithdrawableTreeNode(
+              applicationId = application.id,
+              entityType = WithdrawableEntityType.PlacementRequest,
+              entityId = placementRequestNotWithdrawable.id,
+              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+            ),
+          ),
+        ),
+        WithdrawableTreeNode(
+          applicationId = otherApplicationId,
+          entityType = WithdrawableEntityType.Booking,
+          entityId = adhocBookingWithdrawableOtherApp.id,
+          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+        ),
+        WithdrawableTreeNode(
+          applicationId = application.id,
+          entityType = WithdrawableEntityType.Booking,
+          entityId = adhocBookingNotWithdrawable.id,
+          status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+        ),
+      ),
+    )
+
+    val context = WithdrawalContext(
+      triggeringUser = user,
+      triggeringEntityType = WithdrawableEntityType.Application,
+      triggeringEntityId = application.id,
+    )
+
+    assertThatThrownBy {
+      service.withdrawDescendantsOfRootNode(tree, context)
+    }.hasMessage(
+      "Cascade withdrawal for root node belonging to application fb724580-d6df-4e0e-92bb-54573f396202 would " +
+        "remove the following nodes belonging to other applications " +
+        "[PlacementApplication db8c102a-4062-4f8e-ab0f-d5f8953f447c (application 4071072a-3d52-4904-b5bd-32b6420b105a), " +
+        "Booking 843de779-0b23-4517-8dea-f749596e0666 (application 4071072a-3d52-4904-b5bd-32b6420b105a), " +
+        "Booking 3a159ffe-d22e-4a04-9432-c7df4f836098 (application 4071072a-3d52-4904-b5bd-32b6420b105a)]",
+    )
   }
 }


### PR DESCRIPTION
We previously had a bug in the code where withdrawing an application would inadvertently cascade to adhoc bookings from other applications.

Whilst this bug has been fixed and specific regression tests added for the specific scenario, we want to add additional guard rails in the cascade withdrawal logic to ensure is not possible for cascades of any entity types. This is especially important as withdrawal cascades are somewhat opaque on the UI as the user it not explicitly told which entities will be withdrawn on cascade.

This commit adds a check in the withdrawal logic to ensure that all entities being withdrawn belong to the same application as the root entity being withdrawn.

Note that this implementation isn’t perfect as the check only occurs after the root entity has already been withdrawn (ideally this would be blocked). This is acceptable because this scenario should never occur, and the guardrails are only in place to avoid very damaging side affects, which _would_ be blocked.