### PR TITLE
APS-404 Backfill user.teamCodes and capture user updatedAt

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -2,12 +2,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter.StringListConverter
 import java.util.Objects
 import java.util.UUID
+import javax.persistence.Convert
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -231,10 +232,6 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
     nativeQuery = true,
   )
   fun findWorkloadForUserIds(userIds: List<UUID>): List<UserWorkload>
-
-  @Modifying
-  @Query("UPDATE UserEntity u set u.apArea = :apArea where u.id = :userId")
-  fun updateApArea(userId: UUID, apArea: ApAreaEntity)
 }
 
 @Entity
@@ -260,6 +257,8 @@ data class UserEntity(
   @ManyToOne
   @JoinColumn(name = "ap_area_id")
   var apArea: ApAreaEntity?,
+  @Convert(converter = StringListConverter::class)
+  var teamCodes: List<String>?,
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.hibernate.annotations.UpdateTimestamp
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter.StringListConverter
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Convert
@@ -259,6 +261,9 @@ data class UserEntity(
   var apArea: ApAreaEntity?,
   @Convert(converter = StringListConverter::class)
   var teamCodes: List<String>?,
+  val createdAt: OffsetDateTime?,
+  @UpdateTimestamp
+  var updatedAt: OffsetDateTime?,
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/converter/StringListConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/converter/StringListConverter.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter
+
+import javax.persistence.AttributeConverter
+import javax.persistence.Converter
+
+@Converter
+class StringListConverter : AttributeConverter<List<String?>?, String?> {
+  companion object {
+    private const val SPLIT_CHAR = ";"
+  }
+
+  override fun convertToDatabaseColumn(stringList: List<String?>?): String? {
+    return stringList?.joinToString(separator = SPLIT_CHAR)
+  }
+
+  override fun convertToEntityAttribute(string: String?): List<String?>? {
+    if (string == null) {
+      return null
+    }
+
+    if (string.isBlank()) {
+      return emptyList()
+    }
+
+    return string.split(SPLIT_CHAR)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -281,6 +281,7 @@ class UserService(
         probationRegion = staffProbationRegion,
         isActive = true,
         apArea = null,
+        teamCodes = null,
       ),
     )
   }
@@ -339,3 +340,5 @@ class UserService(
       (deliusUser.probationArea.code != user.probationRegion.deliusCode)
   }
 }
+
+fun StaffUserDetails.getTeamCodes() = teams?.let { teams -> teams.map { it.code } } ?: emptyList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.transformQualifications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.transformUserRoles
+import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
 
@@ -206,6 +207,8 @@ class UserService(
         }
       }
 
+      user.updatedAt = OffsetDateTime.now()
+
       user = userRepository.save(user)
     }
 
@@ -282,6 +285,8 @@ class UserService(
         isActive = true,
         apArea = null,
         teamCodes = null,
+        createdAt = OffsetDateTime.now(),
+        updatedAt = null,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1UserMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1UserMappingService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaReposit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.getTeamCodes
 
 @Component
 class Cas1UserMappingService(
@@ -45,9 +46,7 @@ class Cas1UserMappingService(
     val deliusProbationAreaCode = deliusUser.probationArea.code
     val isInNationalProbationArea = listOf("N43", "N41", "XX").contains(deliusProbationAreaCode)
     if (isInNationalProbationArea) {
-      val deliusUserTeamCodes = deliusUser.teams?.let { teams ->
-        teams.map { it.code }
-      } ?: emptyList()
+      val deliusUserTeamCodes = deliusUser.getTeamCodes()
 
       if (deliusUserTeamCodes.isEmpty()) {
         return apAreaForCode(noTeamsApArea)

--- a/src/main/resources/db/migration/all/20240327151433__capture_team_codes_on_migration.sql
+++ b/src/main/resources/db/migration/all/20240327151433__capture_team_codes_on_migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD team_codes TEXT NULL;

--- a/src/main/resources/db/migration/all/20240328091447__capture_created_and_updated_on_user.sql
+++ b/src/main/resources/db/migration/all/20240328091447__capture_created_and_updated_on_user.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+    ADD created_At TIMESTAMP NULL,
+    ADD updated_at TIMESTAMP NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -26,6 +26,7 @@ class UserEntityFactory : Factory<UserEntity> {
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
   private var isActive: Yielded<Boolean> = { true }
   private var apArea: Yielded<ApAreaEntity?> = { null }
+  private var teamCodes: Yielded<List<String>?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -100,6 +101,10 @@ class UserEntityFactory : Factory<UserEntity> {
     )
   }
 
+  fun withTeamCodes(teamCodes: List<String>) = apply {
+    this.teamCodes = { teamCodes }
+  }
+
   override fun produce(): UserEntity = UserEntity(
     id = this.id(),
     name = this.name(),
@@ -114,5 +119,6 @@ class UserEntityFactory : Factory<UserEntity> {
     probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided"),
     isActive = this.isActive(),
     apArea = this.apArea(),
+    teamCodes = this.teamCodes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class UserEntityFactory : Factory<UserEntity> {
@@ -27,6 +28,8 @@ class UserEntityFactory : Factory<UserEntity> {
   private var isActive: Yielded<Boolean> = { true }
   private var apArea: Yielded<ApAreaEntity?> = { null }
   private var teamCodes: Yielded<List<String>?> = { null }
+  private var createdAt: Yielded<OffsetDateTime?> = { null }
+  private var updatedAt: Yielded<OffsetDateTime?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -120,5 +123,7 @@ class UserEntityFactory : Factory<UserEntity> {
     isActive = this.isActive(),
     apArea = this.apArea(),
     teamCodes = this.teamCodes(),
+    createdAt = this.createdAt(),
+    updatedAt = this.updatedAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
 
   @Test
-  fun `Populate ap area`() {
+  fun `Populate ap area and team codes`() {
     val apArea = apAreaEntityFactory.produceAndPersist()
 
     val probationRegion = probationRegionEntityFactory.produceAndPersist {
@@ -29,11 +29,13 @@ class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
     ) { userEntity, _ ->
 
       assertThat(userEntity.apArea).isNull()
+      assertThat(userEntity.teamCodes).isNull()
 
       migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillUserApArea)
 
       val updatedUser = userRepository.findByIdOrNull(userEntity.id)!!
       assertThat(updatedUser.apArea!!.id).isEqualTo(apArea.id)
+      assertThat(updatedUser.teamCodes).isEqualTo(listOf("abc"))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/converter/StringListConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/converter/StringListConverterTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity.converter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter.StringListConverter
+
+class StringListConverterTest {
+
+  @Test
+  fun `convertToDatabaseColumn null`() {
+    val result = StringListConverter().convertToDatabaseColumn(null)
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `convertToDatabaseColumn Empty`() {
+    val result = StringListConverter().convertToDatabaseColumn(listOf())
+    assertThat(result).isEqualTo("")
+  }
+
+  @Test
+  fun `convertToDatabaseColumn OneValue`() {
+    val result = StringListConverter().convertToDatabaseColumn(listOf("first value"))
+    assertThat(result).isEqualTo("first value")
+  }
+
+  @Test
+  fun `convertToDatabaseColumn MultipleValues`() {
+    val result = StringListConverter().convertToDatabaseColumn(listOf("first value", "SECOND VALUE", "third"))
+    assertThat(result).isEqualTo("first value;SECOND VALUE;third")
+  }
+
+  @Test
+  fun `convertToEntityAttribute null`() {
+    val result = StringListConverter().convertToEntityAttribute(null)
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `convertToEntityAttribute Empty`() {
+    val result = StringListConverter().convertToEntityAttribute("")
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `convertToEntityAttribute OneValue`() {
+    val result = StringListConverter().convertToEntityAttribute("first value")
+    assertThat(result).isEqualTo(listOf("first value"))
+  }
+
+  @Test
+  fun `convertToEntityAttribute MultipleValues`() {
+    val result = StringListConverter().convertToEntityAttribute("first value;SECOND VALUE;third")
+    assertThat(result).isEqualTo(listOf("first value", "SECOND VALUE", "third"))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
 
@@ -107,6 +108,7 @@ class UserServiceTest {
       val result = userService.getExistingUserOrCreate(username)
 
       assertThat(result.name).isEqualTo("Jim Jimmerson")
+      assertThat(result.createdAt).isWithinTheLastMinute()
 
       verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
       verify(exactly = 1) { mockUserRepository.save(any()) }


### PR DESCRIPTION
In preparation for capturing and updating ap area in the users table we need to be able to track changes to a user’s team code.

This commit adds a new column to capture team code and updates the existing ap area backfill to also backfill the team codes

New 'created at' and 'updated at' column is added to the user entity to help track when a user was last updated in the database.