### PR TITLE
[CAS-271] Add Name to database to support finding Referrals and Bookings by Name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -426,6 +426,7 @@ class TemporaryAccommodationApplicationEntity(
   var prisonNameOnCreation: String?,
   var personReleaseDate: LocalDate?,
   var pdu: String?,
+  var name: String?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -477,6 +477,7 @@ class ApplicationService(
       prisonNameOnCreation = prisonName,
       personReleaseDate = null,
       pdu = null,
+      name = "${offenderDetails.firstName} ${offenderDetails.surname}",
     )
   }
 

--- a/src/main/resources/db/migration/all/20240321121046__add_name_to_cas3_application.sql
+++ b/src/main/resources/db/migration/all/20240321121046__add_name_to_cas3_application.sql
@@ -1,0 +1,1 @@
+ALTER TABLE temporary_accommodation_applications ADD COLUMN name TEXT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -48,6 +48,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var prisonNameAtReferral: Yielded<String?> = { null }
   private var personReleaseDate: Yielded<LocalDate?> = { null }
   private var pdu: Yielded<String?> = { null }
+  private var name: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -169,6 +170,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.pdu = { pdu }
   }
 
+  fun withName(name: String?) = apply {
+    this.name = { name }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -198,5 +203,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     prisonNameOnCreation = this.prisonNameAtReferral(),
     personReleaseDate = this.personReleaseDate(),
     pdu = this.pdu(),
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2426,6 +2426,7 @@ class ApplicationTest : IntegrationTestBase() {
       `Given a User` { _, _ ->
         `Given an Offender` { offenderDetails, _ ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+          val offenderName = "${offenderDetails.firstName} ${offenderDetails.surname}"
 
           val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
             withAddedAt(OffsetDateTime.now())
@@ -2439,6 +2440,7 @@ class ApplicationTest : IntegrationTestBase() {
             withApplicationSchema(applicationSchema)
             withCreatedByUser(submittingUser)
             withProbationRegion(submittingUser.probationRegion)
+            withName(offenderName)
             withData(
               """
               {}
@@ -2469,6 +2471,7 @@ class ApplicationTest : IntegrationTestBase() {
           val persistedAssessment = persistedApplication.getLatestAssessment() as TemporaryAccommodationAssessmentEntity
 
           assertThat(persistedAssessment.summaryData).isEqualTo("{\"num\":50,\"text\":\"Hello world!\"}")
+          assertThat(persistedApplication.name).isEqualTo(offenderName)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -2159,6 +2159,7 @@ class ApplicationServiceTest {
         .withCreatedByUser(user)
         .withSubmittedAt(null)
         .withProbationRegion(user.probationRegion)
+        .withName(user.name)
         .produce()
         .apply {
           schemaUpToDate = true
@@ -2209,6 +2210,7 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.dutyToReferLocalAuthorityAreaName).isEqualTo("Aberdeen City")
       assertThat(persistedApplication.personReleaseDate).isEqualTo(submitTemporaryAccommodationApplicationWithMiReportingData.personReleaseDate)
       assertThat(persistedApplication.pdu).isEqualTo("Probation Delivery Unit Test")
+      assertThat(persistedApplication.name).isEqualTo(user.name)
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) {


### PR DESCRIPTION
This PR [CAS-271](https://dsdmoj.atlassian.net/browse/CAS-271) includes:

- Add new field *name* to the database
- Save the offender name (first name and surname) retrieved from nDelius to the table when CAS3 application is submitted

[CAS-271]: https://dsdmoj.atlassian.net/browse/CAS-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ