### PR TITLE
[CAS-105]-Enable cas3 remaining domain events in prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -37,7 +37,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 300
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
-    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
     DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false
@@ -74,6 +74,7 @@ generic-service:
     URL-TEMPLATES_API_CAS3_BOOKING-CONFIRMED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/booking-confirmed/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-PROVISIONALLY-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/booking-provisionally-made/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-ARRIVED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/person-arrived/#eventId
+    URL-TEMPLATES_API_CAS3_PERSON-ARRIVED-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/person-arrived-updated/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/person-departed/#eventId
     URL-TEMPLATES_API_CAS3_REFERRAL-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/referral-submitted/#eventId
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId


### PR DESCRIPTION
PR to enabled CAS3 domain events in Prod. The events are

- person.arrived.updated
- person.arrived
- person.departed
- person.departed.updated

We need to deploy this on 2nd April after [CAS-204](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1489?selectedIssue=CAS-204) and [CAS-292](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1489?selectedIssue=CAS-292) are ready for prod deployment.

[CAS-204]: https://dsdmoj.atlassian.net/browse/CAS-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAS-292]: https://dsdmoj.atlassian.net/browse/CAS-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ