### PR TITLE
APS-530 Add additional fields to CAS1 withdrawal emails

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -46,6 +46,7 @@ generic-service:
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
+    URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -38,6 +38,7 @@ generic-service:
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
+    URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -47,6 +47,7 @@ generic-service:
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
+    URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -40,6 +40,7 @@ generic-service:
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
+    URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -37,6 +37,7 @@ class NotifyTemplates {
   val bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
   val bookingWithdrawn = "30cdc876-40a6-41b0-b642-a6b6115c835c"
   val matchRequestWithdrawn = "bb5c68d2-cea1-4924-ba3a-3a8e2beeb640"
+  val matchRequestWithdrawnV2 = "d9830236-6546-4fb7-90b7-8c81ba278123"
   val placementRequestAllocated = "375d83be-c973-44ed-939f-48ffc00230f3"
   val placementRequestAllocatedV2 = "1321c66a-6429-47a7-942c-ce288f1a0648"
   val placementRequestDecisionAccepted = "dd6f7526-05ce-4951-ba98-a2e68962fb43"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -25,6 +25,7 @@ class EmailAddressConfig {
 class NotifyTemplates {
   val applicationSubmitted = "c9944bd8-63c4-473c-8dce-b3636e47d3dd"
   val applicationWithdrawn = "ad6d2449-f5a1-432a-9a96-0835c3f92dad"
+  val applicationWithdrawnV2 = "335b4d51-0be0-432e-9819-469d768d06d5"
   val assessmentAllocated = "2edd59f9-0013-4fbf-91df-7421518b447d"
   val assessmentDeallocated = "331ce452-ea83-4f0c-aec0-5eafe85094f2"
   val appealedAssessmentAllocated = "d378ad90-c20b-49d9-bd8b-5a50e1416dea"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -36,6 +36,7 @@ class NotifyTemplates {
   val bookingMade = "1e3d2ee2-250e-4755-af38-80d24cdc3480"
   val bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
   val bookingWithdrawn = "30cdc876-40a6-41b0-b642-a6b6115c835c"
+  val bookingWithdrawnV2 = "01324632-4450-4416-b48d-5b8fb8922d98"
   val matchRequestWithdrawn = "bb5c68d2-cea1-4924-ba3a-3a8e2beeb640"
   val matchRequestWithdrawnV2 = "d9830236-6546-4fb7-90b7-8c81ba278123"
   val placementRequestAllocated = "375d83be-c973-44ed-939f-48ffc00230f3"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -32,6 +32,7 @@ class NotifyTemplates {
   val assessmentAccepted = "ddf87b15-8866-4bad-a87b-47eba69eb6db"
   val assessmentRejected = "b3a98c60-8fe0-4450-8fd0-6430198ee43b"
   val assessmentWithdrawn = "44ade006-7ac6-4769-aa40-542da56f21b5"
+  val assessmentWithdrawnV2 = "a43968bd-ec69-46a4-bb6f-aacb8eb51cf3"
   val bookingMade = "1e3d2ee2-250e-4755-af38-80d24cdc3480"
   val bookingMadePremises = "337bb149-6f12-4be2-b5a3-a9a73d73c1e1"
   val bookingWithdrawn = "30cdc876-40a6-41b0-b642-a6b6115c835c"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -46,6 +46,7 @@ class NotifyTemplates {
   val placementRequestSubmitted = "deb11bc6-d424-4370-bbe5-41f6a823d292"
   val placementRequestSubmittedV2 = "e7e5b481-aca8-4930-bf4e-b3098834e840"
   val placementRequestWithdrawn = "a5f44549-e849-4a26-abb1-802316081533"
+  val placementRequestWithdrawnV2 = "58bda3a6-c091-4d78-a533-de5991777300"
   val cas2ApplicationSubmitted = "a0823218-91dd-4cf0-9835-4b90024f62c8"
   val cas2NoteAddedForReferrer = "debe17a2-9f79-4d26-88a0-690dd73e2a5b"
   val cas2NoteAddedForAssessor = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -642,7 +642,7 @@ class ApplicationService(
     cas1ApplicationEmailService.applicationWithdrawn(application, user)
 
     application.assessments.map {
-      assessmentService.updateCas1AssessmentWithdrawn(it.id)
+      assessmentService.updateCas1AssessmentWithdrawn(it.id, user)
     }
 
     return CasResult.Success(Unit)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -639,7 +639,7 @@ class ApplicationService(
       ),
     )
 
-    cas1ApplicationEmailService.applicationWithdrawn(application)
+    cas1ApplicationEmailService.applicationWithdrawn(application, user)
 
     application.assessments.map {
       assessmentService.updateCas1AssessmentWithdrawn(it.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -927,7 +927,7 @@ class AssessmentService(
     return AuthorisableActionResult.Success(referralHistoryNoteEntity)
   }
 
-  fun updateCas1AssessmentWithdrawn(assessmentId: UUID) {
+  fun updateCas1AssessmentWithdrawn(assessmentId: UUID, withdrawingUser: UserEntity) {
     val assessment = assessmentRepository.findByIdOrNull(assessmentId)
     if (assessment is ApprovedPremisesAssessmentEntity) {
       val isPendingAssessment = assessment.isPendingAssessment()
@@ -938,6 +938,7 @@ class AssessmentService(
       assessmentEmailService.assessmentWithdrawn(
         assessment = assessment,
         isAssessmentPending = isPendingAssessment,
+        withdrawingUser = withdrawingUser,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1219,7 +1219,13 @@ class BookingService(
     )
 
     val application = booking.application as ApprovedPremisesApplicationEntity?
-    application?.let { cas1BookingEmailService.bookingWithdrawn(it, booking) }
+    application?.let {
+      cas1BookingEmailService.bookingWithdrawn(
+        it,
+        booking,
+        withdrawalContext.triggeringUser,
+      )
+    }
 
     return CasResult.Success(cancellationEntity)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -209,7 +209,7 @@ class PlacementApplicationService(
    *
    * 1. The entity is withdrawable, and error if not
    * 2. The user is allowed to withdraw it, and error if not
-   * 3. If withdrawn, all descdents entities are withdrawn, where applicable
+   * 3. If withdrawn, all descendents entities are withdrawn, where applicable
    */
   @Transactional
   fun withdrawPlacementApplication(
@@ -238,7 +238,11 @@ class PlacementApplicationService(
     val savedApplication = placementApplicationRepository.save(placementApplication)
 
     cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(placementApplication, withdrawalContext)
-    cas1PlacementApplicationEmailService.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy)
+    cas1PlacementApplicationEmailService.placementApplicationWithdrawn(
+      placementApplication = placementApplication,
+      wasBeingAssessedBy = wasBeingAssessedBy,
+      withdrawingUser = withdrawalContext.triggeringUser,
+    )
 
     return CasResult.Success(savedApplication)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -332,7 +332,7 @@ class PlacementRequestService(
     val isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.PlacementRequest
     updateApplicationStatusOnWithdrawal(placementRequest, isUserRequestedWithdrawal)
 
-    cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest)
+    cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest, withdrawalContext.triggeringUser)
     cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext)
 
     return CasResult.Success(toPlacementRequestAndCancellations(placementRequest))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationEmailService.kt
@@ -1,24 +1,40 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 
 @Service
 class Cas1ApplicationEmailService(
   val emailNotifier: EmailNotifier,
   private val notifyConfig: NotifyConfig,
+  @Value("\${url-templates.frontend.application-timeline}") private val applicationTimelineUrlTemplate: UrlTemplate,
+  @Value("\${feature-flags.cas1-aps530-withdrawal-email-improvements}") private val aps530WithdrawalEmailImprovements: Boolean,
 ) {
-  fun applicationWithdrawn(application: ApprovedPremisesApplicationEntity) {
+  fun applicationWithdrawn(
+    application: ApprovedPremisesApplicationEntity,
+    withdrawingUser: UserEntity,
+  ) {
     val applicationCreatedByUser = application.createdByUser
+
+    val templateId = if (aps530WithdrawalEmailImprovements) {
+      notifyConfig.templates.applicationWithdrawnV2
+    } else {
+      notifyConfig.templates.applicationWithdrawn
+    }
 
     applicationCreatedByUser.email?.let { email ->
       emailNotifier.sendEmail(
         recipientEmailAddress = email,
-        templateId = notifyConfig.templates.applicationWithdrawn,
+        templateId = templateId,
         personalisation = mapOf(
           "crn" to application.crn,
+          "applicationTimelineUrl" to applicationTimelineUrlTemplate.resolve("applicationId", application.id.toString()),
+          "withdrawnBy" to withdrawingUser.name,
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -62,11 +62,17 @@ class Cas1PlacementRequestEmailService(
     }
 
     if (!placementRequest.hasActiveBooking()) {
+      val template = if (aps530WithdrawalEmailImprovements) {
+        notifyConfig.templates.matchRequestWithdrawnV2
+      } else {
+        notifyConfig.templates.matchRequestWithdrawn
+      }
+
       val area = application.apArea
       area?.emailAddress?.let { cruEmail ->
         emailNotifier.sendEmail(
           recipientEmailAddress = cruEmail,
-          templateId = notifyConfig.templates.matchRequestWithdrawn,
+          templateId = template,
           personalisation = personalisation,
         )
       }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -232,6 +232,7 @@ url-templates:
   frontend:
     application: http://localhost:3000/applications/#id
     application-appeal: http://localhost:3000/applications/#applicationId/appeals/#appealId
+    application-timeline: http://localhost:3000/applications/#applicationId?tab=timeline
     assessment: http://localhost:3000/assessments/#id
     booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
     cas2:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3287,7 +3287,7 @@ class ApplicationTest : IntegrationTestBase() {
         emailAsserter.assertEmailsRequestedCount(1)
         emailAsserter.assertEmailRequested(
           user.email!!,
-          notifyConfig.templates.applicationWithdrawn,
+          notifyConfig.templates.applicationWithdrawnV2,
         )
       }
     }
@@ -3324,7 +3324,7 @@ class ApplicationTest : IntegrationTestBase() {
           emailAsserter.assertEmailsRequestedCount(2)
           emailAsserter.assertEmailRequested(
             applicant.email!!,
-            notifyConfig.templates.applicationWithdrawn,
+            notifyConfig.templates.applicationWithdrawnV2,
           )
           emailAsserter.assertEmailRequested(
             assessor.email!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -3328,7 +3328,7 @@ class ApplicationTest : IntegrationTestBase() {
           )
           emailAsserter.assertEmailRequested(
             assessor.email!!,
-            notifyConfig.templates.assessmentWithdrawn,
+            notifyConfig.templates.assessmentWithdrawnV2,
           )
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -3182,9 +3182,9 @@ class BookingTest : IntegrationTestBase() {
             assertThat(updatedApplication.status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
 
             emailAsserter.assertEmailsRequestedCount(3)
-            emailAsserter.assertEmailRequested(applicant.email!!, notifyConfig.templates.bookingWithdrawn)
-            emailAsserter.assertEmailRequested(booking.premises.emailAddress!!, notifyConfig.templates.bookingWithdrawn)
-            emailAsserter.assertEmailRequested(apArea.emailAddress!!, notifyConfig.templates.bookingWithdrawn)
+            emailAsserter.assertEmailRequested(applicant.email!!, notifyConfig.templates.bookingWithdrawnV2)
+            emailAsserter.assertEmailRequested(booking.premises.emailAddress!!, notifyConfig.templates.bookingWithdrawnV2)
+            emailAsserter.assertEmailRequested(apArea.emailAddress!!, notifyConfig.templates.bookingWithdrawnV2)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1313,11 +1313,11 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             emailAsserter.assertEmailsRequestedCount(2)
             emailAsserter.assertEmailRequested(
               placementApplicationEntity.createdByUser.email!!,
-              notifyConfig.templates.placementRequestWithdrawn,
+              notifyConfig.templates.placementRequestWithdrawnV2,
             )
             emailAsserter.assertEmailRequested(
               placementApplicationEntity.allocatedToUser!!.email!!,
-              notifyConfig.templates.placementRequestWithdrawn,
+              notifyConfig.templates.placementRequestWithdrawnV2,
             )
           }
         }
@@ -1377,11 +1377,11 @@ class PlacementApplicationsTest : IntegrationTestBase() {
               emailAsserter.assertEmailsRequestedCount(2)
               emailAsserter.assertEmailRequested(
                 placementApplicationEntity.createdByUser.email!!,
-                notifyConfig.templates.placementRequestWithdrawn,
+                notifyConfig.templates.placementRequestWithdrawnV2,
               )
               emailAsserter.assertEmailRequested(
                 placementApplicationEntity.allocatedToUser!!.email!!,
-                notifyConfig.templates.placementRequestWithdrawn,
+                notifyConfig.templates.placementRequestWithdrawnV2,
               )
             }
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1665,7 +1665,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
             emailAsserter.assertEmailsRequestedCount(2)
             emailAsserter.assertEmailRequested(
               placementRequest.application.apArea!!.emailAddress!!,
-              notifyConfig.templates.matchRequestWithdrawn,
+              notifyConfig.templates.matchRequestWithdrawnV2,
             )
             emailAsserter.assertEmailRequested(
               placementRequest.application.createdByUser.email!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1669,7 +1669,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
             )
             emailAsserter.assertEmailRequested(
               placementRequest.application.createdByUser.email!!,
-              notifyConfig.templates.placementRequestWithdrawn,
+              notifyConfig.templates.placementRequestWithdrawnV2,
             )
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1101,7 +1101,7 @@ class WithdrawalTest : IntegrationTestBase() {
     private fun assertBookingWithdrawnEmail(emailAddress: String, booking: BookingEntity) =
       emailAsserter.assertEmailRequested(
         emailAddress,
-        notifyConfig.templates.bookingWithdrawn,
+        notifyConfig.templates.bookingWithdrawnV2,
         mapOf(
           "startDate" to booking.arrivalDate.toString(),
           "endDate" to booking.departureDate.toString(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1125,7 +1125,7 @@ class WithdrawalTest : IntegrationTestBase() {
     private fun assertMatchRequestWithdrawnEmail(emailAddress: String, placementRequest: PlacementRequestEntity) =
       emailAsserter.assertEmailRequested(
         emailAddress,
-        notifyConfig.templates.matchRequestWithdrawn,
+        notifyConfig.templates.matchRequestWithdrawnV2,
         mapOf("startDate" to placementRequest.expectedArrival.toString()),
       )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1088,7 +1088,7 @@ class WithdrawalTest : IntegrationTestBase() {
     private fun assertAssessmentWithdrawnEmail(emailAddress: String) =
       emailAsserter.assertEmailRequested(
         emailAddress,
-        notifyConfig.templates.assessmentWithdrawn,
+        notifyConfig.templates.assessmentWithdrawnV2,
       )
 
     private fun assertApplicationWithdrawnEmail(emailAddress: String, application: ApplicationEntity) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1111,14 +1111,14 @@ class WithdrawalTest : IntegrationTestBase() {
     private fun assertPlacementRequestWithdrawnEmail(emailAddress: String, placementApplication: PlacementApplicationEntity) =
       emailAsserter.assertEmailRequested(
         emailAddress,
-        notifyConfig.templates.placementRequestWithdrawn,
+        notifyConfig.templates.placementRequestWithdrawnV2,
         mapOf("startDate" to placementApplication.placementDates[0].expectedArrival.toString()),
       )
 
     private fun assertPlacementRequestWithdrawnEmail(emailAddress: String, placementRequest: PlacementRequestEntity) =
       emailAsserter.assertEmailRequested(
         emailAddress,
-        notifyConfig.templates.placementRequestWithdrawn,
+        notifyConfig.templates.placementRequestWithdrawnV2,
         mapOf("startDate" to placementRequest.expectedArrival.toString()),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1094,7 +1094,7 @@ class WithdrawalTest : IntegrationTestBase() {
     private fun assertApplicationWithdrawnEmail(emailAddress: String, application: ApplicationEntity) =
       emailAsserter.assertEmailRequested(
         emailAddress,
-        notifyConfig.templates.applicationWithdrawn,
+        notifyConfig.templates.applicationWithdrawnV2,
         mapOf("crn" to application.crn),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -2780,7 +2780,7 @@ class ApplicationServiceTest {
       val domainEventWithdrawnBy = WithdrawnByFactory().produce()
       every { mockDomainEventTransformer.toWithdrawnBy(user) } returns domainEventWithdrawnBy
       every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
-      every { mockCas1ApplicationEmailService.applicationWithdrawn(any()) } just Runs
+      every { mockCas1ApplicationEmailService.applicationWithdrawn(any(), any()) } just Runs
 
       val result = applicationService.withdrawApprovedPremisesApplication(
         application.id,
@@ -2821,7 +2821,7 @@ class ApplicationServiceTest {
         )
       }
 
-      verify { mockCas1ApplicationEmailService.applicationWithdrawn(application) }
+      verify { mockCas1ApplicationEmailService.applicationWithdrawn(application, user) }
     }
 
     @Test
@@ -2841,7 +2841,7 @@ class ApplicationServiceTest {
       val domainEventWithdrawnBy = WithdrawnByFactory().produce()
       every { mockDomainEventTransformer.toWithdrawnBy(user) } returns domainEventWithdrawnBy
       every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
-      every { mockCas1ApplicationEmailService.applicationWithdrawn(any()) } just Runs
+      every { mockCas1ApplicationEmailService.applicationWithdrawn(any(), any()) } just Runs
 
       val result =
         applicationService.withdrawApprovedPremisesApplication(application.id, user, "other", "Some other reason")
@@ -2894,7 +2894,7 @@ class ApplicationServiceTest {
       every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
       every { mockUserAccessService.userMayWithdrawApplication(user, application) } returns true
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockCas1ApplicationEmailService.applicationWithdrawn(any()) } returns Unit
+      every { mockCas1ApplicationEmailService.applicationWithdrawn(any(), any()) } returns Unit
 
       val domainEventWithdrawnBy = WithdrawnByFactory().produce()
       every { mockDomainEventTransformer.toWithdrawnBy(user) } returns domainEventWithdrawnBy

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -2554,6 +2554,11 @@ class AssessmentServiceTest {
       .withEmail("user@test.com")
       .produce()
 
+    private val withdrawingUser: UserEntity = UserEntityFactory()
+      .withDefaultProbationRegion()
+      .withEmail("withdrawing@test.com")
+      .produce()
+
     private val schema = ApprovedPremisesAssessmentJsonSchemaEntity(
       id = UUID.randomUUID(),
       addedAt = OffsetDateTime.now(),
@@ -2579,14 +2584,15 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any()) } just Runs
+      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any()) } just Runs
 
-      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId, withdrawingUser)
 
       verify {
         assessmentEmailServiceMock.assessmentWithdrawn(
           assessment,
           isAssessmentPending = true,
+          withdrawingUser = withdrawingUser,
         )
       }
     }
@@ -2610,14 +2616,15 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any()) } just Runs
+      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any()) } just Runs
 
-      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId, withdrawingUser)
 
       verify {
         assessmentEmailServiceMock.assessmentWithdrawn(
           assessment,
           isAssessmentPending = false,
+          withdrawingUser = withdrawingUser,
         )
       }
     }
@@ -2641,14 +2648,15 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any()) } just Runs
+      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any()) } just Runs
 
-      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId, withdrawingUser)
 
       verify {
         assessmentEmailServiceMock.assessmentWithdrawn(
           assessment,
           isAssessmentPending = false,
+          withdrawingUser = withdrawingUser,
         )
       }
     }
@@ -2672,14 +2680,15 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any()) } just Runs
+      every { assessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any()) } just Runs
 
-      assessmentService.updateCas1AssessmentWithdrawn(assessmentId)
+      assessmentService.updateCas1AssessmentWithdrawn(assessmentId, withdrawingUser)
 
       verify {
         assessmentEmailServiceMock.assessmentWithdrawn(
           assessment,
           isAssessmentPending = false,
+          withdrawingUser = withdrawingUser,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2361,7 +2361,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
       every { mockApplicationService.updateApprovedPremisesApplicationStatus(any(), any()) } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
 
       val cancelledAt = LocalDate.parse("2022-08-25")
       val notes = "notes"
@@ -2450,7 +2450,7 @@ class BookingServiceTest {
 
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
       every { mockApplicationService.updateApprovedPremisesApplicationStatus(any(), any()) } returns Unit
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
 
       val cancelledAt = LocalDate.parse("2022-08-25")
       val notes = "notes"
@@ -2470,7 +2470,7 @@ class BookingServiceTest {
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
 
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity) }
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) }
     }
 
     @Test
@@ -2785,7 +2785,7 @@ class BookingServiceTest {
         )
       } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
 
       val cancelledBooking1 = BookingEntityFactory()
         .withPremises(premises)
@@ -2880,7 +2880,7 @@ class BookingServiceTest {
         )
       } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
 
       val cancelledBooking1 = BookingEntityFactory()
         .withPremises(premises)
@@ -2957,7 +2957,7 @@ class BookingServiceTest {
           ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT,
         )
       } returns Unit
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
 
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -780,7 +780,7 @@ class PlacementApplicationServiceTest {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(placementApplication, withdrawalContext) } returns Unit
-      every { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(any(), any()) } returns Unit
+      every { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(any(), any(), any()) } returns Unit
 
       val result = placementApplicationService.withdrawPlacementApplication(
         placementApplication.id,
@@ -793,7 +793,7 @@ class PlacementApplicationServiceTest {
 
       assertThat(entity.decision).isEqualTo(PlacementApplicationDecision.WITHDRAW)
 
-      verify { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(placementApplication, allocatedTo) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(placementApplication, allocatedTo, user) }
     }
 
     @Test
@@ -809,7 +809,7 @@ class PlacementApplicationServiceTest {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(any(), any()) } returns Unit
-      every { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(any(), any()) } returns Unit
+      every { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(any(), any(), any()) } returns Unit
 
       val result = placementApplicationService.withdrawPlacementApplication(
         placementApplication.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -695,7 +695,7 @@ class PlacementRequestServiceTest {
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
       every { placementRequestRepository.findByApplication(application) } returns listOf(placementRequest)
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
+      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every {
         applicationService.updateApprovedPremisesApplicationStatus(application.id, PENDING_PLACEMENT_REQUEST)
@@ -726,7 +726,7 @@ class PlacementRequestServiceTest {
         )
       }
 
-      verify { cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest) }
+      verify { cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest, user) }
       verify { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext) }
     }
 
@@ -735,7 +735,7 @@ class PlacementRequestServiceTest {
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
+      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
 
@@ -780,7 +780,7 @@ class PlacementRequestServiceTest {
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
+      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
 
@@ -820,7 +820,7 @@ class PlacementRequestServiceTest {
       every { userAccessService.userMayWithdrawPlacementRequest(user, placementRequest) } returns true
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
+      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
 
@@ -857,7 +857,7 @@ class PlacementRequestServiceTest {
     fun `withdrawPlacementRequest sets correct reason if withdrawal triggered by other entity and user permissions not checked`(triggeringEntity: WithdrawableEntityType) {
       every { placementRequestRepository.findByIdOrNull(placementRequestId) } returns placementRequest
       every { placementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
+      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
 
@@ -958,7 +958,7 @@ class PlacementRequestServiceTest {
       every {
         applicationService.updateApprovedPremisesApplicationStatus(application.id, PENDING_PLACEMENT_REQUEST)
       } returns Unit
-      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any()) } returns Unit
+      every { cas1PlacementRequestEmailService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(any(), any()) } returns Unit
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -43,617 +44,637 @@ class Cas1PlacementApplicationEmailServiceTest {
     aps530WithdrawalEmailImprovements = aps530WithdrawalEmailImprovements,
   )
 
-  @Test
-  fun `placementApplicationSubmitted doesnt sent email to applicant if no email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+  @Nested
+  inner class PlacementApplicationSubmitted {
 
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+    @Test
+    fun `placementApplicationSubmitted doesnt sent email to applicant if no email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val application = createApplicationForApplicant(applicant)
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
+      val application = createApplicationForApplicant(applicant)
 
-    service.placementApplicationSubmitted(placementApplication)
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
 
-    mockEmailNotificationService.assertNoEmailsRequested()
+      service.placementApplicationSubmitted(placementApplication)
+
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `placementApplicationSubmitted sends v1 email to applicant if email address defined and not using new withdrawals`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      serviceUsingLegacyWithdrawalsNotifications.placementApplicationSubmitted(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestSubmitted,
+        personalisation,
+      )
+    }
+
+    @Test
+    fun `placementApplicationSubmitted sends v2 email to applicant if email address defined and using new withdrawals`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationSubmitted(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestSubmittedV2,
+        personalisation,
+      )
+    }
   }
 
-  @Test
-  fun `placementApplicationSubmitted sends v1 email to applicant if email address defined and not using new withdrawals`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
+  @Nested
+  inner class PlacementApplicationAllocated {
 
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+    @Test
+    fun `placementApplicationAllocated doesnt send email to applicant if no email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val application = createApplicationForApplicant(applicant)
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
+      val application = createApplicationForApplicant(applicant)
 
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
 
-    serviceUsingLegacyWithdrawalsNotifications.placementApplicationSubmitted(placementApplication)
+      service.placementApplicationAllocated(placementApplication)
 
-    mockEmailNotificationService.assertEmailRequestCount(1)
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
 
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
+    @Test
+    fun `placementApplicationAllocated sends V1 email to applicant if email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
 
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestSubmitted,
-      personalisation,
-    )
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationAllocated(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestAllocated,
+        personalisation,
+      )
+    }
+
+    @Test
+    fun `placementApplicationAllocated sends V2 email to applicant if email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      serviceUsingAps530Improvements.placementApplicationAllocated(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestAllocatedV2,
+        personalisation,
+      )
+    }
   }
 
-  @Test
-  fun `placementApplicationSubmitted sends v2 email to applicant if email address defined and using new withdrawals`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
+  @Nested
+  inner class PlacementApplicationAccepted {
 
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+    @Test
+    fun `placementApplicationAccepted doesnt send email to applicant if no email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val application = createApplicationForApplicant(applicant)
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
+      val application = createApplicationForApplicant(applicant)
 
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
 
-    service.placementApplicationSubmitted(placementApplication)
+      service.placementApplicationAccepted(placementApplication)
 
-    mockEmailNotificationService.assertEmailRequestCount(1)
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
 
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
+    @Test
+    fun `placementApplicationAccepted sends V1 email to applicant if email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
 
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestSubmittedV2,
-      personalisation,
-    )
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationAccepted(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "crn" to TestConstants.CRN,
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestDecisionAccepted,
+        personalisation,
+      )
+    }
+
+    @Test
+    fun `placementApplicationAccepted sends V2 email to applicant if email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      serviceUsingAps530Improvements.placementApplicationAccepted(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestDecisionAcceptedV2,
+        personalisation,
+      )
+    }
   }
 
-  @Test
-  fun `placementApplicationAllocated doesnt send email to applicant if no email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+  @Nested
+  inner class PlacementApplicationRejected {
 
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
+    @Test
+    fun `placementApplicationRejected doesnt send email to applicant if no email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val application = createApplicationForApplicant(applicant)
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
 
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
+      val application = createApplicationForApplicant(applicant)
 
-    service.placementApplicationAllocated(placementApplication)
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
 
-    mockEmailNotificationService.assertNoEmailsRequested()
+      service.placementApplicationRejected(placementApplication)
+
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `placementApplicationRejected sends V1 email to applicant if email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationRejected(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestDecisionRejected,
+        personalisation,
+      )
+    }
+
+    @Test
+    fun `placementApplicationRejected sends V2 email to applicant if email address defined`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val assessor = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(null)
+        .produce()
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationRejected(placementApplication)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "crn" to TestConstants.CRN,
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestDecisionRejected,
+        personalisation,
+      )
+    }
   }
 
-  @Test
-  fun `placementApplicationAllocated sends V1 email to applicant if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationAllocated(placementApplication)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestAllocated,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationAllocated sends V2 email to applicant if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    serviceUsingAps530Improvements.placementApplicationAllocated(placementApplication)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestAllocatedV2,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationAccepted doesnt send email to applicant if no email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    service.placementApplicationAccepted(placementApplication)
-
-    mockEmailNotificationService.assertNoEmailsRequested()
-  }
-
-  @Test
-  fun `placementApplicationAccepted sends V1 email to applicant if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationAccepted(placementApplication)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "crn" to TestConstants.CRN,
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestDecisionAccepted,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationAccepted sends V2 email to applicant if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    serviceUsingAps530Improvements.placementApplicationAccepted(placementApplication)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestDecisionAcceptedV2,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationRejected doesnt send email to applicant if no email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    service.placementApplicationRejected(placementApplication)
-
-    mockEmailNotificationService.assertNoEmailsRequested()
-  }
-
-  @Test
-  fun `placementApplicationRejected sends V1 email to applicant if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationRejected(placementApplication)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestDecisionRejected,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationRejected sends V2 email to applicant if email address defined`() {
-    val applicant = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(APPLICANT_EMAIL)
-      .produce()
-
-    val assessor = UserEntityFactory()
-      .withUnitTestControlProbationRegion()
-      .withEmail(null)
-      .produce()
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationRejected(placementApplication)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "crn" to TestConstants.CRN,
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestDecisionRejected,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationWithdrawn doesnt send email to applicant or assessor if no email addresses defined`() {
-    val applicant = createUser(emailAddress = null)
-    val assessor = createUser(emailAddress = null)
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
-
-    mockEmailNotificationService.assertNoEmailsRequested()
-  }
-
-  @Test
-  fun `placementApplicationWithdrawn sends an email to applicant if email addresses defined`() {
-    val applicant = createUser(emailAddress = APPLICANT_EMAIL)
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = null)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      APPLICANT_EMAIL,
-      notifyConfig.templates.placementRequestWithdrawn,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationWithdrawn sends an email to assessor if email address defined`() {
-    val applicant = createUser(emailAddress = null)
-    val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "applicationUrl" to "http://frontend/applications/${application.id}",
-      "crn" to TestConstants.CRN,
-      "applicationArea" to AREA_NAME,
-      "startDate" to "2020-03-12",
-      "endDate" to "2020-03-22",
-      "additionalDatesSet" to "no",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      ASSESSOR_EMAIL,
-      notifyConfig.templates.placementRequestWithdrawn,
-      personalisation,
-    )
-  }
-
-  @Test
-  fun `placementApplicationWithdrawn sends an email with 'additionalDates' if multiple dates defined due to a legacy placement application`() {
-    val applicant = createUser(emailAddress = null)
-    val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
-
-    val application = createApplicationForApplicant(applicant)
-
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withApplication(application)
-      .withCreatedByUser(applicant)
-      .withAllocatedToUser(assessor)
-      .produce()
-
-    placementApplication.placementDates = mutableListOf(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2020, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2021, 3, 12))
-        .withDuration(10)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
-
-    mockEmailNotificationService.assertEmailRequestCount(1)
-
-    val personalisation = mapOf(
-      "additionalDatesSet" to "yes",
-    )
-
-    mockEmailNotificationService.assertEmailRequested(
-      ASSESSOR_EMAIL,
-      notifyConfig.templates.placementRequestWithdrawn,
-      personalisation,
-    )
+  @Nested
+  inner class PlacementApplicationWithdrawn {
+
+    @Test
+    fun `placementApplicationWithdrawn doesnt send email to applicant or assessor if no email addresses defined`() {
+      val applicant = createUser(emailAddress = null)
+      val assessor = createUser(emailAddress = null)
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
+
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `placementApplicationWithdrawn sends an email to applicant if email addresses defined`() {
+      val applicant = createUser(emailAddress = APPLICANT_EMAIL)
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = null)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestWithdrawn,
+        personalisation,
+      )
+    }
+
+    @Test
+    fun `placementApplicationWithdrawn sends an email to assessor if email address defined`() {
+      val applicant = createUser(emailAddress = null)
+      val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to "2020-03-12",
+        "endDate" to "2020-03-22",
+        "additionalDatesSet" to "no",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        ASSESSOR_EMAIL,
+        notifyConfig.templates.placementRequestWithdrawn,
+        personalisation,
+      )
+    }
+
+    @Test
+    fun `placementApplicationWithdrawn sends an email with 'additionalDates' if multiple dates defined due to a legacy placement application`() {
+      val applicant = createUser(emailAddress = null)
+      val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
+
+      val application = createApplicationForApplicant(applicant)
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withCreatedByUser(applicant)
+        .withAllocatedToUser(assessor)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2020, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+        PlacementDateEntityFactory()
+          .withExpectedArrival(LocalDate.of(2021, 3, 12))
+          .withDuration(10)
+          .withPlacementApplication(placementApplication)
+          .produce(),
+      )
+
+      service.placementApplicationWithdrawn(placementApplication, wasBeingAssessedBy = assessor)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+
+      val personalisation = mapOf(
+        "additionalDatesSet" to "yes",
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        ASSESSOR_EMAIL,
+        notifyConfig.templates.placementRequestWithdrawn,
+        personalisation,
+      )
+    }
   }
 
   private fun createUser(emailAddress: String?) = UserEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -99,6 +99,30 @@ class Cas1PlacementRequestEmailServiceTest {
   }
 
   @Test
+  fun `placementRequestWithdrawn sends match request withdrawn email V2 to CRU if email addresses defined and no booking`() {
+    val application = createApplication(apAreaEmail = CRU_EMAIL)
+    val placementRequest = createPlacementRequest(application, booking = null)
+
+    serviceUsingAps530Improvements.placementRequestWithdrawn(placementRequest, withdrawingUser)
+
+    mockEmailNotificationService.assertEmailRequestCount(1)
+
+    mockEmailNotificationService.assertEmailRequested(
+      CRU_EMAIL,
+      notifyConfig.templates.matchRequestWithdrawnV2,
+      mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "applicationTimelineUrl" to "http://frontend/applications/${application.id}?tab=timeline",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to placementRequest.expectedArrival.toString(),
+        "endDate" to placementRequest.expectedDeparture().toString(),
+        "withdrawnBy" to WITHDRAWING_USER_NAME,
+      ),
+    )
+  }
+
+  @Test
   fun `placementRequestWithdrawn does not send email to applicant if placement request not linked to placement application but no email addresses defined`() {
     val application = createApplication(
       applicantEmail = null,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -150,6 +150,7 @@ url-templates:
   frontend:
     application: http://frontend/applications/#id
     application-appeal: http://frontend/applications/#applicationId/appeals/#appealId
+    application-timeline: http://frontend/applications/#applicationId?tab=timeline
     assessment: http://frontend/assessments/#id
     booking: http://frontend/premises/#premisesId/bookings/#bookingId
     cas2:


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/APS-530

The following emails have been updated to include a link to the application timeline, and the name of the person who triggered the withdrawal:

* application withdrawn
* assessment withdrawn
* request for placement withdrawm
* match request withdrawn
* placement withdrawn

This is controlled by a feature flag that is disabled in prod by default