### PR TITLE
[CAS-276] Migrate name field data from nDelius to Database

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -235,6 +235,20 @@ WHERE taa.probation_region_id = :probationRegionId AND a.submitted_at IS NOT NUL
   @Modifying
   @Query("UPDATE ApprovedPremisesApplicationEntity ap set ap.inmateInOutStatusOnSubmission = :inOutStatus where ap.id = :applicationId")
   fun updateInOutStatus(applicationId: UUID, inOutStatus: String)
+
+  @Query("SELECT taa FROM TemporaryAccommodationApplicationEntity taa WHERE taa.id = :id")
+  fun findTemporaryAccommodationApplicationById(id: UUID): TemporaryAccommodationApplicationEntity?
+
+  @Query(
+    "SELECT * FROM  temporary_accommodation_applications taa " +
+      "LEFT JOIN applications a ON a.id = taa.id " +
+      "WHERE taa.name IS NULL",
+    nativeQuery = true,
+  )
+  fun <T : ApplicationEntity> findAllTemporaryAccommodationApplicationsAndNameNull(
+    type: Class<T>,
+    pageable: Pageable?,
+  ): Slice<TemporaryAccommodationApplicationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateApplicationOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateApplicationOffenderNameJob.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.apache.commons.collections4.ListUtils
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import java.util.stream.Collectors
+import javax.persistence.EntityManager
+
+class Cas3UpdateApplicationOffenderNameJob(
+  private val applicationRepository: ApplicationRepository,
+  private val offenderService: OffenderService,
+  private val entityManager: EntityManager,
+  private val pageSize: Int,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = false
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught")
+  override fun process() {
+    var page = 1
+    var hasNext = true
+    var slice: Slice<TemporaryAccommodationApplicationEntity>
+    var offendersCrn = setOf<String>()
+
+    try {
+      while (hasNext) {
+        log.info("Getting page $page for max page size $pageSize")
+        slice = applicationRepository.findAllTemporaryAccommodationApplicationsAndNameNull(TemporaryAccommodationApplicationEntity::class.java, PageRequest.of(0, pageSize))
+
+        offendersCrn = slice.map { it.crn }.toSet()
+
+        log.info("Updating offenders name with crn ${offendersCrn.joinToString { "," }}")
+
+        val personInfos = splitAndRetrievePersonInfo(offendersCrn, "")
+
+        slice.content.forEach {
+          val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
+          updateApplication(personInfo, it)
+        }
+
+        entityManager.clear()
+        hasNext = slice.hasNext()
+        page += 1
+      }
+    } catch (exception: Exception) {
+      log.error("Unable to update offenders name with crn ${offendersCrn.joinToString { "," }}", exception)
+    }
+  }
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught")
+  private fun updateApplication(personInfo: PersonSummaryInfoResult, it: TemporaryAccommodationApplicationEntity) {
+    try {
+      val offenderName = when (personInfo) {
+        is PersonSummaryInfoResult.Success.Full -> "${personInfo.summary.name.forename} ${personInfo.summary.name.surname}"
+        is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> throw NotFoundProblem(
+          personInfo.crn,
+          "Offender",
+        )
+        is PersonSummaryInfoResult.Success.Restricted -> throw ForbiddenProblem()
+      }
+
+      it.name = offenderName
+      applicationRepository.save(it)
+    } catch (exception: Exception) {
+      log.error("Unable to update offender name with crn ${it.crn} for the application ${it.id}", exception)
+    }
+  }
+
+  private fun splitAndRetrievePersonInfo(crns: Set<String>, deliusUsername: String): Map<String, PersonSummaryInfoResult> {
+    val crnMap = ListUtils.partition(crns.toList(), pageSize)
+      .stream().map { crns ->
+        offenderService.getOffenderSummariesByCrns(crns.toSet(), deliusUsername, ignoreLao = true).associateBy { it.crn }
+      }.collect(Collectors.toList())
+
+    return crnMap.flatMap { it.toList() }.toMap()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1BackfillUs
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateApplicationOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.NoticeTypeMigrationJob
@@ -55,6 +56,7 @@ class MigrationJobService(
           applicationContext.getBean(UserRepository::class.java),
           applicationContext.getBean(UserService::class.java),
         )
+
         MigrationJobType.sentenceTypeAndSituation -> UpdateSentenceTypeAndSituationJob(
           applicationContext.getBean(UpdateSentenceTypeAndSituationRepository::class.java),
         )
@@ -113,6 +115,13 @@ class MigrationJobService(
           applicationContext.getBean(Cas1UserMappingService::class.java),
           applicationContext.getBean(CommunityApiClient::class.java),
           transactionTemplate,
+        )
+
+        MigrationJobType.cas3ApplicationOffenderName -> Cas3UpdateApplicationOffenderNameJob(
+          applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(OffenderService::class.java),
+          applicationContext.getBean(EntityManager::class.java),
+          pageSize,
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3523,6 +3523,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas3_application_offender_name
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8020,6 +8020,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas3_application_offender_name
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4083,6 +4083,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas3_application_offender_name
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3571,6 +3571,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas3_application_offender_name
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateApplicationOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateApplicationOffenderNameJobTest.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+
+class Cas3UpdateApplicationOffenderNameJobTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @Autowired
+  lateinit var applicationRepository: ApplicationRepository
+
+  @Test
+  fun `all applications offender name are updated from Community API`() {
+    `Given an Offender`(
+      offenderDetailsConfigBlock = {
+        withNomsNumber(null)
+      },
+    ) { offenderDetails, _ ->
+
+      val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withPermissiveSchema()
+      }
+
+      val probationRegion = probationRegionEntityFactory.produceAndPersist {
+        withApArea(apAreaEntityFactory.produceAndPersist())
+      }
+
+      val user = userEntityFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      val temporaryAccommodationApplications = generateSequence {
+        temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withApplicationSchema(applicationSchema)
+          withProbationRegion(probationRegion)
+          withCreatedByUser(user)
+        }
+      }.take(10).toList()
+
+      val offendersCrnAndName = temporaryAccommodationApplications.associateBy(
+        keySelector = { it.crn },
+        valueTransform = { NameFactory().produce() },
+      )
+
+      val cases = temporaryAccommodationApplications.map {
+        CaseSummaryFactory()
+          .withCrn(it.crn)
+          .withName(offendersCrnAndName[it.crn]!!)
+          .produce()
+      }
+
+      ApDeliusContext_addListCaseSummaryToBulkResponse(cases)
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3ApplicationOffenderName, 10)
+
+      temporaryAccommodationApplications.forEach {
+        val application = applicationRepository.findTemporaryAccommodationApplicationById(it.id)!!
+        val offenderName = "${offendersCrnAndName[it.crn]?.forename} ${offendersCrnAndName[it.crn]?.surname}"
+        Assertions.assertThat(application.name).isEqualTo(offenderName)
+      }
+    }
+  }
+
+  @Test
+  fun `all applications offender name are updated from Community API when delius name is empty`() {
+    `Given an Offender`(
+      offenderDetailsConfigBlock = {
+        withNomsNumber(null)
+      },
+    ) { offenderDetails, _ ->
+
+      val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withPermissiveSchema()
+      }
+
+      val probationRegion = probationRegionEntityFactory.produceAndPersist {
+        withApArea(apAreaEntityFactory.produceAndPersist())
+      }
+
+      val user = userEntityFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      val temporaryAccommodationApplications = generateSequence {
+        temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withApplicationSchema(applicationSchema)
+          withProbationRegion(probationRegion)
+          withCreatedByUser(user)
+        }
+      }.take(10).toList()
+
+      val offendersCrnAndName = temporaryAccommodationApplications.associateBy(
+        keySelector = { it.crn },
+        valueTransform = { NameFactory().produce() },
+      )
+
+      val cases = temporaryAccommodationApplications.map {
+        CaseSummaryFactory()
+          .withCrn(it.crn)
+          .withName(offendersCrnAndName[it.crn]!!)
+          .produce()
+      }
+
+      ApDeliusContext_addListCaseSummaryToBulkResponse(cases)
+
+      mockOffenderUserAccessCommunityApiCall("", temporaryAccommodationApplications.first().crn, true, true)
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3ApplicationOffenderName, 10)
+
+      temporaryAccommodationApplications.forEach {
+        val application = applicationRepository.findTemporaryAccommodationApplicationById(it.id)!!
+        val offenderName = "${offendersCrnAndName[it.crn]?.forename} ${offendersCrnAndName[it.crn]?.surname}"
+        Assertions.assertThat(application.name).isEqualTo(offenderName)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -163,3 +163,19 @@ fun IntegrationTestBase.ApDeliusContext_addSingleCaseSummaryToBulkResponse(caseS
     ),
   )
 }
+
+fun IntegrationTestBase.ApDeliusContext_addListCaseSummaryToBulkResponse(casesSummary: List<CaseSummary>) {
+  mockSuccessfulGetCallWithBodyAndJsonResponse(
+    url = "/probation-cases/summaries",
+    requestBody = WireMock.equalToJson(
+      objectMapper.writeValueAsString(
+        casesSummary.map { it.crn },
+      ),
+      true,
+      false,
+    ),
+    responseBody = CaseSummaries(
+      cases = casesSummary,
+    ),
+  )
+}


### PR DESCRIPTION
This PR [CAS-276](https://dsdmoj.atlassian.net/browse/CAS-276) includes:

- Create a migration job for CAS3 to feed the name field in Temporary Accommodation Application table with the full name of the offender from nDelius

[CAS-276]: https://dsdmoj.atlassian.net/browse/CAS-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ