### PR TITLE
APS-404 Update and use user's ap area property for CAS1 (Do not merge)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -343,7 +343,7 @@ class ApplicationsController(
 
         if (apAreaId == null) {
           val user = userService.getUserForRequest()
-          apAreaId = user.probationRegion.apArea.id
+          apAreaId = user.apArea!!.id
         }
         applicationService.submitApprovedPremisesApplication(
           applicationId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -26,7 +26,7 @@ class UsersController(
 ) : UsersApiDelegate {
 
   override fun usersIdGet(id: UUID, xServiceName: ServiceName): ResponseEntity<User> {
-    val userEntity = when (val result = userService.updateUserFromCommunityApiById(id)) {
+    val userEntity = when (val result = userService.updateUserFromCommunityApiById(id, xServiceName)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> result.entity
@@ -137,7 +137,7 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    val userEntity = userService.getExistingUserOrCreate(name, true)
+    val userEntity = userService.getExistingUserOrCreate(name, xServiceName, true)
     val userTransformed = userTransformer.transformJpaToApi(userEntity, xServiceName)
     return ResponseEntity.ok(userTransformed)
   }
@@ -156,7 +156,7 @@ class UsersController(
     ApprovedPremisesUserRole.appealsManager -> JpaUserRole.CAS1_APPEALS_MANAGER
   }
 
-  private fun transformApiQualification(apiQualification: uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification =
+  private fun transformApiQualification(apiQualification: UserQualification): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification =
     when (apiQualification) {
       UserQualification.pipe -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.PIPE
       UserQualification.womens -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.WOMENS

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
@@ -67,7 +67,7 @@ fun hasQualificationsAndRoles(
     }
 
     if (apArea != null) {
-      val apAreaID = root.get<ProbationRegionEntity>("probationRegion").get<ApArea>("apArea").get<UUID>("id")
+      val apAreaID = root.get<ApArea>("apArea").get<UUID>("id")
 
       predicates.add(
         criteriaBuilder.and(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -21,6 +21,9 @@ data class ProbationRegionEntity(
   @Id
   val id: UUID,
   val name: String,
+  /**
+   * If the AP Area for a user is required, instead use [UserEntity.apArea]
+   */
   @ManyToOne
   @JoinColumn(name = "ap_area_id")
   val apArea: ApAreaEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
 
 import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
@@ -15,7 +16,7 @@ class UpdateAllUsersFromCommunityApiJob(
     userRepository.findAll().forEach {
       log.info("Updating user ${it.id}")
       try {
-        userService.updateUserFromCommunityApiById(it.id)
+        userService.updateUserFromCommunityApiById(it.id, ServiceName.approvedPremises)
       } catch (exception: Exception) {
         log.error("Unable to update user ${it.id}", exception)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -70,7 +70,8 @@ class UsersSeedJob(
     log.info("Setting roles for ${row.deliusUsername} to exactly ${row.roles.joinToString(",")}, qualifications to exactly: ${row.qualifications.joinToString(",")}")
 
     val user = try {
-      userService.getExistingUserOrCreate(row.deliusUsername)
+      // we assume we're seeding for CAS1 as this is the only service that populates additional fields (ap area, team code)
+      userService.getExistingUserOrCreate(row.deliusUsername, ServiceName.approvedPremises)
     } catch (exception: Exception) {
       throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -147,7 +147,7 @@ class TaskService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    val assigneeUser = when (val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId)) {
+    val assigneeUser = when (val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId, ServiceName.approvedPremises)) {
       is AuthorisableActionResult.Success -> assigneeUserResult.entity
       else -> return AuthorisableActionResult.NotFound()
     }

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -2,15 +2,15 @@
 
 --These are randomly generated names
 
-INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id, delius_staff_code) VALUES
-    ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', 2500041001, '43606be0-9836-441d-9bc1-5586de9ac931', 'STAFFCODE'), -- South West
-    ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
-    ('9807de9d-05b3-49e2-84b8-529790a299cc', 'C. Load-Tester', 'CAS-LOAD-TESTER', 2500041004, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
-    ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
-    ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE'), -- Kent, Surrey & Sussex
-    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE'), -- North East
-    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'BERNARD.BEAKS', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE'), -- East of England
-    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'PANESAR.JASPAL', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE') -- Wales
+INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id, delius_staff_code, ap_area_id) VALUES
+    ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', 2500041001, '43606be0-9836-441d-9bc1-5586de9ac931', 'STAFFCODE', '2cc6bc0f-58cf-4d82-99dd-dfc67b7f5c33'), -- Premises & AP: South West
+    ('f29b6402-b5f0-4f39-a66f-a2bb13eb5d6d', 'A. E2etester', 'APPROVEDPREMISESTESTUSER', 2500041002, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: East of England
+    ('9807de9d-05b3-49e2-84b8-529790a299cc', 'C. Load-Tester', 'CAS-LOAD-TESTER', 2500041004, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: Kent, Surrey & Sussex
+    ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: Kent, Surrey & Sussex
+    ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: Kent, Surrey & Sussex
+    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE', '6025b8c6-883f-4300-bc26-2b01fbd6e272'), -- Premises & AP: North East
+    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'BERNARD.BEAKS', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: East of England
+    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'PANESAR.JASPAL', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE', '56d78348-64d4-4af2-a13c-e5c0d4d30dd0') -- Premises & AP: Wales
 ON CONFLICT (id) DO NOTHING;
 
 UPDATE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityAreaEntityFactory.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class LocalAuthorityAreaEntityFactory : Factory<LocalAuthorityAreaEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var identifier: Yielded<String> = { randomStringUpperCase(5) }
+  private var name: Yielded<String> = { randomStringUpperCase(5) }
+
+  override fun produce(): LocalAuthorityAreaEntity = LocalAuthorityAreaEntity(
+    id = this.id(),
+    identifier = this.identifier(),
+    name = this.name(),
+    premises = mutableListOf(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -104,6 +104,14 @@ class UserEntityFactory : Factory<UserEntity> {
     )
   }
 
+  fun withYieldedApArea(apArea: Yielded<ApAreaEntity>) = apply {
+    this.apArea = apArea
+  }
+
+  fun withApArea(apArea: ApAreaEntity?) = apply {
+    this.apArea = { apArea }
+  }
+
   fun withTeamCodes(teamCodes: List<String>) = apply {
     this.teamCodes = { teamCodes }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2098,7 +2098,7 @@ class ApplicationTest : IntegrationTestBase() {
             assertThat(persistedApplication?.isPipeApplication).isTrue
             assertThat(persistedApplication?.targetLocation).isEqualTo("SW1A 1AA")
             assertThat(persistedApplication?.sentenceType).isEqualTo(SentenceTypeOption.nonStatutory.toString())
-            assertThat(persistedApplication?.apArea?.id).isEqualTo(submittingUser.probationRegion.apArea.id)
+            assertThat(persistedApplication?.apArea?.id).isEqualTo(submittingUser.apArea!!.id)
 
             val createdAssessment =
               approvedPremisesAssessmentRepository.findAll().first { it.application.id == applicationId }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -75,6 +75,8 @@ class ProfileTest : IntegrationTestBase() {
       },
       probationRegion = region,
     ) { userEntity, jwt ->
+      val userApArea = userEntity.apArea!!
+
       webTestClient.get()
         .uri("/profile")
         .header("Authorization", "Bearer $jwt")
@@ -96,7 +98,7 @@ class ProfileTest : IntegrationTestBase() {
               qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
               service = "CAS1",
               isActive = true,
-              apArea = ApArea(region.apArea.id, region.apArea.identifier, region.apArea.name),
+              apArea = ApArea(userApArea.id, userApArea.identifier, userApArea.name),
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
@@ -13,7 +14,7 @@ class UserCaseSensitivityTest : IntegrationTestBase() {
   @Test
   fun `Fetching a user with lowercase username returns the user with normalised uppercase username`() {
     `Given a User` { userEntity, _ ->
-      val returnedUser = userService.getExistingUserOrCreate(userEntity.deliusUsername.lowercase())
+      val returnedUser = userService.getExistingUserOrCreate(userEntity.deliusUsername.lowercase(), ServiceName.approvedPremises)
 
       assertThat(returnedUser.id).isEqualTo(userEntity.id)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -298,7 +298,7 @@ class UsersTest : IntegrationTestBase() {
 
     @Test
     fun `GET to users with no internal role (aka the Applicant pseudo-role) is forbidden`() {
-      `Given a User`() { _, jwt ->
+      `Given a User` { _, jwt ->
         webTestClient.get()
           .uri("/users")
           .header("Authorization", "Bearer $jwt")
@@ -348,17 +348,19 @@ class UsersTest : IntegrationTestBase() {
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
-
+              val apArea = apAreaEntityFactory.produceAndPersist()
               val probationRegion = probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+                withApArea(apArea)
               }
 
               val userOne = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
+                withApArea(apArea)
               }
 
               val userTwo = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
+                withApArea(apArea)
               }
 
               webTestClient.get()
@@ -388,23 +390,26 @@ class UsersTest : IntegrationTestBase() {
 
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"])
-    fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER returns list filtered by AP area`(role: UserRole) {
+    fun `GET to users with a role of either ROLE_ADMIN or WORKFLOW_MANAGER returns list filtered by user's AP area`(role: UserRole) {
       `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
               val apArea = apAreaEntityFactory.produceAndPersist()
 
+              val probationRegionApArea = apAreaEntityFactory.produceAndPersist()
               val probationRegion = probationRegionEntityFactory.produceAndPersist {
-                withApArea(apArea)
+                withApArea(probationRegionApArea)
               }
 
               val userOne = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
+                withApArea(apArea)
               }
 
               val userTwo = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
+                withApArea(apArea)
               }
 
               webTestClient.get()
@@ -820,6 +825,7 @@ class UsersTest : IntegrationTestBase() {
         withId(id)
         withIsActive(false)
         withYieldedProbationRegion { region }
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
       }
 
       `Given a User`(roles = listOf(role)) { _, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
@@ -28,6 +28,8 @@ class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
       },
     ) { userEntity, _ ->
 
+      userEntity.apArea = null
+      userRepository.save(userEntity)
       assertThat(userEntity.apArea).isNull()
       assertThat(userEntity.teamCodes).isNull()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -28,6 +28,11 @@ fun IntegrationTestBase.`Given a User`(
 
   val staffUserDetails = staffUserDetailsFactory.produce()
 
+  val yieldedProbationRegion = probationRegion
+    ?: probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+    }
+
   val user = userEntityFactory.produceAndPersist {
     withId(id)
     withDeliusUsername(staffUserDetails.username)
@@ -35,14 +40,11 @@ fun IntegrationTestBase.`Given a User`(
     withTelephoneNumber(staffUserDetails.telephoneNumber)
     withName("${staffUserDetails.staff.forenames} ${staffUserDetails.staff.surname}")
     withIsActive(isActive)
-    if (probationRegion == null) {
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
-    } else {
-      withProbationRegion(probationRegion)
+    withYieldedProbationRegion {
+      yieldedProbationRegion
+    }
+    withYieldedApArea {
+      yieldedProbationRegion.apArea
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -115,7 +115,7 @@ class TaskServiceTest {
     every { userAccessServiceMock.userCanReallocateTask(any()) } returns true
 
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
-    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId) } returns AuthorisableActionResult.NotFound()
+    every { userServiceMock.updateUserFromCommunityApiById(assigneeUserId, ServiceName.approvedPremises) } returns AuthorisableActionResult.NotFound()
 
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUserId, UUID.randomUUID())
 
@@ -394,7 +394,7 @@ class TaskServiceTest {
       }
       .produce()
 
-    every { userServiceMock.updateUserFromCommunityApiById(user.id) } returns AuthorisableActionResult.Success(user)
+    every { userServiceMock.updateUserFromCommunityApiById(user.id, ServiceName.approvedPremises) } returns AuthorisableActionResult.Success(user)
 
     return user
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PremisesTransformerTest.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LocalAuthorityArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
+import java.util.UUID
+
+class PremisesTransformerTest {
+
+  private val probationRegionTransformer = mockk<ProbationRegionTransformer>()
+  private val apAreaTransformer = mockk<ApAreaTransformer>()
+  private val localAuthorityAreaTransformer = mockk<LocalAuthorityAreaTransformer>()
+  private val characteristicTransformer = mockk<CharacteristicTransformer>()
+  private val probationDeliveryUnitTransformer = mockk<ProbationDeliveryUnitTransformer>()
+
+  private val service = PremisesTransformer(
+    probationRegionTransformer,
+    apAreaTransformer,
+    localAuthorityAreaTransformer,
+    characteristicTransformer,
+    probationDeliveryUnitTransformer,
+  )
+
+  @Test
+  fun `transformJpaToApi CAS1`() {
+    val id = UUID.randomUUID()
+    val apAreaEntity = ApAreaEntityFactory().produce()
+    val probationRegionEntity = ProbationRegionEntityFactory()
+      .withDefaults()
+      .withApArea(apAreaEntity)
+      .produce()
+    val localAuthorityAreaEntity = LocalAuthorityAreaEntityFactory().produce()
+    val characteristics = mutableListOf(CharacteristicEntityFactory().produce())
+
+    val approvedPremisesEntity = ApprovedPremisesEntityFactory()
+      .withDefaults()
+      .withId(id)
+      .withName("theName")
+      .withApCode("theApCode")
+      .withAddressLine1("theAddressLine1")
+      .withAddressLine2("theAddressLine2")
+      .withTown("theTown")
+      .withPostcode("thePostcode")
+      .withNotes("theNotes")
+      .withProbationRegion(probationRegionEntity)
+      .withLocalAuthorityArea(localAuthorityAreaEntity)
+      .withCharacteristics(characteristics)
+      .withStatus(PropertyStatus.active)
+      .produce()
+
+    val probationRegion = ProbationRegion(UUID.randomUUID(), "probationRegion")
+    every { probationRegionTransformer.transformJpaToApi(probationRegionEntity) } returns probationRegion
+
+    val apArea = ApArea(UUID.randomUUID(), "someIdentifier", "someName")
+    every { apAreaTransformer.transformJpaToApi(apAreaEntity) } returns apArea
+
+    val localAuthorityArea = LocalAuthorityArea(UUID.randomUUID(), "identifier", "name")
+    every { localAuthorityAreaTransformer.transformJpaToApi(localAuthorityAreaEntity) } returns localAuthorityArea
+
+    val characteristic = Characteristic(
+      UUID.randomUUID(),
+      "name",
+      Characteristic.ServiceScope.star,
+      Characteristic.ModelScope.premises,
+      "propertyName",
+    )
+    every { characteristicTransformer.transformJpaToApi(characteristics[0]) } returns characteristic
+
+    val result = service.transformJpaToApi(
+      jpa = approvedPremisesEntity,
+      totalBeds = 2,
+      availableBedsForToday = 3,
+    ) as ApprovedPremises
+
+    assertThat(result.id).isEqualTo(id)
+    assertThat(result.name).isEqualTo("theName")
+    assertThat(result.apCode).isEqualTo("theApCode")
+    assertThat(result.addressLine1).isEqualTo("theAddressLine1")
+    assertThat(result.addressLine2).isEqualTo("theAddressLine2")
+    assertThat(result.town).isEqualTo("theTown")
+    assertThat(result.postcode).isEqualTo("thePostcode")
+    assertThat(result.bedCount).isEqualTo(2)
+    assertThat(result.service).isEqualTo("approved-premises")
+    assertThat(result.notes).isEqualTo("theNotes")
+    assertThat(result.availableBedsForToday).isEqualTo(3)
+    assertThat(result.probationRegion).isEqualTo(probationRegion)
+    assertThat(result.apArea).isEqualTo(apArea)
+    assertThat(result.localAuthorityArea).isEqualTo(localAuthorityArea)
+    assertThat(result.characteristics!![0]).isEqualTo(characteristic)
+    assertThat(result.status).isEqualTo(PropertyStatus.active)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -54,7 +54,7 @@ class UserTransformerTest {
   inner class TransformJpaToApi {
 
     @Test
-    fun `Should successfully transfer user entity with role CAS3_REPORTER to reporter`() {
+    fun `transformJpaToApi CAS3 Should successfully transfer user entity with role CAS3_REPORTER to reporter`() {
       val result = userTransformer.transformJpaToApi(
         buildUserEntity(CAS3_REPORTER),
         temporaryAccommodation,
@@ -66,7 +66,7 @@ class UserTransformerTest {
     }
 
     @Test
-    fun `Should successfully transfer user entity with role CAS3_REFERRER to referrer`() {
+    fun `transformJpaToApi CAS3 Should successfully transfer user entity with role CAS3_REFERRER to referrer`() {
       val result = userTransformer.transformJpaToApi(
         buildUserEntity(CAS3_REFERRER),
         temporaryAccommodation,
@@ -78,7 +78,7 @@ class UserTransformerTest {
     }
 
     @Test
-    fun `Should successfully transfer user entity with role CAS1_MATCHER to matcher`() {
+    fun `transformJpaToApi CAS1 Should successfully transfer user entity with role CAS1_MATCHER to matcher`() {
       val result =
         userTransformer.transformJpaToApi(buildUserEntity(CAS1_MATCHER), approvedPremises) as ApprovedPremisesUser
 
@@ -88,7 +88,7 @@ class UserTransformerTest {
     }
 
     @Test
-    fun `should return distinct roles for Approved Premises`() {
+    fun `transformJpaToApi CAS1 should return distinct roles for Approved Premises`() {
       val user = buildUserEntity(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
@@ -109,7 +109,7 @@ class UserTransformerTest {
     }
 
     @Test
-    fun `should return distinct roles for Temporary Accommodation`() {
+    fun `transformJpaToApi CAS3 should return distinct roles for Temporary Accommodation`() {
       val user = buildUserEntity(CAS3_REFERRER)
       user.addRoleForUnitTest(CAS3_REFERRER)
       user.addRoleForUnitTest(CAS3_REFERRER)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserWithWorklo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.WOMENS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_MATCHER
@@ -47,7 +49,6 @@ class UserTransformerTest {
   @BeforeEach
   fun setup() {
     every { probationRegionTransformer.transformJpaToApi(any()) } returns ProbationRegion(randomUUID(), "someName")
-    every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
   }
 
   @Nested
@@ -79,22 +80,36 @@ class UserTransformerTest {
 
     @Test
     fun `transformJpaToApi CAS1 Should successfully transfer user entity with role CAS1_MATCHER to matcher`() {
-      val result =
-        userTransformer.transformJpaToApi(buildUserEntity(CAS1_MATCHER), approvedPremises) as ApprovedPremisesUser
+      val apAreaEntity = ApAreaEntityFactory().produce()
+
+      val user = buildUserEntity(
+        role = CAS1_MATCHER,
+        apArea = apAreaEntity,
+      )
+
+      every { apAreaTransformer.transformJpaToApi(apAreaEntity) } returns apArea
+
+      val result = userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
 
       assertThat(result.roles).contains(matcher)
       assertThat(result.service).isEqualTo("CAS1")
       verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
+      assertThat(result.apArea).isEqualTo(apArea)
     }
 
     @Test
     fun `transformJpaToApi CAS1 should return distinct roles for Approved Premises`() {
-      val user = buildUserEntity(CAS1_MATCHER)
+      val user = buildUserEntity(
+        role = CAS1_MATCHER,
+        apArea = ApAreaEntityFactory().produce(),
+      )
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_WORKFLOW_MANAGER)
       user.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+      every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
 
       val result =
         userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
@@ -126,6 +141,18 @@ class UserTransformerTest {
         ),
       )
     }
+
+    @Test
+    fun `transformJpaToApi CAS1 should error if no ap area`() {
+      val user = buildUserEntity(
+        role = CAS1_MATCHER,
+        apArea = null,
+      )
+
+      assertThatThrownBy {
+        userTransformer.transformJpaToApi(user, approvedPremises)
+      }.hasMessage("Internal Server Error: CAS1 user ${user.id} should have AP Area Set")
+    }
   }
 
   @Nested
@@ -133,11 +160,16 @@ class UserTransformerTest {
 
     @Test
     fun `transformJpaToAPIUserWithWorkload should return distinct roles`() {
-      val user = buildUserEntity(CAS1_MATCHER)
+      val user = buildUserEntity(
+        role = CAS1_MATCHER,
+        apArea = ApAreaEntityFactory().produce(),
+      )
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_WORKFLOW_MANAGER)
+
+      every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
 
       val workload = UserWorkload(
         0,
@@ -145,8 +177,7 @@ class UserTransformerTest {
         0,
       )
 
-      val result =
-        userTransformer.transformJpaToAPIUserWithWorkload(user, workload) as UserWithWorkload
+      val result = userTransformer.transformJpaToAPIUserWithWorkload(user, workload) as UserWithWorkload
 
       assertThat(result.roles).isEqualTo(
         listOf(
@@ -158,7 +189,12 @@ class UserTransformerTest {
 
     @Test
     fun `transformJpaToAPIUserWithWorkload should return AP area`() {
-      val user = buildUserEntity(CAS1_MATCHER)
+      val apAreaEntity = ApAreaEntityFactory().produce()
+
+      val user = buildUserEntity(
+        role = CAS1_MATCHER,
+        apArea = apAreaEntity,
+      )
 
       val workload = UserWorkload(
         0,
@@ -166,19 +202,17 @@ class UserTransformerTest {
         0,
       )
 
-      val result =
-        userTransformer.transformJpaToAPIUserWithWorkload(user, workload) as UserWithWorkload
+      every { apAreaTransformer.transformJpaToApi(apAreaEntity) } returns apArea
+
+      val result = userTransformer.transformJpaToAPIUserWithWorkload(user, workload) as UserWithWorkload
 
       assertThat(result.apArea).isEqualTo(apArea)
-
-      verify {
-        apAreaTransformer.transformJpaToApi(user.probationRegion.apArea)
-      }
     }
   }
 
   private fun buildUserEntity(
     role: UserRole,
+    apArea: ApAreaEntity? = null,
   ) = UserEntityFactory()
     .withId(randomUUID())
     .withName("username")
@@ -187,6 +221,7 @@ class UserTransformerTest {
     .withTelephoneNumber("someNumber")
     .withIsActive(true)
     .withProbationRegion(buildProbationRegionEntity())
+    .withApArea(apArea)
     .produce()
     .addRoleForUnitTest(role)
     .addQualificationForUnitTest(WOMENS)


### PR DESCRIPTION
There are two parts to this PR

1. Update AP Area and Team Codes on the user entity whenever the user is updated (we only update ap area if originating request is for CAS1)
2. Use user.apArea when determining which ap area the user belongs to