### PR TITLE
CAS2-334 add optional isSubmitted param

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSum
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
@@ -38,10 +39,14 @@ class ApplicationsController(
   private val userService: NomisUserService,
 ) : ApplicationsCas2Delegate {
 
-  override fun applicationsGet(): ResponseEntity<List<ApplicationSummary>> {
+  override fun applicationsGet(isSubmitted: Boolean?): ResponseEntity<List<ApplicationSummary>> {
     val user = userService.getUserForRequest()
 
-    val applications = applicationService.getAllApplicationsForUser(user)
+    val applications = when (isSubmitted) {
+      true -> applicationService.getSubmittedApplicationsForUser(user)
+      false -> applicationService.getUnsubmittedApplicationsForUser(user)
+      null -> applicationService.getAllApplicationsForUser(user)
+    }
 
     return ResponseEntity.ok(applications.map { getPersonDetailAndTransformToSummary(it, user) })
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -47,6 +47,42 @@ ORDER BY createdAt DESC
 SELECT
     CAST(a.id AS TEXT) as id,
     a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt
+FROM cas_2_applications a
+WHERE a.created_by_user_id = :userId
+AND a.submitted_at IS NOT NULL
+ORDER BY createdAt DESC
+""",
+    nativeQuery = true,
+  )
+  fun findSubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID):
+    List<Cas2ApplicationSummary>
+
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt
+FROM cas_2_applications a
+WHERE a.created_by_user_id = :userId
+AND a.submitted_at IS NULL
+ORDER BY createdAt DESC
+""",
+    nativeQuery = true,
+  )
+  fun findUnsubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID):
+    List<Cas2ApplicationSummary>
+
+  @Query(
+    """
+SELECT
+    CAST(a.id AS TEXT) as id,
+    a.crn,
     a.noms_number as nomsNumber,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -56,6 +56,14 @@ class ApplicationService(
     return applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id)
   }
 
+  fun getSubmittedApplicationsForUser(user: NomisUserEntity): List<Cas2ApplicationSummary> {
+    return applicationRepository.findSubmittedCas2ApplicationSummariesCreatedByUser(user.id)
+  }
+
+  fun getUnsubmittedApplicationsForUser(user: NomisUserEntity): List<Cas2ApplicationSummary> {
+    return applicationRepository.findUnsubmittedCas2ApplicationSummariesCreatedByUser(user.id)
+  }
+
   fun getAllSubmittedApplicationsForAssessor(pageCriteria: PageCriteria<String>): Pair<List<Cas2ApplicationSummary>, PaginationMetadata?> {
     val pageable = getPageable(pageCriteria)
 

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -47,6 +47,12 @@ paths:
       tags:
         - Operations on CAS2 applications
       summary: List summaries of all CAS2 applications authorised for the logged in user
+      parameters:
+        - name: isSubmitted
+          in: query
+          description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -49,6 +49,12 @@ paths:
       tags:
         - Operations on CAS2 applications
       summary: List summaries of all CAS2 applications authorised for the logged in user
+      parameters:
+        - name: isSubmitted
+          in: query
+          description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
Ref: [CAS2-334](https://dsdmoj.atlassian.net/browse/CAS2-334)

**User Story**
As a consumer of the CAS API
When I make a request to /applications indicating via a query param that I want either in progress or submitted applications
Then I receive the relevant applications

**Technical implementation**
Added optional param `isSubmitted` and if true returns submitted applications, if false returns those without a submission date, and if absent returns all.

[CAS2-334]: https://dsdmoj.atlassian.net/browse/CAS2-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ