### PR TITLE
[APS-496] Introduce 'assessment allocated' domain event type

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -63,6 +63,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -55,6 +55,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -64,6 +64,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -57,6 +57,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
+    URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.EventsApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
@@ -110,6 +111,13 @@ class DomainEventsController(
 
   override fun eventsAssessmentAppealedEventIdGet(eventId: UUID): ResponseEntity<AssessmentAppealedEnvelope> {
     val event = domainEventService.getAssessmentAppealedEvent(eventId)
+      ?: throw NotFoundProblem(eventId, "DomainEvent")
+
+    return ResponseEntity.ok(event.data)
+  }
+
+  override fun eventsAssessmentAllocatedEventIdGet(eventId: UUID): ResponseEntity<AssessmentAllocatedEnvelope> {
+    val event = domainEventService.getAssessmentAllocatedEvent(eventId)
       ?: throw NotFoundProblem(eventId, "DomainEvent")
 
     return ResponseEntity.ok(event.data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
@@ -107,6 +108,8 @@ data class DomainEventEntity(
         objectMapper.readValue(this.data, T::class.java)
       T::class == MatchRequestWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN ->
         objectMapper.readValue(this.data, T::class.java)
+      T::class == AssessmentAllocatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED ->
+        objectMapper.readValue(this.data, T::class.java)
       else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${this.type.name}")
     }
 
@@ -134,6 +137,7 @@ enum class DomainEventType {
   APPROVED_PREMISES_BOOKING_CHANGED,
   APPROVED_PREMISES_APPLICATION_WITHDRAWN,
   APPROVED_PREMISES_ASSESSMENT_APPEALED,
+  APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
   APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
   APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
   CAS2_APPLICATION_SUBMITTED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -9,6 +9,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocato
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedAssessedBy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
@@ -54,6 +56,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -80,6 +83,7 @@ class AssessmentService(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   private val taskDeadlineService: TaskDeadlineService,
   private val assessmentEmailService: Cas1AssessmentEmailService,
+  @Value("\${url-templates.frontend.assessment}") private val assessmentUrlTemplate: UrlTemplate,
 ) {
   fun getVisibleAssessmentSummariesForUserCAS1(
     user: UserEntity,
@@ -230,6 +234,8 @@ class AssessmentService(
         assessmentEmailService.assessmentAllocated(allocatedUser, assessment.id, application.crn, assessment.dueAt, application.noticeType == Cas1ApplicationTimelinessCategory.emergency)
       }
     }
+
+    createAllocatedDomainEvent(assessment, allocatedUser)
 
     return assessment
   }
@@ -776,6 +782,7 @@ class AssessmentService(
       if (allocatedToUser != null) {
         assessmentEmailService.assessmentDeallocated(allocatedToUser, newAssessment.id, application.crn)
       }
+      createAllocatedDomainEvent(newAssessment, assigneeUser)
     }
 
     return AuthorisableActionResult.Success(
@@ -953,6 +960,62 @@ class AssessmentService(
         message = "",
         createdByUser = user,
         type = type,
+      ),
+    )
+  }
+
+  private fun createAllocatedDomainEvent(assessment: AssessmentEntity, allocatedToUser: UserEntity?) {
+    val allocatedToStaffDetails = allocatedToUser?.let {
+      when (val result = communityApiClient.getStaffUserDetails(allocatedToUser.deliusUsername)) {
+        is ClientResult.Success -> result.body
+        is ClientResult.Failure -> result.throwException()
+      }
+    }
+    val actingUserStaffDetails = when (val result = communityApiClient.getStaffUserDetails(userService.getUserForRequest().deliusUsername)) {
+      is ClientResult.Success -> result.body
+      is ClientResult.Failure -> result.throwException()
+    }
+    val id = UUID.randomUUID()
+    val occurredAt = Instant.now()
+    domainEventService.saveAssessmentAllocatedEvent(
+      DomainEvent(
+        id = id,
+        applicationId = assessment.application.id,
+        assessmentId = assessment.id,
+        crn = assessment.application.crn,
+        occurredAt = occurredAt,
+        data = AssessmentAllocatedEnvelope(
+          id = id,
+          timestamp = occurredAt,
+          eventType = "approved-premises.assessment.allocated",
+          eventDetails = AssessmentAllocated(
+            assessmentId = assessment.id,
+            assessmentUrl = assessmentUrlTemplate.resolve("id", assessment.id.toString()),
+            applicationId = assessment.application.id,
+            applicationUrl = applicationUrlTemplate.resolve("id", assessment.application.id.toString()),
+            allocatedAt = Instant.now(),
+            personReference = PersonReference(
+              crn = assessment.application.crn,
+              noms = assessment.application.nomsNumber ?: "Unknown NOMS Number",
+            ),
+            allocatedTo = allocatedToStaffDetails?.let {
+              StaffMember(
+                staffCode = allocatedToStaffDetails.staffCode,
+                staffIdentifier = allocatedToStaffDetails.staffIdentifier,
+                forenames = allocatedToStaffDetails.staff.forenames,
+                surname = allocatedToStaffDetails.staff.surname,
+                username = allocatedToStaffDetails.username,
+              )
+            },
+            allocatedBy = StaffMember(
+              staffCode = actingUserStaffDetails.staffCode,
+              staffIdentifier = actingUserStaffDetails.staffIdentifier,
+              forenames = actingUserStaffDetails.staff.forenames,
+              surname = actingUserStaffDetails.staff.surname,
+              username = actingUserStaffDetails.username,
+            ),
+          ),
+        ),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -107,6 +107,7 @@ class ApplicationTimelineTransformer(
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> TimelineEventType.approvedPremisesBookingChanged
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> TimelineEventType.approvedPremisesApplicationWithdrawn
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> TimelineEventType.approvedPremisesAssessmentAppealed
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> TimelineEventType.approvedPremisesAssessmentAllocated
       DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> TimelineEventType.approvedPremisesPlacementApplicationWithdrawn
       DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> TimelineEventType.approvedPremisesMatchRequestWithdrawn
       else -> throw IllegalArgumentException("Cannot map $domainEventType, only CAS1 is currently supported")

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3462,6 +3462,7 @@ components:
         - approved_premises_application_withdrawn
         - approved_premises_information_request
         - approved_premises_assessment_appealed
+        - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
         - cas3_person_arrived

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7964,6 +7964,7 @@ components:
         - approved_premises_application_withdrawn
         - approved_premises_information_request
         - approved_premises_assessment_appealed
+        - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
         - cas3_person_arrived

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4022,6 +4022,7 @@ components:
         - approved_premises_application_withdrawn
         - approved_premises_information_request
         - approved_premises_assessment_appealed
+        - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
         - cas3_person_arrived

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3553,6 +3553,7 @@ components:
         - approved_premises_application_withdrawn
         - approved_premises_information_request
         - approved_premises_assessment_appealed
+        - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
         - cas3_person_arrived

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1416,7 +1416,6 @@ components:
         - applicationId
         - applicationUrl
         - personReference
-        - allocatedBy
         - allocatedAt
     AssessmentAppealedEnvelope:
       type: object

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -58,6 +58,33 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /events/assessment-allocated/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Apply' events"
+      summary: An assessment-allocated event
+      responses:
+        '200':
+          description: The assessment-allocated event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentAllocatedEnvelope'
+        404:
+          description: No assessment-allocated event found for the provided `eventId`
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /events/application-assessed/{eventId}:
     parameters:
       - name: eventId
@@ -409,6 +436,15 @@ components:
       description: The URL on the Approved Premises service at which a user can view a representation of an AP application and related resources, including bookings
       type: string
       example: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/484b8b5e-6c3b-4400-b200-425bbe410713
+    AssessmentId:
+      description: The UUID of an assessment of an application for an AP place
+      type: string
+      format: uuid
+      example: 484b8b5e-6c3b-4400-b200-425bbe410713
+    AssessmentUrl:
+      description: The URL on the Approved Premises service at which a user can view a representation of an AP assessment and related resources, including bookings
+      type: string
+      example: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/484b8b5e-6c3b-4400-b200-425bbe410713
     AppealId:
       description: The UUID of an appeal for an application
       type: string
@@ -1334,6 +1370,54 @@ components:
         - reason
         - legacyReasonCode
         - destination
+    AssessmentAllocatedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.assessment.allocated
+        eventDetails:
+          $ref: '#/components/schemas/AssessmentAllocated'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
+    AssessmentAllocated:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/AssessmentId'
+        assessmentUrl:
+          $ref: '#/components/schemas/AssessmentUrl'
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        allocatedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+        allocatedTo:
+          $ref: '#/components/schemas/StaffMember'
+        allocatedBy:
+          $ref: '#/components/schemas/StaffMember'
+      required:
+        - assessmentId
+        - assessmentUrl
+        - applicationId
+        - applicationUrl
+        - personReference
+        - allocatedBy
+        - allocatedAt
     AssessmentAppealedEnvelope:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAllocatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAllocatedFactory.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.util.UUID
+
+class AssessmentAllocatedFactory : Factory<AssessmentAllocated> {
+  private var assessmentId: Yielded<UUID> = { UUID.randomUUID() }
+  private var assessmentUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
+  private var allocatedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
+  private var allocatedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var allocatedTo: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
+
+  fun withAssessmentId(assessmentId: UUID) = apply {
+    this.assessmentId = { assessmentId }
+  }
+
+  fun withAssessmentUrl(assessmentUrl: String) = apply {
+    this.assessmentUrl = { assessmentUrl }
+  }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withApplicationUrl(applicationUrl: String) = apply {
+    this.applicationUrl = { applicationUrl }
+  }
+
+  fun withPersonReference(personReference: PersonReference) = apply {
+    this.personReference = { personReference }
+  }
+
+  fun withAllocatedAt(allocatedAt: Instant) = apply {
+    this.allocatedAt = { allocatedAt }
+  }
+
+  fun withAllocatedBy(allocatedBy: StaffMember) = apply {
+    this.allocatedBy = { allocatedBy }
+  }
+
+  fun withAllocatedTo(allocatedTo: StaffMember) = apply {
+    this.allocatedTo = { allocatedTo }
+  }
+
+  override fun produce() = AssessmentAllocated(
+    assessmentId = this.assessmentId(),
+    assessmentUrl = this.assessmentUrl(),
+    applicationId = this.applicationId(),
+    applicationUrl = this.applicationUrl(),
+    personReference = this.personReference(),
+    allocatedAt = this.allocatedAt(),
+    allocatedBy = this.allocatedBy(),
+    allocatedTo = this.allocatedTo(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAllocatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/AssessmentAllocatedFactory.kt
@@ -17,7 +17,7 @@ class AssessmentAllocatedFactory : Factory<AssessmentAllocated> {
   private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
   private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
   private var allocatedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
-  private var allocatedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var allocatedBy: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
   private var allocatedTo: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
 
   fun withAssessmentId(assessmentId: UUID) = apply {
@@ -44,11 +44,11 @@ class AssessmentAllocatedFactory : Factory<AssessmentAllocated> {
     this.allocatedAt = { allocatedAt }
   }
 
-  fun withAllocatedBy(allocatedBy: StaffMember) = apply {
+  fun withAllocatedBy(allocatedBy: StaffMember?) = apply {
     this.allocatedBy = { allocatedBy }
   }
 
-  fun withAllocatedTo(allocatedTo: StaffMember) = apply {
+  fun withAllocatedTo(allocatedTo: StaffMember?) = apply {
     this.allocatedTo = { allocatedTo }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Placeme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationSubmittedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationWithdrawnFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAllocatedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
@@ -725,6 +727,53 @@ class DomainEventTest : IntegrationTestBase() {
       .expectStatus()
       .isOk
       .expectBody(PlacementApplicationWithdrawnEnvelope::class.java)
+      .returnResult()
+
+    assertThat(response.responseBody).isEqualTo(envelopedData)
+  }
+
+  fun `Get Assessment Allocated event without ROLE_APPROVED_PREMISES_EVENTS returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+    )
+
+    webTestClient.get()
+      .uri("/events/assessment-allocated/e4b004f8-bdb2-4bf6-9958-db602be71ed3")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Get Assessment Allocated Event returns 200 with correct body`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
+    )
+
+    val eventId = UUID.randomUUID()
+
+    val envelopedData = AssessmentAllocatedEnvelope(
+      id = eventId,
+      timestamp = Instant.now(),
+      eventType = "approved-premises.assessment.allocated",
+      eventDetails = AssessmentAllocatedFactory().produce(),
+    )
+
+    val event = domainEventFactory.produceAndPersist {
+      withId(eventId)
+      withType(DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED)
+      withData(objectMapper.writeValueAsString(envelopedData))
+    }
+
+    val response = webTestClient.get()
+      .uri("/events/assessment-allocated/${event.id}")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(AssessmentAllocatedEnvelope::class.java)
       .returnResult()
 
     assertThat(response.responseBody).isEqualTo(envelopedData)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
@@ -44,7 +44,7 @@ class SnsDomainEventListener(private val objectMapper: ObjectMapper) {
     }
 
     synchronized(messages) {
-      return messages.first()
+      return messages.removeFirst()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -2764,13 +2764,18 @@ class AssessmentServiceTest {
     }
   }
 
-  private fun assertStaffMemberDetailsMatch(staffMember: StaffMember, staffDetails: StaffUserDetails) = staffMember.staffCode == staffDetails.staffCode &&
-    staffMember.staffIdentifier == staffDetails.staffIdentifier &&
-    staffMember.forenames == staffDetails.staff.forenames &&
-    staffMember.surname == staffDetails.staff.surname &&
-    staffMember.username == staffDetails.username
+  private fun assertStaffMemberDetailsMatch(staffMember: StaffMember?, staffDetails: StaffUserDetails?) = when {
+    staffMember == null -> staffDetails == null
+    else ->
+      staffDetails != null &&
+        staffMember.staffCode == staffDetails.staffCode &&
+        staffMember.staffIdentifier == staffDetails.staffIdentifier &&
+        staffMember.forenames == staffDetails.staff.forenames &&
+        staffMember.surname == staffDetails.staff.surname &&
+        staffMember.username == staffDetails.username
+  }
 
-  private fun assertAllocationDomainEventSent(assessment: AssessmentEntity, actingUserStaffDetails: StaffUserDetails, assigneeUserStaffDetails: StaffUserDetails?) {
+  private fun assertAllocationDomainEventSent(assessment: AssessmentEntity, actingUserStaffDetails: StaffUserDetails?, assigneeUserStaffDetails: StaffUserDetails?) {
     verify(exactly = 1) {
       domainEventServiceMock.saveAssessmentAllocatedEvent(
         match {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -67,6 +67,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -127,6 +128,7 @@ class AssessmentServiceTest {
     UrlTemplate("http://frontend/applications/#id"),
     taskDeadlineServiceMock,
     assessmentEmailServiceMock,
+    UrlTemplate("http://frontend/assessments/#id"),
   )
 
   @Test
@@ -1896,6 +1898,7 @@ class AssessmentServiceTest {
   @ValueSource(booleans = [true, false])
   fun `reallocateAssessment for Approved Premises returns Success, deallocates old assessment and creates a new one, sends allocation email & deallocation email`(createdFromAppeal: Boolean) {
     val assigneeUser = UserEntityFactory()
+      .withDeliusUsername("Assignee User")
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
           .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -1944,6 +1947,17 @@ class AssessmentServiceTest {
 
     val dueAt = OffsetDateTime.now()
 
+    val actingUser = UserEntityFactory()
+      .withDeliusUsername("Acting User")
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }.produce()
+
+    val assigneeUserStaffDetails = StaffUserDetailsFactory().produce()
+    val actingUserStaffDetails = StaffUserDetailsFactory().produce()
+
     every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -1959,6 +1973,14 @@ class AssessmentServiceTest {
     every { assessmentEmailServiceMock.assessmentDeallocated(any(), any(), any()) } just Runs
 
     every { taskDeadlineServiceMock.getDeadline(any<ApprovedPremisesAssessmentEntity>()) } returns dueAt
+
+    every { communityApiClientMock.getStaffUserDetails(assigneeUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, assigneeUserStaffDetails)
+
+    every { userServiceMock.getUserForRequest() } returns actingUser
+
+    every { communityApiClientMock.getStaffUserDetails(actingUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, actingUserStaffDetails)
+
+    every { domainEventServiceMock.saveAssessmentAllocatedEvent(any()) } just Runs
 
     val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
 
@@ -1991,6 +2013,8 @@ class AssessmentServiceTest {
         application.crn,
       )
     }
+
+    assertAllocationDomainEventSent(newAssessment, actingUserStaffDetails, assigneeUserStaffDetails)
   }
 
   @Test
@@ -2236,6 +2260,7 @@ class AssessmentServiceTest {
       UrlTemplate("http://frontend/applications/#id"),
       taskDeadlineServiceMock,
       assessmentEmailServiceMock,
+      UrlTemplate("http://frontend/assessments/#id"),
     )
 
     private val user = UserEntityFactory()
@@ -2424,6 +2449,37 @@ class AssessmentServiceTest {
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
     }
+  }
+
+  @Nested
+  inner class CreateAssessments {
+    private val apSchema = ApprovedPremisesAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}",
+    )
+
+    private val taSchema = TemporaryAccommodationAssessmentJsonSchemaEntity(
+      id = UUID.randomUUID(),
+      addedAt = OffsetDateTime.now(),
+      schema = "{}",
+    )
+
+    private val actingUser = UserEntityFactory()
+      .withDeliusUsername("Acting User")
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }.produce()
+
+    @BeforeEach
+    fun setup() {
+      every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns apSchema
+      every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) } returns taSchema
+
+      every { jsonSchemaServiceMock.validate(apSchema, "{\"test\": \"data\"}") } returns true
+    }
 
     @ParameterizedTest
     @CsvSource(
@@ -2475,6 +2531,9 @@ class AssessmentServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
+      val assigneeUserStaffDetails = StaffUserDetailsFactory().produce()
+      val actingUserStaffDetails = StaffUserDetailsFactory().produce()
+
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
       every { userAllocatorMock.getUserForAssessmentAllocation(any()) } returns userWithLeastAllocatedAssessments
@@ -2487,9 +2546,18 @@ class AssessmentServiceTest {
         every { assessmentEmailServiceMock.assessmentAllocated(any(), any(), any(), any(), any()) } just Runs
       }
 
-      assessmentService.createApprovedPremisesAssessment(application, createdFromAppeal)
+      every { communityApiClientMock.getStaffUserDetails(userWithLeastAllocatedAssessments.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, assigneeUserStaffDetails)
+
+      every { userServiceMock.getUserForRequest() } returns actingUser
+
+      every { communityApiClientMock.getStaffUserDetails(actingUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, actingUserStaffDetails)
+
+      every { domainEventServiceMock.saveAssessmentAllocatedEvent(any()) } just Runs
+
+      val assessment = assessmentService.createApprovedPremisesAssessment(application, createdFromAppeal)
 
       verify { assessmentRepositoryMock.save(match { it.allocatedToUser == userWithLeastAllocatedAssessments && it.dueAt == dueAt }) }
+
       if (createdFromAppeal) {
         verify(exactly = 1) {
           assessmentEmailServiceMock.appealedAssessmentAllocated(
@@ -2509,6 +2577,8 @@ class AssessmentServiceTest {
           )
         }
       }
+
+      assertAllocationDomainEventSent(assessment, actingUserStaffDetails, assigneeUserStaffDetails)
     }
 
     @Test
@@ -2528,7 +2598,7 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as TemporaryAccommodationAssessmentEntity }
 
-      every { userServiceMock.getUserForRequest() } returns user
+      every { userServiceMock.getUserForRequest() } returns actingUser
       every { assessmentReferralHistoryNoteRepositoryMock.save(any()) } returnsArgument 0
 
       val summaryData = object {
@@ -2538,7 +2608,7 @@ class AssessmentServiceTest {
 
       val result = assessmentService.createTemporaryAccommodationAssessment(application, summaryData)
 
-      assertAssessmentHasSystemNote(result, user, ReferralHistorySystemNoteType.SUBMITTED)
+      assertAssessmentHasSystemNote(result, actingUser, ReferralHistorySystemNoteType.SUBMITTED)
       assertThat(result.summaryData).isEqualTo("{\"num\":50,\"text\":\"Hello world!\"}")
 
       verify { assessmentRepositoryMock.save(match { it.application == application }) }
@@ -2691,6 +2761,48 @@ class AssessmentServiceTest {
           withdrawingUser = withdrawingUser,
         )
       }
+    }
+  }
+
+  private fun assertStaffMemberDetailsMatch(staffMember: StaffMember, staffDetails: StaffUserDetails) = staffMember.staffCode == staffDetails.staffCode &&
+    staffMember.staffIdentifier == staffDetails.staffIdentifier &&
+    staffMember.forenames == staffDetails.staff.forenames &&
+    staffMember.surname == staffDetails.staff.surname &&
+    staffMember.username == staffDetails.username
+
+  private fun assertAllocationDomainEventSent(assessment: AssessmentEntity, actingUserStaffDetails: StaffUserDetails, assigneeUserStaffDetails: StaffUserDetails?) {
+    verify(exactly = 1) {
+      domainEventServiceMock.saveAssessmentAllocatedEvent(
+        match {
+          val envelope = it.data
+          val eventDetails = envelope.eventDetails
+
+          val rootDomainEventDataMatches = (
+            it.assessmentId == assessment.id &&
+              it.applicationId == assessment.application.id &&
+              it.crn == assessment.application.crn
+            )
+
+          val envelopeMatches = envelope.eventType == "approved-premises.assessment.allocated"
+
+          val allocatedToUserDetailsMatch = assigneeUserStaffDetails?.let {
+            assertStaffMemberDetailsMatch(eventDetails.allocatedTo!!, assigneeUserStaffDetails)
+          } ?: true
+
+          val allocatedByUserDetailsMatch = assertStaffMemberDetailsMatch(eventDetails.allocatedBy, actingUserStaffDetails)
+
+          val eventDetailsMatch = (
+            eventDetails.assessmentId == assessment.id &&
+              eventDetails.assessmentUrl == "http://frontend/assessments/${assessment.id}" &&
+              eventDetails.personReference.crn == assessment.application.crn &&
+              eventDetails.personReference.noms == assessment.application.nomsNumber!! &&
+              allocatedToUserDetailsMatch &&
+              allocatedByUserDetailsMatch
+            )
+
+          rootDomainEventDataMatches && envelopeMatches && eventDetailsMatch
+        },
+      )
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -110,6 +110,7 @@ class AcceptAssessmentTest {
     UrlTemplate("http://frontend/applications/#id"),
     taskDeadlineServiceMock,
     assessmentEmailServiceMock,
+    UrlTemplate("http://frontend/assessments/#id"),
   )
 
   lateinit var user: UserEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -273,6 +273,9 @@ class ApplicationTimelineTransformerTest {
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED to TimelineEventType.approvedPremisesBookingChanged,
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN to TimelineEventType.approvedPremisesApplicationWithdrawn,
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED to TimelineEventType.approvedPremisesAssessmentAppealed,
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED to TimelineEventType.approvedPremisesAssessmentAllocated,
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN to TimelineEventType.approvedPremisesPlacementApplicationWithdrawn,
+      DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN to TimelineEventType.approvedPremisesMatchRequestWithdrawn,
     )
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -133,6 +133,7 @@ url-templates:
       booking-changed-event-detail: http://api/events/booking-changed/#eventId
       application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
       assessment-appealed-event-detail: http://api/events/assessment-appealed/#eventId
+      assessment-allocated-event-detail: http://api/events/assessment-allocated/#eventId
     cas2:
       application-submitted-event-detail: http://api/events/cas2/application-submitted/#eventId
     cas3:


### PR DESCRIPTION
> See [APS-496 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-496).

This PR introduces the `approved-premises.assessment.allocated` domain event type. This is emitted in two scenarios:

1. when an application is submitted and the assessment is first generated; or
2. when the assessment is reallocated.

Additionally, the event contains information about whether the assessment was assigned automatically.