### PR TITLE
CAS2-217: prevent submissions when there is no Prison Code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Submiss
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import java.net.URI
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service("Cas2SubmissionsController")
 class SubmissionsController(
@@ -88,6 +89,7 @@ class SubmissionsController(
     throw NotFoundProblem(applicationId, "Application")
   }
 
+  @Transactional
   override fun submissionsPost(
     submitApplication: SubmitCas2Application,
   ): ResponseEntity<Unit> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -20,24 +20,22 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserDetailsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Admin`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ManageUsers_mockSuccessfulExternalUsersCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -48,7 +46,7 @@ class Cas2SubmissionTest(
   @Value("\${url-templates.frontend.cas2.submitted-application-overview}") private val submittedApplicationUrlTemplate: String,
 ) : IntegrationTestBase() {
   @SpykBean
-  lateinit var realApplicationRepository: ApplicationRepository
+  lateinit var realApplicationRepository: Cas2ApplicationRepository
 
   @SpykBean
   lateinit var realAssessmentRepository: Cas2AssessmentRepository
@@ -653,6 +651,7 @@ class Cas2SubmissionTest(
 
   @Nested
   inner class PostToSubmit {
+
     @Test
     fun `Submit Cas2 application returns 200`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
@@ -660,7 +659,18 @@ class Cas2SubmissionTest(
 
       `Given a CAS2 User`() { submittingUser, jwt ->
         `Given a CAS2 User` { userEntity, _ ->
-          `Given an Offender` { offenderDetails, _ ->
+          `Given an Offender`(
+            inmateDetailsConfigBlock = {
+              withAssignedLivingUnit(
+                AssignedLivingUnit(
+                  agencyId = "agency_id",
+                  locationId = 123.toLong(),
+                  agencyName = "agency_name",
+                  description = null,
+                ),
+              )
+            },
+          ) { offenderDetails, _ ->
 
             val applicationSchema =
               cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -684,11 +694,6 @@ class Cas2SubmissionTest(
                         }
                """,
               )
-
-              val inmateDetail = InmateDetailFactory()
-                .withOffenderNo(offenderDetails.otherIds.nomsNumber.toString())
-                .produce()
-              PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
             }
 
             Assertions.assertThat(realAssessmentRepository.count()).isEqualTo(0)
@@ -746,7 +751,18 @@ class Cas2SubmissionTest(
     @Test
     fun `When several concurrent submit application requests occur, only one is successful, all others return 400`() {
       `Given a CAS2 User`() { submittingUser, jwt ->
-        `Given an Offender` { offenderDetails, _ ->
+        `Given an Offender`(
+          inmateDetailsConfigBlock = {
+            withAssignedLivingUnit(
+              AssignedLivingUnit(
+                agencyId = "agency_id",
+                locationId = 123.toLong(),
+                agencyName = "agency_name",
+                description = null,
+              ),
+            )
+          },
+        ) { offenderDetails, _ ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
           val applicationSchema = cas2ApplicationJsonSchemaEntityFactory
@@ -773,14 +789,9 @@ class Cas2SubmissionTest(
             )
           }
 
-          val inmateDetail = InmateDetailFactory()
-            .withOffenderNo(offenderDetails.otherIds.nomsNumber.toString())
-            .produce()
-          PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
-
           every { realApplicationRepository.save(any()) } answers {
             Thread.sleep(1000)
-            it.invocation.args[0] as ApplicationEntity
+            it.invocation.args[0] as Cas2ApplicationEntity
           }
 
           val responseStatuses = mutableListOf<HttpStatus>()
@@ -813,6 +824,64 @@ class Cas2SubmissionTest(
 
           Assertions.assertThat(responseStatuses.count { it.value() == 200 }).isEqualTo(1)
           Assertions.assertThat(responseStatuses.count { it.value() == 400 }).isEqualTo(9)
+        }
+      }
+    }
+
+    @Test
+    fun `When there's an error fetching the referred person's prison code, the application is not saved`() {
+      `Given a CAS2 User`() { submittingUser, jwt ->
+        `Given an Offender`(mockNotFoundErrorForPrisonApi = true) { offenderDetails, _ ->
+          val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+          val applicationSchema = cas2ApplicationJsonSchemaEntityFactory
+            .produceAndPersist {
+              withAddedAt(OffsetDateTime.now())
+              withId(UUID.randomUUID())
+              withSchema(
+                schema,
+              )
+            }
+
+          cas2ApplicationEntityFactory.produceAndPersist {
+            withCrn(offenderDetails.otherIds.crn)
+            withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
+            withId(applicationId)
+            withApplicationSchema(applicationSchema)
+            withCreatedByUser(submittingUser)
+            withData(
+              """
+            {
+               "thingId": 123
+            }
+            """,
+            )
+          }
+
+          Assertions.assertThat(domainEventRepository.count()).isEqualTo(0)
+          Assertions.assertThat(realAssessmentRepository.count()).isEqualTo(0)
+
+          webTestClient.post()
+            .uri("/cas2/submissions")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.cas2.value)
+            .bodyValue(
+              SubmitCas2Application(
+                applicationId = applicationId,
+                translatedDocument = {},
+                preferredAreas = "Leeds | Bradford",
+                hdcEligibilityDate = LocalDate.parse("2023-03-30"),
+                conditionalReleaseDate = LocalDate.parse("2023-04-29"),
+                telephoneNumber = "123 456 789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+
+          Assertions.assertThat(domainEventRepository.count()).isEqualTo(0)
+          Assertions.assertThat(realAssessmentRepository.count()).isEqualTo(0)
+          Assertions.assertThat(realApplicationRepository.findById(applicationId).get().submittedAt).isNull()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -652,7 +652,7 @@ class Cas2SubmissionTest(
   }
 
   @Nested
-  inner class PostToCreate {
+  inner class PostToSubmit {
     @Test
     fun `Submit Cas2 application returns 200`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_mockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockServerErrorOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockNotFoundInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockServerErrorInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
@@ -20,6 +21,7 @@ fun IntegrationTestBase.`Given an Offender`(
   inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
   mockServerErrorForCommunityApi: Boolean = false,
   mockServerErrorForPrisonApi: Boolean = false,
+  mockNotFoundErrorForPrisonApi: Boolean = false,
 ): Pair<OffenderDetailSummary, InmateDetail> {
   val inmateDetailsFactory = InmateDetailFactory()
   if (inmateDetailsConfigBlock != null) {
@@ -62,16 +64,23 @@ fun IntegrationTestBase.`Given an Offender`(
     false -> PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetails)
   }
 
+  when (mockNotFoundErrorForPrisonApi) {
+    true -> PrisonAPI_mockNotFoundInmateDetailsCall(inmateDetails.offenderNo)
+    false -> {}
+  }
+
   loadPreemptiveCacheForInmateDetails(inmateDetails.offenderNo)
 
   return Pair(offenderDetails, inmateDetails)
 }
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given an Offender`(
   offenderDetailsConfigBlock: (OffenderDetailsSummaryFactory.() -> Unit)? = null,
   inmateDetailsConfigBlock: (InmateDetailFactory.() -> Unit)? = null,
   mockServerErrorForCommunityApi: Boolean = false,
   mockServerErrorForPrisonApi: Boolean = false,
+  mockNotFoundErrorForPrisonApi: Boolean = false,
   block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit,
 ) {
   val (offenderDetails, inmateDetails) = `Given an Offender`(
@@ -79,6 +88,7 @@ fun IntegrationTestBase.`Given an Offender`(
     inmateDetailsConfigBlock,
     mockServerErrorForCommunityApi,
     mockServerErrorForPrisonApi,
+    mockNotFoundErrorForPrisonApi,
   )
 
   block(offenderDetails, inmateDetails)


### PR DESCRIPTION
More detailed context in Jira ticket https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-200

We had an incident in the dev environment where an application was submitted (a 'submitted at' date was given to it in the database) but the Domain Event failed to emit, because the prison code was missing from the Prison API. 

Here we ensure that this won't happen again by:
- If the API is down/unsuccessful: catching any `UpstreamApiExceptions` thrown by the Prison API (e.g. Not Found) when we try to `apply` the prison code to the Application Entity, and transforming the error into a General Validation Error to be handled by the UI. 
- If the API call succeeds but the prison code is missing: throwing an `UpstreamApiException` error with appropriate message, which then gets turned into a General Validation Error and the UI can display the message.

This is a bit of a band-aid over the issue rather than a solution - although we hope this should never happen in production data (and has not occurred yet). 

We should go on to decide whether we should allow an application to be created if the prison code is missing, or what we can prompt the user to do if the prison code is missing.

We should also consider moving this prison code onto the application data itself so we don't have to continually make potentially-breakable API calls. follow up card here https://dsdmoj.atlassian.net/browse/CAS2-367