### PR TITLE
APS-404 Update ApArea backfill to always populate ap area

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
@@ -40,4 +40,36 @@ class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
       assertThat(updatedUser.teamCodes).isEqualTo(listOf("abc"))
     }
   }
+
+  @Test
+  fun `If staff details not found for user (404), fall back to probation region ap area and set team codes to an empty list`() {
+    val apArea = apAreaEntityFactory.produceAndPersist()
+
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withDefaults()
+      withApArea(apArea)
+    }
+
+    `Given a User`(
+      probationRegion = probationRegion,
+      staffUserDetailsConfigBlock = {
+        this.withTeams(
+          listOf(StaffUserTeamMembershipFactory().withCode("abc").produce()),
+        )
+      },
+      mockStaffUserDetailsCall = false,
+    ) { userEntity, _ ->
+
+      userEntity.apArea = null
+      userRepository.save(userEntity)
+      assertThat(userEntity.apArea).isNull()
+      assertThat(userEntity.teamCodes).isNull()
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillUserApArea)
+
+      val updatedUser = userRepository.findByIdOrNull(userEntity.id)!!
+      assertThat(updatedUser.apArea!!.id).isEqualTo(apArea.id)
+      assertThat(updatedUser.teamCodes).isEmpty()
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.util.UUID
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given a User`(
   id: UUID = UUID.randomUUID(),
   staffUserDetailsConfigBlock: (StaffUserDetailsFactory.() -> Unit)? = null,
@@ -19,6 +20,7 @@ fun IntegrationTestBase.`Given a User`(
   qualifications: List<UserQualification> = emptyList(),
   probationRegion: ProbationRegionEntity? = null,
   isActive: Boolean = true,
+  mockStaffUserDetailsCall: Boolean = true,
 ): Pair<UserEntity, String> {
   val staffUserDetailsFactory = StaffUserDetailsFactory()
 
@@ -64,13 +66,18 @@ fun IntegrationTestBase.`Given a User`(
 
   val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt(staffUserDetails.username)
 
-  CommunityAPI_mockSuccessfulStaffUserDetailsCall(
-    staffUserDetails,
-  )
+  if (mockStaffUserDetailsCall) {
+    CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+      staffUserDetails,
+    )
+  } else {
+    mockOAuth2ClientCredentialsCallIfRequired {}
+  }
 
   return Pair(user, jwt)
 }
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given a User`(
   id: UUID = UUID.randomUUID(),
   staffUserDetailsConfigBlock: (StaffUserDetailsFactory.() -> Unit)? = null,
@@ -78,6 +85,7 @@ fun IntegrationTestBase.`Given a User`(
   qualifications: List<UserQualification> = emptyList(),
   probationRegion: ProbationRegionEntity? = null,
   isActive: Boolean = true,
+  mockStaffUserDetailsCall: Boolean = true,
   block: (userEntity: UserEntity, jwt: String) -> Unit,
 ) {
   val (user, jwt) = `Given a User`(
@@ -87,6 +95,7 @@ fun IntegrationTestBase.`Given a User`(
     qualifications,
     probationRegion,
     isActive,
+    mockStaffUserDetailsCall = mockStaffUserDetailsCall,
   )
 
   return block(user, jwt)


### PR DESCRIPTION
Previously the ap area was not populated if the staff details could not be found. Because the user.ap_area_id is required to show the users on the users page, we really need this to be populated with something, even for inactive users.

This change updates the ap area backfill to fall back to probationRegion.apArea where the staff user details cannot be retrieved