### PR TITLE
APS-585 add request for placement created domain event

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -66,6 +66,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -58,6 +58,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -67,6 +67,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -60,6 +60,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_ASSESSMENT-ALLOCATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-allocated/#eventId
     URL-TEMPLATES_API_CAS1_PLACEMENT-APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/placement-application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_MATCH-REQUEST-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/match-request-withdrawn/#eventId
+    URL-TEMPLATES_API_CAS1_REQUEST-FOR-PLACEMENT-CREATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/request-for-placement-created/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas2/application-submitted/#eventId
     URL-TEMPLATES_API_CAS2_APPLICATION-STATUS-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas2/application-status-updated/#eventId
     URL-TEMPLATES_API_CAS3_APPLICATION: https://approved-premises-api-test.hmpps.service.justice.gov.uk/applications/#applicationId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import java.time.OffsetDateTime
@@ -110,6 +111,8 @@ data class DomainEventEntity(
         objectMapper.readValue(this.data, T::class.java)
       T::class == AssessmentAllocatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED ->
         objectMapper.readValue(this.data, T::class.java)
+      T::class == RequestForPlacementCreatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED ->
+        objectMapper.readValue(this.data, T::class.java)
       else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${this.type.name}")
     }
 
@@ -140,6 +143,7 @@ enum class DomainEventType {
   APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
   APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
   APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
+  APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
   CAS2_APPLICATION_SUBMITTED,
   CAS2_APPLICATION_STATUS_UPDATED,
   CAS3_BOOKING_CANCELLED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -404,6 +404,7 @@ class AssessmentService(
 
       if (createPlacementRequest) {
         placementRequestService.createPlacementRequest(
+          PlacementRequestSource.ASSESSMENT_OF_APPLICATION,
           placementRequirementsValidationResult.entity,
           placementDates!!,
           notes,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1266,6 +1266,7 @@ class BookingService(
     if (reason.id == approvedPremisesBookingAppealedCancellationReasonId && booking.placementRequest != null) {
       val placementRequest = booking.placementRequest!!
       placementRequestService.createPlacementRequest(
+        source = PlacementRequestSource.APPEAL,
         placementRequirements = placementRequest.placementRequirements,
         placementDates = PlacementDates(
           expectedArrival = placementRequest.expectedArrival,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
@@ -54,6 +55,7 @@ class DomainEventService(
   @Value("\${url-templates.api.cas1.placement-application-withdrawn-event-detail}") private val placementApplicationWithdrawnDetailUrlTemplate: UrlTemplate,
   @Value("\${url-templates.api.cas1.match-request-withdrawn-event-detail}") private val matchRequestWithdrawnDetailUrlTemplate: UrlTemplate,
   @Value("\${url-templates.api.cas1.assessment-allocated-event-detail}") private val assessmentAllocatedUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.api.cas1.request-for-placement-created-event-detail}") private val requestForPlacementCreatedUrlTemplate: UrlTemplate,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -71,6 +73,7 @@ class DomainEventService(
   fun getMatchRequestWithdrawnEvent(id: UUID) = get<MatchRequestWithdrawnEnvelope>(id)
   fun getAssessmentAppealedEvent(id: UUID) = get<AssessmentAppealedEnvelope>(id)
   fun getAssessmentAllocatedEvent(id: UUID) = get<AssessmentAllocatedEnvelope>(id)
+  fun getRequestForPlacementCreatedEvent(id: UUID) = get<RequestForPlacementCreatedEnvelope>(id)
 
   private inline fun <reified T> get(id: UUID): DomainEvent<T>? {
     val domainEventEntity = domainEventRepository.findByIdOrNull(id) ?: return null
@@ -232,6 +235,18 @@ class DomainEventService(
     )
 
   @Transactional
+  fun saveRequestForPlacementCreatedEvent(domainEvent: DomainEvent<RequestForPlacementCreatedEnvelope>, emit: Boolean) =
+    saveAndEmit(
+      domainEvent = domainEvent,
+      typeName = "approved-premises.request-for-placement.created",
+      typeDescription = "An Approved Premises Request for Placement has been created",
+      detailUrl = requestForPlacementCreatedUrlTemplate.resolve("eventId", domainEvent.id.toString()),
+      crn = domainEvent.data.eventDetails.personReference.crn,
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
+      emit = emit,
+    )
+
+  @Transactional
   fun saveAssessmentAllocatedEvent(domainEvent: DomainEvent<AssessmentAllocatedEnvelope>) =
     saveAndEmit(
       domainEvent = domainEvent,
@@ -317,6 +332,7 @@ class DomainEventService(
     PlacementApplicationWithdrawnEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN
     MatchRequestWithdrawnEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN
     AssessmentAllocatedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED
+    RequestForPlacementCreatedEnvelope::class.java -> DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED
     else -> throw RuntimeException("Unrecognised domain event type: ${type.name}")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -289,6 +289,10 @@ class PlacementApplicationService(
     val placementApplicationsWithDates = saveDatesOnSubmissionToAnAppPerDate(baselinePlacementApplication, apiPlacementDates)
 
     placementApplicationsWithDates.forEach { placementApplication ->
+      cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(
+        placementApplication,
+        userService.getDeliusUserNameForRequest(),
+      )
       cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication)
       if (baselinePlacementApplication.allocatedToUser != null) {
         cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -217,7 +217,14 @@ class PlacementRequestService(
       )
       val isParole = placementApplicationEntity.placementType == PlacementType.RELEASE_FOLLOWING_DECISION
       val placementRequest =
-        this.createPlacementRequest(placementRequirements, placementDates, notes, isParole, placementApplicationEntity)
+        this.createPlacementRequest(
+          source = PlacementRequestSource.ASSESSMENT_OF_PLACEMENT_APPLICATION,
+          placementRequirements = placementRequirements,
+          placementDates = placementDates,
+          notes = notes,
+          isParole = isParole,
+          placementApplicationEntity = placementApplicationEntity,
+        )
 
       placementDateRepository.save(
         placementDateEntity.apply {
@@ -232,6 +239,7 @@ class PlacementRequestService(
   }
 
   fun createPlacementRequest(
+    source: PlacementRequestSource,
     placementRequirements: PlacementRequirementsEntity,
     placementDates: PlacementDates,
     notes: String?,
@@ -469,4 +477,10 @@ class PlacementRequestService(
     val placementRequest: PlacementRequestEntity,
     val cancellations: List<CancellationEntity>,
   )
+}
+
+enum class PlacementRequestSource {
+  ASSESSMENT_OF_APPLICATION,
+  ASSESSMENT_OF_PLACEMENT_APPLICATION,
+  APPEAL,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -271,7 +271,11 @@ class PlacementRequestService(
     placementRequest.allocatedToUser = allocatedUser
     placementRequest.dueAt = taskDeadlineService.getDeadline(placementRequest)
 
-    return placementRequestRepository.save(placementRequest)
+    val updatedPlacementRequest = placementRequestRepository.save(placementRequest)
+
+    cas1PlacementRequestDomainEventService.placementRequestCreated(updatedPlacementRequest, source)
+
+    return updatedPlacementRequest
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -63,9 +63,10 @@ class UserService(
     return userRepository.findByNameContainingIgnoreCase(name)
   }
 
+  fun getDeliusUserNameForRequest() = httpAuthService.getDeliusPrincipalOrThrow().name
+
   fun getUserForRequest(): UserEntity {
-    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
-    val username = deliusPrincipal.name
+    val username = getDeliusUserNameForRequest()
     val serviceForRequest = requestContextService.getServiceForRequest()
 
     val user = getExistingUserOrCreate(username)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -110,6 +110,7 @@ class ApplicationTimelineTransformer(
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> TimelineEventType.approvedPremisesAssessmentAllocated
       DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> TimelineEventType.approvedPremisesPlacementApplicationWithdrawn
       DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> TimelineEventType.approvedPremisesMatchRequestWithdrawn
+      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> TimelineEventType.approvedPremisesRequestForPlacementCreated
       else -> throw IllegalArgumentException("Cannot map $domainEventType, only CAS1 is currently supported")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -103,3 +103,31 @@ fun latestDateOf(date1: LocalDate, date2: LocalDate): LocalDate {
 
   return date2
 }
+
+@SuppressWarnings("MagicNumber")
+fun toWeekAndDayDurationString(durationInDays: Int): String {
+  if (durationInDays < 7) {
+    return toDaysString(durationInDays)
+  } else if (durationInDays % 7 == 0) {
+    val weeks = durationInDays / 7
+    return toWeeksString(weeks)
+  } else {
+    val weeks = durationInDays / 7
+    val days = durationInDays % 7
+    return "${toWeeksString(weeks)} and ${toDaysString(days)}"
+  }
+}
+
+@SuppressWarnings("MagicNumber")
+private fun toDaysString(days: Int) = if (days != 1) {
+  "$days days"
+} else {
+  "1 day"
+}
+
+@SuppressWarnings("MagicNumber")
+private fun toWeeksString(weeks: Int) = if (weeks != 1) {
+  "$weeks weeks"
+} else {
+  "1 week"
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -215,6 +215,7 @@ url-templates:
       placement-application-withdrawn-event-detail: http://localhost:3000/events/placement-application-withdrawn/#eventId
       match-request-withdrawn-event-detail: http://localhost:3000/events/match-request-withdrawn/#eventId
       assessment-allocated-event-detail: http://localhost:3000/events/assessment-allocated/#eventId
+      request-for-placement-created-event-detail: http://localhost:3000/events/request-for-placement-created/#eventId
     cas2:
       application-submitted-event-detail: http://localhost:3000/events/cas2/application-submitted/#eventId
       application-status-updated-event-detail: http://localhost:3000/events/cas2/application-status-updated/#eventId

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3465,6 +3465,7 @@ components:
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
+        - approved_premises_request_for_placement_created
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7967,6 +7967,7 @@ components:
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
+        - approved_premises_request_for_placement_created
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4025,6 +4025,7 @@ components:
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
+        - approved_premises_request_for_placement_created
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3556,6 +3556,7 @@ components:
         - approved_premises_assessment_allocated
         - approved_premises_placement_application_withdrawn
         - approved_premises_match_request_withdrawn
+        - approved_premises_request_for_placement_created
         - cas3_person_arrived
         - cas3_person_departed
         - application_timeline_note

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -409,6 +409,33 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /events/request-for-placement-created/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Manage' events"
+      summary: A 'request-for-placement-created' event
+      responses:
+        '200':
+          description: The 'request-for-placement-created' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestForPlacementCreatedEnvelope'
+        404:
+          description: No 'request-for-placement-created' event found for the provided `eventId`
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
 components:
   responses:
     500Response:
@@ -464,6 +491,11 @@ components:
       type: string
       format: uuid
       example: 14c80733-4b6d-4f35-b724-66955aac320c
+    RequestForPlacementId:
+      description: The UUID of a request for placement. Currently a proxy for PlacementApplicationId
+      type: string
+      format: uuid
+      example: 484b8b5e-6c3b-4400-b200-425bbe410713
     LegacyApCode:
       description: The 'Q code' used in Delius to identify an Approved Premises
       type: string
@@ -1475,6 +1507,70 @@ components:
         - appealDetail
         - decision
         - decisionDetail
+    RequestForPlacementCreatedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          type: string
+          example: approved-premises.request-for-placement.created
+        eventDetails:
+          $ref: '#/components/schemas/RequestForPlacementCreated'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
+    RequestForPlacementCreated:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        deliusEventNumber:
+          $ref: '#/components/schemas/DeliusEventNumber'
+        requestForPlacementId:
+          $ref: '#/components/schemas/RequestForPlacementId'
+        createdAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
+        createdBy:
+          $ref: '#/components/schemas/StaffMember'
+        expectedArrival:
+          type: string
+          example: '2023-01-30'
+          format: date
+        duration:
+          type: integer
+          example: 7
+        requestForPlacementType:
+          $ref: '#/components/schemas/RequestForPlacementType'
+      required:
+        - applicationId
+        - applicationUrl
+        - requestForPlacementId
+        - createdAt
+        - personReference
+        - deliusEventNumber
+        - expectedArrival
+        - duration
+        - requestForPlacementType
+    RequestForPlacementType:
+      type: string
+      enum:
+        - initial
+        - rotl
+        - releaseFollowingDecisions
+        - additionalPlacement
     AppealDecision:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RequestForPlacementCreatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RequestForPlacementCreatedFactory.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class RequestForPlacementCreatedFactory : Factory<RequestForPlacementCreated> {
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
+  private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var createdAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
+  private var createdBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var expectedArrival: Yielded<LocalDate> = { LocalDate.now() }
+  private var duration: Yielded<Int> = { randomInt(0, 1000) }
+  private var requestForPlacementType: Yielded<RequestForPlacementType> = { RequestForPlacementType.additionalPlacement }
+  private var requestForPlacementId: Yielded<UUID> = { UUID.randomUUID() }
+
+  fun withRequestForPlacementType(requestForPlacementType: RequestForPlacementType) = apply {
+    this.requestForPlacementType = { requestForPlacementType }
+  }
+
+  fun withExpectedArrival(expectedArrival: LocalDate) = apply {
+    this.expectedArrival = { expectedArrival }
+  }
+
+  fun withDuration(duration: Int) = apply {
+    this.duration = { duration }
+  }
+
+  fun withApplicationUrl(applicationUrl: String) = apply {
+    this.applicationUrl = { applicationUrl }
+  }
+
+  override fun produce() = RequestForPlacementCreated(
+    applicationId = this.applicationId(),
+    applicationUrl = this.applicationUrl(),
+    personReference = this.personReference(),
+    deliusEventNumber = this.deliusEventNumber(),
+    createdAt = this.createdAt(),
+    createdBy = this.createdBy(),
+    expectedArrival = this.expectedArrival(),
+    duration = this.duration(),
+    requestForPlacementType = this.requestForPlacementType(),
+    requestForPlacementId = this.requestForPlacementId(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2118,10 +2118,9 @@ class ApplicationTest : IntegrationTestBase() {
             assertThat(persistedAssessmentAllocatedEvent).isNotNull
             assertThat(persistedAssessmentAllocatedEvent!!.crn).isEqualTo(offenderDetails.otherIds.crn)
 
-            snsDomainEventListener.blockForMessage()
-            val emittedMessage = snsDomainEventListener.blockForMessage()
+            snsDomainEventListener.blockForMessage("approved-premises.assessment.allocated")
+            val emittedMessage = snsDomainEventListener.blockForMessage("approved-premises.application.submitted")
 
-            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.submitted")
             val emittedMessageDescription = "An application has been submitted for an Approved Premises placement"
             assertThat(emittedMessage.description).isEqualTo(emittedMessageDescription)
             assertThat(emittedMessage.detailUrl).matches("http://api/events/application-submitted/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2070,9 +2070,8 @@ class AssessmentTest : IntegrationTestBase() {
             assertThat(persistedAssessment.document).isEqualTo("{\"document\":\"value\"}")
             assertThat(persistedAssessment.submittedAt).isNotNull
 
-            val emittedMessage = snsDomainEventListener.blockForMessage()
+            val emittedMessage = snsDomainEventListener.blockForMessage("approved-premises.application.assessed")
 
-            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.assessed")
             assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")
             assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
@@ -2162,9 +2161,8 @@ class AssessmentTest : IntegrationTestBase() {
             assertThat(persistedAssessment.document).isEqualTo("{\"document\":\"value\"}")
             assertThat(persistedAssessment.submittedAt).isNotNull
 
-            val emittedMessage = snsDomainEventListener.blockForMessage()
+            val emittedMessage = snsDomainEventListener.blockForMessage("approved-premises.application.assessed")
 
-            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.assessed")
             assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")
             assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)
@@ -2307,9 +2305,8 @@ class AssessmentTest : IntegrationTestBase() {
         assertThat(persistedAssessment.document).isEqualTo("{\"document\":\"value\"}")
         assertThat(persistedAssessment.submittedAt).isNotNull
 
-        val emittedMessage = snsDomainEventListener.blockForMessage()
+        val emittedMessage = snsDomainEventListener.blockForMessage("approved-premises.application.assessed")
 
-        assertThat(emittedMessage.eventType).isEqualTo("approved-premises.application.assessed")
         assertThat(emittedMessage.description).isEqualTo("An application has been assessed for an Approved Premises placement")
         assertThat(emittedMessage.detailUrl).matches("http://api/events/application-assessed/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
         assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(assessment.application.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -753,9 +753,8 @@ class BookingTest : IntegrationTestBase() {
               .jsonPath("$.bed.id").isEqualTo(bed.id.toString())
               .jsonPath("$.bed.name").isEqualTo(bed.name)
 
-            val emittedMessage = snsDomainEventListener.blockForMessage()
+            val emittedMessage = snsDomainEventListener.blockForMessage("approved-premises.booking.made")
 
-            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.booking.made")
             assertThat(emittedMessage.description).isEqualTo("An Approved Premises booking has been made")
             assertThat(emittedMessage.detailUrl).matches("http://api/events/booking-made/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
             assertThat(emittedMessage.additionalInformation.applicationId).isEqualTo(linkedApplication.id)
@@ -4493,9 +4492,8 @@ class BookingTest : IntegrationTestBase() {
     eventDescription: String,
     detailUrl: String,
   ) {
-    val emittedMessage = snsDomainEventListener.blockForMessage()
+    val emittedMessage = snsDomainEventListener.blockForMessage(eventType)
 
-    assertThat(emittedMessage.eventType).isEqualTo(eventType)
     assertThat(emittedMessage.description).isEqualTo(eventDescription)
     assertThat(emittedMessage.detailUrl).matches("$detailUrl/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}")
     assertThat(emittedMessage.personReference.identifiers).containsExactlyInAnyOrder(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -87,7 +87,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.notification.EmailNotificationAsserter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.DomainEventAsserter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
@@ -506,6 +507,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var snsDomainEventListener: SnsDomainEventListener
+
+  @Autowired
+  lateinit var domainEventAsserter: DomainEventAsserter
 
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1307,8 +1307,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
                 serializableToJsonNode(placementApplicationEntity.document) == serializableToJsonNode(it.document)
             }
 
-            val emittedMessage = snsDomainEventListener.blockForMessage()
-            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.placement-application.withdrawn")
+            snsDomainEventListener.blockForMessage("approved-premises.placement-application.withdrawn")
 
             emailAsserter.assertEmailsRequestedCount(2)
             emailAsserter.assertEmailRequested(
@@ -1371,8 +1370,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
                   serializableToJsonNode(placementApplicationEntity.document) == serializableToJsonNode(it.document)
               }
 
-              val emittedMessage = snsDomainEventListener.blockForMessage()
-              assertThat(emittedMessage.eventType).isEqualTo("approved-premises.placement-application.withdrawn")
+              snsDomainEventListener.blockForMessage("approved-premises.placement-application.withdrawn")
 
               emailAsserter.assertEmailsRequestedCount(2)
               emailAsserter.assertEmailRequested(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1659,8 +1659,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
             assertThat(persistedPlacementRequest.isWithdrawn).isTrue
             assertThat(persistedPlacementRequest.withdrawalReason).isEqualTo(PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
 
-            val emittedMessage = snsDomainEventListener.blockForMessage()
-            assertThat(emittedMessage.eventType).isEqualTo("approved-premises.match-request.withdrawn")
+            snsDomainEventListener.blockForMessage("approved-premises.match-request.withdrawn")
 
             emailAsserter.assertEmailsRequestedCount(2)
             emailAsserter.assertEmailRequested(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
@@ -39,7 +39,7 @@ class SnsDomainEventListener(private val objectMapper: ObjectMapper) {
     var waitedCount = 0
     while (!contains(eventType)) {
       if (waitedCount >= Duration.ofSeconds(15).toMillis()) {
-        fail<Any>("Did not receive SQS message of type $eventType from SNS topic after 15s")
+        fail<Any>("Did not receive SQS message of type $eventType from SNS topic after 15s. Have messages of type ${messages.map { m -> m.eventType }}")
       }
 
       Thread.sleep(100)
@@ -51,13 +51,7 @@ class SnsDomainEventListener(private val objectMapper: ObjectMapper) {
     }
   }
 
-  fun isEmpty(): Boolean {
-    synchronized(messages) {
-      return messages.isEmpty()
-    }
-  }
-
-  fun contains(eventType: String): Boolean {
+  private fun contains(eventType: String): Boolean {
     synchronized(messages) {
       return messages.firstOrNull { it.eventType == eventType } != null
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
@@ -7,6 +7,7 @@ import org.springframework.jms.annotation.JmsListener
 import org.springframework.stereotype.Service
 import org.springframework.test.context.event.annotation.BeforeTestMethod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
+import java.time.Duration
 
 @Service
 class SnsDomainEventListener(private val objectMapper: ObjectMapper) {
@@ -34,23 +35,31 @@ class SnsDomainEventListener(private val objectMapper: ObjectMapper) {
   @BeforeTestMethod
   fun clearMessages() = messages.clear()
 
-  fun blockForMessage(): SnsEvent {
+  fun blockForMessage(eventType: String): SnsEvent {
     var waitedCount = 0
-    while (isEmpty()) {
-      if (waitedCount == 300) fail<Any>("Never received SQS message from SNS topic after 30s")
+    while (!contains(eventType)) {
+      if (waitedCount >= Duration.ofSeconds(15).toMillis()) {
+        fail<Any>("Did not receive SQS message of type $eventType from SNS topic after 15s")
+      }
 
       Thread.sleep(100)
-      waitedCount += 1
+      waitedCount += 100
     }
 
     synchronized(messages) {
-      return messages.removeFirst()
+      return messages.first { it.eventType == eventType }
     }
   }
 
   fun isEmpty(): Boolean {
     synchronized(messages) {
       return messages.isEmpty()
+    }
+  }
+
+  fun contains(eventType: String): Boolean {
+    synchronized(messages) {
+      return messages.firstOrNull { it.eventType == eventType } != null
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/DomainEventAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/DomainEventAsserter.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SnsDomainEventListener
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import java.util.UUID
+
+@Component
+class DomainEventAsserter(
+  val snsDomainEventListener: SnsDomainEventListener,
+  val domainEventRepository: DomainEventRepository,
+) {
+
+  fun blockForEmittedDomainEvent(eventType: String) = snsDomainEventListener.blockForMessage(eventType)
+
+  fun assertDomainEventOfTypeNotStored(applicationId: UUID, eventType: DomainEventType) {
+    assertThat(
+      domainEventRepository
+        .findAllTimelineEventsByApplicationId(applicationId)
+        .map { it.type },
+    ).doesNotContain(eventType)
+  }
+
+  fun assertDomainEventOfTypeStored(applicationId: UUID, eventType: DomainEventType) {
+    assertThat(
+      domainEventRepository
+        .findAllTimelineEventsByApplicationId(applicationId)
+        .map { it.type },
+    ).contains(eventType)
+  }
+
+  fun assertDomainEventsOfTypeStored(applicationId: UUID, eventType: DomainEventType, expectedCount: Int) {
+    assertThat(
+      domainEventRepository
+        .findAllTimelineEventsByApplicationId(applicationId)
+        .count { it.type == eventType },
+    ).isEqualTo(expectedCount)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.notification
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter
 
 import org.assertj.core.api.Assertions.assertThat
 import org.slf4j.Logger

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -126,6 +126,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.GetBookingForPremisesResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -2657,6 +2658,7 @@ class BookingServiceTest {
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every {
         mockPlacementRequestService.createPlacementRequest(
+          source = PlacementRequestSource.APPEAL,
           placementRequirements = originalPlacementRequirements,
           placementDates = PlacementDates(
             expectedArrival = originalPlacementRequest.expectedArrival,
@@ -2667,7 +2669,7 @@ class BookingServiceTest {
           null,
         )
       } answers {
-        val placementRequirementsArgument = it.invocation.args[0] as PlacementRequirementsEntity
+        val placementRequirementsArgument = it.invocation.args[1] as PlacementRequirementsEntity
         PlacementRequestEntityFactory()
           .withPlacementRequirements(placementRequirementsArgument)
           .withApplication(application)
@@ -2698,6 +2700,7 @@ class BookingServiceTest {
 
       verify(exactly = 1) {
         mockPlacementRequestService.createPlacementRequest(
+          source = PlacementRequestSource.APPEAL,
           placementRequirements = originalPlacementRequirements,
           placementDates = PlacementDates(
             expectedArrival = originalPlacementRequest.expectedArrival,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -175,6 +175,8 @@ class PlacementApplicationServiceTest {
       every { placementDateRepository.saveAll(any<List<PlacementDateEntity>>()) } answers { emptyList() }
       every { placementDateRepository.save(any()) } answers { it.invocation.args[0] as PlacementDateEntity }
 
+      every { userService.getDeliusUserNameForRequest() } returns "theUsername"
+      every { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(any(), any()) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication) } returns Unit
 
@@ -195,13 +197,15 @@ class PlacementApplicationServiceTest {
     }
 
     @Test
-    fun `Submitting an application saves a single date to a placement application and triggers emails`() {
+    fun `Submitting an application saves a single date to a placement application, triggers emails and domain event`() {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java) } returns placementApplication.schemaVersion
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { placementDateRepository.save(any()) } answers { it.invocation.args[0] as PlacementDateEntity }
 
+      every { userService.getDeliusUserNameForRequest() } returns "theUsername"
+      every { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(any(), any()) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationSubmitted(placementApplication) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationAllocated(placementApplication) } returns Unit
 
@@ -225,18 +229,21 @@ class PlacementApplicationServiceTest {
       assertThat(updatedPlacementApp.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
       assertThat(updatedPlacementApp.placementDates[0].duration).isEqualTo(5)
 
+      verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(updatedPlacementApp, "theUsername") }
       verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp) }
       verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp) }
     }
 
     @Test
-    fun `Submitting an application saves multiple dates to individual placement applications and triggers emails per resultant placement application`() {
+    fun `Submitting an application saves multiple dates to individual placement applications and triggers emails and domain event per resultant placement application`() {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java) } returns placementApplication.schemaVersion
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
       every { placementDateRepository.save(any()) } answers { it.invocation.args[0] as PlacementDateEntity }
 
+      every { userService.getDeliusUserNameForRequest() } returns "theUsername"
+      every { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(any(), any()) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationSubmitted(any()) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationAllocated(any()) } returns Unit
 
@@ -262,6 +269,7 @@ class PlacementApplicationServiceTest {
       assertThat(updatedPlacementApp1.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 4, 1))
       assertThat(updatedPlacementApp1.placementDates[0].duration).isEqualTo(5)
       assertThat(updatedPlacementApp1.submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(updatedPlacementApp1, "theUsername") }
       verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp1) }
       verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp1) }
 
@@ -269,6 +277,7 @@ class PlacementApplicationServiceTest {
       assertThat(updatedPlacementApp2.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 5, 2))
       assertThat(updatedPlacementApp2.placementDates[0].duration).isEqualTo(10)
       assertThat(updatedPlacementApp2.submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(updatedPlacementApp2, "theUsername") }
       verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp2) }
       verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp2) }
 
@@ -276,6 +285,7 @@ class PlacementApplicationServiceTest {
       assertThat(updatedPlacementApp3.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 6, 3))
       assertThat(updatedPlacementApp3.placementDates[0].duration).isEqualTo(15)
       assertThat(updatedPlacementApp3.submissionGroupId).isEqualTo(firstSubmissionGroupId)
+      verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(updatedPlacementApp3, "theUsername") }
       verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp3) }
       verify { cas1PlacementApplicationEmailService.placementApplicationSubmitted(updatedPlacementApp3) }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -69,6 +69,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CruService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
@@ -166,6 +167,7 @@ class PlacementRequestServiceTest {
     )
 
     val placementRequest = placementRequestService.createPlacementRequest(
+      source = PlacementRequestSource.ASSESSMENT_OF_APPLICATION,
       placementRequirements,
       placementDates,
       "Some notes",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -60,6 +60,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequirementsService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -372,7 +373,7 @@ class AcceptAssessmentTest {
     verifyDomainEventSent(offenderDetails, staffUserDetails, assessment)
 
     verify(exactly = 0) {
-      placementRequestServiceMock.createPlacementRequest(any(), any(), any(), false, null)
+      placementRequestServiceMock.createPlacementRequest(any(), any(), any(), any(), false, null)
     }
 
     verify(exactly = 1) {
@@ -415,7 +416,7 @@ class AcceptAssessmentTest {
 
     every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.Success(placementRequirementEntity)
 
-    every { placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes, false, null) } returns PlacementRequestEntityFactory()
+    every { placementRequestServiceMock.createPlacementRequest(any(), any(), any(), any(), any(), any()) } returns PlacementRequestEntityFactory()
       .withPlacementRequirements(
         PlacementRequirementsEntityFactory()
           .withApplication(assessment.application as ApprovedPremisesApplicationEntity)
@@ -458,7 +459,14 @@ class AcceptAssessmentTest {
     verifyDomainEventSent(offenderDetails, staffUserDetails, assessment)
 
     verify(exactly = 1) {
-      placementRequestServiceMock.createPlacementRequest(placementRequirementEntity, placementDates, notes, false, null)
+      placementRequestServiceMock.createPlacementRequest(
+        source = PlacementRequestSource.ASSESSMENT_OF_APPLICATION,
+        placementRequirements = placementRequirementEntity,
+        placementDates = placementDates,
+        notes = notes,
+        isParole = false,
+        placementApplicationEntity = null,
+      )
     }
 
     verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -3,22 +3,33 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.DatePeriod
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.WithdrawnByFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationDomainEventServiceTest.TestConstants.CRN
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationDomainEventServiceTest.TestConstants.USERNAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -26,31 +37,100 @@ class Cas1PlacementApplicationDomainEventServiceTest {
 
   private object TestConstants {
     const val CRN = "CRN123"
+    const val USERNAME = "theUserName"
   }
 
   val domainEventService = mockk<DomainEventService>()
   val domainEventTransformer = mockk<DomainEventTransformer>()
+  val communityApiClient = mockk<CommunityApiClient>()
+
   val service = Cas1PlacementApplicationDomainEventService(
     domainEventService,
     domainEventTransformer,
+    communityApiClient,
     applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
   )
+
+  val user = UserEntityFactory()
+    .withUnitTestControlProbationRegion()
+    .produce()
+
+  val application = ApprovedPremisesApplicationEntityFactory()
+    .withCrn(CRN)
+    .withCreatedByUser(user)
+    .withSubmittedAt(OffsetDateTime.now())
+    .produce()
+
+  @Nested
+  inner class PlacementApplicationSubmitted {
+
+    @ParameterizedTest
+    @CsvSource(
+      "ROTL,rotl",
+      "RELEASE_FOLLOWING_DECISION,releaseFollowingDecisions",
+      "ADDITIONAL_PLACEMENT,additionalPlacement",
+    )
+    fun `it creates a domain event`(placementType: PlacementType, expectedRequestForPlacementType: RequestForPlacementType) {
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withApplication(application)
+        .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
+        .withDecision(null)
+        .withCreatedByUser(user)
+        .withPlacementType(placementType)
+        .produce()
+
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withPlacementApplication(placementApplication)
+          .withExpectedArrival(LocalDate.of(2024, 5, 3))
+          .withDuration(7)
+          .produce(),
+      )
+
+      val staffUserDetails = StaffUserDetailsFactory().produce()
+      every { communityApiClient.getStaffUserDetails(USERNAME) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = staffUserDetails,
+      )
+
+      val staffMember = StaffMemberFactory().produce()
+      every { domainEventTransformer.toStaffMember(staffUserDetails) } returns staffMember
+      every { domainEventService.saveRequestForPlacementCreatedEvent(any(), any()) } returns Unit
+
+      service.placementApplicationSubmitted(placementApplication, USERNAME)
+
+      verify {
+        domainEventService.saveRequestForPlacementCreatedEvent(
+          withArg {
+            assertThat(it.id).isNotNull()
+            assertThat(it.applicationId).isEqualTo(application.id)
+            assertThat(it.crn).isEqualTo(CRN)
+            assertThat(it.occurredAt).isWithinTheLastMinute()
+
+            val eventDetails = it.data.eventDetails
+            assertThat(eventDetails.applicationId).isEqualTo(application.id)
+            assertThat(eventDetails.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
+            assertThat(eventDetails.requestForPlacementId).isEqualTo(placementApplication.id)
+            assertThat(eventDetails.personReference.crn).isEqualTo(CRN)
+            assertThat(eventDetails.personReference.noms).isEqualTo(application.nomsNumber)
+            assertThat(eventDetails.deliusEventNumber).isEqualTo(application.eventNumber)
+            assertThat(eventDetails.createdAt).isWithinTheLastMinute()
+            assertThat(eventDetails.createdBy).isEqualTo(staffMember)
+            assertThat(eventDetails.expectedArrival).isEqualTo(LocalDate.of(2024, 5, 3))
+            assertThat(eventDetails.duration).isEqualTo(7)
+            assertThat(eventDetails.requestForPlacementType).isEqualTo(expectedRequestForPlacementType)
+          },
+          emit = false,
+        )
+      }
+    }
+  }
 
   @Nested
   inner class PlacementApplicationWithdrawn {
 
     @Test
     fun `it creates a domain event`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCrn(TestConstants.CRN)
-        .withCreatedByUser(user)
-        .withSubmittedAt(OffsetDateTime.now())
-        .produce()
-
       val placementApplication = PlacementApplicationEntityFactory()
         .withApplication(application)
         .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
@@ -64,11 +144,6 @@ class Cas1PlacementApplicationDomainEventServiceTest {
           .withPlacementApplication(placementApplication)
           .withExpectedArrival(LocalDate.of(2024, 5, 3))
           .withDuration(7)
-          .produce(),
-        PlacementDateEntityFactory()
-          .withPlacementApplication(placementApplication)
-          .withExpectedArrival(LocalDate.of(2025, 2, 2))
-          .withDuration(14)
           .produce(),
       )
 
@@ -87,31 +162,24 @@ class Cas1PlacementApplicationDomainEventServiceTest {
 
       verify(exactly = 1) {
         domainEventService.savePlacementApplicationWithdrawnEvent(
-          match {
-            val data = it.data.eventDetails
+          withArg {
+            assertThat(it.id).isNotNull()
+            assertThat(it.applicationId).isEqualTo(application.id)
+            assertThat(it.crn).isEqualTo(CRN)
+            assertThat(it.occurredAt).isWithinTheLastMinute()
 
-            it.applicationId == application.id &&
-              it.crn == application.crn &&
-              data.applicationId == application.id &&
-              data.applicationUrl == "http://frontend/applications/${application.id}" &&
-              data.placementApplicationId == placementApplication.id &&
-              data.personReference == PersonReference(
-              crn = application.crn,
-              noms = application.nomsNumber!!,
-            ) &&
-              data.deliusEventNumber == application.eventNumber &&
-              data.withdrawnBy == withdrawnBy
-            data.withdrawalReason == "ALTERNATIVE_PROVISION_IDENTIFIED" &&
-              data.placementDates == listOf(
-              DatePeriod(
-                LocalDate.of(2024, 5, 3),
-                LocalDate.of(2024, 5, 10),
-              ),
-              DatePeriod(
-                LocalDate.of(2025, 2, 2),
-                LocalDate.of(2025, 2, 16),
-              ),
-            )
+            val eventDetails = it.data.eventDetails
+            assertThat(eventDetails.applicationId).isEqualTo(application.id)
+            assertThat(eventDetails.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
+            assertThat(eventDetails.placementApplicationId).isEqualTo(placementApplication.id)
+            assertThat(eventDetails.personReference.crn).isEqualTo(CRN)
+            assertThat(eventDetails.personReference.noms).isEqualTo(application.nomsNumber)
+            assertThat(eventDetails.deliusEventNumber).isEqualTo(application.eventNumber)
+            assertThat(eventDetails.withdrawnBy).isEqualTo(withdrawnBy)
+            assertThat(eventDetails.withdrawalReason).isEqualTo("ALTERNATIVE_PROVISION_IDENTIFIED")
+            assertThat(eventDetails.placementDates).hasSize(1)
+            assertThat(eventDetails.placementDates!![0].startDate).isEqualTo(LocalDate.of(2024, 5, 3))
+            assertThat(eventDetails.placementDates!![0].endDate).isEqualTo(LocalDate.of(2024, 5, 10))
           },
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
@@ -4,10 +4,12 @@ import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.DatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
@@ -17,11 +19,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.WithdrawnByFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestDomainEventServiceTest.TestConstants.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -38,42 +43,100 @@ class Cas1PlacementRequestDomainEventServiceTest {
     domainEventTransformer,
     applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
   )
+  val user = UserEntityFactory()
+    .withUnitTestControlProbationRegion()
+    .produce()
+
+  val application = ApprovedPremisesApplicationEntityFactory()
+    .withCrn(CRN)
+    .withCreatedByUser(user)
+    .withSubmittedAt(OffsetDateTime.now())
+    .produce()
+
+  val assessment = ApprovedPremisesAssessmentEntityFactory()
+    .withApplication(application)
+    .produce()
+
+  val placementRequirements = PlacementRequirementsEntityFactory()
+    .withApplication(application)
+    .withAssessment(assessment)
+    .produce()
+
+  val placementRequest = PlacementRequestEntityFactory()
+    .withApplication(application)
+    .withPlacementRequirements(placementRequirements)
+    .withPlacementApplication(null)
+    .withAssessment(assessment)
+    .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
+    .withWithdrawalReason(PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
+    .withExpectedArrival(LocalDate.of(2024, 5, 3))
+    .withDuration(7)
+    .produce()
+
+  @Nested
+  inner class PlacementRequestCreated {
+
+    @Test
+    fun `if source is appeal, don't create a domain event`() {
+      service.placementRequestCreated(
+        placementRequest = placementRequest,
+        source = PlacementRequestSource.APPEAL,
+      )
+
+      verify { domainEventService wasNot Called }
+    }
+
+    @Test
+    fun `if source is assessment of placement application, don't create a domain event`() {
+      service.placementRequestCreated(
+        placementRequest = placementRequest,
+        source = PlacementRequestSource.ASSESSMENT_OF_PLACEMENT_APPLICATION,
+      )
+
+      verify { domainEventService wasNot Called }
+    }
+
+    @Test
+    fun `if source is application assessment, create a domain event`() {
+      every { domainEventService.saveRequestForPlacementCreatedEvent(any(), any()) } returns Unit
+
+      service.placementRequestCreated(
+        placementRequest = placementRequest,
+        source = PlacementRequestSource.ASSESSMENT_OF_APPLICATION,
+      )
+
+      verify {
+        domainEventService.saveRequestForPlacementCreatedEvent(
+          withArg {
+            assertThat(it.id).isNotNull()
+            assertThat(it.applicationId).isEqualTo(application.id)
+            assertThat(it.crn).isEqualTo(CRN)
+            assertThat(it.occurredAt).isWithinTheLastMinute()
+
+            val eventDetails = it.data.eventDetails
+            assertThat(eventDetails.applicationId).isEqualTo(application.id)
+            assertThat(eventDetails.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
+            assertThat(eventDetails.requestForPlacementId).isEqualTo(placementRequest.id)
+            assertThat(eventDetails.personReference.crn).isEqualTo(CRN)
+            assertThat(eventDetails.personReference.noms).isEqualTo(application.nomsNumber)
+            assertThat(eventDetails.deliusEventNumber).isEqualTo(application.eventNumber)
+            assertThat(eventDetails.createdAt).isWithinTheLastMinute()
+            assertThat(eventDetails.createdBy).isNull()
+            assertThat(eventDetails.expectedArrival).isEqualTo(LocalDate.of(2024, 5, 3))
+            assertThat(eventDetails.duration).isEqualTo(7)
+            assertThat(eventDetails.requestForPlacementType).isEqualTo(RequestForPlacementType.initial)
+          },
+          emit = false,
+        )
+      }
+    }
+  }
 
   @Nested
   inner class PlacementRequestWithdrawn {
 
     @Test
     fun `it creates a domain event if for the applications arrival date`() {
-      val user = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .produce()
-
-      val application = ApprovedPremisesApplicationEntityFactory()
-        .withCrn(TestConstants.CRN)
-        .withCreatedByUser(user)
-        .withSubmittedAt(OffsetDateTime.now())
-        .produce()
-
-      val assessment = ApprovedPremisesAssessmentEntityFactory()
-        .withApplication(application)
-        .produce()
-
-      val placementRequirements = PlacementRequirementsEntityFactory()
-        .withApplication(application)
-        .withAssessment(assessment)
-        .produce()
-
-      val placementRequest = PlacementRequestEntityFactory()
-        .withApplication(application)
-        .withPlacementRequirements(placementRequirements)
-        .withPlacementApplication(null)
-        .withAssessment(assessment)
-        .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
-        .withWithdrawalReason(PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
-        .withExpectedArrival(LocalDate.of(2024, 5, 3))
-        .withDuration(7)
-        .produce()
-
       val withdrawnBy = WithdrawnByFactory().produce()
       every { domainEventTransformer.toWithdrawnBy(user) } returns withdrawnBy
       every { domainEventService.saveMatchRequestWithdrawnEvent(any()) } returns Unit

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/DatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/DatesTest.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.countOverlappingDays
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.overlaps
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormattedHourOfDay
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toWeekAndDayDurationString
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -117,5 +121,34 @@ class DatesTest {
     val dateTime = OffsetDateTime.parse("2024-01-01T11:15:00Z")
 
     assertThat(dateTime.toUiFormattedHourOfDay()).isEqualTo("11am")
+  }
+
+  @Nested
+  inner class ToWeekAndDayDurationString {
+
+    @ParameterizedTest
+    @CsvSource(
+      "0, 0 days",
+      "1, 1 day",
+      "2, 2 days",
+      "3, 3 days",
+      "4, 4 days",
+      "5, 5 days",
+      "6, 6 days",
+      "7, 1 week",
+      "8, 1 week and 1 day",
+      "9, 1 week and 2 days",
+      "10, 1 week and 3 days",
+      "11, 1 week and 4 days",
+      "12, 1 week and 5 days",
+      "13, 1 week and 6 days",
+      "14, 2 weeks",
+      "15, 2 weeks and 1 day",
+      "23, 3 weeks and 2 days",
+      "365, 52 weeks and 1 day",
+    )
+    fun `toWeekAndDayDurationString 0 days`(days: Int, expectedResult: String) {
+      assertThat(toWeekAndDayDurationString(days)).isEqualTo(expectedResult)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssertJExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssertJExtensions.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import org.assertj.core.api.AbstractInstantAssert
 import org.assertj.core.api.AbstractLocalDateTimeAssert
 import org.assertj.core.api.AbstractOffsetDateTimeAssert
 import org.assertj.core.api.Assertions
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
@@ -13,4 +15,8 @@ fun AbstractOffsetDateTimeAssert<*>.isWithinTheLastMinute() {
 
 fun AbstractLocalDateTimeAssert<*>.isWithinTheLastMinute() {
   this.isCloseTo(LocalDateTime.now(), Assertions.within(1, ChronoUnit.MINUTES))
+}
+
+fun AbstractInstantAssert<*>.isWithinTheLastMinute() {
+  this.isCloseTo(Instant.now(), Assertions.within(1, ChronoUnit.MINUTES))
 }


### PR DESCRIPTION
This PR adds a new 'Request for Placement Created' domain event. This is not emitted to SNS as it's only (current) purpose is to show on the timeline when request for placements are created in an application.

The domain event is raised when an application with arrival date/duration is assessed (at which point the placement_request is created), and when the user creates requests for placements after application assessment

The screenshot below shows the domain event rendered on the timeline for all variations:

![Screenshot 2024-04-09 at 15 31 38](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/c31d4bca-3707-44f3-9fe2-9e294323b1f3)
