### PR TITLE
(CAS2-377) Fix submitted time shown for CAS2 submitted report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -19,10 +19,7 @@ interface Cas2SubmittedApplicationReportRepository : JpaRepository<DomainEventEn
         events.data -> 'eventDetails' ->> 'preferredAreas' AS preferredAreas,
         CAST(events.data -> 'eventDetails' ->> 'hdcEligibilityDate' as DATE) AS hdcEligibilityDate,
         CAST(events.data -> 'eventDetails' ->> 'conditionalReleaseDate' as DATE) AS conditionalReleaseDate,
-        TO_CHAR(
-          CAST(events.data -> 'eventDetails' ->> 'submittedAt' AS TIMESTAMP),
-          'YYYY-MM-DD"T"HH24:MI:SS'
-        ) AS submittedAt,
+        TO_CHAR(events.occurred_at,'YYYY-MM-DD"T"HH24:MI:SS') AS submittedAt,
         TO_CHAR(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS startedAt
       FROM domain_events events
       JOIN cas_2_applications applications

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UpstreamApiExcep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
-import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
@@ -285,7 +284,7 @@ class ApplicationService(
             applicationId = application.id,
             applicationUrl = applicationUrlTemplate
               .replace("#id", application.id.toString()),
-            submittedAt = Instant.now(),
+            submittedAt = eventOccurredAt.toInstant(),
             personReference = PersonReference(
               noms = application.nomsNumber ?: "Unknown NOMS Number",
               crn = application.crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -98,13 +98,13 @@ class Cas2ReportsTest : IntegrationTestBase() {
       val event2Id = UUID.randomUUID()
       val event3Id = UUID.randomUUID()
 
-      val oldSubmitted = Instant.now().minusSeconds(daysInSeconds(365))
-      val oldCreated = oldSubmitted.minusSeconds(daysInSeconds(7))
+      val oldSubmitted = OffsetDateTime.now().minusDays(365)
+      val oldCreated = oldSubmitted.minusDays(7)
 
-      val newerSubmitted = Instant.now().minusSeconds(daysInSeconds(100))
-      val newerCreated = newerSubmitted.minusSeconds(daysInSeconds(7))
+      val newerSubmitted = OffsetDateTime.now().minusDays(100)
+      val newerCreated = newerSubmitted.minusDays(7)
 
-      val tooOldSubmitted = Instant.now().minusSeconds(daysInSeconds(366))
+      val tooOldSubmitted = OffsetDateTime.now().minusDays(366)
       val tooOldCreated = tooOldSubmitted.minusSeconds(daysInSeconds(7))
 
       val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -130,9 +130,9 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedByUser(user1)
         withCrn("CRN_1")
         withNomsNumber("NOMS_1")
-        withCreatedAt(oldCreated.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withCreatedAt(oldCreated)
         withData("{}")
-        withSubmittedAt(oldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withSubmittedAt(oldSubmitted)
       }
 
       val application2 = cas2ApplicationEntityFactory.produceAndPersist {
@@ -141,9 +141,9 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedByUser(user2)
         withCrn("CRN_2")
         withNomsNumber("NOMS_2")
-        withCreatedAt(newerCreated.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withCreatedAt(newerCreated)
         withData("{}")
-        withSubmittedAt(newerSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withSubmittedAt(newerSubmitted)
       }
 
       // outside time limit -- should not feature in report
@@ -151,19 +151,19 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withId(applicationId3)
         withApplicationSchema(applicationSchema)
         withCreatedByUser(user2)
-        withCreatedAt(tooOldCreated.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withCreatedAt(tooOldCreated)
         withData("{}")
-        withSubmittedAt(tooOldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withSubmittedAt(tooOldSubmitted)
       }
 
       val event1Details = Cas2ApplicationSubmittedEventDetailsFactory()
-        .withSubmittedAt(oldSubmitted)
+        .withSubmittedAt(oldSubmitted.toInstant())
         .produce()
       val event2Details = Cas2ApplicationSubmittedEventDetailsFactory()
-        .withSubmittedAt(newerSubmitted)
+        .withSubmittedAt(newerSubmitted.toInstant())
         .produce()
       val event3Details = Cas2ApplicationSubmittedEventDetailsFactory()
-        .withSubmittedAt(tooOldSubmitted)
+        .withSubmittedAt(tooOldSubmitted.toInstant())
         .produce()
 
       val event1ToSave = Cas2ApplicationSubmittedEvent(
@@ -191,7 +191,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withId(event1Id)
         withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
         withData(objectMapper.writeValueAsString(event1ToSave))
-        withOccurredAt(oldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withOccurredAt(oldSubmitted)
         withApplicationId(applicationId1)
       }
 
@@ -199,7 +199,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withId(event2Id)
         withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
         withData(objectMapper.writeValueAsString(event2ToSave))
-        withOccurredAt(newerSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withOccurredAt(newerSubmitted)
         withApplicationId(applicationId2)
       }
 
@@ -209,7 +209,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withId(event3Id)
         withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
         withData(objectMapper.writeValueAsString(event3ToSave))
-        withOccurredAt(tooOldSubmitted.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+        withOccurredAt(tooOldSubmitted)
         withApplicationId(applicationId3)
       }
 
@@ -223,7 +223,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           preferredAreas = event2Details.preferredAreas.toString(),
           hdcEligibilityDate = event2Details.hdcEligibilityDate.toString(),
           conditionalReleaseDate = event2Details.conditionalReleaseDate.toString(),
-          submittedAt = event2Details.submittedAt.toString().split(".").first(),
+          submittedAt = event2.occurredAt.toString().split(".").first(),
           submittedBy = event2Details.submittedBy.staffMember.username.toString(),
           startedAt = application2.createdAt.toString().split(".").first(),
         ),
@@ -236,7 +236,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           preferredAreas = event1Details.preferredAreas.toString(),
           hdcEligibilityDate = event1Details.hdcEligibilityDate.toString(),
           conditionalReleaseDate = event1Details.conditionalReleaseDate.toString(),
-          submittedAt = event1Details.submittedAt.toString().split(".").first(),
+          submittedAt = event1.occurredAt.toString().split(".").first(),
           submittedBy = event1Details.submittedBy.staffMember.username.toString(),
           startedAt = application1.createdAt.toString().split(".").first(),
         ),


### PR DESCRIPTION
We were previously using the `Instant` created on
the event data, which did not take into account
timezones/british summer time.

Using the `occurred_at` timestamp means we are
using an OffsetDatetime/ `TIMESTAMP WITH TIMEZONE` which is the same format used for
`application.created_at` and means it should
reflect the correct local time at which the event
happened. It also means we don't have to dig into
the JSON data to find the the timestamp.

This change is happening in the SQL query itself - we don't have unit tests for these queries, and
it's difficult to test in integration tests, see
this commit for information
https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/260b1c6ded66c71d8495eca6512d9663be0dfe9e

But I think we have enough confidence by checking
that the `createdAt` of the report matches the
`occurredAt` of the event entity.

I've also tidied up the tests to use less verbose
means of getting timestamp.