### PR TITLE
APS-617: Add qualifications for Recovery-focused and Mental Health premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -163,5 +163,7 @@ class UsersController(
       UserQualification.lao -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.LAO
       UserQualification.emergency -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.EMERGENCY
       UserQualification.esap -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.ESAP
+      UserQualification.mentalHealthSpecialist -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.MENTAL_HEALTH_SPECIALIST
+      UserQualification.recoveryFocused -> uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification.RECOVERY_FOCUSED
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -373,6 +373,8 @@ class ApprovedPremisesApplicationEntity(
       ApprovedPremisesType.PIPE -> requiredQualifications += UserQualification.PIPE
       ApprovedPremisesType.ESAP -> requiredQualifications += UserQualification.ESAP
       ApprovedPremisesType.RFAP -> requiredQualifications += UserQualification.RECOVERY_FOCUSED
+      ApprovedPremisesType.MHAP_ST_JOSEPHS -> requiredQualifications += UserQualification.MENTAL_HEALTH_SPECIALIST
+      ApprovedPremisesType.MHAP_ELLIOTT_HOUSE -> requiredQualifications += UserQualification.MENTAL_HEALTH_SPECIALIST
       else -> {}
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -372,6 +372,7 @@ class ApprovedPremisesApplicationEntity(
     when (apType) {
       ApprovedPremisesType.PIPE -> requiredQualifications += UserQualification.PIPE
       ApprovedPremisesType.ESAP -> requiredQualifications += UserQualification.ESAP
+      ApprovedPremisesType.RFAP -> requiredQualifications += UserQualification.RECOVERY_FOCUSED
       else -> {}
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -24,6 +24,8 @@ interface TaskRepository : JpaRepository<Task, UUID> {
           WHEN :requiredQualification = 'pipe' THEN apa.ap_type = 'PIPE'
           WHEN :requiredQualification = 'emergency' THEN (apa.notice_type = 'emergency' OR apa.notice_type = 'shortNotice')
           WHEN :requiredQualification = 'esap' THEN apa.ap_type = 'ESAP'
+          WHEN :requiredQualification = 'recovery_focused' THEN apa.ap_type = 'RFAP'
+          WHEN :requiredQualification = 'mental_health_specialist' THEN (apa.ap_type = 'MHAP_ST_JOSEPHS' OR apa.ap_type = 'MHAP_ELLIOTT_HOUSE')
           ELSE true
         END
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -336,6 +336,8 @@ enum class UserQualification {
   LAO,
   ESAP,
   EMERGENCY,
+  RECOVERY_FOCUSED,
+  MENTAL_HEALTH_SPECIALIST,
 }
 
 interface UserWorkload {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -97,5 +97,7 @@ class UserTransformer(
     UserQualification.LAO -> ApiUserQualification.lao
     UserQualification.ESAP -> ApiUserQualification.esap
     UserQualification.EMERGENCY -> ApiUserQualification.emergency
+    UserQualification.MENTAL_HEALTH_SPECIALIST -> ApiUserQualification.mentalHealthSpecialist
+    UserQualification.RECOVERY_FOCUSED -> ApiUserQualification.recoveryFocused
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
@@ -11,6 +11,8 @@ fun transformQualifications(qualification: ApiUserQualification): UserQualificat
   ApiUserQualification.lao -> UserQualification.LAO
   ApiUserQualification.pipe -> UserQualification.PIPE
   ApiUserQualification.womens -> UserQualification.WOMENS
+  ApiUserQualification.mentalHealthSpecialist -> UserQualification.MENTAL_HEALTH_SPECIALIST
+  ApiUserQualification.recoveryFocused -> UserQualification.RECOVERY_FOCUSED
 }
 
 fun transformUserRoles(approvedPremisesUserRole: ApprovedPremisesUserRole): UserRole = when (approvedPremisesUserRole) {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2978,6 +2978,8 @@ components:
         - lao
         - emergency
         - esap
+        - recovery_focused
+        - mental_health_specialist
     ServiceName:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7480,6 +7480,8 @@ components:
         - lao
         - emergency
         - esap
+        - recovery_focused
+        - mental_health_specialist
     ServiceName:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3538,6 +3538,8 @@ components:
         - lao
         - emergency
         - esap
+        - recovery_focused
+        - mental_health_specialist
     ServiceName:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3069,6 +3069,8 @@ components:
         - lao
         - emergency
         - esap
+        - recovery_focused
+        - mental_health_specialist
     ServiceName:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -821,6 +821,8 @@ class TasksTest : IntegrationTestBase() {
                 UserQualification.WOMENS,
                 UserQualification.ESAP,
                 UserQualification.PIPE,
+                UserQualification.RECOVERY_FOCUSED,
+                UserQualification.MENTAL_HEALTH_SPECIALIST,
               ).forEach { qualification ->
                 assessmentTasks[qualification] = listOf(
                   createAssessmentTask(qualification),
@@ -858,9 +860,26 @@ class TasksTest : IntegrationTestBase() {
 
       @ParameterizedTest
       @CsvSource(
-        "assessment,WOMENS", "assessment,PIPE", "assessment,ESAP", "assessment,EMERGENCY",
-        "placementRequest,WOMENS", "placementRequest,PIPE", "placementRequest,ESAP", "placementRequest,EMERGENCY",
-        "placementApplication,WOMENS", "placementApplication,PIPE", "placementApplication,ESAP", "placementApplication,EMERGENCY",
+        "assessment,WOMENS",
+        "assessment,PIPE",
+        "assessment,ESAP",
+        "assessment,EMERGENCY",
+        "assessment,RECOVERY_FOCUSED",
+        "assessment,MENTAL_HEALTH_SPECIALIST",
+
+        "placementRequest,WOMENS",
+        "placementRequest,PIPE",
+        "placementRequest,ESAP",
+        "placementRequest,EMERGENCY",
+        "placementRequest,RECOVERY_FOCUSED",
+        "placementRequest,MENTAL_HEALTH_SPECIALIST",
+
+        "placementApplication,WOMENS",
+        "placementApplication,PIPE",
+        "placementApplication,ESAP",
+        "placementApplication,EMERGENCY",
+        "placementApplication,RECOVERY_FOCUSED",
+        "placementApplication,MENTAL_HEALTH_SPECIALIST",
       )
       fun `Get all tasks filters by task type and required qualification`(taskType: TaskType, qualification: UserQualification) {
         val url = "/tasks?type=${taskType.value}&requiredQualification=${qualification.name.lowercase()}"
@@ -881,7 +900,7 @@ class TasksTest : IntegrationTestBase() {
       }
 
       @ParameterizedTest
-      @EnumSource(value = UserQualification::class, names = ["WOMENS", "EMERGENCY", "ESAP", "PIPE"])
+      @EnumSource(value = UserQualification::class, names = ["WOMENS", "EMERGENCY", "ESAP", "PIPE", "RECOVERY_FOCUSED", "MENTAL_HEALTH_SPECIALIST"])
       fun `Get all tasks required qualification`(qualification: UserQualification) {
         val url = "/tasks?requiredQualification=${qualification.name.lowercase()}"
         val expectedTasks = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -153,6 +153,8 @@ private fun ApprovedPremisesApplicationEntityFactory.applyQualification(required
     UserQualification.PIPE -> withApType(ApprovedPremisesType.PIPE)
     UserQualification.ESAP -> withApType(ApprovedPremisesType.ESAP)
     UserQualification.WOMENS -> withIsWomensApplication(true)
+    UserQualification.RECOVERY_FOCUSED -> withApType(ApprovedPremisesType.RFAP)
+    UserQualification.MENTAL_HEALTH_SPECIALIST -> withApType(ApprovedPremisesType.MHAP_ST_JOSEPHS)
     else -> { }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -57,6 +57,8 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
       UserQualification.PIPE -> withApType(ApprovedPremisesType.PIPE)
       UserQualification.ESAP -> withApType(ApprovedPremisesType.ESAP)
       UserQualification.WOMENS -> withIsWomensApplication(true)
+      UserQualification.RECOVERY_FOCUSED -> withApType(ApprovedPremisesType.RFAP)
+      UserQualification.MENTAL_HEALTH_SPECIALIST -> withApType(ApprovedPremisesType.MHAP_ST_JOSEPHS)
       else -> { }
     }
     withNoticeType(noticeType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
@@ -79,7 +79,13 @@ class ApprovedPremisesApplicationEntityTest {
     }
 
     @ParameterizedTest
-    @CsvSource("PIPE,PIPE", "ESAP,ESAP", "RFAP,RECOVERY_FOCUSED")
+    @CsvSource(
+      "PIPE,PIPE",
+      "ESAP,ESAP",
+      "RFAP,RECOVERY_FOCUSED",
+      "MHAP_ST_JOSEPHS,MENTAL_HEALTH_SPECIALIST",
+      "MHAP_ELLIOTT_HOUSE,MENTAL_HEALTH_SPECIALIST",
+    )
     fun `returns matching qualification for an application made to that type of premises`(apType: ApprovedPremisesType, qualification: UserQualification?) {
       val user = UserEntityFactory()
         .withDefaultProbationRegion()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import java.time.OffsetDateTime
 
 class ApprovedPremisesApplicationEntityTest {
@@ -72,6 +73,21 @@ class ApprovedPremisesApplicationEntityTest {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(user)
         .withNoticeType(noticeType)
+        .produce()
+
+      assertThat(application.getRequiredQualifications()).isEqualTo(listOfNotNull(qualification))
+    }
+
+    @ParameterizedTest
+    @CsvSource("PIPE,PIPE", "ESAP,ESAP")
+    fun `returns matching qualification for an application made to that type of premises`(apType: ApprovedPremisesType, qualification: UserQualification?) {
+      val user = UserEntityFactory()
+        .withDefaultProbationRegion()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withApType(apType)
         .produce()
 
       assertThat(application.getRequiredQualifications()).isEqualTo(listOfNotNull(qualification))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -59,18 +60,21 @@ class ApprovedPremisesApplicationEntityTest {
     assertThat(application.isShortNoticeApplication()).isNull()
   }
 
-  @ParameterizedTest
-  @CsvSource("emergency,EMERGENCY", "shortNotice,EMERGENCY", "standard,")
-  fun `getRequiredQualifications returns correctly for timeliness categories`(noticeType: Cas1ApplicationTimelinessCategory, qualification: UserQualification?) {
-    val user = UserEntityFactory()
-      .withDefaultProbationRegion()
-      .produce()
+  @Nested
+  inner class GetRequiredQualifications {
+    @ParameterizedTest
+    @CsvSource("emergency,EMERGENCY", "shortNotice,EMERGENCY", "standard,")
+    fun `returns correctly for timeliness categories`(noticeType: Cas1ApplicationTimelinessCategory, qualification: UserQualification?) {
+      val user = UserEntityFactory()
+        .withDefaultProbationRegion()
+        .produce()
 
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(user)
-      .withNoticeType(noticeType)
-      .produce()
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withNoticeType(noticeType)
+        .produce()
 
-    assertThat(application.getRequiredQualifications()).isEqualTo(listOfNotNull(qualification))
+      assertThat(application.getRequiredQualifications()).isEqualTo(listOfNotNull(qualification))
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/ApprovedPremisesApplicationEntityTest.kt
@@ -79,7 +79,7 @@ class ApprovedPremisesApplicationEntityTest {
     }
 
     @ParameterizedTest
-    @CsvSource("PIPE,PIPE", "ESAP,ESAP")
+    @CsvSource("PIPE,PIPE", "ESAP,ESAP", "RFAP,RECOVERY_FOCUSED")
     fun `returns matching qualification for an application made to that type of premises`(apType: ApprovedPremisesType, qualification: UserQualification?) {
       val user = UserEntityFactory()
         .withDefaultProbationRegion()


### PR DESCRIPTION
See Jira [APS-617: Add mental health and recovery focused as user qualifications](https://dsdmoj.atlassian.net/browse/APS-617)

In this PR we add two new user qualifications for handling tasks related to particular types of premises:
  
- `recovery-focused` for applications with the `RFAP` type
- `mental-health-specialist` for application with either `MHAP_ST_JOSEPHS` or `MHAP_ELLIOTT_HOUSE` type

The mapping between types of application and the user qualifications are made in `ApprovedPremisesApplicationEntity.getRequiredQualifications()`.

Through the `TaskEntity` it's now possible to filter tasks according to these "required qualifications" as they related to types of premises.