### PR TITLE
APS-594 Log in sentry if email has missing personalisation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SentryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SentryService.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import io.sentry.Sentry
+import org.springframework.stereotype.Service
+
+@Service
+class SentryService {
+  fun captureException(throwable: Throwable) {
+    Sentry.captureException(throwable)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/EmailNotificationServiceTest.kt
@@ -6,6 +6,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.slf4j.Logger
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
@@ -17,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NotifyGuestLi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SendEmailRequestedEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 
@@ -25,6 +28,7 @@ class EmailNotificationServiceTest {
   private val mockGuestListNotificationClient = mockk<NotificationClient>()
   private val mockNotifyGuestListUserRepository = mockk<NotifyGuestListUserRepository>()
   private val mockApplicationEventPublisher = mockk<ApplicationEventPublisher>()
+  private val mockSentryService = mockk<SentryService>()
 
   @Test
   fun `sendEmail does not send an email if feature flag is set to DISABLED`() {
@@ -239,7 +243,7 @@ class EmailNotificationServiceTest {
   @Test
   fun `sendEmail logs an error if the notification fails`() {
     val logger = mockk<Logger>()
-    val exception = mockk<NotificationClientException>()
+    val exception = NotificationClientException("oh dear")
     val emailNotificationService = createServiceWithConfig {
       mode = NotifyMode.ENABLED
     }
@@ -276,6 +280,63 @@ class EmailNotificationServiceTest {
 
     verify {
       logger.error("Unable to send template $templateId to user ${user.email}", exception)
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    quoteCharacter = '\'',
+    textBlock = """
+    'Status code: 400 {"errors":[{"error":"BadRequestError","message":"Missing personalisation: applicationUrl"}],"status_code":400}', true
+    'Status code: 400 {"errors":[{"error":"BadRequestError","message":"Missing personalisation: additionalDatesSet"}],"status_code":400}', true
+    'Status code: 400 {"errors":[{"error":"BadRequestError","message":"Can\\u2019t send to this recipient using a team-only API key"}],"status_code":400}', false
+    'Status code: 400 {"errors":[{"error":"ValidationError","message":"email_address Not a valid email address"}],"status_code":400}',false""",
+  )
+  fun `sendEmail logs exception in sentry if there is a personalisation error`(
+    message: String,
+    shouldRaiseInSentry: Boolean,
+  ) {
+    val logger = mockk<Logger>()
+    val exception = NotificationClientException(message)
+    val emailNotificationService = createServiceWithConfig {
+      mode = NotifyMode.ENABLED
+    }
+    emailNotificationService.log = logger
+
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val templateId = "f3d78814-383f-4b5f-a681-9bd3ab912888"
+    val personalisation = mapOf(
+      "name" to "Jim",
+      "assessmentUrl" to "https://frontend/assessment/73eff3e8-d2f0-434f-a776-4f975b891444",
+    )
+
+    every { mockApplicationEventPublisher.publishEvent(any(SendEmailRequestedEvent::class)) } returns Unit
+    every {
+      mockNormalNotificationClient.sendEmail(
+        "f3d78814-383f-4b5f-a681-9bd3ab912888",
+        user.email,
+        personalisation,
+        null,
+        null,
+      )
+    } throws exception
+
+    every { mockSentryService.captureException(any()) } returns Unit
+    every { logger.error(any<String>(), any()) } returns Unit
+
+    emailNotificationService.sendEmail(
+      recipientEmailAddress = user.email!!,
+      templateId = templateId,
+      personalisation = personalisation,
+    )
+
+    if (shouldRaiseInSentry) {
+      verify { mockSentryService.captureException(exception) }
+    } else {
+      verify { mockSentryService wasNot Called }
     }
   }
 
@@ -373,5 +434,6 @@ class EmailNotificationServiceTest {
     normalNotificationClient = mockNormalNotificationClient,
     guestListNotificationClient = mockGuestListNotificationClient,
     applicationEventPublisher = mockApplicationEventPublisher,
+    sentryService = mockSentryService,
   )
 }


### PR DESCRIPTION
Whilst some exceptions if notify can be ignored (e.g. user not on guest list for test environments, invalid email address), we should be raising alerts if the message sent to notify does not include all of the personalisation expected of the corresponding template