### PR TITLE
APS-530 Move assessment withdrawn email logic into CAS1 Assessment Email Service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -78,8 +78,6 @@ class AssessmentService(
   private val userAllocator: UserAllocator,
   private val objectMapper: ObjectMapper,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
-  @Value("\${feature-flags.cas1-use-new-withdrawal-logic}")
-  private val sendNewWithdrawalNotifications: Boolean,
   private val taskDeadlineService: TaskDeadlineService,
   private val assessmentEmailService: Cas1AssessmentEmailService,
 ) {
@@ -937,20 +935,10 @@ class AssessmentService(
       assessment.isWithdrawn = true
       assessmentRepository.save(assessment)
 
-      val allocatedUserEmail = assessment.allocatedToUser?.email
-      if (sendNewWithdrawalNotifications &&
-        isPendingAssessment &&
-        allocatedUserEmail != null
-      ) {
-        emailNotificationService.sendEmail(
-          recipientEmailAddress = allocatedUserEmail,
-          templateId = notifyConfig.templates.assessmentWithdrawn,
-          personalisation = mapOf(
-            "applicationUrl" to applicationUrlTemplate.resolve("id", assessment.application.id.toString()),
-            "crn" to assessment.application.crn,
-          ),
-        )
-      }
+      assessmentEmailService.assessmentWithdrawn(
+        assessment = assessment,
+        isAssessmentPending = isPendingAssessment,
+      )
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -2546,198 +2546,169 @@ class AssessmentServiceTest {
     }
   }
 
-  @Test
-  fun `updateCas1AssessmentWithdrawn send email if assessment active and allocated`() {
-    val assessmentId = UUID.randomUUID()
+  @Nested
+  inner class UpdateCas1AssessmentWithdrawn {
 
-    val allocatedUser = UserEntityFactory()
-      .withDefaultProbationRegion()
-      .withEmail("user@test.com")
-      .produce()
+    @Test
+    fun `updateCas1AssessmentWithdrawn triggers email`() {
+      val assessmentId = UUID.randomUUID()
 
-    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
-      id = UUID.randomUUID(),
-      addedAt = OffsetDateTime.now(),
-      schema = "{}",
-    )
+      val allocatedUser = UserEntityFactory()
+        .withDefaultProbationRegion()
+        .withEmail("user@test.com")
+        .produce()
 
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withId(assessmentId)
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
-          .produce(),
+      val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+        id = UUID.randomUUID(),
+        addedAt = OffsetDateTime.now(),
+        schema = "{}",
       )
-      .withAssessmentSchema(schema)
-      .withData("{\"test\": \"data\"}")
-      .withAllocatedToUser(allocatedUser)
-      .withSubmittedAt(null)
-      .withReallocatedAt(null)
-      .withIsWithdrawn(false)
-      .produce()
 
-    every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
-    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-    every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withId(assessmentId)
+        .withApplication(
+          ApprovedPremisesApplicationEntityFactory()
+            .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
+            .produce(),
+        )
+        .withAssessmentSchema(schema)
+        .withData("{\"test\": \"data\"}")
+        .withAllocatedToUser(allocatedUser)
+        .withSubmittedAt(null)
+        .withReallocatedAt(null)
+        .withIsWithdrawn(false)
+        .produce()
 
-    assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
+      every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
 
-    verify(exactly = 1) {
-      emailNotificationServiceMock.sendEmail(
-        "user@test.com",
-        "44ade006-7ac6-4769-aa40-542da56f21b5",
-        match {
-          it["crn"] == assessment.application.crn &&
-            it["applicationUrl"] == "http://frontend/applications/${assessment.application.id}"
-        },
-      )
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+
+      verify(exactly = 1) {
+        emailNotificationServiceMock.sendEmail(
+          "user@test.com",
+          "44ade006-7ac6-4769-aa40-542da56f21b5",
+          match {
+            it["crn"] == assessment.application.crn &&
+              it["applicationUrl"] == "http://frontend/applications/${assessment.application.id}"
+          },
+        )
+      }
     }
-  }
 
-  @Test
-  fun `updateCas1AssessmentWithdrawn dont send email if assessment withdrawn`() {
-    val assessmentId = UUID.randomUUID()
+    @Test
+    fun `updateCas1AssessmentWithdrawn dont send email if assessment withdrawn`() {
+      val assessmentId = UUID.randomUUID()
 
-    val allocatedUser = UserEntityFactory()
-      .withDefaultProbationRegion()
-      .withEmail("user@test.com")
-      .produce()
+      val allocatedUser = UserEntityFactory()
+        .withDefaultProbationRegion()
+        .withEmail("user@test.com")
+        .produce()
 
-    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
-      id = UUID.randomUUID(),
-      addedAt = OffsetDateTime.now(),
-      schema = "{}",
-    )
-
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withId(assessmentId)
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
-          .produce(),
+      val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+        id = UUID.randomUUID(),
+        addedAt = OffsetDateTime.now(),
+        schema = "{}",
       )
-      .withAssessmentSchema(schema)
-      .withData("{\"test\": \"data\"}")
-      .withAllocatedToUser(allocatedUser)
-      .withSubmittedAt(null)
-      .withReallocatedAt(null)
-      .withIsWithdrawn(true)
-      .produce()
 
-    every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
-    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withId(assessmentId)
+        .withApplication(
+          ApprovedPremisesApplicationEntityFactory()
+            .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
+            .produce(),
+        )
+        .withAssessmentSchema(schema)
+        .withData("{\"test\": \"data\"}")
+        .withAllocatedToUser(allocatedUser)
+        .withSubmittedAt(null)
+        .withReallocatedAt(null)
+        .withIsWithdrawn(true)
+        .produce()
 
-    assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
-    verify { emailNotificationServiceMock wasNot Called }
-  }
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
 
-  @Test
-  fun `updateCas1AssessmentWithdrawn dont send email if assessment submitted`() {
-    val assessmentId = UUID.randomUUID()
+      verify { emailNotificationServiceMock wasNot Called }
+    }
 
-    val allocatedUser = UserEntityFactory()
-      .withDefaultProbationRegion()
-      .withEmail("user@test.com")
-      .produce()
+    @Test
+    fun `updateCas1AssessmentWithdrawn dont send email if assessment submitted`() {
+      val assessmentId = UUID.randomUUID()
 
-    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
-      id = UUID.randomUUID(),
-      addedAt = OffsetDateTime.now(),
-      schema = "{}",
-    )
+      val allocatedUser = UserEntityFactory()
+        .withDefaultProbationRegion()
+        .withEmail("user@test.com")
+        .produce()
 
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withId(assessmentId)
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
-          .produce(),
+      val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+        id = UUID.randomUUID(),
+        addedAt = OffsetDateTime.now(),
+        schema = "{}",
       )
-      .withAssessmentSchema(schema)
-      .withData("{\"test\": \"data\"}")
-      .withAllocatedToUser(allocatedUser)
-      .withSubmittedAt(OffsetDateTime.now())
-      .withReallocatedAt(null)
-      .withIsWithdrawn(false)
-      .produce()
 
-    every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
-    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withId(assessmentId)
+        .withApplication(
+          ApprovedPremisesApplicationEntityFactory()
+            .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
+            .produce(),
+        )
+        .withAssessmentSchema(schema)
+        .withData("{\"test\": \"data\"}")
+        .withAllocatedToUser(allocatedUser)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withReallocatedAt(null)
+        .withIsWithdrawn(false)
+        .produce()
 
-    assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
-    verify { emailNotificationServiceMock wasNot Called }
-  }
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
 
-  @Test
-  fun `updateCas1AssessmentWithdrawn dont send email if assessment reallocated`() {
-    val assessmentId = UUID.randomUUID()
+      verify { emailNotificationServiceMock wasNot Called }
+    }
 
-    val allocatedUser = UserEntityFactory()
-      .withDefaultProbationRegion()
-      .withEmail("user@test.com")
-      .produce()
+    @Test
+    fun `updateCas1AssessmentWithdrawn dont send email if assessment reallocated`() {
+      val assessmentId = UUID.randomUUID()
 
-    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
-      id = UUID.randomUUID(),
-      addedAt = OffsetDateTime.now(),
-      schema = "{}",
-    )
+      val allocatedUser = UserEntityFactory()
+        .withDefaultProbationRegion()
+        .withEmail("user@test.com")
+        .produce()
 
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withId(assessmentId)
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
-          .produce(),
+      val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
+        id = UUID.randomUUID(),
+        addedAt = OffsetDateTime.now(),
+        schema = "{}",
       )
-      .withAssessmentSchema(schema)
-      .withData("{\"test\": \"data\"}")
-      .withAllocatedToUser(allocatedUser)
-      .withSubmittedAt(null)
-      .withReallocatedAt(OffsetDateTime.now())
-      .withIsWithdrawn(false)
-      .produce()
 
-    every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
-    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withId(assessmentId)
+        .withApplication(
+          ApprovedPremisesApplicationEntityFactory()
+            .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
+            .produce(),
+        )
+        .withAssessmentSchema(schema)
+        .withData("{\"test\": \"data\"}")
+        .withAllocatedToUser(allocatedUser)
+        .withSubmittedAt(null)
+        .withReallocatedAt(OffsetDateTime.now())
+        .withIsWithdrawn(false)
+        .produce()
 
-    assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
-    verify { emailNotificationServiceMock wasNot Called }
-  }
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
 
-  @Test
-  fun `updateCas1AssessmentWithdrawn dont send email if assessment not allocated`() {
-    val assessmentId = UUID.randomUUID()
-
-    val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
-      id = UUID.randomUUID(),
-      addedAt = OffsetDateTime.now(),
-      schema = "{}",
-    )
-
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withId(assessmentId)
-      .withApplication(
-        ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(UserEntityFactory().withDefaultProbationRegion().produce())
-          .produce(),
-      )
-      .withAssessmentSchema(schema)
-      .withData("{\"test\": \"data\"}")
-      .withAllocatedToUser(null)
-      .withSubmittedAt(null)
-      .withReallocatedAt(null)
-      .withIsWithdrawn(false)
-      .produce()
-
-    every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
-    every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-
-    assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
-
-    verify { emailNotificationServiceMock wasNot Called }
+      verify { emailNotificationServiceMock wasNot Called }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -108,7 +108,6 @@ class AcceptAssessmentTest {
     userAllocator,
     objectMapperMock,
     UrlTemplate("http://frontend/applications/#id"),
-    sendNewWithdrawalNotifications = true,
     taskDeadlineServiceMock,
     assessmentEmailServiceMock,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentEmailServiceTest.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentEmailService.Companion.NEXT_WORKING_DAY_EMERGENCY_DEADLINE_COPY
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentEmailService.Companion.SAME_DAY_EMERGENCY_DEADLINE_COPY
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentEmailService.Companion.STANDARD_DEADLINE_COPY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1AssessmentEmailServiceTest.Constants.ALLOCATED_EMAIL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1AssessmentEmailServiceTest.Constants.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockEmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
@@ -20,14 +22,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormattedHourOf
 import java.time.OffsetDateTime
 import java.util.UUID
 
-object Cas1AssessmentEmailServiceTestConstants {
-  const val ALLOCATED_USER_EMAIL = "applicant@test.com"
-  const val DEALLOCATED_USER_EMAIL = "deallocated@test.com"
-  const val APPEALED_ASSESSMENT_ALLOCATED_USER_EMAIL = "appealed@test.com"
-  const val CRN = "CRN123"
-}
-
 class Cas1AssessmentEmailServiceTest {
+
+  object Constants {
+    const val ALLOCATED_EMAIL = "applicant@test.com"
+    const val CRN = "CRN123"
+  }
+
   private val notifyConfig = NotifyConfig()
   private val mockEmailNotificationService = MockEmailNotificationService()
   private val mockWorkingDayCountService = mockk<WorkingDayCountService>()
@@ -48,32 +49,42 @@ class Cas1AssessmentEmailServiceTest {
   inner class AssessmentAllocated {
     private val applicant = UserEntityFactory()
       .withUnitTestControlProbationRegion()
-      .withEmail(Cas1AssessmentEmailServiceTestConstants.ALLOCATED_USER_EMAIL)
+      .withEmail(ALLOCATED_EMAIL)
       .produce()
     private val assessmentID = UUID.randomUUID()
 
     @Test
     fun `assessmentAllocated sends an email to a user if they have an email address and no deadline`() {
-      service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, null, false)
+      service.assessmentAllocated(applicant, assessmentID, CRN, null, false)
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
-        Cas1AssessmentEmailServiceTestConstants.ALLOCATED_USER_EMAIL,
+        ALLOCATED_EMAIL,
         notifyConfig.templates.assessmentAllocated,
-        expectedAssessmentAllocatedPersonalisation(applicant.name, Cas1AssessmentEmailServiceTestConstants.CRN, assessmentID, DEFAULT_DEADLINE_COPY),
+        expectedAssessmentAllocatedPersonalisation(
+          applicant.name,
+          CRN,
+          assessmentID,
+          DEFAULT_DEADLINE_COPY,
+        ),
       )
     }
 
     @Test
     fun `assessmentAllocated sends an email to a user if they have an email address and an emergency assessment with a deadline of today`() {
       val deadline = OffsetDateTime.now().minusHours(2)
-      service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, deadline, true)
+      service.assessmentAllocated(applicant, assessmentID, CRN, deadline, true)
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
-        Cas1AssessmentEmailServiceTestConstants.ALLOCATED_USER_EMAIL,
+        ALLOCATED_EMAIL,
         notifyConfig.templates.assessmentAllocated,
-        expectedAssessmentAllocatedPersonalisation(applicant.name, Cas1AssessmentEmailServiceTestConstants.CRN, assessmentID, SAME_DAY_EMERGENCY_DEADLINE_COPY),
+        expectedAssessmentAllocatedPersonalisation(
+          applicant.name,
+          CRN,
+          assessmentID,
+          SAME_DAY_EMERGENCY_DEADLINE_COPY,
+        ),
       )
     }
 
@@ -82,15 +93,20 @@ class Cas1AssessmentEmailServiceTest {
       every { mockWorkingDayCountService.getCompleteWorkingDaysFromNowUntil(any()) } returns 2
       val deadline = OffsetDateTime.now().plusDays(2)
 
-      service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, deadline, true)
+      service.assessmentAllocated(applicant, assessmentID, CRN, deadline, true)
 
       val expectedDeadlineCopy = NEXT_WORKING_DAY_EMERGENCY_DEADLINE_COPY.format(deadline.toUiFormattedHourOfDay(), deadline.toLocalDate().toUiFormat())
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
-        Cas1AssessmentEmailServiceTestConstants.ALLOCATED_USER_EMAIL,
+        ALLOCATED_EMAIL,
         notifyConfig.templates.assessmentAllocated,
-        expectedAssessmentAllocatedPersonalisation(applicant.name, Cas1AssessmentEmailServiceTestConstants.CRN, assessmentID, expectedDeadlineCopy),
+        expectedAssessmentAllocatedPersonalisation(
+          applicant.name,
+          CRN,
+          assessmentID,
+          expectedDeadlineCopy,
+        ),
       )
     }
 
@@ -99,15 +115,20 @@ class Cas1AssessmentEmailServiceTest {
       every { mockWorkingDayCountService.getCompleteWorkingDaysFromNowUntil(any()) } returns 10
       val deadline = OffsetDateTime.now().plusDays(10)
 
-      service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, deadline, false)
+      service.assessmentAllocated(applicant, assessmentID, CRN, deadline, false)
 
       val expectedDeadlineCopy = STANDARD_DEADLINE_COPY.format("10")
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
-        Cas1AssessmentEmailServiceTestConstants.ALLOCATED_USER_EMAIL,
+        ALLOCATED_EMAIL,
         notifyConfig.templates.assessmentAllocated,
-        expectedAssessmentAllocatedPersonalisation(applicant.name, Cas1AssessmentEmailServiceTestConstants.CRN, assessmentID, expectedDeadlineCopy),
+        expectedAssessmentAllocatedPersonalisation(
+          applicant.name,
+          CRN,
+          assessmentID,
+          expectedDeadlineCopy,
+        ),
       )
     }
 
@@ -119,7 +140,13 @@ class Cas1AssessmentEmailServiceTest {
         .produce()
       val assessmentID = UUID.randomUUID()
 
-      service.assessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN, OffsetDateTime.now(), false)
+      service.assessmentAllocated(
+        applicant,
+        assessmentID,
+        CRN,
+        OffsetDateTime.now(),
+        false,
+      )
       mockEmailNotificationService.assertEmailRequestCount(0)
     }
 
@@ -137,19 +164,19 @@ class Cas1AssessmentEmailServiceTest {
     fun `assessmentDeallocated sends an email when the user has an email address`() {
       val applicant = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .withEmail(Cas1AssessmentEmailServiceTestConstants.DEALLOCATED_USER_EMAIL)
+        .withEmail(ALLOCATED_EMAIL)
         .produce()
       val assessmentID = UUID.randomUUID()
 
-      service.assessmentDeallocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN)
+      service.assessmentDeallocated(applicant, assessmentID, CRN)
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
-        Cas1AssessmentEmailServiceTestConstants.DEALLOCATED_USER_EMAIL,
+        ALLOCATED_EMAIL,
         notifyConfig.templates.assessmentDeallocated,
         mapOf(
           "name" to applicant.name,
-          "crn" to Cas1AssessmentEmailServiceTestConstants.CRN,
+          "crn" to CRN,
           "assessmentUrl" to "http://frontend/assessments/$assessmentID",
         ),
       )
@@ -163,7 +190,7 @@ class Cas1AssessmentEmailServiceTest {
         .produce()
       val assessmentID = UUID.randomUUID()
 
-      service.assessmentDeallocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN)
+      service.assessmentDeallocated(applicant, assessmentID, CRN)
       mockEmailNotificationService.assertEmailRequestCount(0)
     }
   }
@@ -174,19 +201,19 @@ class Cas1AssessmentEmailServiceTest {
     fun `appealedAssessmentAllocated sends an email when the user has an email address`() {
       val applicant = UserEntityFactory()
         .withUnitTestControlProbationRegion()
-        .withEmail(Cas1AssessmentEmailServiceTestConstants.APPEALED_ASSESSMENT_ALLOCATED_USER_EMAIL)
+        .withEmail(ALLOCATED_EMAIL)
         .produce()
       val assessmentID = UUID.randomUUID()
 
-      service.appealedAssessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN)
+      service.appealedAssessmentAllocated(applicant, assessmentID, CRN)
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
-        Cas1AssessmentEmailServiceTestConstants.APPEALED_ASSESSMENT_ALLOCATED_USER_EMAIL,
+        ALLOCATED_EMAIL,
         notifyConfig.templates.appealedAssessmentAllocated,
         mapOf(
           "name" to applicant.name,
-          "crn" to Cas1AssessmentEmailServiceTestConstants.CRN,
+          "crn" to CRN,
           "assessmentUrl" to "http://frontend/assessments/$assessmentID",
         ),
       )
@@ -200,7 +227,7 @@ class Cas1AssessmentEmailServiceTest {
         .produce()
       val assessmentID = UUID.randomUUID()
 
-      service.appealedAssessmentAllocated(applicant, assessmentID, Cas1AssessmentEmailServiceTestConstants.CRN)
+      service.appealedAssessmentAllocated(applicant, assessmentID, CRN)
       mockEmailNotificationService.assertEmailRequestCount(0)
     }
   }


### PR DESCRIPTION
Email logic is now in the Cas1AssessmentEmail service, isolating the logic and making it easier to make future changes