### PR TITLE
APS-404 Populate ap_area_id for any new user, regardless of the CAS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -137,7 +137,7 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    val userEntity = userService.getExistingUserOrCreate(name, xServiceName, true)
+    val userEntity = userService.getExistingUserOrCreate(name, true)
     val userTransformed = userTransformer.transformJpaToApi(userEntity, xServiceName)
     return ResponseEntity.ok(userTransformed)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -70,8 +70,7 @@ class UsersSeedJob(
     log.info("Setting roles for ${row.deliusUsername} to exactly ${row.roles.joinToString(",")}, qualifications to exactly: ${row.qualifications.joinToString(",")}")
 
     val user = try {
-      // we assume we're seeding for CAS1 as this is the only service that populates additional fields (ap area, team code)
-      userService.getExistingUserOrCreate(row.deliusUsername, ServiceName.approvedPremises)
+      userService.getExistingUserOrCreate(row.deliusUsername)
     } catch (exception: Exception) {
       throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -68,7 +68,7 @@ class UserService(
     val username = deliusPrincipal.name
     val serviceForRequest = requestContextService.getServiceForRequest()
 
-    val user = getExistingUserOrCreate(username, serviceForRequest)
+    val user = getExistingUserOrCreate(username)
 
     if (serviceForRequest == ServiceName.temporaryAccommodation) {
       if (!user.hasAnyRole(*UserRole.getAllRolesForService(ServiceName.temporaryAccommodation).toTypedArray())) {
@@ -243,7 +243,7 @@ class UserService(
     }
   }
 
-  fun getExistingUserOrCreate(username: String, forService: ServiceName?, throwProblemOn404: Boolean = false): UserEntity {
+  fun getExistingUserOrCreate(username: String, throwProblemOn404: Boolean = false): UserEntity {
     val normalisedUsername = username.uppercase()
 
     val existingUser = userRepository.findByDeliusUsername(normalisedUsername)
@@ -275,11 +275,7 @@ class UserService(
       }
     }
 
-    val apArea = if (forService == ServiceName.approvedPremises) {
-      cas1UserMappingService.determineApArea(staffProbationRegion, staffUserDetails)
-    } else {
-      null
-    }
+    val apArea = cas1UserMappingService.determineApArea(staffProbationRegion, staffUserDetails)
 
     return userRepository.save(
       UserEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
@@ -14,7 +13,7 @@ class UserCaseSensitivityTest : IntegrationTestBase() {
   @Test
   fun `Fetching a user with lowercase username returns the user with normalised uppercase username`() {
     `Given a User` { userEntity, _ ->
-      val returnedUser = userService.getExistingUserOrCreate(userEntity.deliusUsername.lowercase(), ServiceName.approvedPremises)
+      val returnedUser = userService.getExistingUserOrCreate(userEntity.deliusUsername.lowercase())
 
       assertThat(returnedUser.id).isEqualTo(userEntity.id)
     }


### PR DESCRIPTION
Previously we only populated users.ap_area_id for CAS1 users, because we didn’t want logins to fail for CAS3 users if the ap area couldn’t be resolved.

We then realised that this caused an issue when viewing the user management page, as this page list users regardless of which CAS they first logged into, meaning some of these users would not have an ap_area_id value defined. This led to errors as all CAS1 users are assumed to have an ap_area_id defined.

This change ensures that users.ap_area_id will always be populated. A more long term solution is required to ensure that CAS3/2 logins do not have to resolve users.ap_area_id as this is unreleated to these systems