### PR TITLE
APS-549 Use placement_app submission date for due at calcs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -41,7 +41,7 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   fun findByApplication(application: ApplicationEntity): List<PlacementApplicationEntity>
 
-  @Query("SELECT p from PlacementApplicationEntity p WHERE p.dueAt IS NULL")
+  @Query("SELECT p from PlacementApplicationEntity p WHERE p.dueAt IS NULL AND p.submittedAt IS NOT NULL")
   fun findAllWithNullDueAt(pageable: Pageable?): Slice<PlacementApplicationEntity>
 
   @Modifying

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
@@ -37,7 +37,7 @@ class TaskDeadlineService(
   }
 
   fun getDeadline(placementApplication: PlacementApplicationEntity): OffsetDateTime {
-    return addWorkingDays(placementApplication.createdAt, STANDARD_PLACEMENT_APPLICATION_TIMEFRAME)
+    return addWorkingDays(placementApplication.submittedAt!!, STANDARD_PLACEMENT_APPLICATION_TIMEFRAME)
   }
 
   fun addWorkingDays(date: OffsetDateTime, workingDays: Int): OffsetDateTime = workingDayCountService.addWorkingDays(date.toLocalDate(), workingDays).toLocalDateTime()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TaskDueMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TaskDueMigrationJobTest.kt
@@ -95,6 +95,7 @@ class TaskDueMigrationJobTest : IntegrationTestBase() {
         withApplication(application)
         withCreatedByUser(user)
         withSchemaVersion(placementApplicationSchema)
+        withSubmittedAt(OffsetDateTime.now())
         withDueAt(null)
       }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1782,6 +1782,7 @@ class TasksTest : IntegrationTestBase() {
                   withPermissiveSchema()
                 },
                 crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
               ) { placementApplication ->
                 val placementDate = placementDateFactory.produceAndPersist {
                   withPlacementApplication(placementApplication)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
@@ -166,13 +166,15 @@ class TaskDeadlineServiceTest {
   }
 
   @Test
-  fun `getDeadline returns a deadline of the placement application's created date plus 10 working days for a placement application`() {
-    val createdAt = OffsetDateTime.parse("2023-01-01T15:00:00Z")
+  fun `getDeadline returns a deadline of the placement application's submitted date plus 10 working days for a placement application`() {
+    val createdAt = OffsetDateTime.parse("2022-01-01T15:00:00Z")
+    val submittedAt = OffsetDateTime.parse("2023-01-01T15:00:00Z")
     val placementRequest = createPlacementRequest(noticeType = Cas1ApplicationTimelinessCategory.shortNotice, isEsap = true, createdAt = createdAt)
     val placementApplication = PlacementApplicationEntityFactory()
       .withApplication(placementRequest.application)
       .withCreatedByUser(placementRequest.application.createdByUser)
       .withCreatedAt(createdAt)
+      .withSubmittedAt(submittedAt)
       .produce()
 
     val result = taskDeadlineService.getDeadline(placementApplication)
@@ -181,7 +183,7 @@ class TaskDeadlineServiceTest {
 
     verify(exactly = 1) {
       workingDayCountService.addWorkingDays(
-        placementApplication.createdAt.toLocalDate(),
+        submittedAt.toLocalDate(),
         TaskDeadlineService.STANDARD_PLACEMENT_APPLICATION_TIMEFRAME,
       )
     }


### PR DESCRIPTION
This commit changes the placement application due at calculation to use the submission date instead of the creation date.

The previous behaviour isn’t generally an issue because users can’t start creating a request for placement on the UI and then return to it later unless they bookmark it, which is unlikely.