### PR TITLE
make statusDetails not required for domain events

### DIFF
--- a/src/main/resources/static/cas2-domain-events-api.yml
+++ b/src/main/resources/static/cas2-domain-events-api.yml
@@ -193,7 +193,6 @@ components:
         - name
         - label
         - description
-        - statusDetails
     Cas2StatusDetail:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas2/Cas2StatusFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas2/Cas2StatusFactory.kt
@@ -9,7 +9,7 @@ class Cas2StatusFactory : Factory<Cas2Status> {
   private var name: Yielded<String> = { "moreInfoRequested" }
   private var label: Yielded<String> = { "More information requested" }
   private var description: Yielded<String> = { "More information about the application has been requested" }
-  private var statusDetails = emptyList<Cas2StatusDetail>()
+  private var statusDetails: List<Cas2StatusDetail>? = null
 
   fun withName(name: String) = apply {
     this.name = { name }


### PR DESCRIPTION
This field was previously made required here:
https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1560/files#diff-ede7289ac96e28a0df3cb05d249672fb0be71380ba3278b33c4ce1be19068b23 such that all new status update events would have
a list or empty list of details, but this did not
apply to older events, which is causing the API to error
https://ministryofjustice.sentry.io/issues/5135641959/

By making it not a required field on the API model this should allow the API to return old status
update events. This seems preferrable to
undertaking a risky migration on production data
to set empty lists on any updates that do not have this field.