### PR TITLE
(CAS2-370) Return latest status update with submitted applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -85,10 +85,17 @@ SELECT
     a.crn,
     a.noms_number as nomsNumber,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    asu.label as latestStatusUpdate,
     a.created_at as createdAt,
     a.submitted_at as submittedAt
 FROM cas_2_applications a
-WHERE a.submitted_at IS NOT NULL
+LEFT JOIN
+    (SELECT DISTINCT ON (application_id) su.application_id, su.label
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+ON a.id = asu.application_id
+WHERE a.created_by_user_id = '975464f9-f6f5-4526-ba7e-7b0c50fb231f'
+AND a.submitted_at IS NOT NULL
 """,
     countQuery =
     """
@@ -176,6 +183,7 @@ interface AppSummary {
   fun getCreatedByUserId(): UUID
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?
+  fun getLatestStatusUpdate(): String?
 }
 
 interface Cas2ApplicationSummary : AppSummary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -52,6 +52,7 @@ class ApplicationsTransformer(
         createdAt = jpaSummary.getCreatedAt().toInstant(),
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
         status = getStatusFromSummary(jpaSummary),
+        latestStatusUpdate = jpaSummary.getLatestStatusUpdate(),
         type = "CAS2",
       )
   }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1860,6 +1860,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
           required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6357,6 +6357,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
           required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2420,6 +2420,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
           required:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1908,6 +1908,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -93,6 +93,7 @@ class ApplicationServiceTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getStatusUpdates() = null
       }
 
       PaginationConfig(defaultPageSize = 10).postInit()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -145,8 +145,7 @@ class ApplicationsTransformerTest {
   inner class TransformJpaSummaryToSummary {
 
     @Test
-    fun `transforms an in progress CAS2 application correctly`
-    () {
+    fun `transforms an in progress CAS2 application correctly`() {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
         override fun getCrn() = randomStringMultiCaseWithNumbers(6)
@@ -154,6 +153,7 @@ class ApplicationsTransformerTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
+        override fun getLatestStatusUpdate() = null
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
@@ -164,6 +164,7 @@ class ApplicationsTransformerTest {
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
+      assertThat(result.latestStatusUpdate).isNull()
     }
 
     @Test
@@ -175,6 +176,7 @@ class ApplicationsTransformerTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getLatestStatusUpdate(): String? = "my latest status update"
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
@@ -184,6 +186,7 @@ class ApplicationsTransformerTest {
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+      assertThat(result.latestStatusUpdate).isEqualTo("my latest status update")
     }
   }
 }


### PR DESCRIPTION
[Jira ticket CAS2-370](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-370)

Work in progress branch as I roll off.

We'd like to return the latest status update on an Application to display it in the dashboard.

Unfortunately I've been unable to get the the `ApplicationTransformer` to fetch the `latestStatusUpdate` field, and it keeps returning `null` for this value, despite me updating the SQL query I thought would fix the issue.

Hopefully this is something someone can take on in my absence! Commit messages should have more detail to help pick up the trail.