### PR TITLE
APS-404 Cas1ValidateApAreaUserMapping job improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1ValidateApAreaUserMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1ValidateApAreaUserMapping.kt
@@ -4,11 +4,11 @@ import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserMappingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserMappingService
 
 class Cas1ValidateApAreaUserMapping(
   private val userRepository: UserRepository,
-  private val userMappingService: UserMappingService,
+  private val cas1UserMappingService: Cas1UserMappingService,
   private val communityApiClient: CommunityApiClient,
 ) : MigrationJob() {
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -25,15 +25,16 @@ class Cas1ValidateApAreaUserMapping(
           is ClientResult.Failure -> staffDetailsResult.throwException()
         }
 
-        userMappingService.determineApArea(
+        cas1UserMappingService.determineApArea(
           usersProbationRegion = user.probationRegion,
           deliusUser = staffDetails,
         )
       } catch (exception: Exception) {
-        log.error("Unable to update user ${user.id}", exception)
+        log.error("Unable to find area for user ${user.id}", exception)
       }
 
-      Thread.sleep(100)
+      Thread.sleep(50)
     }
+    log.info("ap area check complete")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.TaskDueMigrati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserMappingService
 import javax.persistence.EntityManager
 
 @Service
@@ -109,7 +110,7 @@ class MigrationJobService(
 
         MigrationJobType.cas1ValidateApAreaUserMapping -> Cas1ValidateApAreaUserMapping(
           applicationContext.getBean(UserRepository::class.java),
-          applicationContext.getBean(UserMappingService::class.java),
+          applicationContext.getBean(Cas1UserMappingService::class.java),
           applicationContext.getBean(CommunityApiClient::class.java),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1UserMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1UserMappingService.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 
 @Component
-class UserMappingService(
+class Cas1UserMappingService(
   private val apAreaRepository: ApAreaRepository,
 ) {
   private val deliusTeamMappings = listOf(
@@ -36,7 +36,7 @@ class UserMappingService(
   fun determineApArea(
     usersProbationRegion: ProbationRegionEntity,
     deliusUser: StaffUserDetails,
-  ): ApAreaEntity? {
+  ): ApAreaEntity {
     val deliusProbationAreaCode = deliusUser.probationArea.code
     val isInNationalProbationArea = listOf("N43", "N41", "XX").contains(deliusProbationAreaCode)
     if (isInNationalProbationArea) {
@@ -56,6 +56,9 @@ class UserMappingService(
       }
 
       return apAreaRepository.findByIdentifier(deliusTeamMapping.apAreaCode)
+        ?: throw InternalServerErrorProblem(
+          "Could not find AP Area for code ${deliusTeamMapping.apAreaCode}",
+        )
     } else {
       return usersProbationRegion.apArea
     }


### PR DESCRIPTION
Reduced delay (integration teams suggested no delay way fine)

Updated user mapping service to ensure that an area will always be returned and an exception thrown otherwise

Renamed UserMappingService to Cas1UserMappingService as it’s returning a CAS1 specific entity (ApAreaEntity)