### PR TITLE
[APS-496] Introduce 'request for placement allocated' domain event

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -65,6 +65,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/placement-application-allocated/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -57,6 +57,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/placement-application-allocated/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -66,6 +66,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-ALLOCATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/placement-application-allocated/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -59,6 +59,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/placement-application-allocated/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.MatchRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
@@ -97,6 +98,13 @@ class DomainEventsController(
 
   override fun eventsPlacementApplicationWithdrawnEventIdGet(eventId: UUID): ResponseEntity<PlacementApplicationWithdrawnEnvelope> {
     val event = domainEventService.getPlacementApplicationWithdrawnEvent(eventId)
+      ?: throw NotFoundProblem(eventId, "DomainEvent")
+
+    return ResponseEntity.ok(event.data)
+  }
+
+  override fun eventsPlacementApplicationAllocatedEventIdGet(eventId: UUID): ResponseEntity<PlacementApplicationAllocatedEnvelope> {
+    val event = domainEventService.getPlacementApplicationAllocatedEvent(eventId)
       ?: throw NotFoundProblem(eventId, "DomainEvent")
 
     return ResponseEntity.ok(event.data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.MatchRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
@@ -107,6 +108,8 @@ data class DomainEventEntity(
         objectMapper.readValue(this.data, T::class.java)
       T::class == PlacementApplicationWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN ->
         objectMapper.readValue(this.data, T::class.java)
+      T::class == PlacementApplicationAllocatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED ->
+        objectMapper.readValue(this.data, T::class.java)
       T::class == MatchRequestWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN ->
         objectMapper.readValue(this.data, T::class.java)
       T::class == AssessmentAllocatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED ->
@@ -142,6 +145,7 @@ enum class DomainEventType {
   APPROVED_PREMISES_ASSESSMENT_APPEALED,
   APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
   APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
+  APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
   APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
   CAS2_APPLICATION_SUBMITTED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.MatchRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
@@ -53,6 +54,7 @@ class DomainEventService(
   @Value("\${url-templates.api.cas1.application-withdrawn-event-detail}") private val applicationWithdrawnDetailUrlTemplate: String,
   @Value("\${url-templates.api.cas1.assessment-appealed-event-detail}") private val assessmentAppealedDetailUrlTemplate: String,
   @Value("\${url-templates.api.cas1.placement-application-withdrawn-event-detail}") private val placementApplicationWithdrawnDetailUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.api.cas1.placement-application-allocated-event-detail}") private val placementApplicationAllocatedDetailUrlTemplate: UrlTemplate,
   @Value("\${url-templates.api.cas1.match-request-withdrawn-event-detail}") private val matchRequestWithdrawnDetailUrlTemplate: UrlTemplate,
   @Value("\${url-templates.api.cas1.assessment-allocated-event-detail}") private val assessmentAllocatedUrlTemplate: UrlTemplate,
   @Value("\${url-templates.api.cas1.request-for-placement-created-event-detail}") private val requestForPlacementCreatedUrlTemplate: UrlTemplate,
@@ -70,6 +72,7 @@ class DomainEventService(
   fun getBookingChangedEvent(id: UUID) = get<BookingChangedEnvelope>(id)
   fun getApplicationWithdrawnEvent(id: UUID) = get<ApplicationWithdrawnEnvelope>(id)
   fun getPlacementApplicationWithdrawnEvent(id: UUID) = get<PlacementApplicationWithdrawnEnvelope>(id)
+  fun getPlacementApplicationAllocatedEvent(id: UUID) = get<PlacementApplicationAllocatedEnvelope>(id)
   fun getMatchRequestWithdrawnEvent(id: UUID) = get<MatchRequestWithdrawnEnvelope>(id)
   fun getAssessmentAppealedEvent(id: UUID) = get<AssessmentAppealedEnvelope>(id)
   fun getAssessmentAllocatedEvent(id: UUID) = get<AssessmentAllocatedEnvelope>(id)
@@ -224,6 +227,17 @@ class DomainEventService(
     )
 
   @Transactional
+  fun savePlacementApplicationAllocatedEvent(domainEvent: DomainEvent<PlacementApplicationAllocatedEnvelope>) =
+    saveAndEmit(
+      domainEvent = domainEvent,
+      typeName = "approved-premises.placement-application.allocated",
+      typeDescription = "An Approved Premises Request for Placement has been allocated",
+      detailUrl = placementApplicationAllocatedDetailUrlTemplate.resolve("eventId", domainEvent.id.toString()),
+      crn = domainEvent.data.eventDetails.personReference.crn,
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
+    )
+
+  @Transactional
   fun saveMatchRequestWithdrawnEvent(domainEvent: DomainEvent<MatchRequestWithdrawnEnvelope>) =
     saveAndEmit(
       domainEvent = domainEvent,
@@ -330,6 +344,7 @@ class DomainEventService(
     ApplicationWithdrawnEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN
     AssessmentAppealedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED
     PlacementApplicationWithdrawnEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN
+    PlacementApplicationAllocatedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED
     MatchRequestWithdrawnEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN
     AssessmentAllocatedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED
     RequestForPlacementCreatedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -156,6 +156,7 @@ class PlacementApplicationService(
     val newPlacementApplication = currentPlacementApplication.copy(
       id = UUID.randomUUID(),
       reallocatedAt = null,
+      allocatedAt = currentPlacementApplication.reallocatedAt,
       allocatedToUser = assigneeUser,
       createdAt = dateTimeNow,
       dueAt = null,
@@ -164,6 +165,10 @@ class PlacementApplicationService(
     newPlacementApplication.dueAt = taskDeadlineService.getDeadline(newPlacementApplication)
 
     placementApplicationRepository.save(newPlacementApplication)
+    cas1PlacementApplicationDomainEventService.placementApplicationAllocated(
+      newPlacementApplication,
+      userService.getUserForRequest(),
+    )
 
     val newPlacementDates = placementDateRepository.saveAll(
       currentPlacementApplication.placementDates.map {
@@ -305,6 +310,10 @@ class PlacementApplicationService(
       cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication)
       if (baselinePlacementApplication.allocatedToUser != null) {
         cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication)
+        cas1PlacementApplicationDomainEventService.placementApplicationAllocated(
+          placementApplication,
+          userService.getUserForRequest(),
+        )
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DomainEventTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DomainEventTransformer.kt
@@ -30,6 +30,12 @@ class DomainEventTransformer(private val communityApiClient: CommunityApiClient)
     )
   }
 
+  fun toStaffMember(user: UserEntity) =
+    when (val result = communityApiClient.getStaffUserDetails(user.deliusUsername)) {
+      is ClientResult.Success -> toStaffMember(result.body)
+      is ClientResult.Failure -> result.throwException()
+    }
+
   fun toStaffMember(staffDetails: StaffUserDetails): StaffMember {
     return StaffMember(
       staffCode = staffDetails.staffCode,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -213,6 +213,7 @@ url-templates:
       application-withdrawn-event-detail: http://localhost:3000/events/application-withdrawn/#eventId
       assessment-appealed-event-detail: http://localhost:3000/events/assessment-appealed/#eventId
       placement-application-withdrawn-event-detail: http://localhost:3000/events/placement-application-withdrawn/#eventId
+      placement-application-allocated-event-detail: http://localhost:3000/events/placement-application-allocated/#eventId
       match-request-withdrawn-event-detail: http://localhost:3000/events/match-request-withdrawn/#eventId
       assessment-allocated-event-detail: http://localhost:3000/events/assessment-allocated/#eventId
       request-for-placement-created-event-detail: http://localhost:3000/events/request-for-placement-created/#eventId

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3485,6 +3485,7 @@ components:
         - approved_premises_assessment_appealed
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
+        - approved_premises_placement_application_allocated
         - approved_premises_match_request_withdrawn
         - approved_premises_request_for_placement_created
         - cas3_person_arrived

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7994,6 +7994,7 @@ components:
         - approved_premises_assessment_appealed
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
+        - approved_premises_placement_application_allocated
         - approved_premises_match_request_withdrawn
         - approved_premises_request_for_placement_created
         - cas3_person_arrived

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4045,6 +4045,7 @@ components:
         - approved_premises_assessment_appealed
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
+        - approved_premises_placement_application_allocated
         - approved_premises_match_request_withdrawn
         - approved_premises_request_for_placement_created
         - cas3_person_arrived

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3576,6 +3576,7 @@ components:
         - approved_premises_assessment_appealed
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
+        - approved_premises_placement_application_allocated
         - approved_premises_match_request_withdrawn
         - approved_premises_request_for_placement_created
         - cas3_person_arrived

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -382,6 +382,33 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /events/placement-application-allocated/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Manage' events"
+      summary: A 'placement-application-allocated' event
+      responses:
+        '200':
+          description: The 'placement-application-allocated' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlacementApplicationAllocatedEnvelope'
+        404:
+          description: No 'placement-application-allocated' event found for the provided `eventId`
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /events/match-request-withdrawn/{eventId}:
     parameters:
       - name: eventId
@@ -855,6 +882,55 @@ components:
         - withdrawnAt
         - withdrawnBy
         - withdrawalReason
+    PlacementApplicationAllocatedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.placement-application.allocated
+        eventDetails:
+          $ref: '#/components/schemas/PlacementApplicationAllocated'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
+    PlacementApplicationAllocated:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
+        placementApplicationId:
+          $ref: '#/components/schemas/PlacementApplicationId'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        allocatedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+        allocatedTo:
+          $ref: '#/components/schemas/StaffMember'
+        allocatedBy:
+          $ref: '#/components/schemas/StaffMember'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatePeriod'
+      required:
+        - applicationId
+        - applicationUrl
+        - placementApplicationId
+        - personReference
+        - allocatedAt
+        - placementDates
     MatchRequestWithdrawnEnvelope:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlacementApplicationAllocatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlacementApplicationAllocatedFactory.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.util.UUID
+
+class PlacementApplicationAllocatedFactory : Factory<PlacementApplicationAllocated> {
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var placementApplicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
+  private var allocatedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
+  private var placementDates: Yielded<List<DatePeriod>> = { emptyList() }
+  private var allocatedTo: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
+  private var allocatedBy: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withApplicationUrl(applicationUrl: String) = apply {
+    this.applicationUrl = { applicationUrl }
+  }
+
+  fun withPlacementApplicationId(placementApplicationId: UUID) = apply {
+    this.placementApplicationId = { placementApplicationId }
+  }
+
+  fun withPersonReference(personReference: PersonReference) = apply {
+    this.personReference = { personReference }
+  }
+
+  fun withPersonReference(configuration: PersonReferenceFactory.() -> Unit) = apply {
+    this.personReference = { PersonReferenceFactory().apply(configuration).produce() }
+  }
+
+  fun withAllocatedAt(allocatedAt: Instant) = apply {
+    this.allocatedAt = { allocatedAt }
+  }
+
+  fun withPlacementDates(placementDates: List<DatePeriod>) = apply {
+    this.placementDates = { placementDates }
+  }
+
+  fun withAllocatedTo(allocatedTo: StaffMember?) = apply {
+    this.allocatedTo = { allocatedTo }
+  }
+
+  fun withAllocatedTo(configuration: StaffMemberFactory.() -> Unit) = apply {
+    this.allocatedTo = { StaffMemberFactory().apply(configuration).produce() }
+  }
+
+  fun withAllocatedBy(allocatedBy: StaffMember?) = apply {
+    this.allocatedBy = { allocatedBy }
+  }
+
+  fun withAllocatedBy(configuration: StaffMemberFactory.() -> Unit) = apply {
+    this.allocatedBy = { StaffMemberFactory().apply(configuration).produce() }
+  }
+
+  override fun produce() = PlacementApplicationAllocated(
+    applicationId = this.applicationId(),
+    applicationUrl = this.applicationUrl(),
+    placementApplicationId = this.placementApplicationId(),
+    personReference = this.personReference(),
+    allocatedAt = this.allocatedAt(),
+    placementDates = this.placementDates(),
+    allocatedTo = this.allocatedTo(),
+    allocatedBy = this.allocatedBy(),
+  )
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -134,6 +134,7 @@ url-templates:
       application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
       assessment-appealed-event-detail: http://api/events/assessment-appealed/#eventId
       assessment-allocated-event-detail: http://api/events/assessment-allocated/#eventId
+      placement-application-allocated-event-detail: http://api/events/placement-application-allocated/#eventId
     cas2:
       application-submitted-event-detail: http://api/events/cas2/application-submitted/#eventId
     cas3:


### PR DESCRIPTION
> See [APS-496 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-496).

This PR introduces the `approved-premises.placement-application.allocated` domain event type. This is emitted in two scenarios:

1. when a request for placement is submitted; or
2. when the request for placement is reallocated.

**NB**: this PR is currently set to merge into `APS-496-api-workflow-manager-reviews-task-allocation-history` instead of `main` for clarity, as this PR depends on changes introduced in #1699. This PR should not be merged until after that one.