### PR TITLE
(Chore) Improve enum conversion

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -150,18 +150,22 @@ enum class PlacementType {
   ADDITIONAL_PLACEMENT,
 }
 
-enum class PlacementApplicationDecision {
-  ACCEPTED,
-  REJECTED,
-  WITHDRAW,
-  WITHDRAWN_BY_PP,
+enum class PlacementApplicationDecision(val apiValue: ApiPlacementApplicationDecision) {
+  ACCEPTED(ApiPlacementApplicationDecision.accepted),
+  REJECTED(ApiPlacementApplicationDecision.rejected),
+  WITHDRAW(ApiPlacementApplicationDecision.withdraw),
+  WITHDRAWN_BY_PP(ApiPlacementApplicationDecision.withdrawnByPp),
   ;
 
-  fun convertToApi() = when (this) {
-    ACCEPTED -> ApiPlacementApplicationDecision.accepted
-    REJECTED -> ApiPlacementApplicationDecision.rejected
-    WITHDRAW -> ApiPlacementApplicationDecision.withdraw
-    WITHDRAWN_BY_PP -> ApiPlacementApplicationDecision.withdrawnByPp
+  companion object {
+    fun valueOf(apiValue: ApiPlacementApplicationDecision): PlacementApplicationDecision? {
+      for (e in entries) {
+        if (e.apiValue == apiValue) {
+          return e
+        }
+      }
+      return null
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -361,7 +361,7 @@ class PlacementApplicationService(
     }
 
     placementApplicationEntity.apply {
-      decision = mapToJpaDecision(placementApplicationDecisionEnvelope.decision)
+      decision = JpaPlacementApplicationDecision.valueOf(placementApplicationDecisionEnvelope.decision)
       decisionMadeAt = OffsetDateTime.now()
     }
 
@@ -375,13 +375,6 @@ class PlacementApplicationService(
     }
 
     return CasResult.Success(savedApplication)
-  }
-
-  private fun mapToJpaDecision(decision: uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision) = when (decision) {
-    ApiPlacementApplicationDecision.accepted -> JpaPlacementApplicationDecision.ACCEPTED
-    ApiPlacementApplicationDecision.rejected -> JpaPlacementApplicationDecision.REJECTED
-    ApiPlacementApplicationDecision.withdraw -> JpaPlacementApplicationDecision.WITHDRAW
-    ApiPlacementApplicationDecision.withdrawnByPp -> JpaPlacementApplicationDecision.WITHDRAWN_BY_PP
   }
 
   private fun getPlacementType(apiPlacementType: ApiPlacementType): PlacementType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -94,7 +94,7 @@ class TaskTransformer(
     placementType = getPlacementType(placementApplication.placementType!!),
     apArea = getApArea(placementApplication.application),
     outcomeRecordedAt = placementApplication.decisionMadeAt?.toInstant(),
-    outcome = placementApplication.decision?.convertToApi(),
+    outcome = placementApplication.decision?.apiValue,
   )
 
   private fun getApArea(application: ApplicationEntity): ApArea? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementApplicationEntityTest.kt
@@ -16,7 +16,20 @@ class PlacementApplicationEntityTest {
       "WITHDRAWN_BY_PP,withdrawnByPp",
     ],
   )
-  fun `PlacementApplicationDecision#convertToApi converts to the API enum values correctly`(decision: PlacementApplicationDecision, apiDecision: ApiPlacementApplicationDecision) {
-    assertThat(decision.convertToApi()).isEqualTo(apiDecision)
+  fun `PlacementApplicationDecision#apiValue converts to the API enum values correctly`(decision: PlacementApplicationDecision, apiDecision: ApiPlacementApplicationDecision) {
+    assertThat(decision.apiValue).isEqualTo(apiDecision)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "accepted,ACCEPTED",
+      "rejected,REJECTED",
+      "withdraw,WITHDRAW",
+      "withdrawnByPp,WITHDRAWN_BY_PP",
+    ],
+  )
+  fun `PlacementApplicationDecision#valueOf gets the enum value from the API value`(apiDecision: ApiPlacementApplicationDecision, decision: PlacementApplicationDecision) {
+    assertThat(PlacementApplicationDecision.valueOf(apiDecision)).isEqualTo(decision)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -317,7 +317,7 @@ class TaskTransformerTest {
       val result = taskTransformer.transformPlacementApplicationToTask(placementApplication, "First Last")
 
       assertThat(result.status).isEqualTo(TaskStatus.complete)
-      assertThat(result.outcome).isEqualTo(decision.convertToApi())
+      assertThat(result.outcome).isEqualTo(decision.apiValue)
       assertThat(result.outcomeRecordedAt).isEqualTo(decisionMadeAt.toInstant())
     }
 


### PR DESCRIPTION
This updates the changes made recently to `PlacementApplicationDecision` to enable easy conversion from JPA enum to API enum and vice-versa. Hopefully this is a pattern we can replicate elsewhere.