### PR TITLE
CAS2-344 enable bulk CRN search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -102,7 +102,7 @@ class OffenderService(
     }
   }
 
-  private fun getOffenderSummariesByCrns(
+  fun getOffenderSummariesByCrns(
     crns: Set<String>,
   ): Map<String, ClientResult<OffenderDetailSummary>> {
     if (crns.isEmpty()) return emptyMap()
@@ -141,7 +141,10 @@ class OffenderService(
 
   private fun getInfoForPerson(crn: String): PersonInfoResult {
     var offenderResponse = offenderDetailsDataSource.getOffenderDetailSummary(crn)
+    return getInfoForOffender(crn, offenderResponse)
+  }
 
+  fun getInfoForOffender(crn: String, offenderResponse: ClientResult<OffenderDetailSummary>): PersonInfoResult {
     val offender = when (offenderResponse) {
       is ClientResult.Success -> offenderResponse.body
 


### PR DESCRIPTION
JIRA ticket: https://dsdmoj.atlassian.net/browse/CAS2-344

Following the implementation of bulk searching CRN’s in [this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1649) for /submissions we should do the same on /applications.

Replaces `getPersonDetailAndTransformToSummary` with `getPeopleDetailsAndTransformToSummaries` that uses the `getOffenderSummariesByCrns` function in the CAS2 offenderService.

Once we have a map of all the offender detail summaries this is used to build the PersonInfoResult.

The call to `offenderDetailsDataSource.getOffenderDetailSummary` in `getInfoForPerson` is replaced with data collected in bulk.

So:

1. Do the search to get map of offender summaries with crn as key
2. Iterate through each application and for each application
-- use the crn to get the relevant offender summary from the map in step 1
-- use the nomsNumber to go get the inmateDetails from the inmate API
-- build the person info result and then use that to pass into `transformJpaSummaryToSummary`