### PR TITLE
APS-544 Update CAS1 booking cancellation reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -16,7 +16,7 @@ interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity,
     val CAS1_RELATED_APP_WITHDRAWN_ID: UUID = UUID.fromString("bcb90030-b2d3-47d1-b289-a8b8c8898576")
   }
 
-  @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*'")
+  @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*' ORDER by c.sortOrder ASC, c.name ASC")
   fun findAllByServiceScope(serviceName: String): List<CancellationReasonEntity>
 
   fun findByNameAndServiceScope(name: String, serviceScope: String): CancellationReasonEntity?
@@ -30,6 +30,7 @@ data class CancellationReasonEntity(
   val name: String,
   val isActive: Boolean,
   val serviceScope: String,
+  val sortOrder: Int,
 ) {
   override fun toString() = "CancellationReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationReasonTransformer.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 
 @Component
-class CancellationReasonTransformer() {
+class CancellationReasonTransformer {
   fun transformJpaToApi(jpa: CancellationReasonEntity) = CancellationReason(
     id = jpa.id,
     name = jpa.name,

--- a/src/main/resources/db/migration/all/20240326122914__add_sort_order_col_to_booking_cancellation_reasons.sql
+++ b/src/main/resources/db/migration/all/20240326122914__add_sort_order_col_to_booking_cancellation_reasons.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cancellation_reasons ADD COLUMN sort_order integer NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/all/20240402150339__update_cas1_booking_cancellation_reasons.sql
+++ b/src/main/resources/db/migration/all/20240402150339__update_cas1_booking_cancellation_reasons.sql
@@ -1,0 +1,22 @@
+UPDATE cancellation_reasons
+SET is_active = false
+WHERE service_scope = 'approved-premises'
+  AND name IN ('The placement is being transferred','The AP requested it');
+
+UPDATE cancellation_reasons
+SET name = 'Person has been deprioritised at this AP'
+WHERE service_scope = 'approved-premises' AND name = 'The placement has been deprioritised (it''s a lower tier)';
+
+UPDATE cancellation_reasons
+SET name = 'Probation Practitioner requested it'
+WHERE service_scope = 'approved-premises' AND name = 'The probation practitioner requested it';
+
+UPDATE cancellation_reasons
+SET name = 'AP has appealed placement'
+WHERE service_scope = 'approved-premises' AND name = 'The assessment is being appealed';
+
+INSERT INTO cancellation_reasons (id, name, is_active, service_scope)
+VALUES
+    ('c4ae53be-8bf6-4139-b530-254eb79bf79f', 'An alternative AP placement needs to be found', true, 'approved-premises');
+
+UPDATE cancellation_reasons SET sort_order = 99 WHERE service_scope = 'approved-premises' and name = 'Other';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
@@ -12,6 +12,7 @@ class CancellationReasonEntityFactory : Factory<CancellationReasonEntity> {
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
   private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
+  private var sortOrder: Yielded<Int> = { 0 }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -34,5 +35,6 @@ class CancellationReasonEntityFactory : Factory<CancellationReasonEntity> {
     name = this.name(),
     isActive = this.isActive(),
     serviceScope = this.serviceScope(),
+    sortOrder = this.sortOrder(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
@@ -16,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
+import java.util.UUID
 
 class ReferenceDataTest : IntegrationTestBase() {
   @Autowired
@@ -515,17 +517,25 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Cancellation Reasons for only approved premises returns 200 with correct body`() {
-    cancellationReasonRepository.deleteAll()
-
-    cancellationReasonEntityFactory.produceAndPersistMultiple(10)
-
-    val expectedCancellationReasons = cancellationReasonEntityFactory.produceAndPersistMultiple(10) {
-      withServiceScope(ServiceName.approvedPremises.value)
-    }
-
-    val expectedJson = objectMapper.writeValueAsString(
-      expectedCancellationReasons.map(cancellationReasonTransformer::transformJpaToApi),
+    val expectedCancellationReasons = listOf(
+      CancellationReason(UUID.fromString("c4ae53be-8bf6-4139-b530-254eb79bf79f"), "An alternative AP placement needs to be found", true, "approved-premises"),
+      CancellationReason(UUID.fromString("b43a314a-7e25-459b-8a82-7bbcc9313caa"), "AP has appealed placement", true, "approved-premises"),
+      CancellationReason(UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2"), "Booking successfully appealed", false, "approved-premises"),
+      CancellationReason(UUID.fromString("eece6c5d-7554-4eaa-884c-d2bdd71ae627"), "Deceased", false, "approved-premises"),
+      CancellationReason(UUID.fromString("3a5afbfc-3c0f-11ee-be56-0242ac120002"), "Error in booking", false, "approved-premises"),
+      CancellationReason(UUID.fromString("7c310cfd-3952-456d-b0ee-0f7817afe64a"), "Error in Booking Details", false, "approved-premises"),
+      CancellationReason(UUID.fromString("6b07a333-f838-4426-8f01-bdf70c965983"), "Person has been deprioritised at this AP", true, "approved-premises"),
+      CancellationReason(UUID.fromString("d39572ea-9e42-460c-ae88-b6b30fca0b09"), "Probation Practitioner requested it", true, "approved-premises"),
+      CancellationReason(UUID.fromString("bcb90030-b2d3-47d1-b289-a8b8c8898576"), "Related application withdrawn", false, "approved-premises"),
+      CancellationReason(UUID.fromString("0a115fa4-6fd0-4b23-8e31-e6d1769c3985"), "Related placement request withdrawn", false, "approved-premises"),
+      CancellationReason(UUID.fromString("0e068767-c62e-43b5-866d-f0fb1d02ad83"), "Related request for placement withdrawn", false, "approved-premises"),
+      CancellationReason(UUID.fromString("3c2a6820-d59d-4c06-a194-7873e9a7b63a"), "The AP requested it", false, "approved-premises"),
+      CancellationReason(UUID.fromString("b5688d29-762d-499c-be42-708729aef5ed"), "The placement is being transferred", false, "approved-premises"),
+      CancellationReason(UUID.fromString("a693e972-a092-428f-9222-d802849c7121"), "Withdrawn by Approved Premises", false, "approved-premises"),
+      CancellationReason(UUID.fromString("1d6f3c6e-3a86-49b4-bfca-2513a078aba3"), "Other", true, "approved-premises"),
     )
+
+    val expectedJson = objectMapper.writeValueAsString(expectedCancellationReasons)
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -544,7 +544,7 @@ class BookingTransformerTest {
         CancellationEntity(
           id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
           date = LocalDate.parse("2022-08-10"),
-          reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises"),
+          reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises", sortOrder = 0),
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -627,7 +627,13 @@ class BookingTransformerTest {
         CancellationEntity(
           id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
           date = LocalDate.parse("2022-08-10"),
-          reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
+          reason = CancellationReasonEntity(
+            id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"),
+            name = "Because",
+            isActive = true,
+            serviceScope = ServiceName.temporaryAccommodation.value,
+            sortOrder = 0,
+          ),
           notes = null,
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -636,7 +642,13 @@ class BookingTransformerTest {
         CancellationEntity(
           id = UUID.fromString("d34415c3-d128-45a0-9950-b84491ab8d11"),
           date = LocalDate.parse("2022-08-10"),
-          reason = CancellationReasonEntity(id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"), name = "Some other reason", isActive = true, serviceScope = ServiceName.temporaryAccommodation.value),
+          reason = CancellationReasonEntity(
+            id = UUID.fromString("dd6444f7-af56-436c-8451-ca993617471e"),
+            name = "Some other reason",
+            isActive = true,
+            serviceScope = ServiceName.temporaryAccommodation.value,
+            sortOrder = 0,
+          ),
           notes = "Original reason chosen in error",
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-02T12:34:56.789Z"),


### PR DESCRIPTION
This PR introduces a sort order column to booking cancellation_reasons. Cancellation reasons are sorted by sort order and then name, where lowest sort order numbers (0) are shown first.

![Screenshot 2024-04-02 at 16 00 35](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/64a5675d-076f-414f-b21a-ca5bc63e6920)
