### PR TITLE
(APS-514) Add notice type field to applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -327,6 +328,8 @@ class ApprovedPremisesApplicationEntity(
   @OneToOne
   @JoinColumn(name = "case_manager_cas1_application_user_details_id")
   var caseManagerUserDetails: Cas1ApplicationUserDetailsEntity?,
+  @Enumerated(value = EnumType.STRING)
+  var noticeType: Cas1ApplicationTimelinessCategory?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/NoticeTypeMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/NoticeTypeMigrationJob.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import java.util.UUID
+
+@Repository
+interface NoticeTypeMigrationJobApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
+  @Modifying
+  @Query(
+    "UPDATE ApprovedPremisesApplicationEntity ap set " +
+      "ap.noticeType = 'emergency' " +
+      "where ap.isEmergencyApplication = true",
+  )
+  fun updateEmergencyApplicationNoticeType()
+
+  @Modifying
+  @Query("UPDATE ApprovedPremisesApplicationEntity ap set ap.noticeType = :noticeType where ap.id in :ids")
+  fun updateApplicationNoticeType(ids: List<UUID>, noticeType: Cas1ApplicationTimelinessCategory)
+
+  @Query("SELECT ap FROM ApprovedPremisesApplicationEntity ap where ap.isEmergencyApplication = false")
+  fun getApplicationsThatRequireNoticeTypeUpdating(pageable: Pageable): Slice<ApprovedPremisesApplicationEntity>
+}
+
+class NoticeTypeMigrationJob(
+  private val applicationRepository: NoticeTypeMigrationJobApplicationRepository,
+  private val pageSize: Int,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = true
+
+  override fun process() {
+    applicationRepository.updateEmergencyApplicationNoticeType()
+
+    var page = 0
+    var hasNext = true
+    var slice: Slice<ApprovedPremisesApplicationEntity>
+
+    val shortNoticeApplicationIds = mutableListOf<UUID>()
+    val standardApplicationIds = mutableListOf<UUID>()
+
+    while (hasNext) {
+      log.info("Getting page $page")
+      slice = applicationRepository.getApplicationsThatRequireNoticeTypeUpdating(PageRequest.of(page, pageSize))
+      slice.content.forEach {
+        if (it.isShortNoticeApplication() == true) {
+          shortNoticeApplicationIds.add(it.id)
+        } else {
+          standardApplicationIds.add(it.id)
+        }
+      }
+      hasNext = slice.hasNext()
+      page += 1
+    }
+
+    log.info("Updating ${shortNoticeApplicationIds.count()} short notice applications")
+    applicationRepository.updateApplicationNoticeType(shortNoticeApplicationIds, Cas1ApplicationTimelinessCategory.shortNotice)
+
+    log.info("Updating ${standardApplicationIds.count()} standard notice applications")
+    applicationRepository.updateApplicationNoticeType(standardApplicationIds, Cas1ApplicationTimelinessCategory.standard)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -347,6 +347,7 @@ class ApplicationService(
       applicantUserDetails = null,
       caseManagerIsNotApplicant = null,
       caseManagerUserDetails = null,
+      noticeType = null,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
@@ -804,6 +805,14 @@ class ApplicationService(
         existingEntry = this.caseManagerUserDetails,
         updatedValues = if (submitApplication.caseManagerIsNotApplicant == true) { submitApplication.caseManagerUserDetails } else null,
       )
+      this.noticeType = submitApplication.noticeType
+        ?: if (submitApplication.isEmergencyApplication) {
+          Cas1ApplicationTimelinessCategory.emergency
+        } else if (this.isShortNoticeApplication() == true) {
+          Cas1ApplicationTimelinessCategory.shortNotice
+        } else {
+          Cas1ApplicationTimelinessCategory.standard
+        }
     }
 
     assessmentService.createApprovedPremisesAssessment(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -25,6 +25,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.NoticeTypeMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.NoticeTypeMigrationJobApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.TaskDueMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationJob
@@ -95,6 +97,11 @@ class MigrationJobService(
           applicationContext.getBean(PlacementRequestRepository::class.java),
           applicationContext.getBean(EntityManager::class.java),
           transactionTemplate,
+        )
+
+        MigrationJobType.cas1NoticeTypes -> NoticeTypeMigrationJob(
+          applicationContext.getBean(NoticeTypeMigrationJobApplicationRepository::class.java),
+          pageSize,
         )
       }
 

--- a/src/main/resources/db/migration/all/20240319095635__add_notice_type_field_to_applications.sql
+++ b/src/main/resources/db/migration/all/20240319095635__add_notice_type_field_to_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises_applications ADD COLUMN "notice_type" text NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3512,6 +3512,7 @@ components:
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
+        - update_cas1_notice_types
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2202,6 +2202,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
             - isPipeApplication
             - isWomensApplication
@@ -2299,6 +2301,12 @@ components:
         - residencyManagement
         - bailAssessment
         - bailSentence
+    Cas1ApplicationTimelinessCategory:
+      type: string
+      enum:
+        - standard
+        - emergency
+        - shortNotice
     PrisonCaseNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8009,6 +8009,7 @@ components:
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
+        - update_cas1_notice_types
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6699,6 +6699,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
             - isPipeApplication
             - isWomensApplication
@@ -6796,6 +6798,12 @@ components:
         - residencyManagement
         - bailAssessment
         - bailSentence
+    Cas1ApplicationTimelinessCategory:
+      type: string
+      enum:
+        - standard
+        - emergency
+        - shortNotice
     PrisonCaseNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2755,6 +2755,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
             - isPipeApplication
             - isWomensApplication
@@ -2852,6 +2854,12 @@ components:
         - residencyManagement
         - bailAssessment
         - bailSentence
+    Cas1ApplicationTimelinessCategory:
+      type: string
+      enum:
+        - standard
+        - emergency
+        - shortNotice
     PrisonCaseNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4065,6 +4065,7 @@ components:
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
+        - update_cas1_notice_types
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3560,6 +3560,7 @@ components:
         - update_cas2_applications_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
+        - update_cas1_notice_types
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2250,6 +2250,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
           required:
             - isPipeApplication
             - isWomensApplication
@@ -2347,6 +2349,12 @@ components:
         - residencyManagement
         - bailAssessment
         - bailSentence
+    Cas1ApplicationTimelinessCategory:
+      type: string
+      enum:
+        - standard
+        - emergency
+        - shortNotice
     PrisonCaseNote:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -57,6 +58,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var applicantUserDetails: Yielded<Cas1ApplicationUserDetailsEntity?> = { null }
   private var caseManagerIsNotApplicant: Yielded<Boolean?> = { null }
   private var caseManagerUserDetails: Yielded<Cas1ApplicationUserDetailsEntity?> = { null }
+  private var noticeType: Yielded<Cas1ApplicationTimelinessCategory?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -206,6 +208,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.caseManagerUserDetails = { casManagerUserDetails }
   }
 
+  fun withNoticeType(noticeType: Cas1ApplicationTimelinessCategory?) = apply {
+    this.noticeType = { noticeType }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -244,5 +250,6 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     applicantUserDetails = this.applicantUserDetails(),
     caseManagerIsNotApplicant = this.caseManagerIsNotApplicant(),
     caseManagerUserDetails = this.caseManagerUserDetails(),
+    noticeType = this.noticeType(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/NoticeTypeMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/NoticeTypeMigrationJobTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+import java.time.OffsetDateTime
+import java.util.UUID
+import kotlin.random.Random
+
+class NoticeTypeMigrationJobTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @Test
+  fun `it should migrate notice types of applications`() {
+    val emergencyApplicationIds = generateSequence {
+      createApplication(true, OffsetDateTime.now(), OffsetDateTime.now())
+    }.take(5).toMutableList().map { it.id }
+
+    val shortNoticeApplicationIds = generateSequence {
+      val createdAt = OffsetDateTime.now().minusDays(Random.nextLong(1, 365))
+      val arrivalDate = createdAt.plusDays(Random.nextLong(1, 27))
+      createApplication(false, createdAt, arrivalDate)
+    }.take(9).toMutableList().map { it.id }
+
+    val standardApplicationIds = generateSequence {
+      val createdAt = OffsetDateTime.now().minusDays(Random.nextLong(1, 365))
+      val arrivalDate = createdAt.plusDays(Random.nextLong(28, 365))
+      createApplication(false, createdAt, arrivalDate)
+    }.take(12).toMutableList().map { it.id }
+
+    val unsubmittedApplicationIds = generateSequence {
+      val createdAt = OffsetDateTime.now().minusDays(Random.nextLong(1, 365))
+      createApplication(null, createdAt, null)
+    }.take(4).toMutableList().map { it.id }
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1NoticeTypes, 1)
+
+    assertApplicationsHaveCorrectNoticeType(emergencyApplicationIds, Cas1ApplicationTimelinessCategory.emergency)
+    assertApplicationsHaveCorrectNoticeType(shortNoticeApplicationIds, Cas1ApplicationTimelinessCategory.shortNotice)
+    assertApplicationsHaveCorrectNoticeType(standardApplicationIds, Cas1ApplicationTimelinessCategory.standard)
+    assertApplicationsHaveCorrectNoticeType(unsubmittedApplicationIds, null)
+  }
+
+  private fun assertApplicationsHaveCorrectNoticeType(applicationIds: List<UUID>, noticeType: Cas1ApplicationTimelinessCategory?) {
+    val applications = approvedPremisesApplicationRepository.findAllById(applicationIds)
+
+    applications.forEach {
+      assertThat(it.noticeType).isEqualTo(noticeType)
+    }
+  }
+
+  private fun createApplication(isEmergencyApplication: Boolean?, createdAt: OffsetDateTime, arrivalDate: OffsetDateTime?): ApprovedPremisesApplicationEntity {
+    val (applicant, _) = `Given a User`()
+    val (offenderDetails, _) = `Given an Offender`()
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withAddedAt(OffsetDateTime.now())
+      withId(UUID.randomUUID())
+      withPermissiveSchema()
+    }
+
+    return approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCrn(offenderDetails.otherIds.crn)
+      withCreatedByUser(applicant)
+      withApplicationSchema(applicationSchema)
+      withSubmittedAt(OffsetDateTime.now())
+      withIsEmergencyApplication(isEmergencyApplication)
+      withCreatedAt(createdAt)
+      withArrivalDate(arrivalDate)
+    }
+  }
+}


### PR DESCRIPTION
This adds a new `noticeType` field to applications, to allow us to get/set the notice type of an application via the frontend and eventually replace the `isEmergencyApplicaiton` field.  The values are:

- `emergency` - less than 7 days between when the application was created and the arrival date
- `shortNotice` - less than 28 days between when the application was created and the arrival date
- `standard` - more than 28 days between when the application was created and the arrival date

There is also a backfill task to backfill the status of all applications. Once the work is implemented in the frontend to send the `noticeType` directly, we can simplify some of the short notice and emergency code and have one source of truth for an application's notice type, as well as assign short notice applications to emergency assessors.