### PR TITLE
Tidy up user update on change tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -332,6 +332,10 @@ class UserService(
   }
 
   private fun userHasChanged(user: UserEntity, deliusUser: StaffUserDetails): Boolean {
-    return (deliusUser.email !== user.email) || (deliusUser.telephoneNumber !== user.telephoneNumber) || (deliusUser.staff.fullName != user.name) || (deliusUser.staffCode != user.deliusStaffCode) || (deliusUser.probationArea.code != user.probationRegion.deliusCode)
+    return (deliusUser.email !== user.email) ||
+      (deliusUser.telephoneNumber !== user.telephoneNumber) ||
+      (deliusUser.staff.fullName != user.name) ||
+      (deliusUser.staffCode != user.deliusStaffCode) ||
+      (deliusUser.probationArea.code != user.probationRegion.deliusCode)
   }
 }


### PR DESCRIPTION
Before making any more changes to the update user logic i’ve given the tests a tidy up and added a test for each field that triggers an entity update