### PR TITLE
CAS2-341 change sort order for applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -35,6 +35,7 @@ SELECT
     a.submitted_at as submittedAt
 FROM cas_2_applications a
 WHERE a.created_by_user_id = :userId
+ORDER BY createdAt DESC
 """,
     nativeQuery = true,
   )


### PR DESCRIPTION
Ref JIRA ticket [CAS2-341](https://dsdmoj.atlassian.net/browse/CAS2-341)

**User Story**

As a CAS2 user
When I request a list of applications
Then the most recently created should be at the top of the list

**Technical Notes**

The `findAllCas2ApplicationSummariesCreatedByUser` function has been modified to order the results by descending `createdAt` by adding an `ORDER BY` clause to the SQL.

An additional integration test has been included in `Get all applications returns 200 with correct body` which checks that two applications are returned in correct order.


[CAS2-341]: https://dsdmoj.atlassian.net/browse/CAS2-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ