### PR TITLE
[CAS-225] Populate Release Date in Temporary Accommodation Application table from json

### DIFF
--- a/src/main/resources/db/migration/all/20240325170535__backfill_new_release_date_field_on_cas3_referrals.sql
+++ b/src/main/resources/db/migration/all/20240325170535__backfill_new_release_date_field_on_cas3_referrals.sql
@@ -1,0 +1,7 @@
+UPDATE temporary_accommodation_applications AS ta
+SET person_release_date = (
+    SELECT TO_DATE(app.data->'eligibility'->'release-date'->>'releaseDate','YYYY-MM-DD')
+    FROM applications AS app
+    WHERE app.id = ta.id AND service ='temporary-accommodation' And app.data is not null
+)
+WHERE person_release_date IS NULL;


### PR DESCRIPTION
This PR [CAS-225](https://dsdmoj.atlassian.net/browse/CAS-225) will populate the release date field in temporary accommodation application from data json field


[CAS-225]: https://dsdmoj.atlassian.net/browse/CAS-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ