### PR TITLE
[APS-590] Introduce personal timeline endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -64,6 +64,7 @@ import java.net.URI
 import java.util.UUID
 import javax.transaction.Transactional
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary as JPAApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus.Companion as DomainApprovedPremisesApplicationStatus
 
 @Service
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -108,7 +109,7 @@ class ApplicationsController(
       throw ForbiddenProblem()
     }
     val user = userService.getUserForRequest()
-    val statusTransformed = applicationsTransformer.transformApiApprovedPremisesApplicationStatusToJpa(status)
+    val statusTransformed = status?.let { DomainApprovedPremisesApplicationStatus.valueOf(it) }
 
     val (applications, metadata) =
       applicationService.getAllApprovedPremisesApplications(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
@@ -3,14 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus as ApiApprovedPremisesApplicationStatus
 
-enum class ApprovedPremisesApplicationStatus {
-  STARTED,
-  SUBMITTED,
-  REJECTED,
-  AWAITING_ASSESSMENT,
-  UNALLOCATED_ASSESSMENT,
-  ASSESSMENT_IN_PROGRESS,
+enum class ApprovedPremisesApplicationStatus(val apiValue: ApiApprovedPremisesApplicationStatus) {
+  STARTED(ApiApprovedPremisesApplicationStatus.started),
+  SUBMITTED(ApiApprovedPremisesApplicationStatus.submitted),
+  REJECTED(ApiApprovedPremisesApplicationStatus.rejected),
+  AWAITING_ASSESSMENT(ApiApprovedPremisesApplicationStatus.awaitingAssesment),
+  UNALLOCATED_ASSESSMENT(ApiApprovedPremisesApplicationStatus.unallocatedAssesment),
+  ASSESSMENT_IN_PROGRESS(ApiApprovedPremisesApplicationStatus.assesmentInProgress),
 
   /**
    * An application has been assessed and a [PlacementRequestEntity] has been created which requires a [BookingEntity].
@@ -18,19 +19,25 @@ enum class ApprovedPremisesApplicationStatus {
    * Note - If a [PlacementApplicationEntity] is assessed the application _will not_ enter this state
    * (it will remain as PENDING_PLACEMENT_REQUEST)
    */
-  AWAITING_PLACEMENT,
+  AWAITING_PLACEMENT(ApiApprovedPremisesApplicationStatus.awaitingPlacement),
 
   /**
    * A [BookingEntity] has been created for a [PlacementRequestEntity]
    */
-  PLACEMENT_ALLOCATED,
-  INAPPLICABLE,
-  WITHDRAWN,
-  REQUESTED_FURTHER_INFORMATION,
+  PLACEMENT_ALLOCATED(ApiApprovedPremisesApplicationStatus.placementAllocated),
+  INAPPLICABLE(ApiApprovedPremisesApplicationStatus.inapplicable),
+  WITHDRAWN(ApiApprovedPremisesApplicationStatus.withdrawn),
+  REQUESTED_FURTHER_INFORMATION(ApiApprovedPremisesApplicationStatus.requestedFurtherInformation),
 
   /**
    * An application has been assessed. Because no arrival date was defined,
    * one or more [PlacementApplicationEntity]s are required
    */
-  PENDING_PLACEMENT_REQUEST,
+  PENDING_PLACEMENT_REQUEST(ApiApprovedPremisesApplicationStatus.pendingPlacementRequest),
+  ;
+
+  companion object {
+    fun valueOf(apiValue: ApiApprovedPremisesApplicationStatus): ApprovedPremisesApplicationStatus? =
+      ApprovedPremisesApplicationStatus.entries.firstOrNull { it.apiValue == apiValue }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimeline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonalTimeline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+
+@Component
+class PersonalTimelineTransformer(
+  private val userTransformer: UserTransformer,
+) {
+  fun transformApplicationsAndTimelineEvents(
+    applicationsAndTimelineEvents: Map<ApprovedPremisesApplicationEntity, List<TimelineEvent>>,
+  ) = PersonalTimeline(
+    applications = applicationsAndTimelineEvents.map { transformApplication(it.key, it.value) },
+  )
+
+  private fun transformApplication(
+    application: ApprovedPremisesApplicationEntity,
+    timelineEvents: List<TimelineEvent>,
+  ) = ApplicationTimeline(
+    id = application.id,
+    createdAt = application.createdAt.toInstant(),
+    status = application.status.apiValue,
+    createdBy = userTransformer.transformJpaToApi(application.createdByUser, ServiceName.approvedPremises),
+    timelineEvents = timelineEvents,
+  )
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3440,6 +3440,38 @@ components:
         - createdAt
         - typeCode
         - typeDescription
+    PersonalTimeline:
+      type: object
+      properties:
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationTimeline'
+      required:
+        - applications
+    ApplicationTimeline:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+        createdBy:
+          $ref: '#/components/schemas/User'
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEvent'
+      required:
+        - id
+        - createdAt
+        - status
+        - createdBy
+        - timelineEvents
     TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1483,6 +1483,35 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /people/{crn}/timeline:
+    get:
+      summary: Returns a timeline of all applications for a Person.
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch the timeline for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/PersonalTimeline'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1485,6 +1485,35 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /people/{crn}/timeline:
+    get:
+      summary: Returns a timeline of all applications for a Person.
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch the timeline for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/PersonalTimeline'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -7949,6 +7978,38 @@ components:
         - createdAt
         - typeCode
         - typeDescription
+    PersonalTimeline:
+      type: object
+      properties:
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationTimeline'
+      required:
+        - applications
+    ApplicationTimeline:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+        createdBy:
+          $ref: '#/components/schemas/User'
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEvent'
+      required:
+        - id
+        - createdAt
+        - status
+        - createdBy
+        - timelineEvents
     TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4000,6 +4000,38 @@ components:
         - createdAt
         - typeCode
         - typeDescription
+    PersonalTimeline:
+      type: object
+      properties:
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationTimeline'
+      required:
+        - applications
+    ApplicationTimeline:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+        createdBy:
+          $ref: '#/components/schemas/User'
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEvent'
+      required:
+        - id
+        - createdAt
+        - status
+        - createdBy
+        - timelineEvents
     TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3531,6 +3531,38 @@ components:
         - createdAt
         - typeCode
         - typeDescription
+    PersonalTimeline:
+      type: object
+      properties:
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationTimeline'
+      required:
+        - applications
+    ApplicationTimeline:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+        createdBy:
+          $ref: '#/components/schemas/User'
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEvent'
+      required:
+        - id
+        - createdAt
+        - status
+        - createdBy
+        - timelineEvents
     TimelineEvent:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApprovedPremisesUserFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApprovedPremisesUserFactory.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class ApprovedPremisesUserFactory : Factory<ApprovedPremisesUser> {
+  private var qualifications: Yielded<List<UserQualification>> = { listOf() }
+  private var roles: Yielded<List<ApprovedPremisesUserRole>> = { listOf() }
+  private var apArea: Yielded<ApArea> = {
+    ApArea(
+      UUID.randomUUID(),
+      randomStringUpperCase(6),
+      randomStringMultiCaseWithNumbers(20),
+    )
+  }
+  private var service: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var deliusUsername: Yielded<String> = { randomStringUpperCase(6) }
+  private var region: Yielded<ProbationRegion> = {
+    ProbationRegion(
+      UUID.randomUUID(),
+      randomStringMultiCaseWithNumbers(20),
+    )
+  }
+  private var email: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+  private var telephoneNumber: Yielded<String?> = { null }
+  private var isActive: Yielded<Boolean?> = { true }
+
+  fun withQualifications(qualifications: List<UserQualification>) = apply {
+    this.qualifications = { qualifications }
+  }
+
+  fun withRoles(roles: List<ApprovedPremisesUserRole>) = apply {
+    this.roles = { roles }
+  }
+
+  fun withApArea(apArea: ApArea) = apply {
+    this.apArea = { apArea }
+  }
+
+  fun withService(service: String) = apply {
+    this.service = { service }
+  }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withDeliusUsername(deliusUsername: String) = apply {
+    this.deliusUsername = { deliusUsername }
+  }
+
+  fun withRegion(region: ProbationRegion) = apply {
+    this.region = { region }
+  }
+
+  fun withEmail(email: String?) = apply {
+    this.email = { email }
+  }
+
+  fun withTelephoneNumber(telephoneNumber: String?) = apply {
+    this.telephoneNumber = { telephoneNumber }
+  }
+
+  fun withIsActive(isActive: Boolean?) = apply {
+    this.isActive = { isActive }
+  }
+
+  override fun produce() = ApprovedPremisesUser(
+    qualifications = this.qualifications(),
+    roles = this.roles(),
+    apArea = this.apArea(),
+    service = this.service(),
+    id = this.id(),
+    name = this.name(),
+    deliusUsername = this.deliusUsername(),
+    region = this.region(),
+    email = this.email(),
+    telephoneNumber = this.telephoneNumber(),
+    isActive = this.isActive(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/TimelineEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/TimelineEventFactory.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.util.UUID
+
+class TimelineEventFactory : Factory<TimelineEvent> {
+  private var type: Yielded<TimelineEventType?> = { randomOf(TimelineEventType.entries) }
+  private var id: Yielded<UUID?> = { UUID.randomUUID() }
+  private var occurredAt: Yielded<Instant?> = { Instant.now().randomDateTimeBefore(7) }
+  private var content: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+  private var createdBy: Yielded<User?> = { null }
+  private var associatedUrls: Yielded<List<TimelineEventAssociatedUrl>?> = { null }
+
+  fun withType(type: TimelineEventType?) = apply {
+    this.type = { type }
+  }
+
+  fun withId(id: UUID?) = apply {
+    this.id = { id }
+  }
+
+  fun withOccurredAt(occurredAt: Instant?) = apply {
+    this.occurredAt = { occurredAt }
+  }
+
+  fun withContent(content: String?) = apply {
+    this.content = { content }
+  }
+
+  fun withCreatedBy(createdBy: User?) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  fun withCreatedBy(configuration: ApprovedPremisesUserFactory.() -> Unit) = apply {
+    this.createdBy = { ApprovedPremisesUserFactory().apply(configuration).produce() }
+  }
+
+  fun withAssociatedUrls(associatedUrls: List<TimelineEventAssociatedUrl>?) = apply {
+    this.associatedUrls = { associatedUrls }
+  }
+
+  override fun produce() = TimelineEvent(
+    type = this.type(),
+    id = this.id()?.toString(),
+    occurredAt = this.occurredAt(),
+    content = this.content(),
+    createdBy = this.createdBy(),
+    associatedUrls = this.associatedUrls(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
@@ -1,0 +1,305 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimeline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonalTimeline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+
+class PersonalTimelineTest : IntegrationTestBase() {
+  @Test
+  fun `Getting a personal timeline for a CRN without a JWT returns 401`() {
+    webTestClient.get()
+      .uri("/people/CRN/timeline")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN with a non-Delius JWT returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "other-auth-source",
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/timeline")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN with a NOMIS JWT returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "nomis",
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/timeline")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN with ROLE_POM returns 403`() {
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius",
+      roles = listOf("ROLE_POM"),
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/timeline")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN without ROLE_PROBATION returns 403`() {
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius",
+      roles = listOf("ROLE_OTHER"),
+    )
+
+    webTestClient.get()
+      .uri("/people/CRN/timeline")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN that does not exist returns 404`() {
+    `Given a User` { _, jwt ->
+      wiremockServer.stubFor(
+        get(WireMock.urlEqualTo("/secure/offenders/crn/CRN"))
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(404),
+          ),
+      )
+
+      webTestClient.get()
+        .uri("/people/CRN/timeline")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN returns OK with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        `Given an Application`(userEntity, crn = offenderDetails.otherIds.crn) { application ->
+          val domainEvents = domainEventFactory.produceAndPersistMultiple(2) {
+            withCrn(offenderDetails.otherIds.crn)
+            withApplicationId(application.id)
+          }
+
+          webTestClient.get()
+            .uri("/people/${offenderDetails.otherIds.crn}/timeline")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                PersonalTimeline(
+                  applications = listOf(
+                    ApplicationTimeline(
+                      id = application.id,
+                      createdAt = application.createdAt.toInstant(),
+                      status = ApprovedPremisesApplicationStatus.started,
+                      createdBy = ApprovedPremisesUser(
+                        qualifications = emptyList(),
+                        roles = emptyList(),
+                        apArea = ApArea(
+                          id = userEntity.apArea!!.id,
+                          identifier = userEntity.apArea!!.identifier,
+                          name = userEntity.apArea!!.name,
+                        ),
+                        service = "CAS1",
+                        id = userEntity.id,
+                        name = userEntity.name,
+                        deliusUsername = userEntity.deliusUsername,
+                        region = ProbationRegion(
+                          id = userEntity.probationRegion.id,
+                          name = userEntity.probationRegion.name,
+                        ),
+                        email = userEntity.email,
+                        telephoneNumber = userEntity.telephoneNumber,
+                        isActive = userEntity.isActive,
+                      ),
+                      timelineEvents = listOf(
+                        TimelineEvent(
+                          type = TimelineEventType.approvedPremisesApplicationSubmitted,
+                          id = domainEvents[0].id.toString(),
+                          occurredAt = domainEvents[0].occurredAt.toInstant(),
+                          content = "The application was submitted",
+                          createdBy = null,
+                          associatedUrls = listOf(
+                            TimelineEventAssociatedUrl(
+                              type = TimelineEventUrlType.application,
+                              url = "http://frontend/applications/${application.id}",
+                            ),
+                          ),
+                        ),
+                        TimelineEvent(
+                          type = TimelineEventType.approvedPremisesApplicationSubmitted,
+                          id = domainEvents[1].id.toString(),
+                          occurredAt = domainEvents[1].occurredAt.toInstant(),
+                          content = "The application was submitted",
+                          createdBy = null,
+                          associatedUrls = listOf(
+                            TimelineEventAssociatedUrl(
+                              type = TimelineEventUrlType.application,
+                              url = "http://frontend/applications/${application.id}",
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            )
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN with no applications returns OK with correct body`() {
+    `Given a User` { _, jwt ->
+      `Given an Offender` { offenderDetails, _ ->
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/timeline")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              PersonalTimeline(
+                applications = emptyList(),
+              ),
+            ),
+          )
+      }
+    }
+  }
+
+  @Test
+  fun `Getting a personal timeline for a CRN without a NomsNumber returns OK with correct body`() {
+    `Given a User` { userEntity, jwt ->
+      `Given an Offender`(
+        offenderDetailsConfigBlock = {
+          withNomsNumber(null)
+        },
+      ) { offenderDetails, _ ->
+        `Given an Application`(userEntity, crn = offenderDetails.otherIds.crn) { application ->
+          val domainEvents = domainEventFactory.produceAndPersistMultiple(2) {
+            withCrn(offenderDetails.otherIds.crn)
+            withApplicationId(application.id)
+          }
+
+          webTestClient.get()
+            .uri("/people/${offenderDetails.otherIds.crn}/timeline")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                PersonalTimeline(
+                  applications = listOf(
+                    ApplicationTimeline(
+                      id = application.id,
+                      createdAt = application.createdAt.toInstant(),
+                      status = ApprovedPremisesApplicationStatus.started,
+                      createdBy = ApprovedPremisesUser(
+                        qualifications = emptyList(),
+                        roles = emptyList(),
+                        apArea = ApArea(
+                          id = userEntity.apArea!!.id,
+                          identifier = userEntity.apArea!!.identifier,
+                          name = userEntity.apArea!!.name,
+                        ),
+                        service = "CAS1",
+                        id = userEntity.id,
+                        name = userEntity.name,
+                        deliusUsername = userEntity.deliusUsername,
+                        region = ProbationRegion(
+                          id = userEntity.probationRegion.id,
+                          name = userEntity.probationRegion.name,
+                        ),
+                        email = userEntity.email,
+                        telephoneNumber = userEntity.telephoneNumber,
+                        isActive = userEntity.isActive,
+                      ),
+                      timelineEvents = listOf(
+                        TimelineEvent(
+                          type = TimelineEventType.approvedPremisesApplicationSubmitted,
+                          id = domainEvents[0].id.toString(),
+                          occurredAt = domainEvents[0].occurredAt.toInstant(),
+                          content = "The application was submitted",
+                          createdBy = null,
+                          associatedUrls = listOf(
+                            TimelineEventAssociatedUrl(
+                              type = TimelineEventUrlType.application,
+                              url = "http://frontend/applications/${application.id}",
+                            ),
+                          ),
+                        ),
+                        TimelineEvent(
+                          type = TimelineEventType.approvedPremisesApplicationSubmitted,
+                          id = domainEvents[1].id.toString(),
+                          occurredAt = domainEvents[1].occurredAt.toInstant(),
+                          content = "The application was submitted",
+                          createdBy = null,
+                          associatedUrls = listOf(
+                            TimelineEventAssociatedUrl(
+                              type = TimelineEventUrlType.application,
+                              url = "http://frontend/applications/${application.id}",
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            )
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/ApprovedPremisesApplicationStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/ApprovedPremisesApplicationStatusTest.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus as ApiApprovedPremisesApplicationStatus
+
+class ApprovedPremisesApplicationStatusTest {
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "started,STARTED",
+      "submitted,SUBMITTED",
+      "rejected,REJECTED",
+      "awaitingAssesment,AWAITING_ASSESSMENT",
+      "unallocatedAssesment,UNALLOCATED_ASSESSMENT",
+      "assesmentInProgress,ASSESSMENT_IN_PROGRESS",
+      "awaitingPlacement,AWAITING_PLACEMENT",
+      "placementAllocated,PLACEMENT_ALLOCATED",
+      "inapplicable,INAPPLICABLE",
+      "withdrawn,WITHDRAWN",
+      "requestedFurtherInformation,REQUESTED_FURTHER_INFORMATION",
+      "pendingPlacementRequest,PENDING_PLACEMENT_REQUEST",
+    ],
+  )
+  fun `valueOf gets the enum value from the API value`(
+    apiValue: ApiApprovedPremisesApplicationStatus,
+    expectedValue: ApprovedPremisesApplicationStatus,
+  ) {
+    assertThat(ApprovedPremisesApplicationStatus.valueOf(apiValue)).isEqualTo(expectedValue)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -455,15 +455,6 @@ class ApplicationsTransformerTest {
     assertThat(result.risks).isNotNull
   }
 
-  @ParameterizedTest
-  @MethodSource("applicationStatusArgs")
-  fun `transformApiApprovedPremisesApplicationStatusToJpa transforms statuses correctly`(args: Pair<ApiApprovedPremisesApplicationStatus, ApprovedPremisesApplicationStatus>) {
-    val (apiStatus, jpaStatus) = args
-    assertThat(applicationsTransformer.transformApiApprovedPremisesApplicationStatusToJpa(apiStatus)).isEqualTo(
-      jpaStatus,
-    )
-  }
-
   private companion object {
     @JvmStatic
     fun applicationStatusArgs() = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonalTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonalTimelineTransformerTest.kt
@@ -1,0 +1,98 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimeline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApprovedPremisesUserFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.TimelineEventFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonalTimelineTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus as DomainApplicationStatus
+
+class PersonalTimelineTransformerTest {
+  private val userTransformer = mockk<UserTransformer>()
+
+  private val personalTimelineTransformer = PersonalTimelineTransformer(userTransformer)
+
+  companion object {
+    private fun assertApplicationMatches(
+      actual: ApplicationTimeline,
+      expectedApplication: ApprovedPremisesApplicationEntity,
+      expectedUser: User,
+      expectedTimelineEvents: List<TimelineEvent>,
+    ) {
+      assertThat(actual.id).isEqualTo(expectedApplication.id)
+      assertThat(actual.createdAt).isEqualTo(expectedApplication.createdAt.toInstant())
+      assertThat(actual.status).isEqualTo(expectedApplication.status.apiValue)
+      assertThat(actual.createdBy).isEqualTo(expectedUser)
+      assertThat(actual.timelineEvents).isEqualTo(expectedTimelineEvents)
+    }
+  }
+
+  @SuppressWarnings("detekt:DestructuringDeclarationWithTooManyEntries")
+  @Test
+  fun `transformApplicationsAndTimelineEvents creates the expected PersonalTimeline`() {
+    val (application0, application1, application2, application3) = ApprovedPremisesApplicationEntityFactory()
+      .withYieldedCreatedByUser {
+        UserEntityFactory()
+          .withDefaultProbationRegion()
+          .produce()
+      }
+      .withStatus(randomOf(DomainApplicationStatus.entries))
+      .produceMany()
+      .take(4)
+      .toList()
+
+    val timelineEvents0 = emptyList<TimelineEvent>()
+
+    val timelineEvents1 = TimelineEventFactory()
+      .produceMany()
+      .take(1)
+      .toList()
+
+    val timelineEvents2 = TimelineEventFactory().produceMany()
+      .take(2)
+      .toList()
+
+    val timelineEvents3 = TimelineEventFactory()
+      .produceMany()
+      .take(3)
+      .toList()
+
+    val applicationsAndTimelineEvents = mapOf(
+      application0 to timelineEvents0,
+      application1 to timelineEvents1,
+      application2 to timelineEvents2,
+      application3 to timelineEvents3,
+    )
+
+    val (user0, user1, user2, user3) = ApprovedPremisesUserFactory()
+      .produceMany()
+      .take(4)
+      .toList()
+
+    every { userTransformer.transformJpaToApi(application0.createdByUser, ServiceName.approvedPremises) } returns user0
+    every { userTransformer.transformJpaToApi(application1.createdByUser, ServiceName.approvedPremises) } returns user1
+    every { userTransformer.transformJpaToApi(application2.createdByUser, ServiceName.approvedPremises) } returns user2
+    every { userTransformer.transformJpaToApi(application3.createdByUser, ServiceName.approvedPremises) } returns user3
+
+    val transformedPersonalTimeline = personalTimelineTransformer
+      .transformApplicationsAndTimelineEvents(applicationsAndTimelineEvents)
+
+    assertThat(transformedPersonalTimeline.applications).hasSize(4)
+
+    assertApplicationMatches(transformedPersonalTimeline.applications[0], application0, user0, timelineEvents0)
+    assertApplicationMatches(transformedPersonalTimeline.applications[1], application1, user1, timelineEvents1)
+    assertApplicationMatches(transformedPersonalTimeline.applications[2], application2, user2, timelineEvents2)
+    assertApplicationMatches(transformedPersonalTimeline.applications[3], application3, user3, timelineEvents3)
+  }
+}


### PR DESCRIPTION
> See [APS-590 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-590).

This PR introduces the `GET /people/{crn}/timeline` endpoint. This works similarly to calling the `GET /applications/{applicationId}/timeline` endpoint for each application associated with a particular CRN.

A successful response from the personal timeline endpoint looks like this:
```jsonc
{ // PersonalTimeline
  "applications": [
    { // ApplicationTimeline
      "id": "00000000-0000-0000-0000-000000000000",
      "createdAt": "2024-01-01T12:34:56.789Z",
      "status": "started",
      "createdBy": { // User
        "id": "00000000-0000-0000-0000-000000000000",
        "name": "Some User",
        "deliusUsername": "SOMEUSER",
        "email": "some.user@example.com",
        "telephoneNumber": "01234 567890",
        "isActive": true,
        "region": {
          "id": "00000000-0000-0000-0000-000000000000",
          "name": "Some Probation Region"
        }
      },
      "timelineEvents": [
        { // TimelineEvent
          "type": "approved_premises_application_submitted",
          "id": "00000000-0000-0000-0000-000000000000",
          "occurredAt": "2024-04-03T07:12:05.905Z",
          "content": "The application was submitted",
          "createdBy": { // User
            // ...
          },
          "associatedUrls": [
            {
              "type": "application",
              "url": "https://path/to/the/application"
            }
          ]
        },
        // ...
      ]
    },
    // ...
  ]
}
```