### PR TITLE
APS-496 Add default assessment-allocated-event-detail url

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -214,6 +214,7 @@ url-templates:
       assessment-appealed-event-detail: http://localhost:3000/events/assessment-appealed/#eventId
       placement-application-withdrawn-event-detail: http://localhost:3000/events/placement-application-withdrawn/#eventId
       match-request-withdrawn-event-detail: http://localhost:3000/events/match-request-withdrawn/#eventId
+      assessment-allocated-event-detail: http://localhost:3000/events/assessment-allocated/#eventId
     cas2:
       application-submitted-event-detail: http://localhost:3000/events/cas2/application-submitted/#eventId
       application-status-updated-event-detail: http://localhost:3000/events/cas2/application-status-updated/#eventId


### PR DESCRIPTION
Without this we can’t start up in local