### PR TITLE
CAS2-336: remove `Person` on Cas2SubmittedApplicationSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -176,12 +176,10 @@ class SubmissionsController(
     application: Cas2ApplicationSummary,
   ):
     Cas2SubmittedApplicationSummary {
-    val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
-    val personName = offenderService.getOffenderNameOrPlaceholder(personInfo)
+    val personName = offenderService.getOffenderNameOrPlaceholder(application.getCrn())
 
     return submissionsTransformer.transformJpaSummaryToApiRepresentation(
       application,
-      personInfo,
       personName,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -82,13 +82,19 @@ class OffenderService(
     }
   }
 
-  fun getOffenderNameOrPlaceholder(personInfoResult: PersonInfoResult.Success): String {
-    return when (personInfoResult) {
-      is PersonInfoResult.Success.Full ->
-        "${personInfoResult.offenderDetailSummary.firstName} " +
-          personInfoResult.offenderDetailSummary.surname
+  fun getOffenderNameOrPlaceholder(crn: String): String {
+    return when (val offenderResponse = offenderDetailsDataSource.getOffenderDetailSummary(crn)) {
+      is ClientResult.Success ->
+        "${offenderResponse.body.firstName} ${offenderResponse.body.surname}"
 
-      is PersonInfoResult.Success.Restricted -> "Unknown"
+      is ClientResult.Failure.StatusCode ->
+        if (offenderResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
+          return "Person Not Found"
+        } else {
+          return "Unknown"
+        }
+
+      is ClientResult.Failure -> return "Unknown"
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -47,13 +47,10 @@ class SubmissionsTransformer(
 
   fun transformJpaSummaryToApiRepresentation(
     jpaSummary: Cas2ApplicationSummary,
-    personInfo:
-      PersonInfoResult.Success,
     personName: String,
   ): Cas2SubmittedApplicationSummary {
     return Cas2SubmittedApplicationSummary(
       id = jpaSummary.getId(),
-      person = personTransformer.transformModelToPersonApi(personInfo),
       personName = personName,
       createdByUserId = jpaSummary.getCreatedByUserId(),
       createdAt = jpaSummary.getCreatedAt().toInstant(),

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1960,8 +1960,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        person:
-          $ref: '#/components/schemas/Person'
         crn:
           type: string
         nomsNumber:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6457,8 +6457,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        person:
-          $ref: '#/components/schemas/Person'
         crn:
           type: string
         nomsNumber:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2513,8 +2513,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        person:
-          $ref: '#/components/schemas/Person'
         crn:
           type: string
         nomsNumber:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2008,8 +2008,6 @@ components:
         createdByUserId:
           type: string
           format: uuid
-        person:
-          $ref: '#/components/schemas/Person'
         crn:
           type: string
         nomsNumber:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -299,7 +299,6 @@ class Cas2SubmissionTest(
     ) {
       Assertions.assertThat(response).matches {
         expectedSubmittedApplication.id == it.id &&
-          expectedSubmittedApplication.crn == it.person.crn &&
           expectedSubmittedApplication.crn == it.crn &&
           expectedSubmittedApplication.nomsNumber == it.nomsNumber &&
           expectedSubmittedApplication.createdAt.toInstant() == it.createdAt &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -21,7 +21,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
@@ -129,11 +128,6 @@ class SubmissionsTransformerTest {
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
       }
 
-      val personInfo = mockk<PersonInfoResult.Success>()
-      val person = mockk<Person>()
-
-      every { mockPersonTransformer.transformModelToPersonApi(personInfo) } returns person
-
       val expectedSubmittedApplicationSummary = Cas2SubmittedApplicationSummary(
         id = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809"),
         crn = "CRN123",
@@ -142,12 +136,10 @@ class SubmissionsTransformerTest {
         createdAt = Instant.parse("2023-04-19T13:25:00+01:00"),
         submittedAt = Instant.parse("2023-04-19T13:25:30+01:00"),
         personName = "Example Offender",
-        person = person,
       )
 
       val transformation = applicationTransformer.transformJpaSummaryToApiRepresentation(
         applicationSummary,
-        personInfo,
         "Example Offender",
       )
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CAS2-336 


as we now have the `personName`, `crn`,`nomsNumber` fields as top level fields ([see this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1621) and [this UI one](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/583)), we can
simplify how we are getting the person's name from the `offenderDetailsDataSource`.

I'm also slightly changing the error behaviour -previously we called the function `getInfoForPersonOrThrowInternalServerError` which would throw an error if there person was 'Not
Found'. For our purposes here in CAS2, I don't think we need to throw an error at this point - if the person is not found on Nomis/Delius then we still want to go ahead and show the application, but with placeholder copy. It could be that the application still needs to be processed or viewed even if the applicant is no longer in the system.