### PR TITLE
CAS2-345: Calculate HDC dates for seed data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedUtils.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
+import org.json.JSONObject
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2ApplicationDataFormattedDate
+import java.time.OffsetDateTime
+
 fun String?.trimToNull(): String? {
   if (this.isNullOrBlank()) return null
 
@@ -477,4 +481,23 @@ fun String.canonicalise(): String {
     .replace("-", " ")
     .replace(Regex("[^a-z\\s]"), "")
     .replace(Regex("\\s+"), " ")
+}
+
+@SuppressWarnings("MagicNumber")
+fun insertHdcDates(data: String): String {
+  val obj = JSONObject(data)
+  val conditionalReleaseDate = OffsetDateTime.now().plusDays(22)
+  val hdcDate = conditionalReleaseDate.minusMonths(2)
+  val dates = mapOf(
+    "hdcEligibilityDate" to hdcDate.toCas2ApplicationDataFormattedDate(),
+    "hdcEligibilityDate-year" to hdcDate.year.toString(),
+    "hdcEligibilityDate-month" to hdcDate.month.value.toString(),
+    "hdcEligibilityDate-day" to hdcDate.dayOfMonth.toString(),
+    "conditionalReleaseDate" to conditionalReleaseDate.toCas2ApplicationDataFormattedDate(),
+    "conditionalReleaseDate-year" to conditionalReleaseDate.year.toString(),
+    "conditionalReleaseDate-month" to conditionalReleaseDate.month.value.toString(),
+    "conditionalReleaseDate-day" to conditionalReleaseDate.dayOfMonth.toString(),
+  )
+  obj.put("hdc-licence-dates", mapOf("hdc-licence-dates" to dates))
+  return obj.toString()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.insertHdcDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import java.io.IOException
 import java.io.InputStreamReader
@@ -124,7 +125,7 @@ class Cas2ApplicationsSeedJob(
 
   private fun dataFor(state: String, nomsNumber: String): String {
     if (state != "NOT_STARTED") {
-      return dataFixtureFor(nomsNumber)
+      return insertHdcDates(dataFixtureFor(nomsNumber))
     }
     return "{}"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.insertHdcDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
@@ -153,7 +154,7 @@ class Cas2AutoScript(
 
   private fun dataFor(state: String, nomsNumber: String): String {
     if (state != "NOT_STARTED") {
-      return dataFixtureFor(nomsNumber)
+      return insertHdcDates(dataFixtureFor(nomsNumber))
     }
     return "{}"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -12,6 +12,7 @@ val cas1UiExtendedDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("E
 val cas2UiExtendedDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM y")
 val cas1UiTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("ha")
 val cas2UiTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mma")
+val cas2ApplicationDataDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
 fun LocalDate.getDaysUntilInclusive(end: LocalDate): List<LocalDate> {
   val result = mutableListOf<LocalDate>()
@@ -100,6 +101,11 @@ fun LocalDate.toUtcOffsetDateTime(): OffsetDateTime = OffsetDateTime.of(
 fun OffsetDateTime.toUiFormattedHourOfDay(): String = this.format(cas1UiTimeFormat).lowercase()
 
 fun OffsetDateTime.toCas2UiFormattedHourOfDay(): String = this.format(cas2UiTimeFormat).lowercase()
+
+/*
+  takes OffsetDateTime and returns string in "yyyy-mm-dd" format
+ */
+fun OffsetDateTime.toCas2ApplicationDataFormattedDate(): String = this.format(cas2ApplicationDataDateFormat).lowercase()
 
 fun earliestDateOf(date1: LocalDate, date2: LocalDate): LocalDate {
   if (date1.isBefore(date2)) return date1

--- a/src/main/resources/db/seed/local+dev+test/cas2_application_data/data_A1234AI.json
+++ b/src/main/resources/db/seed/local+dev+test/cas2_application_data/data_A1234AI.json
@@ -13,18 +13,6 @@
       "consentDate-day": "1"
     }
   },
-  "hdc-licence-dates": {
-    "hdc-licence-dates": {
-      "hdcEligibilityDate": "2024-02-28",
-      "hdcEligibilityDate-year": "2024",
-      "hdcEligibilityDate-month": "2",
-      "hdcEligibilityDate-day": "22",
-      "conditionalReleaseDate": "2024-02-22",
-      "conditionalReleaseDate-year": "2024",
-      "conditionalReleaseDate-month": "2",
-      "conditionalReleaseDate-day": "28"
-    }
-  },
   "referrer-details": {
     "confirm-details": {
       "name": "Roger Smith",

--- a/src/main/resources/db/seed/local+dev+test/cas2_application_data/document_A1234AI.json
+++ b/src/main/resources/db/seed/local+dev+test/cas2_application_data/document_A1234AI.json
@@ -34,7 +34,7 @@
             },
             {
               "question": "Conditional release date",
-              "answer": "28 February 2024"
+              "answer": "28 April 2024"
             }
           ]
         },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
@@ -97,6 +97,11 @@ class SeedCas2ApplicationTest : SeedTestBase() {
     assertThat(persistedApplication).isNotNull
 
     assertThat(serializableToJsonNode(persistedApplication.data)).isNotEmpty()
+    assertThat(
+      serializableToJsonNode(persistedApplication.data)
+        .get("hdc-licence-dates")
+        .get("hdc-licence-dates"),
+    ).isNotEmpty()
     assertThat(serializableToJsonNode(persistedApplication.document)).isEmpty()
     assertThat(persistedApplication.assessment).isNull()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas2AutoScriptTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.insertHdcDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
@@ -101,13 +103,16 @@ class Cas2AutoScriptTest {
 
     every { mockApplicationService.createCas2ApplicationSubmittedEvent(any()) } answers { }
     every { mockStatusUpdateService.createStatusUpdatedDomainEvent(any()) } answers { }
+    mockkStatic(::insertHdcDates)
   }
 
   @Test
   fun `creates 3 applications for each Nomis User`() {
+    every { insertHdcDates(any<String>()) } returns "{}"
     autoScript.script()
 
     verify(exactly = 3) { mockApplicationRepository.save(any()) }
+    verify(exactly = 3) { insertHdcDates(any()) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/SeedUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/SeedUtilsTest.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import org.assertj.core.api.Assertions
+import org.json.JSONObject
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.insertHdcDates
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class SeedUtilsTest {
+
+  @Nested
+  inner class InsertHdcDates {
+    @Test
+    fun `inserts HDC dates into JSON string`() {
+      mockkStatic(OffsetDateTime::class)
+      every { OffsetDateTime.now() } returns OffsetDateTime.of(
+        2024,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        ZoneOffset.UTC,
+      )
+
+      val output = insertHdcDates("{}")
+      val dataJson = JSONObject(output)
+      val hdcDates = dataJson.getJSONObject("hdc-licence-dates").getJSONObject("hdc-licence-dates")
+
+      Assertions.assertThat(hdcDates.toString()).isEqualTo(
+        JSONObject(
+          mapOf(
+            "hdcEligibilityDate" to "2023-11-23",
+            "hdcEligibilityDate-year" to "2023",
+            "hdcEligibilityDate-month" to "11",
+            "hdcEligibilityDate-day" to "23",
+            "conditionalReleaseDate" to "2024-01-23",
+            "conditionalReleaseDate-year" to "2024",
+            "conditionalReleaseDate-month" to "1",
+            "conditionalReleaseDate-day" to "23",
+          ),
+        ).toString(),
+      )
+    }
+  }
+}


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CAS2-305

As the frontend work is now completed to throw validation errors on HDC/CRD dates that don't meet the requirements below, we need to ensure our seeded data for in-progress applications has valid dates, otherwise the task will not show as 'complete'. 

There is a risk that if we change or remove the `hdc-licence-dates` task on the frontend then this function will become out of date, but we have the same problem with the JSON we  build the applications from currently so I think it's bearable?

In this PR is a utility function that creates dates to this criteria:

* HDC cannot be more than 6 months before CR, but must be before the CRD
* CRD must be more than 21 days in future

And is then used in the auto script and local seeding job.



