### PR TITLE
CAS2-338: Bulk search CRNs for CAS2 Submissions 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -63,7 +63,7 @@ class SubmissionsController(
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),
-    ).body(applications.map { getPersonDetailAndTransformToSummary(it) })
+    ).body(getPersonNamesAndTransformToSummaries(applications))
   }
 
   override fun submissionsApplicationIdGet(applicationId: UUID): ResponseEntity<Cas2SubmittedApplication> {
@@ -172,16 +172,13 @@ class SubmissionsController(
     nomisUserService.getUserForRequest()
   }
 
-  private fun getPersonDetailAndTransformToSummary(
-    application: Cas2ApplicationSummary,
-  ):
-    Cas2SubmittedApplicationSummary {
-    val personName = offenderService.getOffenderNameOrPlaceholder(application.getCrn())
-
-    return submissionsTransformer.transformJpaSummaryToApiRepresentation(
-      application,
-      personName,
-    )
+  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummary>):
+    List<Cas2SubmittedApplicationSummary> {
+    val crns = applicationSummaries.map { it.getCrn() }
+    val personNamesMap = offenderService.getOffenderNamesOrPlaceholder(crns.toSet())
+    return applicationSummaries.map { application ->
+      submissionsTransformer.transformJpaSummaryToApiRepresentation(application, personNamesMap[application.getCrn()]!!)
+    }
   }
 
   private fun getPersonDetailAndTransform(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -175,7 +175,9 @@ class SubmissionsController(
   private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummary>):
     List<Cas2SubmittedApplicationSummary> {
     val crns = applicationSummaries.map { it.getCrn() }
-    val personNamesMap = offenderService.getOffenderNamesOrPlaceholder(crns.toSet())
+
+    val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
+
     return applicationSummaries.map { application ->
       submissionsTransformer.transformJpaSummaryToApiRepresentation(application, personNamesMap[application.getCrn()]!!)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/OffenderServiceTest.kt
@@ -490,6 +490,63 @@ class OffenderServiceTest {
     }
   }
 
+  @Nested
+  inner class GetOffenderNamesOrPlaceholder {
+    @Test
+    fun `returns Not Found when offender is PersonInfoResult-NotFound, status 404`() {
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf("NOTFOUND")) } returns mapOf(
+        "NOTFOUND" to
+          ClientResult
+            .Failure
+            .StatusCode(
+              HttpMethod.GET,
+              "/secure/offenders/crn/ABC123",
+              HttpStatus.NOT_FOUND,
+              null,
+              true,
+            ),
+      )
+
+      val result = offenderService.getOffenderNamesOrPlaceholder(setOf("NOTFOUND"))
+      assertThat(result).isEqualTo(mapOf("NOTFOUND" to "Person Not Found"))
+    }
+
+    @Test
+    fun `returns Unknown when offender returns any other code except 404`() {
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf("UNKNOWN")) } returns mapOf(
+        "UNKNOWN" to
+          ClientResult
+            .Failure
+            .StatusCode(
+              HttpMethod.GET,
+              "/secure/offenders/crn/ABC123",
+              HttpStatus.FORBIDDEN,
+              null,
+              true,
+            ),
+      )
+
+      val result = offenderService.getOffenderNamesOrPlaceholder(setOf("UNKNOWN"))
+      assertThat(result).isEqualTo(mapOf("UNKNOWN" to "Unknown"))
+    }
+
+    @Test
+    fun `returns the person's full name when offender is PersonInfoResult-Full`() {
+      val offenderDetailSummary = OffenderDetailsSummaryFactory()
+        .withFirstName("ExampleFirst")
+        .withLastName("ExampleLast")
+        .produce()
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf("FULL")) } returns mapOf(
+        "FULL" to ClientResult.Success(
+          status = HttpStatus.OK,
+          body = offenderDetailSummary,
+        ),
+      )
+      val result = offenderService.getOffenderNamesOrPlaceholder(setOf("FULL"))
+      assertThat(result).isEqualTo(mapOf("FULL" to "ExampleFirst ExampleLast"))
+    }
+  }
+
   private fun mock404RoSH(crn: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.NOT_FOUND, body = null)
 
   private fun mock500RoSH(crn: String) = every { mockApOASysContextApiClient.getRoshRatings(crn) } returns StatusCode(HttpMethod.GET, "/rosh/a-crn", HttpStatus.INTERNAL_SERVER_ERROR, body = null)


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CAS2-338

Following investigating the slow response times of the /submissions endpoint, we think we can increase the efficiency  by bulk searching for CRN's. This will also help when we introduce the Prison dashboard.

Previously we iterated through each application and [make an individual call for the OffenderSummary here](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/938a6dda5c012a3b80080ef109d80de6f63fdeee/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt#L86 )

This PR

* uses the `offenderDetailsDataSource.getOffenderDetailSummaries` method to search for a list of CRN's, and then return a map of `crn` -> `personName`. 
* The map can then be used by the `SubmissionsController` to map back to the relevant `applications`
* I then introduced a `partition` on a max search number set by CAS3, to protect against the off chance that this is called without pagination, and to future-proof if we want to use for reports or a dashboard.

