### PR TITLE
Add latest status update to submitted applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -49,8 +49,14 @@ SELECT
     a.crn,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    a.submitted_at as submittedAt,
+    asu.label as latestStatusUpdate
 FROM cas_2_applications a
+LEFT JOIN
+    (SELECT DISTINCT ON (application_id) su.application_id, su.label
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+ON a.id = asu.application_id
 WHERE a.created_by_user_id = :userId
 AND a.submitted_at IS NOT NULL
 ORDER BY createdAt DESC
@@ -177,6 +183,7 @@ interface AppSummary {
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?
   fun getHdcEligibilityDate(): LocalDate?
+  fun getLatestStatusUpdate(): String?
 }
 
 interface Cas2ApplicationSummary : AppSummary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -50,10 +50,12 @@ SELECT
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
     a.submitted_at as submittedAt,
-    asu.label as latestStatusUpdate
+    asu.label as latestStatusUpdateLabel,
+    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
 FROM cas_2_applications a
 LEFT JOIN
-    (SELECT DISTINCT ON (application_id) su.application_id, su.label
+    (SELECT DISTINCT ON (application_id) su.application_id, 
+      su.label, su.status_id
     FROM cas_2_status_updates su
     ORDER BY su.application_id, su.created_at DESC) as asu
 ON a.id = asu.application_id
@@ -183,7 +185,8 @@ interface AppSummary {
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?
   fun getHdcEligibilityDate(): LocalDate?
-  fun getLatestStatusUpdate(): String?
+  fun getLatestStatusUpdateLabel(): String?
+  fun getLatestStatusUpdateStatusId(): UUID?
 }
 
 interface Cas2ApplicationSummary : AppSummary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -52,7 +52,7 @@ class ApplicationsTransformer(
         createdAt = jpaSummary.getCreatedAt().toInstant(),
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
         status = getStatusFromSummary(jpaSummary),
-        latestStatusUpdate = jpaSummary.getLatestStatusUpdate(),
+        latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
         type = "CAS2",
         hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -52,6 +52,7 @@ class ApplicationsTransformer(
         createdAt = jpaSummary.getCreatedAt().toInstant(),
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
         status = getStatusFromSummary(jpaSummary),
+        latestStatusUpdate = jpaSummary.getLatestStatusUpdate(),
         type = "CAS2",
         hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
@@ -34,5 +36,16 @@ class StatusUpdateTransformer(
       name = jpa.statusDetail(jpa.statusUpdate.statusId, jpa.statusDetailId).name,
       label = jpa.label,
     )
+  }
+
+  fun transformJpaSummaryToLatestStatusUpdateApi(jpa: Cas2ApplicationSummary): LatestCas2StatusUpdate? {
+    if (jpa.getLatestStatusUpdateStatusId() !== null) {
+      return LatestCas2StatusUpdate(
+        statusId = jpa.getLatestStatusUpdateStatusId()!!,
+        label = jpa.getLatestStatusUpdateLabel()!!,
+      )
+    } else {
+      return null
+    }
   }
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1875,7 +1875,7 @@ components:
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:
-              type: string
+              $ref: '#/components/schemas/LatestCas2StatusUpdate'
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:
@@ -2046,6 +2046,18 @@ components:
       required:
         - id
         - name
+        - label
+    LatestCas2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
         - label
     ApplicationStatus:
       type: string

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1874,6 +1874,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6376,6 +6376,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6377,7 +6377,7 @@ components:
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:
-              type: string
+              $ref: '#/components/schemas/LatestCas2StatusUpdate'
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:
@@ -6548,6 +6548,18 @@ components:
       required:
         - id
         - name
+        - label
+    LatestCas2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
         - label
     ApplicationStatus:
       type: string

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2434,6 +2434,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2435,7 +2435,7 @@ components:
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:
-              type: string
+              $ref: '#/components/schemas/LatestCas2StatusUpdate'
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:
@@ -2606,6 +2606,18 @@ components:
       required:
         - id
         - name
+        - label
+    LatestCas2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
         - label
     ApplicationStatus:
       type: string

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1965,6 +1965,8 @@ components:
               format: uuid
             status:
               $ref: '#/components/schemas/ApplicationStatus'
+            latestStatusUpdate:
+              type: string
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1966,7 +1966,7 @@ components:
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:
-              type: string
+              $ref: '#/components/schemas/LatestCas2StatusUpdate'
             risks:
               $ref: '#/components/schemas/PersonRisks'
             hdcEligibilityDate:
@@ -2137,6 +2137,18 @@ components:
       required:
         - id
         - name
+        - label
+    LatestCas2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
         - label
     ApplicationStatus:
       type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -444,6 +444,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               }
               // this is the one that should be returned as lastStatusUpdate
               cas2StatusUpdateEntityFactory.produceAndPersist {
+                withStatusId(UUID.fromString("c74c3e54-52d8-4aa2-86f6-05190985efee"))
                 withLabel("more recent status update")
                 withApplication(cas2ApplicationRepository.findById(submittedIds.first()).get())
                 withAssessor(assessor)
@@ -523,7 +524,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
       val uuids = responseBody.map { it.id }.toSet()
       Assertions.assertThat(uuids).isEqualTo(submittedIds)
-      Assertions.assertThat(responseBody[0].latestStatusUpdate).isEqualTo("more recent status update")
+      Assertions.assertThat(responseBody[0].latestStatusUpdate?.label).isEqualTo("more recent status update")
+      Assertions.assertThat(responseBody[0].latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("c74c3e54-52d8-4aa2-86f6-05190985efee"))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -436,6 +436,19 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 )
               }
 
+              // add two status updates to the first submitted application
+              cas2StatusUpdateEntityFactory.produceAndPersist {
+                withLabel("older status update")
+                withApplication(cas2ApplicationRepository.findById(submittedIds.first()).get())
+                withAssessor(assessor)
+              }
+              // this is the one that should be returned as lastStatusUpdate
+              cas2StatusUpdateEntityFactory.produceAndPersist {
+                withLabel("more recent status update")
+                withApplication(cas2ApplicationRepository.findById(submittedIds.first()).get())
+                withAssessor(assessor)
+              }
+
               // create 4 x un-submitted in-progress applications for this user
               repeat(4) {
                 unSubmittedIds.add(
@@ -510,6 +523,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
       val uuids = responseBody.map { it.id }.toSet()
       Assertions.assertThat(uuids).isEqualTo(submittedIds)
+      Assertions.assertThat(responseBody[0].latestStatusUpdate).isEqualTo("more recent status update")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -86,6 +86,7 @@ class ApplicationServiceTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
+        override fun getLatestStatusUpdate(): String? = null
       }
 
       PaginationConfig(defaultPageSize = 10).postInit()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -86,7 +86,8 @@ class ApplicationServiceTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
-        override fun getLatestStatusUpdate(): String? = null
+        override fun getLatestStatusUpdateLabel(): String? = null
+        override fun getLatestStatusUpdateStatusId(): UUID? = null
       }
 
       PaginationConfig(defaultPageSize = 10).postInit()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
@@ -68,6 +69,7 @@ class ApplicationsTransformerTest {
       isActive = user.isActive,
     )
     every { mockStatusUpdateTransformer.transformJpaToApi(any()) } returns mockk<Cas2StatusUpdate>()
+    every { mockStatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns mockk<LatestCas2StatusUpdate>()
     every { mockTimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf()
   }
 
@@ -156,8 +158,11 @@ class ApplicationsTransformerTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
         override fun getHdcEligibilityDate() = null
-        override fun getLatestStatusUpdate() = null
+        override fun getLatestStatusUpdateLabel() = null
+        override fun getLatestStatusUpdateStatusId() = null
       }
+
+      every { mockStatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns null
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
@@ -181,8 +186,14 @@ class ApplicationsTransformerTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
-        override fun getLatestStatusUpdate(): String = "my latest status update"
+        override fun getLatestStatusUpdateStatusId() = UUID.fromString("ae544aee-7170-4794-99fb-703090cbc7db")
+        override fun getLatestStatusUpdateLabel() = "my latest status update"
       }
+
+      every { mockStatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns LatestCas2StatusUpdate(
+        statusId = application.getLatestStatusUpdateStatusId(),
+        label = application.getLatestStatusUpdateLabel(),
+      )
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
@@ -192,7 +203,8 @@ class ApplicationsTransformerTest {
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
       assertThat(result.hdcEligibilityDate).isEqualTo("2023-04-29")
-      assertThat(result.latestStatusUpdate).isEqualTo("my latest status update")
+      assertThat(result.latestStatusUpdate?.label).isEqualTo("my latest status update")
+      assertThat(result.latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("ae544aee-7170-4794-99fb-703090cbc7db"))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -156,6 +156,7 @@ class ApplicationsTransformerTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
         override fun getHdcEligibilityDate() = null
+        override fun getLatestStatusUpdate() = null
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
@@ -167,6 +168,7 @@ class ApplicationsTransformerTest {
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
       assertThat(result.hdcEligibilityDate).isNull()
+      assertThat(result.latestStatusUpdate).isNull()
     }
 
     @Test
@@ -179,6 +181,7 @@ class ApplicationsTransformerTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
+        override fun getLatestStatusUpdate(): String = "my latest status update"
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
@@ -189,6 +192,7 @@ class ApplicationsTransformerTest {
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
       assertThat(result.hdcEligibilityDate).isEqualTo("2023-04-29")
+      assertThat(result.latestStatusUpdate).isEqualTo("my latest status update")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -128,6 +128,7 @@ class SubmissionsTransformerTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
+        override fun getLatestStatusUpdate(): String? = null
       }
 
       val expectedSubmittedApplicationSummary = Cas2SubmittedApplicationSummary(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -128,7 +128,8 @@ class SubmissionsTransformerTest {
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
-        override fun getLatestStatusUpdate(): String? = null
+        override fun getLatestStatusUpdateLabel(): String? = null
+        override fun getLatestStatusUpdateStatusId(): UUID? = null
       }
 
       val expectedSubmittedApplicationSummary = Cas2SubmittedApplicationSummary(


### PR DESCRIPTION
We're working towards displaying the latest status update for submitted applications on a dashboard for users:
![Screenshot 2024-04-04 at 11 35 52](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/f457e3cc-3c2b-43ea-a8d9-2eb71b37a1e2)

This commit adds a nullable `latestStatusUpdate` field to the query used after a GET request to `/applications?isSubmitted=true`.

As an Application can have many Status Updates and we just want the latest one, it's using a LEFT JOIN to go and get the relevant status update connected to each submitted application. 
![Screenshot 2024-04-04 at 11 38 52](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/46e196da-ed0e-4894-bbe4-cf9eebf33fa5)

We will need to do some performance testing to understand more about how efficient this will be - we don't currently have any Gatling setup, so we should do this manually when we have the frontend implementation. This endpoint will always be queried in pages, and from looking at production data most applications have no more than 6 status updates, so we don't think the risk is too high atm.