### PR TITLE
APS-620 Allow for null NOMS Number in appeal domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -1,15 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealed
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -17,26 +10,21 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealEmailService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealDecision as DomainEventApiAppealDecision
 
 @Service
 class AppealService(
   private val appealRepository: AppealRepository,
   private val assessmentService: AssessmentService,
-  private val domainEventService: DomainEventService,
-  private val communityApiClient: CommunityApiClient,
   private val cas1AppealEmailService: Cas1AppealEmailService,
-  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.frontend.application-appeal}") private val applicationAppealUrlTemplate: UrlTemplate,
+  private val cas1AppealDomainEventService: Cas1AppealDomainEventService,
 ) {
   fun getAppeal(appealId: UUID, application: ApplicationEntity): AuthorisableActionResult<AppealEntity> {
     val appeal = appealRepository.findByIdOrNull(appealId)
@@ -90,7 +78,7 @@ class AppealService(
           ),
         )
 
-        saveEvent(appeal)
+        cas1AppealDomainEventService.appealRecordCreated(appeal)
 
         when (decision) {
           AppealDecision.accepted -> {
@@ -106,58 +94,4 @@ class AppealService(
       },
     )
   }
-
-  private fun saveEvent(appeal: AppealEntity) {
-    val id = UUID.randomUUID()
-    val timestamp = appeal.createdAt.toInstant()
-
-    val staffDetails = when (val result = communityApiClient.getStaffUserDetails(appeal.createdBy.deliusUsername)) {
-      is ClientResult.Success -> result.body
-      is ClientResult.Failure -> result.throwException()
-    }
-
-    domainEventService.saveAssessmentAppealedEvent(
-      DomainEvent(
-        id = id,
-        applicationId = appeal.application.id,
-        assessmentId = null,
-        bookingId = null,
-        crn = appeal.application.crn,
-        occurredAt = timestamp,
-        data = AssessmentAppealedEnvelope(
-          id = id,
-          timestamp = timestamp,
-          eventType = "approved-premises.assessment.appealed",
-          eventDetails = AssessmentAppealed(
-            applicationId = appeal.application.id,
-            applicationUrl = applicationUrlTemplate.resolve("id", appeal.application.id.toString()),
-            appealId = appeal.id,
-            appealUrl = applicationAppealUrlTemplate.resolve(
-              mapOf("applicationId" to appeal.application.id.toString(), "appealId" to appeal.id.toString()),
-            ),
-            personReference = PersonReference(
-              crn = appeal.application.crn,
-              noms = appeal.application.nomsNumber!!,
-            ),
-            deliusEventNumber = (appeal.application as ApprovedPremisesApplicationEntity).eventNumber,
-            createdAt = timestamp,
-            createdBy = StaffMember(
-              staffCode = staffDetails.staffCode,
-              staffIdentifier = staffDetails.staffIdentifier,
-              forenames = staffDetails.staff.forenames,
-              surname = staffDetails.staff.surname,
-              username = staffDetails.username,
-            ),
-            appealDetail = appeal.appealDetail,
-            decision = parseDecision(appeal.decision),
-            decisionDetail = appeal.decisionDetail,
-          ),
-        ),
-      ),
-    )
-  }
-
-  private fun parseDecision(value: String): DomainEventApiAppealDecision =
-    DomainEventApiAppealDecision.entries.firstOrNull { it.value == value }
-      ?: throw IllegalArgumentException("Unknown appeal decision type '$value'")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
@@ -54,7 +54,7 @@ class Cas1AppealDomainEventService(
             ),
             personReference = PersonReference(
               crn = appeal.application.crn,
-              noms = appeal.application.nomsNumber!!,
+              noms = appeal.application.nomsNumber ?: "Unknown NOMS Number",
             ),
             deliusEventNumber = (appeal.application as ApprovedPremisesApplicationEntity).eventNumber,
             createdAt = timestamp,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.util.UUID
+
+@Service
+class Cas1AppealDomainEventService(
+  private val domainEventService: DomainEventService,
+  private val communityApiClient: CommunityApiClient,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.application-appeal}") private val applicationAppealUrlTemplate: UrlTemplate,
+) {
+
+  fun appealRecordCreated(appeal: AppealEntity) {
+    val id = UUID.randomUUID()
+    val timestamp = appeal.createdAt.toInstant()
+
+    val staffDetails = when (val result = communityApiClient.getStaffUserDetails(appeal.createdBy.deliusUsername)) {
+      is ClientResult.Success -> result.body
+      is ClientResult.Failure -> result.throwException()
+    }
+
+    domainEventService.saveAssessmentAppealedEvent(
+      DomainEvent(
+        id = id,
+        applicationId = appeal.application.id,
+        assessmentId = null,
+        bookingId = null,
+        crn = appeal.application.crn,
+        occurredAt = timestamp,
+        data = AssessmentAppealedEnvelope(
+          id = id,
+          timestamp = timestamp,
+          eventType = "approved-premises.assessment.appealed",
+          eventDetails = AssessmentAppealed(
+            applicationId = appeal.application.id,
+            applicationUrl = applicationUrlTemplate.resolve("id", appeal.application.id.toString()),
+            appealId = appeal.id,
+            appealUrl = applicationAppealUrlTemplate.resolve(
+              mapOf("applicationId" to appeal.application.id.toString(), "appealId" to appeal.id.toString()),
+            ),
+            personReference = PersonReference(
+              crn = appeal.application.crn,
+              noms = appeal.application.nomsNumber!!,
+            ),
+            deliusEventNumber = (appeal.application as ApprovedPremisesApplicationEntity).eventNumber,
+            createdAt = timestamp,
+            createdBy = StaffMember(
+              staffCode = staffDetails.staffCode,
+              staffIdentifier = staffDetails.staffIdentifier,
+              forenames = staffDetails.staff.forenames,
+              surname = staffDetails.staff.surname,
+              username = staffDetails.username,
+            ),
+            appealDetail = appeal.appealDetail,
+            decision = parseDecision(appeal.decision),
+            decisionDetail = appeal.decisionDetail,
+          ),
+        ),
+      ),
+    )
+  }
+
+  private fun parseDecision(value: String): AppealDecision =
+    AppealDecision.entries.firstOrNull { it.value == value }
+      ?: throw IllegalArgumentException("Unknown appeal decision type '$value'")
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AppealServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
+import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -12,55 +13,39 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EmptySource
 import org.junit.jupiter.params.provider.ValueSource
-import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AppealService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.util.Optional
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealDecision as DomainEventApiAppealDecision
 
 class AppealServiceTest {
   private val appealRepository = mockk<AppealRepository>()
   private val assessmentService = mockk<AssessmentService>()
-  private val domainEventService = mockk<DomainEventService>()
-  private val communityApiClient = mockk<CommunityApiClient>()
   private val cas1AppealEmailService = mockk<Cas1AppealEmailService>()
-  private val applicationUrlTemplate = mockk<UrlTemplate>()
-  private val applicationAppealUrlTemplate = mockk<UrlTemplate>()
+  private val cas1AppealDomainEventService = mockk<Cas1AppealDomainEventService>()
 
   private val appealService = AppealService(
     appealRepository,
     assessmentService,
-    domainEventService,
-    communityApiClient,
     cas1AppealEmailService,
-    applicationUrlTemplate,
-    applicationAppealUrlTemplate,
+    cas1AppealDomainEventService,
   )
 
   private val probationRegion = ProbationRegionEntityFactory()
@@ -72,10 +57,6 @@ class AppealServiceTest {
 
   private val createdByUser = UserEntityFactory()
     .withProbationRegion(probationRegion)
-    .produce()
-
-  private val staffUserDetails = StaffUserDetailsFactory()
-    .withUsername(createdByUser.deliusUsername)
     .produce()
 
   private val application = ApprovedPremisesApplicationEntityFactory()
@@ -143,6 +124,9 @@ class AppealServiceTest {
       )
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Unauthorised::class.java)
+
+      verify { cas1AppealEmailService wasNot Called }
+      verify { cas1AppealDomainEventService wasNot Called }
     }
 
     @Test
@@ -164,6 +148,9 @@ class AppealServiceTest {
       assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
       val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
       assertThat(resultEntity.validationMessages).containsEntry("$.appealDate", "mustNotBeFuture")
+
+      verify { cas1AppealEmailService wasNot Called }
+      verify { cas1AppealDomainEventService wasNot Called }
     }
 
     @ParameterizedTest
@@ -187,6 +174,9 @@ class AppealServiceTest {
       assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
       val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
       assertThat(resultEntity.validationMessages).containsEntry("$.appealDetail", "empty")
+
+      verify { cas1AppealEmailService wasNot Called }
+      verify { cas1AppealDomainEventService wasNot Called }
     }
 
     @ParameterizedTest
@@ -210,6 +200,9 @@ class AppealServiceTest {
       assertThat(result.entity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
       val resultEntity = result.entity as ValidatableActionResult.FieldValidationError
       assertThat(resultEntity.validationMessages).containsEntry("$.decisionDetail", "empty")
+
+      verify { cas1AppealEmailService wasNot Called }
+      verify { cas1AppealDomainEventService wasNot Called }
     }
 
     @Test
@@ -220,10 +213,7 @@ class AppealServiceTest {
 
       every { appealRepository.save(any()) } returnsArgument 0
       every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
-      every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
-      every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
-      every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
-      every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
+      every { cas1AppealDomainEventService.appealRecordCreated(any()) } just Runs
       every { cas1AppealEmailService.appealSuccess(any(), any()) } returns Unit
 
       mockkStatic(UUID::class) {
@@ -257,47 +247,6 @@ class AppealServiceTest {
     }
 
     @Test
-    fun `Creates a domain event`() {
-      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
-
-      val now = LocalDate.now()
-
-      every { appealRepository.save(any()) } returnsArgument 0
-      every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
-      every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
-      every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
-      every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
-      every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
-      every { cas1AppealEmailService.appealSuccess(any(), any()) } returns Unit
-
-      mockkStatic(UUID::class) {
-        every { UUID.randomUUID() } returns appealId
-
-        val result = appealService.createAppeal(
-          now,
-          "Some information about why the appeal is being made",
-          AppealDecision.accepted,
-          "Some information about the decision made",
-          application,
-          assessment,
-          createdByUser,
-        )
-
-        assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-        result as AuthorisableActionResult.Success
-        assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
-
-        verify(exactly = 1) {
-          domainEventService.saveAssessmentAppealedEvent(
-            match {
-              it.matches()
-            },
-          )
-        }
-      }
-    }
-
-    @Test
     fun `Does not create a new assessment if the appeal was rejected`() {
       createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
 
@@ -305,10 +254,7 @@ class AppealServiceTest {
 
       every { appealRepository.save(any()) } returnsArgument 0
       every { assessmentService.createApprovedPremisesAssessment(any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
-      every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
-      every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
-      every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
-      every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
+      every { cas1AppealDomainEventService.appealRecordCreated(any()) } just Runs
       every { cas1AppealEmailService.appealFailed(any()) } returns Unit
 
       mockkStatic(UUID::class) {
@@ -328,9 +274,9 @@ class AppealServiceTest {
         result as AuthorisableActionResult.Success
         assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
 
-        verify(exactly = 0) {
-          assessmentService.createApprovedPremisesAssessment(any())
-        }
+        verify { assessmentService wasNot Called }
+        verify(exactly = 0) { cas1AppealEmailService.appealSuccess(any(), any()) }
+        verify { cas1AppealDomainEventService.appealRecordCreated(any()) }
       }
     }
 
@@ -342,10 +288,7 @@ class AppealServiceTest {
 
       every { appealRepository.save(any()) } returnsArgument 0
       every { assessmentService.createApprovedPremisesAssessment(any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
-      every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
-      every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
-      every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
-      every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
+      every { cas1AppealDomainEventService.appealRecordCreated(any()) } just Runs
       every { cas1AppealEmailService.appealFailed(any()) } returns Unit
 
       mockkStatic(UUID::class) {
@@ -365,24 +308,21 @@ class AppealServiceTest {
         result as AuthorisableActionResult.Success
         assertThat(result.entity).isInstanceOf(ValidatableActionResult.Success::class.java)
 
-        verify(exactly = 1) {
-          cas1AppealEmailService.appealFailed(application)
-        }
+        verify(exactly = 1) { cas1AppealEmailService.appealFailed(application) }
+        verify(exactly = 0) { cas1AppealEmailService.appealSuccess(any(), any()) }
+        verify { cas1AppealDomainEventService.appealRecordCreated(any()) }
       }
     }
 
     @Test
-    fun `Creates a new assessment if the appeal was accepted`() {
+    fun `Creates a new assessment if the appeal was accepted and triggers emails and domain events`() {
       createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
 
       val now = LocalDate.now()
 
       every { appealRepository.save(any()) } returnsArgument 0
       every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
-      every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
-      every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
-      every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
-      every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
+      every { cas1AppealDomainEventService.appealRecordCreated(any()) } just Runs
       every { cas1AppealEmailService.appealSuccess(any(), any()) } returns Unit
 
       mockkStatic(UUID::class) {
@@ -405,39 +345,17 @@ class AppealServiceTest {
         verify(exactly = 1) {
           assessmentService.createApprovedPremisesAssessment(application, createdFromAppeal = true)
         }
-      }
-    }
-
-    @Test
-    fun `Sends emails when the appeal was accepted`() {
-      createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
-
-      val now = LocalDate.now()
-
-      every { appealRepository.save(any()) } returnsArgument 0
-      every { assessmentService.createApprovedPremisesAssessment(any(), any()) } returns mockk<ApprovedPremisesAssessmentEntity>()
-      every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
-      every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
-      every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
-      every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
-      every { cas1AppealEmailService.appealSuccess(any(), any()) } returns Unit
-
-      mockkStatic(UUID::class) {
-        every { UUID.randomUUID() } returns appealId
-
-        val result = appealService.createAppeal(
-          now,
-          "Some information about why the appeal is being made",
-          AppealDecision.accepted,
-          "Some information about the decision made",
-          application,
-          assessment,
-          createdByUser,
-        )
 
         verify(exactly = 1) {
           cas1AppealEmailService.appealSuccess(
             application,
+            match { it.application == application && it.createdBy == createdByUser },
+          )
+        }
+        verify(exactly = 0) { cas1AppealEmailService.appealFailed(any()) }
+
+        verify(exactly = 1) {
+          cas1AppealDomainEventService.appealRecordCreated(
             match { it.application == application && it.createdBy == createdByUser },
           )
         }
@@ -453,34 +371,5 @@ class AppealServiceTest {
         this.application == application &&
         this.assessment == assessment &&
         this.createdBy == createdByUser
-
-    private fun DomainEvent<AssessmentAppealedEnvelope>.matches() =
-      this.applicationId == application.id &&
-        this.assessmentId == null &&
-        this.bookingId == null &&
-        this.crn == application.crn &&
-        withinSeconds(10).matches(this.occurredAt.toString()) &&
-        this.data.matches()
-
-    private fun AssessmentAppealedEnvelope.matches() =
-      this.eventDetails.applicationId == application.id &&
-        this.eventDetails.applicationUrl == "http://frontend/applications/${application.id}" &&
-        this.eventDetails.appealId == appealId &&
-        this.eventDetails.appealUrl == "http://frontend/applications/${application.id}/appeals/$appealId" &&
-        this.eventDetails.personReference.crn == application.crn &&
-        this.eventDetails.personReference.noms == application.nomsNumber &&
-        this.eventDetails.deliusEventNumber == application.eventNumber &&
-        withinSeconds(10).matches(this.eventDetails.createdAt.toString()) &&
-        this.eventDetails.createdBy.matches() &&
-        this.eventDetails.appealDetail == "Some information about why the appeal is being made" &&
-        this.eventDetails.decision == DomainEventApiAppealDecision.accepted &&
-        this.eventDetails.decisionDetail == "Some information about the decision made"
-
-    private fun StaffMember.matches() =
-      this.staffCode == staffUserDetails.staffCode &&
-        this.staffIdentifier == staffUserDetails.staffIdentifier &&
-        this.forenames == staffUserDetails.staff.forenames &&
-        this.surname == staffUserDetails.staff.surname &&
-        this.username == staffUserDetails.username
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AppealDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AppealDomainEventServiceTest.kt
@@ -1,0 +1,139 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealDomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1AppealDomainEventServiceTest {
+
+  private val domainEventService = mockk<DomainEventService>()
+  private val communityApiClient = mockk<CommunityApiClient>()
+  private val applicationUrlTemplate = mockk<UrlTemplate>()
+  private val applicationAppealUrlTemplate = mockk<UrlTemplate>()
+
+  private val service = Cas1AppealDomainEventService(
+    domainEventService,
+    communityApiClient,
+    applicationUrlTemplate,
+    applicationAppealUrlTemplate,
+  )
+
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withApArea(
+      ApAreaEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  private val createdByUser = UserEntityFactory()
+    .withProbationRegion(probationRegion)
+    .produce()
+
+  private val staffUserDetails = StaffUserDetailsFactory()
+    .withUsername(createdByUser.deliusUsername)
+    .produce()
+
+  private val application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(createdByUser)
+    .produce()
+
+  private val assessment = ApprovedPremisesAssessmentEntityFactory()
+    .withApplication(application)
+    .produce()
+
+  private val appealId = UUID.randomUUID()
+
+  @Test
+  fun appealRecordCreated() {
+    createdByUser.addRoleForUnitTest(UserRole.CAS1_APPEALS_MANAGER)
+
+    val now = LocalDate.now()
+
+    every { domainEventService.saveAssessmentAppealedEvent(any()) } just Runs
+    every { communityApiClient.getStaffUserDetails(createdByUser.deliusUsername) } returns ClientResult.Success(
+      HttpStatus.OK,
+      staffUserDetails,
+    )
+    every { applicationUrlTemplate.resolve(any(), any()) } returns "http://frontend/applications/${application.id}"
+    every { applicationAppealUrlTemplate.resolve(any()) } returns "http://frontend/applications/${application.id}/appeals/$appealId"
+
+    mockkStatic(UUID::class) {
+      every { UUID.randomUUID() } returns appealId
+
+      service.appealRecordCreated(
+        AppealEntityFactory()
+          .withApplication(application)
+          .withAssessment(assessment)
+          .withAppealDate(now)
+          .withDecision(AppealDecision.accepted)
+          .withCreatedBy(createdByUser)
+          .withAppealDetail("Some information about why the appeal is being made")
+          .withDecisionDetail("Some information about the decision made")
+          .produce(),
+      )
+
+      verify(exactly = 1) {
+        domainEventService.saveAssessmentAppealedEvent(
+          match {
+            it.matches()
+          },
+        )
+      }
+    }
+  }
+
+  fun DomainEvent<AssessmentAppealedEnvelope>.matches() =
+    this.applicationId == application.id &&
+      this.assessmentId == null &&
+      this.bookingId == null &&
+      this.crn == application.crn &&
+      withinSeconds(10).matches(this.occurredAt.toString()) &&
+      this.data.matches()
+
+  private fun AssessmentAppealedEnvelope.matches() =
+    this.eventDetails.applicationId == application.id &&
+      this.eventDetails.applicationUrl == "http://frontend/applications/${application.id}" &&
+      this.eventDetails.appealId == appealId &&
+      this.eventDetails.appealUrl == "http://frontend/applications/${application.id}/appeals/$appealId" &&
+      this.eventDetails.personReference.crn == application.crn &&
+      this.eventDetails.personReference.noms == application.nomsNumber &&
+      this.eventDetails.deliusEventNumber == application.eventNumber &&
+      withinSeconds(10).matches(this.eventDetails.createdAt.toString()) &&
+      this.eventDetails.createdBy.matches() &&
+      this.eventDetails.appealDetail == "Some information about why the appeal is being made" &&
+      this.eventDetails.decision == uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AppealDecision.accepted &&
+      this.eventDetails.decisionDetail == "Some information about the decision made"
+
+  private fun StaffMember.matches() =
+    this.staffCode == staffUserDetails.staffCode &&
+      this.staffIdentifier == staffUserDetails.staffIdentifier &&
+      this.forenames == staffUserDetails.staff.forenames &&
+      this.surname == staffUserDetails.staff.surname &&
+      this.username == staffUserDetails.username
+}


### PR DESCRIPTION
This relates to https://dsdmoj.atlassian.net/browse/APS-620 where the user is getting a null pointer when attempting to create an appear.

This PR also moves the appeals domain event logic into a standalone class