### PR TITLE
(Fix) Set createdAt in UpdateApplicationCas1 test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -923,6 +923,7 @@ class ApplicationServiceTest {
       .withApplicationSchema(newestSchema)
       .withId(applicationId)
       .withCreatedByUser(user)
+      .withCreatedAt(OffsetDateTime.now())
       .produce()
       .apply {
         schemaUpToDate = true


### PR DESCRIPTION
Now we’re relying on the created at date (at least temporarily) to get the noticeType, we need to ensure that the date the application is created is consistent (rather than being a random date in the past) to avoid flaky tests. This sets that `createdAt` date to now, so when we set the arrivalDate as 10 days or 7 months from now, we get a predictable response for the noticeType