### PR TITLE
APS-568 Update booking domain event descriptions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -28,7 +28,7 @@ class DomainEventDescriber(
       DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> buildPersonDepartedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> buildBookingNotMadeDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> buildBookingCancelledDescription(domainEventSummary)
-      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> "The booking had its arrival or departure date changed"
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> "The placement had its arrival or departure date changed"
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> buildApplicationWithdrawnDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> buildAssessmentAppealedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> buildPlacementApplicationWithdrawnDescription(domainEventSummary)
@@ -55,7 +55,10 @@ class DomainEventDescriber(
 
   private fun buildBookingMadeDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingMadeEvent(domainEventSummary.id())
-    return event.describe { "A booking was made for between ${it.eventDetails.arrivalOn} and ${it.eventDetails.departureOn}" }
+    return event.describe {
+      "A placement at ${it.eventDetails.premises.name} was booked for " +
+        "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()}"
+    }
   }
 
   private fun buildPersonArrivedDescription(domainEventSummary: DomainEventSummary): String? {
@@ -75,12 +78,12 @@ class DomainEventDescriber(
 
   private fun buildBookingNotMadeDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingNotMadeEvent(domainEventSummary.id())
-    return event.describe { "A booking was not made for the placement request. The reason was: ${it.eventDetails.failureDescription}" }
+    return event.describe { "A placement was not made for the placement request. The reason was: ${it.eventDetails.failureDescription}" }
   }
 
   private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
-    return event.describe { "The booking was cancelled. The reason was: '${it.eventDetails.cancellationReason}'" }
+    return event.describe { "The placement was cancelled. The reason was: '${it.eventDetails.cancellationReason}'" }
   }
 
   private fun buildAssessmentAppealedDescription(domainEventSummary: DomainEventSummary): String? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -78,6 +78,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonArrivedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonDepartedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonNotArrivedFactory
@@ -2706,13 +2707,13 @@ class ApplicationTest : IntegrationTestBase() {
         val domainEventDescriptions = listOf(
           "The application was submitted",
           "The application was assessed and accepted",
-          "A booking was made for between 2024-01-01 and 2024-04-01",
+          "A placement at The Premises was booked for Monday 1 January 2024 to Monday 1 April 2024",
           "The person moved into the premises on 2024-01-01",
           "The person was due to move into the premises on 2024-01-01 but did not arrive",
           "The person moved out of the premises on 2024-04-01",
-          "A booking was not made for the placement request. The reason was: no suitable premises",
-          "The booking was cancelled. The reason was: 'additional sentencing'",
-          "The booking had its arrival or departure date changed",
+          "A placement was not made for the placement request. The reason was: no suitable premises",
+          "The placement was cancelled. The reason was: 'additional sentencing'",
+          "The placement had its arrival or departure date changed",
           "The application was assessed and accepted",
         )
 
@@ -2751,13 +2752,13 @@ class ApplicationTest : IntegrationTestBase() {
         val domainEventDescriptions = listOf(
           "The application was submitted",
           "The application was assessed and accepted",
-          "A booking was made for between 2024-01-01 and 2024-04-01",
+          "A placement at The Premises was booked for Monday 1 January 2024 to Monday 1 April 2024",
           "The person moved into the premises on 2024-01-01",
           "The person was due to move into the premises on 2024-01-01 but did not arrive",
           "The person moved out of the premises on 2024-04-01",
-          "A booking was not made for the placement request. The reason was: no suitable premises",
-          "The booking was cancelled. The reason was: 'additional sentencing'",
-          "The booking had its arrival or departure date changed",
+          "A placement was not made for the placement request. The reason was: no suitable premises",
+          "The placement was cancelled. The reason was: 'additional sentencing'",
+          "The placement had its arrival or departure date changed",
           "The application was assessed and accepted",
         )
 
@@ -2906,6 +2907,7 @@ class ApplicationTest : IntegrationTestBase() {
                 .withBookingId(booking.id)
                 .withArrivalOn(LocalDate.parse("2024-01-01"))
                 .withDepartureOn(LocalDate.parse("2024-04-01"))
+                .withPremises(EventPremisesFactory().withName("The Premises").produce())
                 .produce(),
             ),
           )
@@ -2930,7 +2932,7 @@ class ApplicationTest : IntegrationTestBase() {
             TimelineEventAssociatedUrl(type = TimelineEventUrlType.application, url = "http://frontend/applications/$applicationId"),
             TimelineEventAssociatedUrl(type = TimelineEventUrlType.booking, url = "http://frontend/premises/${premises.id}/bookings/${booking.id}"),
           ),
-          content = "A booking was made for between 2024-01-01 and 2024-04-01",
+          content = "A placement at The Premises was booked for Monday 1 January 2024 to Monday 1 April 2024",
         )
 
         val expected = listOf(
@@ -3060,6 +3062,11 @@ class ApplicationTest : IntegrationTestBase() {
                 .withApplicationId(applicationId)
                 .withArrivalOn(LocalDate.parse("2024-01-01"))
                 .withDepartureOn(LocalDate.parse("2024-04-01"))
+                .withPremises(
+                  EventPremisesFactory()
+                    .withName("The Premises")
+                    .produce(),
+                )
                 .produce(),
             ),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Assessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.MatchRequestWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonArrivedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PersonDepartedFactory
@@ -79,10 +80,11 @@ class DomainEventDescriberTest {
     assertThat(result).isEqualTo("The application was assessed and $decision")
   }
 
-  @ParameterizedTest
-  @CsvSource(value = ["2024-01-01,2024-04-01", "2024-01-02,2024-04-02"])
-  fun `Returns expected description for booking made event`(arrivalDate: LocalDate, departureDate: LocalDate) {
+  @Test
+  fun `Returns expected description for booking made event`() {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_MADE)
+    val arrivalDate = LocalDate.of(2024, 1, 1)
+    val departureDate = LocalDate.of(2024, 4, 1)
 
     every { mockDomainEventService.getBookingMadeEvent(any()) } returns buildDomainEvent {
       BookingMadeEnvelope(
@@ -92,13 +94,18 @@ class DomainEventDescriberTest {
         eventDetails = BookingMadeFactory()
           .withArrivalOn(arrivalDate)
           .withDepartureOn(departureDate)
+          .withPremises(
+            EventPremisesFactory()
+              .withName("The Premises Name")
+              .produce(),
+          )
           .produce(),
       )
     }
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A booking was made for between $arrivalDate and $departureDate")
+    assertThat(result).isEqualTo("A placement at The Premises Name was booked for Monday 1 January 2024 to Monday 1 April 2024")
   }
 
   @ParameterizedTest
@@ -182,7 +189,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A booking was not made for the placement request. The reason was: $reason")
+    assertThat(result).isEqualTo("A placement was not made for the placement request. The reason was: $reason")
   }
 
   @ParameterizedTest
@@ -203,7 +210,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The booking was cancelled. The reason was: '$reason'")
+    assertThat(result).isEqualTo("The placement was cancelled. The reason was: '$reason'")
   }
 
   @Test
@@ -212,7 +219,7 @@ class DomainEventDescriberTest {
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The booking had its arrival or departure date changed")
+    assertThat(result).isEqualTo("The placement had its arrival or departure date changed")
   }
 
   @Test


### PR DESCRIPTION
Replace the word ‘booking’ with ‘placement’ for all booking events

Add premises name to booking made event, and use the UI Date/Time format for easier to read dates

https://dsdmoj.atlassian.net/browse/APS-586

![Screenshot 2024-04-08 at 13 01 02](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/e3db2317-f713-4be2-ab36-8d455795efcb)
