### PR TITLE
[CAS-291]-Backfill the bedspace end date as current date for archived premises

### DIFF
--- a/src/main/resources/db/migration/all/20240402174247__backfill_bed_enddate_for_archived_premises.sql
+++ b/src/main/resources/db/migration/all/20240402174247__backfill_bed_enddate_for_archived_premises.sql
@@ -1,0 +1,9 @@
+UPDATE beds
+SET end_date = CURRENT_DATE
+WHERE end_date IS NULL
+AND room_id IN (
+	SELECT distinct(r.id)
+	FROM ROOMS r
+	JOIN PREMISES p ON (p.id=r.premises_id)
+	WHERE p.SERVICE='temporary-accommodation' AND p.STATUS='archived'
+);


### PR DESCRIPTION
This PR is to back-fill the bedSpace end-date for the CAS3 premises which are already `archived`.