### PR TITLE
[CAS-251] Add PDU to database and Referrals report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -424,6 +424,7 @@ class TemporaryAccommodationApplicationEntity(
   var dutyToReferLocalAuthorityAreaName: String?,
   var prisonNameOnCreation: String?,
   var personReleaseDate: LocalDate?,
+  var pdu: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
@@ -41,6 +41,7 @@ class TransitionalAccommodationReferralReportGenerator : ReportGenerator<
         town = referralData.town,
         postCode = referralData.postCode,
         probationRegion = referralData.probationRegionName,
+        pdu = referralData.pdu,
         referralSubmittedDate = referralData.referralSubmittedDate,
         referralRejected = AssessmentDecision.REJECTED.name == referralData.assessmentDecision,
         rejectionReason = referralData.assessmentRejectionReason,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
@@ -21,6 +21,7 @@ data class TransitionalAccommodationReferralReportRow(
   val town: String?,
   val postCode: String?,
   val probationRegion: String,
+  val pdu: String?,
   val referralSubmittedDate: LocalDate?,
   val referralRejected: Boolean?,
   val rejectionReason: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
@@ -34,7 +34,8 @@ interface TransitionalAccommodationReferralReportRepository : JpaRepository<Book
       taa.prison_name_on_creation as prisonNameOnCreation,
       taa.person_release_date as personReleaseDate,
       premises.town as town,
-      premises.postcode as postCode
+      premises.postcode as postCode,
+      taa.pdu as pdu
     FROM temporary_accommodation_assessments aa
     JOIN assessments a on aa.assessment_id = a.id AND a.service='temporary-accommodation' AND a.reallocated_at IS NULL
     JOIN applications ap on a.application_id = ap.id AND ap.service='temporary-accommodation'
@@ -71,6 +72,7 @@ interface TransitionalAccommodationReferralReportData {
   val dutyToReferMade: Boolean?
   val dateDutyToReferMade: LocalDate?
   val probationRegionName: String
+  val pdu: String?
   val dutyToReferLocalAuthorityAreaName: String?
   val assessmentDecision: String?
   val assessmentRejectionReason: String?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -474,6 +474,7 @@ class ApplicationService(
       dutyToReferLocalAuthorityAreaName = null,
       prisonNameOnCreation = prisonName,
       personReleaseDate = null,
+      pdu = null,
     )
   }
 
@@ -912,6 +913,7 @@ class ApplicationService(
       eligibilityReason = submitApplication.eligibilityReason
       dutyToReferLocalAuthorityAreaName = submitApplication.dutyToReferLocalAuthorityAreaName
       personReleaseDate = submitApplication.personReleaseDate
+      pdu = submitApplication.pdu
     }
 
     assessmentService.createTemporaryAccommodationAssessment(application, submitApplication.summaryData)

--- a/src/main/resources/db/migration/all/20240319141046__add_pdu_to_cas3_application.sql
+++ b/src/main/resources/db/migration/all/20240319141046__add_pdu_to_cas3_application.sql
@@ -1,0 +1,1 @@
+ALTER TABLE temporary_accommodation_applications ADD COLUMN pdu TEXT NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2268,6 +2268,8 @@ components:
               type: string
               format: date
               example: '2024-02-21'
+            pdu:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6765,6 +6765,8 @@ components:
               type: string
               format: date
               example: '2024-02-21'
+            pdu:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2821,6 +2821,8 @@ components:
               type: string
               format: date
               example: '2024-02-21'
+            pdu:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2316,6 +2316,8 @@ components:
               type: string
               format: date
               example: '2024-02-21'
+            pdu:
+              type: string
             summaryData:
               $ref: '#/components/schemas/AnyValue'
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -47,6 +47,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var dutyToReferLocalAuthorityAreaName: Yielded<String?> = { null }
   private var prisonNameAtReferral: Yielded<String?> = { null }
   private var personReleaseDate: Yielded<LocalDate?> = { null }
+  private var pdu: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -164,6 +165,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.personReleaseDate = { personReleaseDate }
   }
 
+  fun withPdu(pdu: String?) = apply {
+    this.pdu = { pdu }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -192,5 +197,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     dutyToReferLocalAuthorityAreaName = this.dutyToReferLocalAuthorityAreaName(),
     prisonNameOnCreation = this.prisonNameAtReferral(),
     personReleaseDate = this.personReleaseDate(),
+    pdu = this.pdu(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2501,6 +2501,7 @@ class ApplicationTest : IntegrationTestBase() {
             withApplicationSchema(applicationSchema)
             withCreatedByUser(submittingUser)
             withProbationRegion(submittingUser.probationRegion)
+            withPdu("Probation Delivery Unit Test")
             withData(
               """
               {}
@@ -2522,6 +2523,7 @@ class ApplicationTest : IntegrationTestBase() {
                   val text = "Hello world!"
                 },
                 personReleaseDate = LocalDate.now(),
+                pdu = "Probation Delivery Unit Test",
               ),
             )
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/TransitionalAccommodationReferralReportsTest.kt
@@ -185,6 +185,7 @@ class TransitionalAccommodationReferralReportsTest : IntegrationTestBase() {
           }
           withPrisonNameAtReferral("HM Hounslow")
           withPersonReleaseDate(LocalDate.now())
+          withPdu("Probation Delivery Unit Test")
         }
 
         val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
@@ -468,6 +469,7 @@ class TransitionalAccommodationReferralReportsTest : IntegrationTestBase() {
     assertThat(actualReferralReportRow.accommodationRequiredDate).isEqualTo(application.arrivalDate?.toLocalDate())
     assertThat(actualReferralReportRow.prisonAtReferral).isEqualTo(application.prisonNameOnCreation)
     assertThat(actualReferralReportRow.releaseDate).isEqualTo(application.personReleaseDate)
+    assertThat(actualReferralReportRow.pdu).isEqualTo(application.pdu)
   }
 
   private fun createTemporaryAccommodationAssessmentForStatus(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1903,6 +1903,7 @@ class ApplicationServiceTest {
       eligibilityReason = "homelessFromApprovedPremises",
       dutyToReferLocalAuthorityAreaName = "Aberdeen City",
       personReleaseDate = LocalDate.now().plusDays(1),
+      pdu = "Probation Delivery Unit Test",
     )
 
     @BeforeEach
@@ -2148,6 +2149,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.eligibilityReason).isEqualTo("homelessFromApprovedPremises")
       assertThat(persistedApplication.dutyToReferLocalAuthorityAreaName).isEqualTo("Aberdeen City")
       assertThat(persistedApplication.personReleaseDate).isEqualTo(submitTemporaryAccommodationApplicationWithMiReportingData.personReleaseDate)
+      assertThat(persistedApplication.pdu).isEqualTo("Probation Delivery Unit Test")
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/ReportServiceTest.kt
@@ -210,6 +210,7 @@ class ReportServiceTest {
     personReleaseDate = null,
     town = null,
     postCode = null,
+    pdu = null,
   )
 
   @Suppress("LongParameterList")
@@ -238,5 +239,6 @@ class ReportServiceTest {
     override val personReleaseDate: LocalDate?,
     override val town: String?,
     override val postCode: String?,
+    override val pdu: String?,
   ) : TransitionalAccommodationReferralReportData
 }


### PR DESCRIPTION
This PR [CAS-251](https://dsdmoj.atlassian.net/browse/CAS-251) includes:

1. Capture and store pdu as first class field in CAS3 application.
2. Populate the stored pdu into CAS3's referral report

[CAS-251]: https://dsdmoj.atlassian.net/browse/CAS-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ