### PR TITLE
ASP-594 Add correct personalisation for PR withdrawn email

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -34,6 +34,7 @@ class Cas1PlacementRequestEmailService(
       "applicationArea" to application.apArea?.name,
       "startDate" to placementRequest.expectedArrival.toString(),
       "endDate" to placementRequest.expectedDeparture().toString(),
+      "additionalDatesSet" to "no",
     )
 
     if (withdrawingUser != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -193,6 +193,7 @@ class Cas1PlacementRequestEmailServiceTest {
         "applicationArea" to AREA_NAME,
         "startDate" to placementRequest.expectedArrival.toString(),
         "endDate" to placementRequest.expectedDeparture().toString(),
+        "additionalDatesSet" to "no",
       ),
     )
   }
@@ -227,6 +228,7 @@ class Cas1PlacementRequestEmailServiceTest {
         "startDate" to placementRequest.expectedArrival.toString(),
         "endDate" to placementRequest.expectedDeparture().toString(),
         "withdrawnBy" to WITHDRAWING_USER_NAME,
+        "additionalDatesSet" to "no",
       ),
     )
   }


### PR DESCRIPTION
The ‘additionalDateSet’ personalisation was missing, but is used in the template.

This is only an issue for withdrawal emails related to the original application dates