### PR TITLE
APS-438 Fixed incorrect UUID in Cas1 Fix PA LinksJob

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1FixPlacementApplicationLinksJob.kt
@@ -50,8 +50,12 @@ class Cas1FixPlacementApplicationLinksJob(
     log.info("Applying manual link fixes for ${manualLinkFixes.size} fixes")
 
     manualLinkFixes.forEach { fix ->
-      transactionTemplate.executeWithoutResult {
-        applyManualFix(fix)
+      try {
+        transactionTemplate.executeWithoutResult {
+          applyManualFix(fix)
+        }
+      } catch (e: IllegalStateException) {
+        log.error(e.message)
       }
     }
   }
@@ -62,15 +66,19 @@ class Cas1FixPlacementApplicationLinksJob(
     log.info("Automatically Fixing PlacementApplication to PlacementRequest relationships for ${applicationIds.size} applications")
 
     applicationIds.forEach { applicationId ->
-      transactionTemplate.executeWithoutResult {
-        applyAutomatedFixes(UUID.fromString(applicationId))
+      try {
+        transactionTemplate.executeWithoutResult {
+          applyAutomatedFixes(UUID.fromString(applicationId))
+        }
+      } catch (e: IllegalStateException) {
+        log.error(e.message)
       }
     }
   }
 
   @SuppressWarnings("ReturnCount")
   fun applyManualFix(manualLinkFix: ManualLinkFix) {
-    val application = applicationRepository.findByIdOrNull(UUID.fromString(manualLinkFix.applicationId))
+    val application = applicationRepository.findByIdOrNull(manualLinkFix.applicationId)
     if (application == null) {
       log.error("Could not find application for id ${manualLinkFix.applicationId} when applying manual fix")
       return
@@ -81,14 +89,14 @@ class Cas1FixPlacementApplicationLinksJob(
     val approvedPremisesApplicationEntity = application as ApprovedPremisesApplicationEntity
     val placementRequest = approvedPremisesApplicationEntity
       .placementRequests
-      .firstOrNull { it.id.toString() == manualLinkFix.placementRequestId }
+      .firstOrNull { it.id == manualLinkFix.placementRequestId }
 
     if (placementRequest == null) {
       log.error("Could not find placement request for id ${manualLinkFix.placementRequestId} when applying manual fix")
       return
     }
 
-    val placementApplication = placementApplicationRepository.findByIdOrNull(UUID.fromString(manualLinkFix.placementApplicationId))
+    val placementApplication = placementApplicationRepository.findByIdOrNull(manualLinkFix.placementApplicationId)
 
     if (placementApplication == null) {
       log.error("Could not find placement application for id ${manualLinkFix.placementApplicationId} when applying manual fix")
@@ -219,9 +227,9 @@ class Cas1FixPlacementApplicationLinksJob(
   )
 
   data class ManualLinkFix(
-    val applicationId: String,
-    val placementRequestId: String,
-    val placementApplicationId: String,
+    val applicationId: UUID,
+    val placementRequestId: UUID,
+    val placementApplicationId: UUID,
   )
 
   // Some links could not be fixed automatically by this migration job. After manual (human) analysis
@@ -229,79 +237,79 @@ class Cas1FixPlacementApplicationLinksJob(
   // See https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4781965318/CAS-1+PlacementApplication+to+PlacementRequest+link+Backfill
   val manualLinkFixes = listOf(
     ManualLinkFix(
-      applicationId = "fcba419e-7802-4c05-947f-7b24988aa795",
-      placementRequestId = "af242c35-07ff-4545-839a-b4b89e735e63",
-      placementApplicationId = "09b26c6d-570d-4b4f-804c-72ac71325cc0",
+      applicationId = UUID.fromString("fcba419e-7802-4c05-947f-7b24988aa795"),
+      placementRequestId = UUID.fromString("af242c35-07ff-4545-839a-b4b89e735e63"),
+      placementApplicationId = UUID.fromString("09b26c6d-570d-4b4f-804c-72ac71325cc0"),
     ),
     ManualLinkFix(
-      applicationId = "75337979-e4c9-45f9-b829-948d8516f364",
-      placementRequestId = "c1131478-2b3c-4dd8-84c4-88698184d632",
-      placementApplicationId = "218b7567-460b-447c-9481-7315ba53c23e",
+      applicationId = UUID.fromString("75337979-e4c9-45f9-b829-948d8516f364"),
+      placementRequestId = UUID.fromString("c1131478-2b3c-4dd8-84c4-88698184d632"),
+      placementApplicationId = UUID.fromString("218b7567-460b-447c-9481-7315ba53c23e"),
     ),
     ManualLinkFix(
-      applicationId = "9c4597e3-a615-4f08-b697-39b5cb2fc152",
-      placementRequestId = "44f15784-3497-4df5-9035-f65b741685c9",
-      placementApplicationId = "2ef871f6-a4da-46a9-96f7-a2901f80aa40",
+      applicationId = UUID.fromString("9c4597e3-a615-4f08-b697-39b5cb2fc152"),
+      placementRequestId = UUID.fromString("44f15784-3497-4df5-9035-f65b741685c9"),
+      placementApplicationId = UUID.fromString("2ef871f6-a4da-46a9-96f7-a2901f80aa40"),
     ),
     ManualLinkFix(
-      applicationId = "fe998691-61c6-489a-b94a-f62f112acd43",
-      placementRequestId = "d70a8012-bc3d-43ad-93f2-d0b5724dc3bc",
-      placementApplicationId = "4af4831b-a930-4de7-b612-1999b3e0313f",
+      applicationId = UUID.fromString("fe998691-61c6-489a-b94a-f62f112acd43"),
+      placementRequestId = UUID.fromString("d70a8012-bc3d-43ad-93f2-d0b5724dc3bc"),
+      placementApplicationId = UUID.fromString("4af4831b-a930-4de7-b612-1999b3e0313f"),
     ),
     ManualLinkFix(
-      applicationId = "4434ef73-abc1-451d-8c3e-eb9d43cd10ae",
-      placementRequestId = "d2478632-1616-467d-8b6b-f11bfe03729b",
-      placementApplicationId = "4532f7117-f5f9-498e-92ee-eb961de98af0",
+      applicationId = UUID.fromString("4434ef73-abc1-451d-8c3e-eb9d43cd10ae"),
+      placementRequestId = UUID.fromString("d2478632-1616-467d-8b6b-f11bfe03729b"),
+      placementApplicationId = UUID.fromString("532f7117-f5f9-498e-92ee-eb961de98af0"),
     ),
     ManualLinkFix(
-      applicationId = "4434ef73-abc1-451d-8c3e-eb9d43cd10ae",
-      placementRequestId = "5bccc0d4-f541-438a-a803-152e1d3ebd54",
-      placementApplicationId = "8848e951-b51d-43f3-a205-d7404a732d5f",
+      applicationId = UUID.fromString("4434ef73-abc1-451d-8c3e-eb9d43cd10ae"),
+      placementRequestId = UUID.fromString("5bccc0d4-f541-438a-a803-152e1d3ebd54"),
+      placementApplicationId = UUID.fromString("8848e951-b51d-43f3-a205-d7404a732d5f"),
     ),
     ManualLinkFix(
-      applicationId = "95b2aaa5-9314-49de-b272-b9e0bb8ee643",
-      placementRequestId = "bfdee07a-f0f8-428d-9d34-28455fc10ec7",
-      placementApplicationId = "81d60dd8-df26-4820-9b8c-828b2bdbaaa4",
+      applicationId = UUID.fromString("95b2aaa5-9314-49de-b272-b9e0bb8ee643"),
+      placementRequestId = UUID.fromString("bfdee07a-f0f8-428d-9d34-28455fc10ec7"),
+      placementApplicationId = UUID.fromString("81d60dd8-df26-4820-9b8c-828b2bdbaaa4"),
     ),
     ManualLinkFix(
-      applicationId = "9fff5bbd-c538-446e-a3c8-5c770e05bdb6",
-      placementRequestId = "46765be3-b46b-4202-9cc1-118cb6d73928",
-      placementApplicationId = "8cf4c9de-0e29-4af7-8621-437e6f7bc644",
+      applicationId = UUID.fromString("9fff5bbd-c538-446e-a3c8-5c770e05bdb6"),
+      placementRequestId = UUID.fromString("46765be3-b46b-4202-9cc1-118cb6d73928"),
+      placementApplicationId = UUID.fromString("8cf4c9de-0e29-4af7-8621-437e6f7bc644"),
     ),
     ManualLinkFix(
-      applicationId = "ce51f404-3f8e-400c-b235-89e2ce5461d7",
-      placementRequestId = "a8e380ee-10ce-48ba-98fa-9c115d722649",
-      placementApplicationId = "9ef0080c-f83f-4f81-8219-4a7c61a70388",
+      applicationId = UUID.fromString("ce51f404-3f8e-400c-b235-89e2ce5461d7"),
+      placementRequestId = UUID.fromString("a8e380ee-10ce-48ba-98fa-9c115d722649"),
+      placementApplicationId = UUID.fromString("9ef0080c-f83f-4f81-8219-4a7c61a70388"),
     ),
     ManualLinkFix(
-      applicationId = "e3a87d85-fa54-4654-b804-4d0fb9253121",
-      placementRequestId = "f681fa85-69df-46b6-bd05-cf4191c1d6d6",
-      placementApplicationId = "af74d224-04d5-4598-a9a9-6e086ec2b60b",
+      applicationId = UUID.fromString("e3a87d85-fa54-4654-b804-4d0fb9253121"),
+      placementRequestId = UUID.fromString("f681fa85-69df-46b6-bd05-cf4191c1d6d6"),
+      placementApplicationId = UUID.fromString("af74d224-04d5-4598-a9a9-6e086ec2b60b"),
     ),
     ManualLinkFix(
-      applicationId = "e3a87d85-fa54-4654-b804-4d0fb9253121",
-      placementRequestId = "7a4f4108-9874-474a-8c70-528986cb3368",
-      placementApplicationId = "6ebea4ff-34e7-4c64-ac20-b8b218c0f706",
+      applicationId = UUID.fromString("e3a87d85-fa54-4654-b804-4d0fb9253121"),
+      placementRequestId = UUID.fromString("7a4f4108-9874-474a-8c70-528986cb3368"),
+      placementApplicationId = UUID.fromString("6ebea4ff-34e7-4c64-ac20-b8b218c0f706"),
     ),
     ManualLinkFix(
-      applicationId = "ab02981b-a7f3-4075-8cff-27e5edad597d",
-      placementRequestId = "55b0e01f-4006-4c5b-b61e-dfe1d47a27d3",
-      placementApplicationId = "c0886c1c-11ac-4ce7-93a8-ce180e61bf36",
+      applicationId = UUID.fromString("ab02981b-a7f3-4075-8cff-27e5edad597d"),
+      placementRequestId = UUID.fromString("55b0e01f-4006-4c5b-b61e-dfe1d47a27d3"),
+      placementApplicationId = UUID.fromString("c0886c1c-11ac-4ce7-93a8-ce180e61bf36"),
     ),
     ManualLinkFix(
-      applicationId = "cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74",
-      placementRequestId = "1aab2f12-d71b-47cc-af74-4e3a72d4af04",
-      placementApplicationId = "c45764f2-98d6-4af5-a784-2faa16e6b2c9",
+      applicationId = UUID.fromString("cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74"),
+      placementRequestId = UUID.fromString("1aab2f12-d71b-47cc-af74-4e3a72d4af04"),
+      placementApplicationId = UUID.fromString("c45764f2-98d6-4af5-a784-2faa16e6b2c9"),
     ),
     ManualLinkFix(
-      applicationId = "cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74",
-      placementRequestId = "e7a98cc9-8a71-4c9d-b5f5-470e321bf24b",
-      placementApplicationId = "2d6e7e0d-7202-47d9-847c-f50614018d9b",
+      applicationId = UUID.fromString("cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74"),
+      placementRequestId = UUID.fromString("e7a98cc9-8a71-4c9d-b5f5-470e321bf24b"),
+      placementApplicationId = UUID.fromString("2d6e7e0d-7202-47d9-847c-f50614018d9b"),
     ),
     ManualLinkFix(
-      applicationId = "cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74",
-      placementRequestId = "18a532f7-7893-47a1-ab8e-1e34d7b3ff46",
-      placementApplicationId = "ec618a23-2ad3-4df0-bb91-a81cdaaab677",
+      applicationId = UUID.fromString("cd508e65-6f2b-4bb1-8aa6-6ae3fee57c74"),
+      placementRequestId = UUID.fromString("18a532f7-7893-47a1-ab8e-1e34d7b3ff46"),
+      placementApplicationId = UUID.fromString("ec618a23-2ad3-4df0-bb91-a81cdaaab677"),
     ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
@@ -110,9 +110,9 @@ class Cas1FixPlacementApplicationLinksJobTest {
 
     service.applyManualFix(
       ManualLinkFix(
-        applicationId = applicationWithNoArrivalDate.id.toString(),
-        placementApplicationId = placementApp1.id.toString(),
-        placementRequestId = placementRequest3.id.toString(),
+        applicationId = applicationWithNoArrivalDate.id,
+        placementApplicationId = placementApp1.id,
+        placementRequestId = placementRequest3.id,
       ),
     )
 


### PR DESCRIPTION
UUIDs are now defined as actual UUIDs to capture invalid UUIDs on startup

Also now capturing and logging runtime errors during migration as these are otherwise swallowed