### PR TITLE
(APS-602) Show completed tasks in task allocation section

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -77,6 +77,7 @@ class TasksController(
     allocatedToUserId: UUID?,
     requiredQualification: ApiUserQualification?,
     crnOrName: String?,
+    isCompleted: Boolean?,
   ): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
@@ -100,6 +101,7 @@ class TasksController(
         allocatedToUserId = allocatedToUserId,
         requiredQualification = requiredQualification,
         crnOrName = crnOrName,
+        isCompleted = isCompleted ?: false,
       ),
       PageCriteria(
         sortBy = sortBy ?: TaskSortField.createdAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -56,7 +56,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         'ASSESSMENT' in :taskTypes AND
         assessment.is_withdrawn IS NOT TRUE
         AND assessment.reallocated_at IS NULL
-        AND assessment.submitted_at IS NULL
+        AND (
+          (:completed = true AND assessment.submitted_at IS NOT NULL) OR (:completed = false AND assessment.submitted_at IS NULL)
+        )
         AND (
           (:isAllocated IS NULL) OR 
           (
@@ -94,7 +96,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         'PLACEMENT_APPLICATION' in :taskTypes AND
         placement_application.submitted_at IS NOT NULL
         AND placement_application.reallocated_at IS NULL
-        AND placement_application.decision IS NULL
+        AND (
+          (:completed = true AND placement_application.decision IS NOT NULL) OR (:completed = false AND placement_application.decision IS NULL)
+        )
         AND (
           (:isAllocated IS NULL) OR 
           (
@@ -130,11 +134,13 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         LEFT JOIN ap_areas area ON area.id = apa.ap_area_id
         LEFT JOIN users u ON u.id = placement_request.allocated_to_user_id
       WHERE
-        'PLACEMENT_REQUEST' IN :taskTypes AND
-        placement_request.booking_id IS NULL
+        'PLACEMENT_REQUEST' IN :taskTypes
         AND placement_request.reallocated_at IS NULL
         AND placement_request.is_withdrawn IS FALSE
-        AND booking_not_made.id IS NULL
+        AND (
+          (:completed = true AND (placement_request.booking_id IS NOT NULL OR booking_not_made.id IS NOT NULL)) OR 
+          (:completed = false AND placement_request.booking_id IS NULL AND booking_not_made.id IS NULL)
+        )
         AND (
           (:isAllocated IS NULL) OR 
           (
@@ -175,6 +181,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     allocatedToUserId: UUID?,
     requiredQualification: String?,
     crnOrName: String?,
+    completed: Boolean,
     pageable: Pageable?,
   ): Page<Task>
 
@@ -190,6 +197,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     allocatedToUserId: UUID?,
     requiredQualification: String?,
     crnOrName: String?,
+    completed: Boolean,
     pageable: Pageable?,
   ): Page<Task>
 
@@ -205,6 +213,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     allocatedToUserId: UUID?,
     requiredQualification: String?,
     crnOrName: String?,
+    completed: Boolean,
     pageable: Pageable?,
   ): Page<Task>
 
@@ -220,6 +229,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
     allocatedToUserId: UUID?,
     requiredQualification: String?,
     crnOrName: String?,
+    completed: Boolean,
     pageable: Pageable?,
   ): Page<Task>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -52,6 +52,7 @@ class TaskService(
     val allocatedToUserId: UUID?,
     val requiredQualification: UserQualification?,
     val crnOrName: String?,
+    val isCompleted: Boolean,
   )
 
   fun getAll(
@@ -136,6 +137,7 @@ class TaskService(
       filterCriteria.allocatedToUserId,
       filterCriteria.requiredQualification?.value,
       filterCriteria.crnOrName,
+      filterCriteria.isCompleted,
       pageable,
     )
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2847,6 +2847,11 @@ paths:
           description: search by CRN or name
           schema:
             type: string
+        - name: isCompleted
+          in: query
+          description: filter by if the tasks are completed (defaults to `false`)
+          schema:
+            type: boolean
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2849,6 +2849,11 @@ paths:
           description: search by CRN or name
           schema:
             type: string
+        - name: isCompleted
+          in: query
+          description: filter by if the tasks are completed (defaults to `false`)
+          schema:
+            type: boolean
       responses:
         200:
           description: successfully retrieved tasks

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -32,24 +32,32 @@ fun IntegrationTestBase.`Given a Placement Application`(
   requiredQualification: UserQualification? = null,
   noticeType: Cas1ApplicationTimelinessCategory? = null,
 ): PlacementApplicationEntity {
+  val userApArea = apAreaEntityFactory.produceAndPersist()
+
+  val assessmentAllocatedToUser = userEntityFactory.produceAndPersist {
+    withYieldedProbationRegion {
+      probationRegionEntityFactory.produceAndPersist {
+        withApArea(userApArea)
+      }
+    }
+    withApArea(userApArea)
+  }
+
+  val assessmentCreatedByUser = userEntityFactory.produceAndPersist {
+    withYieldedProbationRegion {
+      probationRegionEntityFactory.produceAndPersist {
+        withApArea(userApArea)
+      }
+    }
+    withApArea(userApArea)
+  }
+
   val (_, application) = `Given an Assessment for Approved Premises`(
     decision = assessmentDecision,
     submittedAt = OffsetDateTime.now(),
     crn = crn,
-    allocatedToUser = userEntityFactory.produceAndPersist {
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
-    },
-    createdByUser = userEntityFactory.produceAndPersist {
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
-    },
+    allocatedToUser = assessmentAllocatedToUser,
+    createdByUser = assessmentCreatedByUser,
     apArea = apArea,
     name = name,
     requiredQualification = requiredQualification,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -352,6 +352,7 @@ class TaskServiceTest {
     val allocatedToUserId = UUID.randomUUID()
     val requiredQualification = UserQualification.pipe
     val crnOrName = "CRN123"
+    val isCompleted = false
 
     every { page.content } returns tasks
     every {
@@ -362,6 +363,7 @@ class TaskServiceTest {
         allocatedToUserId,
         requiredQualification.value,
         crnOrName,
+        isCompleted,
         PageRequest.of(0, 10, Sort.by("created_at").ascending()),
       )
     } returns page
@@ -373,7 +375,18 @@ class TaskServiceTest {
 
     every { getMetadata(page, pageCriteria) } returns metadata
 
-    val result = taskService.getAll(TaskService.TaskFilterCriteria(AllocatedFilter.allocated, apAreaId, taskEntityTypes, allocatedToUserId, requiredQualification, crnOrName), pageCriteria)
+    val result = taskService.getAll(
+      TaskService.TaskFilterCriteria(
+        AllocatedFilter.allocated,
+        apAreaId,
+        taskEntityTypes,
+        allocatedToUserId,
+        requiredQualification,
+        crnOrName,
+        isCompleted,
+      ),
+      pageCriteria,
+    )
 
     val expectedTasks = listOf(
       assessments.map { TypedTask.Assessment(it) },


### PR DESCRIPTION
This allows us to optionally return completed tasks instead of incomplete tasks (which is the default).

This makes the SQL a tad more complex. When we have time we should really think about refactoring to have actual Task entities which map to the relevant Assessment / Placement Application / Placement Request, but this is probably OK for now.