### PR TITLE
CAS2 Application endpoint returns the HDC Eligibility date for submit…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -176,6 +176,7 @@ interface AppSummary {
   fun getCreatedByUserId(): UUID
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?
+  fun getHdcEligibilityDate(): LocalDate?
 }
 
 interface Cas2ApplicationSummary : AppSummary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -53,6 +53,7 @@ class ApplicationsTransformer(
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
         status = getStatusFromSummary(jpaSummary),
         type = "CAS2",
+        hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
       )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1876,6 +1876,9 @@ components:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            hdcEligibilityDate:
+              type: string
+              format: date
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6378,6 +6378,9 @@ components:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            hdcEligibilityDate:
+              type: string
+              format: date
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2436,6 +2436,9 @@ components:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            hdcEligibilityDate:
+              type: string
+              format: date
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1967,6 +1967,9 @@ components:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
               $ref: '#/components/schemas/PersonRisks'
+            hdcEligibilityDate:
+              type: string
+              format: date
           required:
             - createdByUserId
             - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -223,7 +223,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 firstApplicationEntity.crn == it.person.crn &&
                 firstApplicationEntity.createdAt.toInstant() == it.createdAt &&
                 firstApplicationEntity.createdByUser.id == it.createdByUserId &&
-                firstApplicationEntity.submittedAt?.toInstant() == it.submittedAt
+                firstApplicationEntity.submittedAt?.toInstant() == it.submittedAt &&
+                firstApplicationEntity.hdcEligibilityDate == it.hdcEligibilityDate
             }
 
             Assertions.assertThat(responseBody).noneMatch {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -85,6 +85,7 @@ class ApplicationServiceTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
       }
 
       PaginationConfig(defaultPageSize = 10).postInit()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Timelin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -154,6 +155,7 @@ class ApplicationsTransformerTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
+        override fun getHdcEligibilityDate() = null
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
@@ -164,6 +166,7 @@ class ApplicationsTransformerTest {
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
+      assertThat(result.hdcEligibilityDate).isNull()
     }
 
     @Test
@@ -175,6 +178,7 @@ class ApplicationsTransformerTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
       }
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
@@ -184,6 +188,7 @@ class ApplicationsTransformerTest {
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
+      assertThat(result.hdcEligibilityDate).isEqualTo("2023-04-29")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Submiss
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -126,6 +127,7 @@ class SubmissionsTransformerTest {
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
+        override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
       }
 
       val expectedSubmittedApplicationSummary = Cas2SubmittedApplicationSummary(


### PR DESCRIPTION
…ted applications

HDC eligibility date was added [as a first-class field on CAS2 Applications a while ago for domain events.](https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/86740d6d36673d064e84c647dc7d89358828590e). 

This change extends the CAS2 Application summary object so that it includes this field.