### PR TITLE
(Fix) Carry out one update task per page of data on Notice Type migration job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -101,6 +101,7 @@ class MigrationJobService(
 
         MigrationJobType.cas1NoticeTypes -> NoticeTypeMigrationJob(
           applicationContext.getBean(NoticeTypeMigrationJobApplicationRepository::class.java),
+          applicationContext.getBean(EntityManager::class.java),
           pageSize,
         )
       }


### PR DESCRIPTION
Storing all those UUIDs in two arrays gave us memory issues