### PR TITLE
CAS2-121 refactor the reports end point

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
@@ -5,15 +5,16 @@ import org.springframework.core.io.Resource
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.ReportsCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ReportsService
 import java.io.ByteArrayOutputStream
 
 @Service("Cas2ReportsController")
 class ReportsController(private val reportService: ReportsService) : ReportsCas2Delegate {
 
-  override fun reportsReportNameGet(reportName: String): ResponseEntity<Resource> {
+  override fun reportsReportNameGet(reportName: Cas2ReportName): ResponseEntity<Resource> {
     val outputStream = ByteArrayOutputStream()
-    when (reportName) {
+    when (reportName.value) {
       "submitted-applications" -> reportService.createSubmittedApplicationsReport(outputStream)
       "application-status-updates" -> reportService.createApplicationStatusUpdatesReport(outputStream)
       "unsubmitted-applications" -> reportService.createUnsubmittedApplicationsReport(outputStream)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
@@ -11,12 +11,6 @@ import java.io.ByteArrayOutputStream
 @Service("Cas2ReportsController")
 class ReportsController(private val reportService: ReportsService) : ReportsCas2Delegate {
 
-  override fun reportsExampleReportGet(): ResponseEntity<Resource> {
-    val outputStream = ByteArrayOutputStream()
-    reportService.createCas2ExampleReport(outputStream)
-    return ResponseEntity.ok(InputStreamResource(outputStream.toByteArray().inputStream()))
-  }
-
   override fun reportsReportNameGet(reportName: String): ResponseEntity<Resource> {
     val outputStream = ByteArrayOutputStream()
     when (reportName) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/Cas2ExampleMetricsRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/Cas2ExampleMetricsRow.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
-
-data class Cas2ExampleMetricsRow(val id: String, val data: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationStatusUpdatesReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2SubmittedApplicationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2UnsubmittedApplicationsReportRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas2ExampleMetricsRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.ApplicationStatusUpdatesReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.SubmittedApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.UnsubmittedApplicationsReportRow
@@ -19,15 +18,6 @@ class ReportsService(
   private val applicationStatusUpdatesReportRepository: Cas2ApplicationStatusUpdatesReportRepository,
   private val unsubmittedApplicationsReportRepository: Cas2UnsubmittedApplicationsReportRepository,
 ) {
-  fun createCas2ExampleReport(outputStream: OutputStream) {
-    // TODO replace this with a real report
-    val exampleData = listOf(Cas2ExampleMetricsRow(id = "123", data = "example"))
-
-    exampleData.toDataFrame()
-      .writeExcel(outputStream) {
-        WorkbookFactory.create(true)
-      }
-  }
 
   fun createSubmittedApplicationsReport(outputStream: OutputStream) {
     val reportData = submittedApplicationReportRepository.generateSubmittedApplicationReportRows().map { row ->

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4456,3 +4456,9 @@ components:
           type: string
       required:
         - name
+    Cas2ReportName:
+      type: string
+      enum:
+        - submitted-applications
+        - application-status-updates
+        - unsubmitted-applications

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -527,7 +527,7 @@ paths:
           description: name of the report to download
           required: true
           schema:
-            type: string
+            $ref: '_shared.yml#/components/schemas/Cas2ReportName'
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -516,19 +516,6 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
-  /reports/example-report:
-    get:
-      tags:
-        - Reports
-      summary: Returns an example spreadsheet of metrics
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-              schema:
-                type: string
-                format: binary
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8953,3 +8953,9 @@ components:
           type: string
       required:
         - name
+    Cas2ReportName:
+      type: string
+      enum:
+        - submitted-applications
+        - application-status-updates
+        - unsubmitted-applications

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -518,19 +518,6 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
-  /reports/example-report:
-    get:
-      tags:
-        - Reports
-      summary: Returns an example spreadsheet of metrics
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-              schema:
-                type: string
-                format: binary
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -529,7 +529,7 @@ paths:
           description: name of the report to download
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/Cas2ReportName'
       responses:
         200:
           description: successful operation
@@ -4996,3 +4996,9 @@ components:
           type: string
       required:
         - name
+    Cas2ReportName:
+      type: string
+      enum:
+        - submitted-applications
+        - application-status-updates
+        - unsubmitted-applications

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4504,3 +4504,9 @@ components:
           type: string
       required:
         - name
+    Cas2ReportName:
+      type: string
+      enum:
+        - submitted-applications
+        - application-status-updates
+        - unsubmitted-applications

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2StatusFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas2ExampleMetricsRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.ApplicationStatusUpdatesReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.SubmittedApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.UnsubmittedApplicationsReportRow
@@ -516,33 +515,6 @@ class Cas2ReportsTest : IntegrationTestBase() {
           Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
         }
     }
-  }
-
-  @Test
-  fun `downloaded report is streamed as a spreadsheet`() {
-    val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username",
-      authSource = "nomis",
-      roles = listOf("ROLE_CAS2_MI"),
-    )
-
-    val expectedDataFrame = listOf(Cas2ExampleMetricsRow(id = "123", data = "example"))
-      .toDataFrame()
-
-    webTestClient.get()
-      .uri("/cas2/reports/example-report")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .consumeWith {
-        val actual = DataFrame
-          .readExcel(it.responseBody!!.inputStream())
-          .convertTo<Cas2ExampleMetricsRow>(ExcessiveColumns.Remove)
-
-        Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
-      }
   }
 
   private fun daysInSeconds(days: Int): Long {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -9,11 +9,13 @@ import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2ApplicationStatusUpdatedEventDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2ApplicationSubmittedEventDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2StatusFactory
@@ -32,14 +34,8 @@ class Cas2ReportsTest : IntegrationTestBase() {
   @Nested
   inner class ControlsOnExternalUsers {
     @ParameterizedTest
-    @ValueSource(
-      strings = [
-        "submitted-applications",
-        "application-status-updates",
-        "unsubmitted-applications",
-      ],
-    )
-    fun `downloading report is forbidden to external users without MI role`(reportName: String) {
+    @EnumSource(value = Cas2ReportName::class)
+    fun `downloading report is forbidden to external users without MI role`(reportName: Cas2ReportName) {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "auth",
@@ -47,7 +43,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/$reportName")
+        .uri("/cas2/reports/${reportName.value}")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -77,14 +73,8 @@ class Cas2ReportsTest : IntegrationTestBase() {
   @Nested
   inner class ControlsOnInternalUsers {
     @ParameterizedTest
-    @ValueSource(
-      strings = [
-        "submitted-applications",
-        "application-status-updates",
-        "unsubmitted-applications",
-      ],
-    )
-    fun `downloading report is forbidden to NOMIS users without MI role`(reportName: String) {
+    @EnumSource(value = Cas2ReportName::class)
+    fun `downloading report is forbidden to NOMIS users without MI role`(reportName: Cas2ReportName) {
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
@@ -92,7 +82,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/$reportName")
+        .uri("/cas2/reports/${reportName.value}")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()


### PR DESCRIPTION
When deleting an old reports endpoint, I noticed that we could probably do with some tidying up of the reports.

This PR

* deletes unused 'example-report' report
* tightens up report endpoint tests
* introduces enum for the report name (see commit message for reasoning)