### PR TITLE
CAS2-333 add optional page parameter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -39,8 +39,8 @@ ORDER BY createdAt DESC
 """,
     nativeQuery = true,
   )
-  fun findAllCas2ApplicationSummariesCreatedByUser(userId: UUID):
-    List<Cas2ApplicationSummary>
+  fun findAllCas2ApplicationSummariesCreatedByUser(userId: UUID, pageable: Pageable?):
+    Page<Cas2ApplicationSummary>
 
   @Query(
     """
@@ -57,8 +57,8 @@ ORDER BY createdAt DESC
 """,
     nativeQuery = true,
   )
-  fun findSubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID):
-    List<Cas2ApplicationSummary>
+  fun findSubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID, pageable: Pageable?):
+    Page<Cas2ApplicationSummary>
 
   @Query(
     """
@@ -75,8 +75,8 @@ ORDER BY createdAt DESC
 """,
     nativeQuery = true,
   )
-  fun findUnsubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID):
-    List<Cas2ApplicationSummary>
+  fun findUnsubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID, pageable: Pageable?):
+    Page<Cas2ApplicationSummary>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -52,16 +52,22 @@ class ApplicationService(
   @Value("\${url-templates.frontend.cas2.submitted-application-overview}") private val submittedApplicationUrlTemplate: String,
 ) {
 
-  fun getAllApplicationsForUser(user: NomisUserEntity): List<Cas2ApplicationSummary> {
-    return applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id)
+  fun getAllApplicationsForUser(user: NomisUserEntity, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val response = applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id, getPageable(pageCriteria))
+    val metadata = getMetadata(response, pageCriteria)
+    return Pair(response.content, metadata)
   }
 
-  fun getSubmittedApplicationsForUser(user: NomisUserEntity): List<Cas2ApplicationSummary> {
-    return applicationRepository.findSubmittedCas2ApplicationSummariesCreatedByUser(user.id)
+  fun getSubmittedApplicationsForUser(user: NomisUserEntity, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val response = applicationRepository.findSubmittedCas2ApplicationSummariesCreatedByUser(user.id, getPageable(pageCriteria))
+    val metadata = getMetadata(response, pageCriteria)
+    return Pair(response.content, metadata)
   }
 
-  fun getUnsubmittedApplicationsForUser(user: NomisUserEntity): List<Cas2ApplicationSummary> {
-    return applicationRepository.findUnsubmittedCas2ApplicationSummariesCreatedByUser(user.id)
+  fun getUnsubmittedApplicationsForUser(user: NomisUserEntity, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val response = applicationRepository.findUnsubmittedCas2ApplicationSummariesCreatedByUser(user.id, getPageable(pageCriteria))
+    val metadata = getMetadata(response, pageCriteria)
+    return Pair(response.content, metadata)
   }
 
   fun getAllSubmittedApplicationsForAssessor(pageCriteria: PageCriteria<String>): Pair<List<Cas2ApplicationSummary>, PaginationMetadata?> {

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -69,13 +69,13 @@ paths:
                   $ref: '_shared.yml#/components/schemas/ApplicationSummary'
           headers:
             X-Pagination-CurrentPage:
-              $ref: '#/components/headers/X-Pagination-CurrentPage'
+              $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'
             X-Pagination-TotalPages:
-              $ref: '#/components/headers/X-Pagination-TotalPages'
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalPages'
             X-Pagination-TotalResults:
-              $ref: '#/components/headers/X-Pagination-TotalResults'
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
-              $ref: '#/components/headers/X-Pagination-TotalResults'
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:
@@ -240,13 +240,13 @@ paths:
                   $ref: '_shared.yml#/components/schemas/Cas2SubmittedApplicationSummary'
           headers:
             X-Pagination-CurrentPage:
-              $ref: '#/components/headers/X-Pagination-CurrentPage'
+              $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'
             X-Pagination-TotalPages:
-              $ref: '#/components/headers/X-Pagination-TotalPages'
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalPages'
             X-Pagination-TotalResults:
-              $ref: '#/components/headers/X-Pagination-TotalResults'
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
-              $ref: '#/components/headers/X-Pagination-TotalResults'
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -53,6 +53,11 @@ paths:
           description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
           schema:
             type: boolean
+        - name: page
+          in: query
+          description: Page number of results to return.  If blank, returns all results
+          schema:
+            type: integer
       responses:
         200:
           description: successful operation
@@ -62,6 +67,15 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ApplicationSummary'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -55,6 +55,11 @@ paths:
           description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
           schema:
             type: boolean
+        - name: page
+          in: query
+          description: Page number of results to return.  If blank, returns all results
+          schema:
+            type: integer
       responses:
         200:
           description: successful operation
@@ -64,6 +69,15 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApplicationSummary'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
         401:
           $ref: '#/components/responses/401Response'
         403:


### PR DESCRIPTION
JIRA ticket: https://dsdmoj.atlassian.net/browse/CAS2-333

**User Story**

With page param:

As a consumer of the CAS API
When I make an index request to /applications?page=x
The I should receive the correct page of results
And any relevant metadata (e.g. total count)

Without page param:

When I make an index request to /applications
The I should receive all the correct applications


**Technical implementation**

The existing pattern recently introduced in this PR to the Submissions controller has been reused:

https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1413