### PR TITLE
CAS-295 Add logs for migrate offender name from nDelius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -122,6 +122,7 @@ class MigrationJobService(
           applicationContext.getBean(OffenderService::class.java),
           applicationContext.getBean(EntityManager::class.java),
           pageSize,
+          applicationContext.getBean(MigrationLogger::class.java),
         )
       }
 


### PR DESCRIPTION
This PR [CAS-295](https://dsdmoj.atlassian.net/browse/CAS-295) is:

- To fix the log for the offenders crn been processed 
- Change the exception when the offender is not found in nDelius 

[CAS-295]: https://dsdmoj.atlassian.net/browse/CAS-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ