### PR TITLE
[APS-523] Allow sorting CAS1 assessments by `dueAt` field

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -77,6 +77,7 @@ class AssessmentController(
           PageCriteria(resolvedSortBy, resolvedSortDirection, page, perPage),
         )
         val transformSummaries = when (sortBy) {
+          AssessmentSortField.assessmentDueAt -> throw BadRequestProblem(errorDetail = "Sorting by due date is not supported for CAS3")
           AssessmentSortField.personName -> transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)).sort(resolvedSortDirection, sortBy)
           else -> transformDomainToApi(user, summaries)
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -102,6 +102,7 @@ class AssessmentService(
       AssessmentSortField.assessmentStatus -> "status"
       AssessmentSortField.assessmentArrivalDate -> "arrivalDate"
       AssessmentSortField.assessmentCreatedAt -> "createdAt"
+      AssessmentSortField.assessmentDueAt -> "dueAt"
       AssessmentSortField.personCrn -> "crn"
       AssessmentSortField.personName -> "personName"
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSumm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 
 fun List<AssessmentSummary>.sort(sortDirection: SortDirection, sortField: AssessmentSortField): List<AssessmentSummary> {
   val comparator = Comparator<AssessmentSummary> { a, b ->
@@ -17,6 +18,7 @@ fun List<AssessmentSummary>.sort(sortDirection: SortDirection, sortField: Assess
         else -> throw RuntimeException("Cannot compare values of types ${a::class.qualifiedName} and ${b::class.qualifiedName} due to incomparable status types.")
       }
       AssessmentSortField.assessmentCreatedAt -> compareValues(a.createdAt, b.createdAt)
+      AssessmentSortField.assessmentDueAt -> throw BadRequestProblem(errorDetail = "Sorting by due date is not supported for CAS3")
     }
 
     when (sortDirection) {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2574,12 +2574,14 @@ components:
         - arrivalDate
         - status
         - createdAt
+        - dueAt
       x-enum-varnames:
         - personName
         - personCrn
         - assessmentArrivalDate
         - assessmentStatus
         - assessmentCreatedAt
+        - assessmentDueAt
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7071,12 +7071,14 @@ components:
         - arrivalDate
         - status
         - createdAt
+        - dueAt
       x-enum-varnames:
         - personName
         - personCrn
         - assessmentArrivalDate
         - assessmentStatus
         - assessmentCreatedAt
+        - assessmentDueAt
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3120,12 +3120,14 @@ components:
         - arrivalDate
         - status
         - createdAt
+        - dueAt
       x-enum-varnames:
         - personName
         - personCrn
         - assessmentArrivalDate
         - assessmentStatus
         - assessmentCreatedAt
+        - assessmentDueAt
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2622,12 +2622,14 @@ components:
         - arrivalDate
         - status
         - createdAt
+        - dueAt
       x-enum-varnames:
         - personName
         - personCrn
         - assessmentArrivalDate
         - assessmentStatus
         - assessmentCreatedAt
+        - assessmentDueAt
     AssessmentDecision:
       type: string
       enum:


### PR DESCRIPTION
> See [APS-523 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-523).

This PR introduces the ability to sort CAS1 assessments using the `dueAt` field.

As CAS1 assessments do not have a due date, the `GET /assessments` endpoint will return a `400 Bad Request` response if this sort field is used for the CAS1 service.