### PR TITLE
(APS-524) Attempt to fix missing documents

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -36,6 +36,8 @@
     <ID>ThrowsCount:TasksTest.kt$TasksTest.GetAllReallocatableTest$@ParameterizedTest @CsvSource(value = ["createdAt,asc", "createdAt,desc", "dueAt,asc", "dueAt,desc", "person,asc", "person,desc", "allocatedTo,asc", "allocatedTo,desc"]) fun `Get all reallocatable tasks returns 200 when no type retains original sort order`(sortBy: String, sortDirection: String)</ID>
     <ID>TooGenericExceptionThrown:TasksTest.kt$TasksTest.GetAllReallocatableTest$throw RuntimeException("Unexpected sortField $sortBy")</ID>
     <ID>LongParameterList:GivenAnAssessment.kt$( allocatedToUser: UserEntity?, createdByUser: UserEntity, crn: String = randomStringMultiCaseWithNumbers(8), reallocated: Boolean = false, data: String? = "{ \"some\": \"data\"}", createdAt: OffsetDateTime? = null, block: ((assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit)? = null, )</ID>
+    <ID>ConstructorParameterNaming:GroupedDocuments.kt$Document$private val _id: String?</ID>
+    <ID>ConstructorParameterNaming:GroupedDocuments.kt$Document$@JsonProperty("id") private val _id: String?</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class GroupedDocuments(
   val documents: List<Document>,
@@ -10,7 +12,8 @@ data class GroupedDocuments(
 }
 
 data class Document(
-  val id: String?,
+  @JsonProperty("id")
+  private val _id: String?,
   val documentName: String,
   val author: String?,
   val type: DocumentType,
@@ -18,7 +21,14 @@ data class Document(
   val createdAt: LocalDateTime,
   val lastModifiedAt: LocalDateTime?,
   val parentPrimaryKeyId: Long?,
-)
+) {
+  // Some Documents don't have IDs, so we need to generate an ID based on the document name
+  // and created at date, which we assume to be immutable
+  val id: String
+    get() = this._id ?: UUID.nameUUIDFromBytes(
+      listOf(this.documentName, this.createdAt).joinToString("").toByteArray(),
+    ).toString()
+}
 
 data class ConvictionDocuments(
   val convictionId: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
@@ -60,7 +60,7 @@ class DocumentFactory : Factory<Document> {
   }
 
   override fun produce(): Document = Document(
-    id = this.id(),
+    _id = this.id(),
     documentName = this.documentName(),
     author = this.author(),
     type = DocumentType(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/GroupedDocumentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/GroupedDocumentsTest.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DocumentFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.GroupedDocumentsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Document
+import java.util.UUID
+
+class GroupedDocumentsTest {
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
+  @Test
+  fun `Document serializes and deserializes correctly`() {
+    val id = UUID.randomUUID().toString()
+    val document = DocumentFactory()
+      .withId(id)
+      .produce()
+
+    val jsonString = objectMapper.writeValueAsString(document)
+    val convertedObject = objectMapper.readValue(jsonString, Document::class.java)
+
+    assertThat(jsonString).contains(id)
+    assertThat(convertedObject.id).isEqualTo(id)
+  }
+
+  @Test
+  fun `Document sets an ID using the document name when the ID is null`() {
+    val document = DocumentFactory()
+      .withId(null)
+      .produce()
+
+    val generatedId = UUID.nameUUIDFromBytes(
+      listOf(document.documentName, document.createdAt).joinToString("").toByteArray(),
+    ).toString()
+
+    assertThat(document.id).isEqualTo(generatedId)
+  }
+
+  @Test
+  fun `Document returns the original ID when it exists`() {
+    val id = UUID.randomUUID().toString()
+    val document = DocumentFactory()
+      .withId(id)
+      .produce()
+
+    val generatedId = UUID.nameUUIDFromBytes(
+      listOf(document.documentName, document.createdAt).joinToString("").toByteArray(),
+    ).toString()
+
+    assertThat(document.id).isEqualTo(id)
+  }
+
+  @Test
+  fun `findDocument finds a document by ID`() {
+    val documentWithId = DocumentFactory().produce()
+    val documentWithoutId = DocumentFactory().withId(null).produce()
+    val convictionLevelDocument = DocumentFactory().produce()
+    val convictionLevelDocumentWithoutId = DocumentFactory().withId(null).produce()
+
+    val groupedDocuments = GroupedDocumentsFactory()
+      .withOffenderLevelDocument(
+        documentWithId,
+      )
+      .withOffenderLevelDocument(
+        documentWithoutId,
+      )
+      .withConvictionLevelDocument(
+        "12345",
+        convictionLevelDocument,
+      )
+      .withConvictionLevelDocument(
+        "12345",
+        convictionLevelDocumentWithoutId,
+      )
+      .produce()
+
+    assertThat(groupedDocuments.findDocument(documentWithId.id)).isEqualTo(documentWithId)
+    assertThat(groupedDocuments.findDocument(documentWithoutId.id)).isEqualTo(documentWithoutId)
+    assertThat(groupedDocuments.findDocument(convictionLevelDocument.id)).isEqualTo(convictionLevelDocument)
+    assertThat(groupedDocuments.findDocument(convictionLevelDocumentWithoutId.id)).isEqualTo(convictionLevelDocumentWithoutId)
+  }
+}


### PR DESCRIPTION
We've had reports from users that documents are missing when they try to attach documents to their application. I have a hunch that this may be down to the fact that not all documents have IDs applied to them. In https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/792 we attempted a short-term fix by filtering out any documents without IDs. Rather than just do this, here we autogenerate unique IDs for documents without an ID, so they still show up.