### PR TITLE
APS-621 Make approved_premises.qcode unique

### DIFF
--- a/src/main/resources/db/migration/all/20240408090349__make_ap_q_code_unique.sql
+++ b/src/main/resources/db/migration/all/20240408090349__make_ap_q_code_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_premises ADD CONSTRAINT approved_premises_q_code_unique UNIQUE (q_code);


### PR DESCRIPTION
We had an error in our seeding data that used the same q_code for two approved premises. This change ensures data like this will be refused during any future seeding.