### PR TITLE
APS-538 Add job to fix broken ‘further info’ assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -216,6 +216,10 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   @Modifying
   @Query("UPDATE ApprovedPremisesAssessmentEntity a SET a.dueAt = :dueAt WHERE a.id = :id")
   fun updateDueAt(id: UUID, dueAt: OffsetDateTime?)
+
+  @Modifying
+  @Query("UPDATE ApprovedPremisesAssessmentEntity a set a.data = :updatedJson where a.id = :id")
+  fun updateData(id: UUID, updatedJson: Any)
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AssessmentMoreInfoBugFixSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AssessmentMoreInfoBugFixSeedJob.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.util.UUID
+
+class Cas1FurtherInfoBugFixSeedJob(
+  fileName: String,
+  private val assessmentRepository: AssessmentRepository,
+) : SeedJob<Cas1FurtherInfoBugFixSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "assessment_id",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1FurtherInfoBugFixSeedCsvRow(
+    assessmentId = columns["assessment_id"]!!.trim(),
+  )
+
+  override fun processRow(row: Cas1FurtherInfoBugFixSeedCsvRow) {
+    val assessment = assessmentRepository.findByIdOrNull(UUID.fromString(row.assessmentId))
+      ?: error("Assessment with identifier '${row.assessmentId}' does not exist")
+
+    val updatedJson = assessment.data?.replace(
+      Regex("sufficient-information-confirm\"\\s*:\\s*\\{\\s*\"confirm\"\\s*:\\s*\"no\"\\s*}"),
+      "sufficient-information-confirm\":{\"confirm\":\"yes\"}",
+    )
+
+    if (updatedJson != null) {
+      assessmentRepository.updateData(assessment.id, updatedJson)
+    }
+
+    log.info("Updated JSON for assessment ${assessment.id}")
+  }
+}
+
+data class Cas1FurtherInfoBugFixSeedCsvRow(
+  val assessmentId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
@@ -46,6 +47,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingAdhocPropertySeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
@@ -226,6 +228,11 @@ class SeedService(
         SeedFileType.approvedPremisesBookingAdhocProperty -> Cas1BookingAdhocPropertySeedJob(
           filename,
           applicationContext.getBean(BookingRepository::class.java),
+        )
+
+        SeedFileType.approvedPremisesAssessmentMoreInfoBugFix -> Cas1FurtherInfoBugFixSeedJob(
+          filename,
+          applicationContext.getBean(AssessmentRepository::class.java),
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3500,6 +3500,7 @@ components:
         - approved_premises_cancel_bookings
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
+        - approved_premises_assessment_more_info_bug_fix
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7997,6 +7997,7 @@ components:
         - approved_premises_cancel_bookings
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
+        - approved_premises_assessment_more_info_bug_fix
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4046,6 +4046,7 @@ components:
         - approved_premises_cancel_bookings
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
+        - approved_premises_assessment_more_info_bug_fix
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3548,6 +3548,7 @@ components:
         - approved_premises_cancel_bookings
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
+        - approved_premises_assessment_more_info_bug_fix
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedAssessmentMoreInfoBugFixTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedAssessmentMoreInfoBugFixTest.kt
@@ -1,0 +1,107 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedCsvRow
+import java.time.OffsetDateTime
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedAssessmentMoreInfoBugFixTest : SeedTestBase() {
+
+  @Test
+  fun `Updates required assessments leaving others unmodified`() {
+    val sampleJson = """{
+      "sufficient-information-confirm": {
+        "confirm": "no"
+      },
+      "information-received": {
+        "informationReceived":"no"
+      },
+      "something": "else"
+      }"""
+
+    val assessment1NoJson = createAssessment(data = null)
+    val assessment2HasFormattedJson = createAssessment(data = sampleJson)
+    val assessment3Unmodified = createAssessment(data = sampleJson)
+    val assessment4FlatJson = createAssessment(data = removeLineBreaks(sampleJson))
+
+    withCsv(
+      "valid-csv",
+      rowsToCsv(
+        listOf(
+          Cas1FurtherInfoBugFixSeedCsvRow(assessment1NoJson.id.toString()),
+          Cas1FurtherInfoBugFixSeedCsvRow(assessment2HasFormattedJson.id.toString()),
+          Cas1FurtherInfoBugFixSeedCsvRow(assessment4FlatJson.id.toString()),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesAssessmentMoreInfoBugFix, "valid-csv")
+
+    val expectedJson = """{
+      "sufficient-information-confirm":{"confirm":"yes"},
+      "information-received": {
+        "informationReceived":"no"
+      },
+      "something": "else"
+      }"""
+
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.data).isNull()
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasFormattedJson.id)!!.data).isEqualTo(expectedJson)
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.data).isEqualTo(sampleJson)
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment4FlatJson.id)!!.data).isEqualTo(removeLineBreaks(expectedJson))
+  }
+
+  fun removeLineBreaks(input: String) = input.replace(Regex("""(\r\n)|\n"""), "")
+
+  private fun createAssessment(data: String?): AssessmentEntity {
+    val (user) = `Given a User`()
+    val (offenderDetails) = `Given an Offender`()
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+      withAddedAt(OffsetDateTime.now())
+    }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCrn(offenderDetails.otherIds.crn)
+      withCreatedByUser(user)
+      withApplicationSchema(applicationSchema)
+    }
+
+    return approvedPremisesAssessmentEntityFactory.produceAndPersist {
+      withAllocatedToUser(user)
+      withApplication(application)
+      withAssessmentSchema(assessmentSchema)
+      withData(data)
+    }
+  }
+
+  private fun rowsToCsv(rows: List<Cas1FurtherInfoBugFixSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "assessment_id",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.assessmentId)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}


### PR DESCRIPTION
There is a known issue that affects assessments where a user has requested further information, and goes back to edit the respons, selecting ‘no’ beacause they don’t want to trigger a re-request. This inconsistent state leads to an infinite loop when the UI is attempting to validate the answers.

This commit introduces a seed job the updates the ‘sufficient information’ response to ‘yes’ to break the infinite loop. It can be used to ‘fix’ assessments in this inconsistent state