### PR TITLE
Placement Application to Placement Request Migration Job Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
@@ -83,11 +83,12 @@ class Cas1FixPlacementApplicationLinksJob(
       // we only started capturing decisionMadeAt in Dec 2023
       .filter { it.placementApplication.decisionMadeAt != null }
 
-    if (placementAppsWithDecisionMadeDateSet.isNotEmpty()) {
+    if (placementAppsWithDecisionMadeDateSet.size == placementAppsAndDate.size) {
       log.error(
-        "We should not be considering PlacementApplications with a non-null decisionMadeAt, because this was " +
+        "We should not be considering applications where all PlacementApplications have a non-null decisionMadeAt, because this was " +
           "only set for decisions made after linking PlacementApplications to PlacementRequests was automatically " +
-          "managed in code. Placement applications are ${placementAppsWithDecisionMadeDateSet.map { describe(it) }}",
+          "managed in code. This suggests an error in the migration logic. " +
+          "Placement applications are ${placementAppsWithDecisionMadeDateSet.map { describe(it) }}",
       )
       return
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
@@ -40,27 +40,80 @@ class Cas1FixPlacementApplicationLinksJob(
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
   override fun process() {
-    val applicationIds = placementApplicationRepository.findApplicationsThatHaveAnAcceptedPlacementApplicationWithoutACorrespondingPlacementRequest()
+    applyManualFixes()
+    applyAutomatedFixes()
 
-    log.info("Fixing PlacementApplication to PlacementRequest relationships for ${applicationIds.size} applications")
-
-    applicationIds.forEach { applicationId ->
-      transactionTemplate.executeWithoutResult {
-        try {
-          updateApplication(UUID.fromString(applicationId))
-        } catch (e: IllegalStateException) {
-          log.error(e.message)
-        }
-      }
-    }
     entityManager.clear()
   }
 
-  @SuppressWarnings("ReturnCount")
-  fun updateApplication(applicationId: UUID) {
-    log.info("Fixing PlacementApplication to PlacementRequest relationships for Application $applicationId")
+  private fun applyManualFixes() {
+    log.info("Applying manual link fixes for ${manualLinkFixes.size} fixes")
 
+    manualLinkFixes.forEach { fix ->
+      transactionTemplate.executeWithoutResult {
+        applyManualFix(fix)
+      }
+    }
+  }
+
+  private fun applyAutomatedFixes() {
+    val applicationIds = placementApplicationRepository.findApplicationsThatHaveAnAcceptedPlacementApplicationWithoutACorrespondingPlacementRequest()
+
+    log.info("Automatically Fixing PlacementApplication to PlacementRequest relationships for ${applicationIds.size} applications")
+
+    applicationIds.forEach { applicationId ->
+      transactionTemplate.executeWithoutResult {
+        applyAutomatedFixes(UUID.fromString(applicationId))
+      }
+    }
+  }
+
+  @SuppressWarnings("ReturnCount")
+  fun applyManualFix(manualLinkFix: ManualLinkFix) {
+    val application = applicationRepository.findByIdOrNull(UUID.fromString(manualLinkFix.applicationId))
+    if (application == null) {
+      log.error("Could not find application for id ${manualLinkFix.applicationId} when applying manual fix")
+      return
+    }
+
+    log.info("Applying manual fix to application ${application.id} (application created ${application.createdAt})")
+
+    val approvedPremisesApplicationEntity = application as ApprovedPremisesApplicationEntity
+    val placementRequest = approvedPremisesApplicationEntity
+      .placementRequests
+      .firstOrNull { it.id.toString() == manualLinkFix.placementRequestId }
+
+    if (placementRequest == null) {
+      log.error("Could not find placement request for id ${manualLinkFix.placementRequestId} when applying manual fix")
+      return
+    }
+
+    val placementApplication = placementApplicationRepository.findByIdOrNull(UUID.fromString(manualLinkFix.placementApplicationId))
+
+    if (placementApplication == null) {
+      log.error("Could not find placement application for id ${manualLinkFix.placementApplicationId} when applying manual fix")
+      return
+    }
+
+    if (placementApplication.application.id != application.id) {
+      log.error("Placement application ${manualLinkFix.placementApplicationId} does not apply to application ${manualLinkFix.applicationId}")
+      return
+    }
+
+    linkPlacementAppToRequest(
+      placementApplication = placementApplication,
+      placementRequest = placementRequest,
+    )
+  }
+
+  @SuppressWarnings("ReturnCount")
+  fun applyAutomatedFixes(applicationId: UUID) {
     val application = applicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity
+
+    log.info(
+      "Fixing PlacementApplication to PlacementRequest relationships for Application $applicationId " +
+        "(application created ${application.createdAt})",
+    )
 
     val unlinkedPlacementRequests = application.placementRequests
       .filter { !it.isReallocated() }
@@ -140,12 +193,20 @@ class Cas1FixPlacementApplicationLinksJob(
     }
 
     placementAppsAndDate.forEach { placementAppAndDate ->
-      val placementApp = placementAppAndDate.placementApplication
-      val placementRequest = placementAppAndDate.placementRequest!!
-      placementRequest.placementApplication = placementApp
-      log.info("Linked PlacementRequest ${placementRequest.id} to PlacementApplication ${placementAppAndDate.placementApplication.id}")
-      placementRequestRepository.save(placementRequest)
+      linkPlacementAppToRequest(
+        placementApplication = placementAppAndDate.placementApplication,
+        placementRequest = placementAppAndDate.placementRequest!!,
+      )
     }
+  }
+
+  private fun linkPlacementAppToRequest(
+    placementApplication: PlacementApplicationEntity,
+    placementRequest: PlacementRequestEntity,
+  ) {
+    placementRequest.placementApplication = placementApplication
+    log.info("Linked PlacementRequest ${placementRequest.id} to PlacementApplication ${placementApplication.id}")
+    placementRequestRepository.save(placementRequest)
   }
 
   private fun describe(placementApp: PlacementAppAndDate) =
@@ -155,5 +216,92 @@ class Cas1FixPlacementApplicationLinksJob(
     val placementApplication: PlacementApplicationEntity,
     val date: PlacementDateEntity,
     var placementRequest: PlacementRequestEntity?,
+  )
+
+  data class ManualLinkFix(
+    val applicationId: String,
+    val placementRequestId: String,
+    val placementApplicationId: String,
+  )
+
+  // Some links could not be fixed automatically by this migration job. After manual (human) analysis
+  // several of these relationships should be determined.
+  // See https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4781965318/CAS-1+PlacementApplication+to+PlacementRequest+link+Backfill
+  val manualLinkFixes = listOf(
+    ManualLinkFix(
+      applicationId = "fcba419e-7802-4c05-947f-7b24988aa795",
+      placementRequestId = "af242c35-07ff-4545-839a-b4b89e735e63",
+      placementApplicationId = "09b26c6d-570d-4b4f-804c-72ac71325cc0",
+    ),
+    ManualLinkFix(
+      applicationId = "75337979-e4c9-45f9-b829-948d8516f364",
+      placementRequestId = "c1131478-2b3c-4dd8-84c4-88698184d632",
+      placementApplicationId = "218b7567-460b-447c-9481-7315ba53c23e",
+    ),
+    ManualLinkFix(
+      applicationId = "9c4597e3-a615-4f08-b697-39b5cb2fc152",
+      placementRequestId = "44f15784-3497-4df5-9035-f65b741685c9",
+      placementApplicationId = "2ef871f6-a4da-46a9-96f7-a2901f80aa40",
+    ),
+    ManualLinkFix(
+      applicationId = "fe998691-61c6-489a-b94a-f62f112acd43",
+      placementRequestId = "d70a8012-bc3d-43ad-93f2-d0b5724dc3bc",
+      placementApplicationId = "4af4831b-a930-4de7-b612-1999b3e0313f",
+    ),
+    ManualLinkFix(
+      applicationId = "4434ef73-abc1-451d-8c3e-eb9d43cd10ae",
+      placementRequestId = "d2478632-1616-467d-8b6b-f11bfe03729b",
+      placementApplicationId = "4532f7117-f5f9-498e-92ee-eb961de98af0",
+    ),
+    ManualLinkFix(
+      applicationId = "4434ef73-abc1-451d-8c3e-eb9d43cd10ae",
+      placementRequestId = "5bccc0d4-f541-438a-a803-152e1d3ebd54",
+      placementApplicationId = "8848e951-b51d-43f3-a205-d7404a732d5f",
+    ),
+    ManualLinkFix(
+      applicationId = "95b2aaa5-9314-49de-b272-b9e0bb8ee643",
+      placementRequestId = "bfdee07a-f0f8-428d-9d34-28455fc10ec7",
+      placementApplicationId = "81d60dd8-df26-4820-9b8c-828b2bdbaaa4",
+    ),
+    ManualLinkFix(
+      applicationId = "9fff5bbd-c538-446e-a3c8-5c770e05bdb6",
+      placementRequestId = "46765be3-b46b-4202-9cc1-118cb6d73928",
+      placementApplicationId = "8cf4c9de-0e29-4af7-8621-437e6f7bc644",
+    ),
+    ManualLinkFix(
+      applicationId = "ce51f404-3f8e-400c-b235-89e2ce5461d7",
+      placementRequestId = "a8e380ee-10ce-48ba-98fa-9c115d722649",
+      placementApplicationId = "9ef0080c-f83f-4f81-8219-4a7c61a70388",
+    ),
+    ManualLinkFix(
+      applicationId = "e3a87d85-fa54-4654-b804-4d0fb9253121",
+      placementRequestId = "f681fa85-69df-46b6-bd05-cf4191c1d6d6",
+      placementApplicationId = "af74d224-04d5-4598-a9a9-6e086ec2b60b",
+    ),
+    ManualLinkFix(
+      applicationId = "e3a87d85-fa54-4654-b804-4d0fb9253121",
+      placementRequestId = "7a4f4108-9874-474a-8c70-528986cb3368",
+      placementApplicationId = "6ebea4ff-34e7-4c64-ac20-b8b218c0f706",
+    ),
+    ManualLinkFix(
+      applicationId = "ab02981b-a7f3-4075-8cff-27e5edad597d",
+      placementRequestId = "55b0e01f-4006-4c5b-b61e-dfe1d47a27d3",
+      placementApplicationId = "c0886c1c-11ac-4ce7-93a8-ce180e61bf36",
+    ),
+    ManualLinkFix(
+      applicationId = "cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74",
+      placementRequestId = "1aab2f12-d71b-47cc-af74-4e3a72d4af04",
+      placementApplicationId = "c45764f2-98d6-4af5-a784-2faa16e6b2c9",
+    ),
+    ManualLinkFix(
+      applicationId = "cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74",
+      placementRequestId = "e7a98cc9-8a71-4c9d-b5f5-470e321bf24b",
+      placementApplicationId = "2d6e7e0d-7202-47d9-847c-f50614018d9b",
+    ),
+    ManualLinkFix(
+      applicationId = "cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74",
+      placementRequestId = "18a532f7-7893-47a1-ab8e-1e34d7b3ff46",
+      placementApplicationId = "ec618a23-2ad3-4df0-bb91-a81cdaaab677",
+    ),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
@@ -68,6 +68,7 @@ class Cas1FixPlacementApplicationLinksJob(
       .toMutableList()
 
     val placementAppsAndDate = placementApplicationRepository.findByApplication(application)
+      .filter { it.placementRequests.isEmpty() }
       .filter { it.isAccepted() }
       .flatMap { placementApp ->
         placementApp.placementDates.map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -304,7 +304,7 @@ class PlacementRequestService(
    *
    * 1. The entity is withdrawable, and error if not
    * 2. The user is allowed to withdraw it, and error if not
-   * 3. If withdrawn, all descdents entities are withdrawn, where applicable
+   * 3. If withdrawn, all descendent entities are withdrawn, where applicable
    */
   @Transactional
   fun withdrawPlacementRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
@@ -282,8 +282,8 @@ class Cas1FixPlacementApplicationLinksJobTest {
     service.updateApplication(applicationWithNoArrivalDate.id)
     verify {
       logger.error(
-        "We should not be considering PlacementApplications with a non-null decisionMadeAt, because this was only set for " +
-          "decisions made after linking PlacementApplications to PlacementRequests was automatically managed in code. " +
+        "We should not be considering applications where all PlacementApplications have a non-null decisionMadeAt, because this was only set for " +
+          "decisions made after linking PlacementApplications to PlacementRequests was automatically managed in code. This suggests an error in the migration logic. " +
           "Placement applications are [${placementAppWithDecisionDate.id} for date 2020-01-02 and duration 10]",
       )
     }


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-438

* Logging improvements
* Don't disregard applications with one or more placement apps with decisionMadeAt Set. Only disregard them if they all have it set
* Add manual fixes into migration for cases where we couldn't programmatically determine lines, but could when reviewing applications manually
* Update migration logic to ignore/leave alone placement applications already linked to placement requests