### PR TITLE
APS-521 show placement app and match request withdrawal reason in timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.javaConstantNameToSentence
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -87,13 +88,19 @@ class DomainEventDescriber(
     return event.describe { "The assessment was appealed and ${it.eventDetails.decision.value}. The reason was: ${it.eventDetails.decisionDetail}" }
   }
 
-  private fun buildPlacementApplicationWithdrawnDescription(domainEventSummary: DomainEventSummary): String {
+  private fun buildPlacementApplicationWithdrawnDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getPlacementApplicationWithdrawnEvent(domainEventSummary.id())
-    val dates = event?.data?.eventDetails?.placementDates ?: emptyList()
-    return "A request for placement was withdrawn" +
-      if (dates.isNotEmpty()) {
-        " for dates " + dates.joinToString(", ") { "${it.startDate.toUiFormat()} to ${it.endDate.toUiFormat()}" }
-      } else { "" }
+
+    return event.describe { data ->
+      val dates = data.eventDetails.placementDates ?: emptyList()
+      val reasonDescription = data.eventDetails.withdrawalReason.javaConstantNameToSentence()
+
+      "A request for placement was withdrawn" +
+        if (dates.isNotEmpty()) {
+          " for dates " + dates.joinToString(", ") { "${it.startDate.toUiFormat()} to ${it.endDate.toUiFormat()}" }
+        } else { "" } +
+        ". The reason was $reasonDescription"
+    }
   }
 
   private fun buildMatchRequestWithdrawnDescription(domainEventSummary: DomainEventSummary): String? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -43,7 +43,7 @@ class DomainEventDescriber(
     return event.describe { data ->
       val formattedWithdrawalReason = data.eventDetails.withdrawalReason.replace("_", " ")
 
-      "The application was withdrawn. The reason was: $formattedWithdrawalReason" +
+      "The application was withdrawn. The reason was: '$formattedWithdrawalReason'" +
         (data.eventDetails.otherWithdrawalReason?.let { " ($it)" } ?: "")
     }
   }
@@ -80,7 +80,7 @@ class DomainEventDescriber(
 
   private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
-    return event.describe { "The booking was cancelled. The reason was: ${it.eventDetails.cancellationReason}" }
+    return event.describe { "The booking was cancelled. The reason was: '${it.eventDetails.cancellationReason}'" }
   }
 
   private fun buildAssessmentAppealedDescription(domainEventSummary: DomainEventSummary): String? {
@@ -99,7 +99,7 @@ class DomainEventDescriber(
         if (dates.isNotEmpty()) {
           " for dates " + dates.joinToString(", ") { "${it.startDate.toUiFormat()} to ${it.endDate.toUiFormat()}" }
         } else { "" } +
-        ". The reason was $reasonDescription"
+        ". The reason was: '$reasonDescription'"
     }
   }
 
@@ -113,7 +113,7 @@ class DomainEventDescriber(
       val reasonDescription = data.eventDetails.withdrawalReason.javaConstantNameToSentence()
 
       "A request for placement was withdrawn for dates ${dates.startDate.toUiFormat()} to ${dates.endDate.toUiFormat()}. " +
-        "The reason was $reasonDescription"
+        "The reason was: '$reasonDescription'"
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -108,9 +108,12 @@ class DomainEventDescriber(
     /**
      * See documentation in [Cas1PlacementRequestDomainEventService] for why this is reported as a request for placement
      **/
-    return event.describe {
-      val dates = it.eventDetails.datePeriod
-      "A request for placement was withdrawn for dates ${dates.startDate.toUiFormat()} to ${dates.endDate.toUiFormat()}"
+    return event.describe { data ->
+      val dates = data.eventDetails.datePeriod
+      val reasonDescription = data.eventDetails.withdrawalReason.javaConstantNameToSentence()
+
+      "A request for placement was withdrawn for dates ${dates.startDate.toUiFormat()} to ${dates.endDate.toUiFormat()}. " +
+        "The reason was $reasonDescription"
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/StringHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/StringHelpers.kt
@@ -6,3 +6,8 @@ fun String.kebabCaseToPascalCase(): String {
   val pattern = "-[a-z]".toRegex()
   return replace(pattern) { it.value.last().uppercase() }.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 }
+
+fun String.javaConstantNameToSentence():
+  String = replace("_", " ")
+  .lowercase()
+  .replaceFirstChar { it.uppercase() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2702,7 +2702,7 @@ class ApplicationTest : IntegrationTestBase() {
           "The person was due to move into the premises on 2024-01-01 but did not arrive",
           "The person moved out of the premises on 2024-04-01",
           "A booking was not made for the placement request. The reason was: no suitable premises",
-          "The booking was cancelled. The reason was: additional sentencing",
+          "The booking was cancelled. The reason was: 'additional sentencing'",
           "The booking had its arrival or departure date changed",
           "The application was assessed and accepted",
         )
@@ -2747,7 +2747,7 @@ class ApplicationTest : IntegrationTestBase() {
           "The person was due to move into the premises on 2024-01-01 but did not arrive",
           "The person moved out of the premises on 2024-04-01",
           "A booking was not made for the placement request. The reason was: no suitable premises",
-          "The booking was cancelled. The reason was: additional sentencing",
+          "The booking was cancelled. The reason was: 'additional sentencing'",
           "The booking had its arrival or departure date changed",
           "The application was assessed and accepted",
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonDep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonNotArrivedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
@@ -287,13 +288,14 @@ class DomainEventDescriberTest {
         timestamp = Instant.now(),
         eventType = "approved-premises.placement-application.withdrawn",
         eventDetails = PlacementApplicationWithdrawnFactory()
+          .withWithdrawalReason(PlacementApplicationWithdrawalReason.RELATED_APPLICATION_WITHDRAWN.toString())
           .produce(),
       )
     }
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A request for placement was withdrawn")
+    assertThat(result).isEqualTo("A request for placement was withdrawn. The reason was Related application withdrawn")
   }
 
   @Test
@@ -306,6 +308,7 @@ class DomainEventDescriberTest {
         timestamp = Instant.now(),
         eventType = "approved-premises.placement-application.withdrawn",
         eventDetails = PlacementApplicationWithdrawnFactory()
+          .withWithdrawalReason(PlacementApplicationWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST.toString())
           .withPlacementDates(
             listOf(
               DatePeriod(LocalDate.of(2024, 1, 2), LocalDate.of(2024, 3, 4)),
@@ -318,7 +321,10 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A request for placement was withdrawn for dates Tuesday 2 January 2024 to Monday 4 March 2024, Monday 6 May 2024 to Monday 8 July 2024")
+    assertThat(result).isEqualTo(
+      "A request for placement was withdrawn for dates Tuesday 2 January 2024 to Monday 4 March 2024, Monday 6 May 2024 to Monday 8 July 2024. " +
+        "The reason was Duplicate placement request",
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonNot
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
@@ -337,6 +338,7 @@ class DomainEventDescriberTest {
         timestamp = Instant.now(),
         eventType = "approved-premises.match-request.withdrawn",
         eventDetails = MatchRequestWithdrawnFactory()
+          .withWithdrawalReason(PlacementRequestWithdrawalReason.NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION.toString())
           .withDatePeriod(DatePeriod(LocalDate.of(2024, 1, 2), LocalDate.of(2024, 3, 4)))
           .produce(),
       )
@@ -344,7 +346,10 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A request for placement was withdrawn for dates Tuesday 2 January 2024 to Monday 4 March 2024")
+    assertThat(result).isEqualTo(
+      "A request for placement was withdrawn for dates Tuesday 2 January 2024 to Monday 4 March 2024. " +
+        "The reason was No capacity due to placement prioritisation",
+    )
   }
 
   private fun <T> buildDomainEvent(builder: (UUID) -> T): DomainEvent<T> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -203,7 +203,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The booking was cancelled. The reason was: $reason")
+    assertThat(result).isEqualTo("The booking was cancelled. The reason was: '$reason'")
   }
 
   @Test
@@ -233,7 +233,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The application was withdrawn. The reason was: change in circumstances new application to be submitted")
+    assertThat(result).isEqualTo("The application was withdrawn. The reason was: 'change in circumstances new application to be submitted'")
   }
 
   @Test
@@ -254,7 +254,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The application was withdrawn. The reason was: the main withdrawal reason (additional reason)")
+    assertThat(result).isEqualTo("The application was withdrawn. The reason was: 'the main withdrawal reason' (additional reason)")
   }
 
   @ParameterizedTest
@@ -296,7 +296,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A request for placement was withdrawn. The reason was Related application withdrawn")
+    assertThat(result).isEqualTo("A request for placement was withdrawn. The reason was: 'Related application withdrawn'")
   }
 
   @Test
@@ -324,7 +324,7 @@ class DomainEventDescriberTest {
 
     assertThat(result).isEqualTo(
       "A request for placement was withdrawn for dates Tuesday 2 January 2024 to Monday 4 March 2024, Monday 6 May 2024 to Monday 8 July 2024. " +
-        "The reason was Duplicate placement request",
+        "The reason was: 'Duplicate placement request'",
     )
   }
 
@@ -348,7 +348,7 @@ class DomainEventDescriberTest {
 
     assertThat(result).isEqualTo(
       "A request for placement was withdrawn for dates Tuesday 2 January 2024 to Monday 4 March 2024. " +
-        "The reason was No capacity due to placement prioritisation",
+        "The reason was: 'No capacity due to placement prioritisation'",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/StringHelpersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/StringHelpersTest.kt
@@ -2,11 +2,17 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.javaConstantNameToSentence
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.kebabCaseToPascalCase
 
 class StringHelpersTest {
   @Test
-  fun `Converts kebab-case to PascalCase`() {
+  fun kebabCaseToPascalCase() {
     assertThat("kebab-case".kebabCaseToPascalCase()).isEqualTo("KebabCase")
+  }
+
+  @Test
+  fun javaConstantNameToSentence() {
+    assertThat("MY_CONSTANT_NAME".javaConstantNameToSentence()).isEqualTo("My constant name")
   }
 }


### PR DESCRIPTION
This PR updates all 4 withdrawal timeline event descriptions to use consistent formatting. Examples below:

![Screenshot 2024-03-20 at 15 23 42](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/f86d08a8-b995-4915-83d5-1e1116a96187)
![Screenshot 2024-03-20 at 15 24 19](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/b9042ea6-c5ef-4710-bdb4-c29bfc1c0029)
![Screenshot 2024-03-20 at 15 24 10](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/7addd840-d35d-4e42-ba34-d1b676730ba0)
![Screenshot 2024-03-20 at 15 27 09](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/ef25f0db-88f0-4762-8ebc-99f1fd8b1a3e)
