### PR TITLE
(APS-603) Allow applications to be filtered by ap area

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -36,6 +36,7 @@
     <ID>ThrowsCount:TasksTest.kt$TasksTest.GetAllReallocatableTest$@ParameterizedTest @CsvSource(value = ["createdAt,asc", "createdAt,desc", "dueAt,asc", "dueAt,desc", "person,asc", "person,desc", "allocatedTo,asc", "allocatedTo,desc"]) fun `Get all reallocatable tasks returns 200 when no type retains original sort order`(sortBy: String, sortDirection: String)</ID>
     <ID>TooGenericExceptionThrown:TasksTest.kt$TasksTest.GetAllReallocatableTest$throw RuntimeException("Unexpected sortField $sortBy")</ID>
     <ID>LongParameterList:GivenAnAssessment.kt$( allocatedToUser: UserEntity?, createdByUser: UserEntity, crn: String = randomStringMultiCaseWithNumbers(8), reallocated: Boolean = false, data: String? = "{ \"some\": \"data\"}", createdAt: OffsetDateTime? = null, block: ((assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit)? = null, )</ID>
+    <ID>CyclomaticComplexMethod:GetAllApprovedPremisesApplicationsTest.kt$GetAllApprovedPremisesApplicationsTest$private fun ApprovedPremisesApplicationSummary.matches(applicationEntity: ApprovedPremisesApplicationEntity): Boolean</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -102,6 +102,7 @@ class ApplicationsController(
     sortDirection: SortDirection?,
     status: ApprovedPremisesApplicationStatus?,
     sortBy: ApplicationSortField?,
+    apAreaId: UUID?,
   ): ResponseEntity<List<ApplicationSummary>> {
     if (xServiceName != ServiceName.approvedPremises) {
       throw ForbiddenProblem()
@@ -116,6 +117,7 @@ class ApplicationsController(
         sortDirection,
         statusTransformed,
         sortBy,
+        apAreaId,
       )
 
     return ResponseEntity.ok().headers(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -74,6 +74,9 @@ AND (
 AND (
     :status IS NULL OR (apa.status = :#{#status?.toString()})
 )
+AND (
+    (CAST(:apAreaId AS uuid) IS NULL) OR (apa.ap_area_id = :apAreaId)
+)
 """,
     countQuery = """
     SELECT COUNT(*)
@@ -89,6 +92,9 @@ AND (
       AND (
           :status IS NULL OR (apa.status = :#{#status?.toString()})
       )
+      AND (
+          (CAST(:apAreaId AS uuid) IS NULL) OR (apa.ap_area_id = :apAreaId)
+      )
     """,
     nativeQuery = true,
   )
@@ -96,6 +102,7 @@ AND (
     pageable: Pageable?,
     crnOrName: String?,
     status: ApprovedPremisesApplicationStatus?,
+    apAreaId: UUID?,
   ): Page<ApprovedPremisesApplicationSummary>
 
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -122,6 +122,7 @@ class ApplicationService(
     sortDirection: SortDirection?,
     status: ApprovedPremisesApplicationStatus?,
     sortBy: ApplicationSortField?,
+    pageSize: Int? = 10,
   ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
     val sortField = when (sortBy) {
       ApplicationSortField.arrivalDate -> "arrivalDate"
@@ -129,7 +130,7 @@ class ApplicationService(
       ApplicationSortField.tier -> "tier"
       else -> "a.created_at"
     }
-    val pageable = getPageable(sortField, sortDirection, page)
+    val pageable = getPageable(sortField, sortDirection, page, pageSize)
 
     val response = applicationRepository.findAllApprovedPremisesSummaries(
       pageable,
@@ -137,7 +138,7 @@ class ApplicationService(
       status,
     )
 
-    return Pair(response.content, getMetadata(response, page))
+    return Pair(response.content, getMetadata(response, page, pageSize))
   }
 
   private fun getAllApprovedPremisesApplicationsForUser(user: UserEntity) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -122,6 +122,7 @@ class ApplicationService(
     sortDirection: SortDirection?,
     status: ApprovedPremisesApplicationStatus?,
     sortBy: ApplicationSortField?,
+    apAreaId: UUID?,
     pageSize: Int? = 10,
   ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
     val sortField = when (sortBy) {
@@ -136,6 +137,7 @@ class ApplicationService(
       pageable,
       crnOrName,
       status,
+      apAreaId,
     )
 
     return Pair(response.content, getMetadata(response, page, pageSize))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PaginationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/PaginationUtils.kt
@@ -79,8 +79,8 @@ fun <T> wrapWithMetadata(page: Page<T>, pageCriteria: PageCriteria<*>): Pair<Lis
 fun <T> getMetadata(response: Page<T>, pageCriteria: PageCriteria<*>): PaginationMetadata? =
   getMetadataWithSize(response, pageCriteria.page, pageCriteria.perPage)
 
-fun <T> getMetadata(response: Page<T>, page: Int?): PaginationMetadata? {
-  return getMetadataWithSize(response, page, 10)
+fun <T> getMetadata(response: Page<T>, page: Int?, size: Int? = 10): PaginationMetadata? {
+  return getMetadataWithSize(response, page, size)
 }
 
 fun <T> getMetadataWithSize(response: Page<T>, page: Int?, pageSize: Int?): PaginationMetadata? {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1737,6 +1737,13 @@ paths:
           description: The field to sort the results by.
           schema:
             $ref: '_shared.yml#/components/schemas/ApplicationSortField'
+        - name: apAreaId
+          in: query
+          required: false
+          description: Approved Premises Area ID to filter results by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1739,6 +1739,13 @@ paths:
           description: The field to sort the results by.
           schema:
             $ref: '#/components/schemas/ApplicationSortField'
+        - name: apAreaId
+          in: query
+          required: false
+          description: Approved Premises Area ID to filter results by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
@@ -1,0 +1,263 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import kotlin.random.Random
+
+class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  private lateinit var applicationService: ApplicationService
+
+  private lateinit var crn1: String
+  private lateinit var crn2: String
+
+  var name = "Search by name"
+
+  private lateinit var allApplications: MutableList<ApprovedPremisesApplicationEntity>
+
+  @BeforeAll
+  fun setup() {
+    `Given a User` { userEntity, _ ->
+      `Given an Offender` { offenderDetails, _ ->
+        `Given an Offender` { offenderDetails2, _ ->
+          crn1 = offenderDetails.otherIds.crn
+          crn2 = offenderDetails2.otherIds.crn
+
+          val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          }
+
+          allApplications = mutableListOf(
+            approvedPremisesApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withCrn(crn1)
+              withCreatedByUser(userEntity)
+              withCreatedAt(OffsetDateTime.now().minusDays(6))
+              withArrivalDate(OffsetDateTime.now().plusDays(12))
+              withRiskRatings(
+                PersonRisksFactory().withTier(
+                  RiskWithStatus(
+                    RiskTier("Z", LocalDate.now()),
+                  ),
+                ).produce(),
+              )
+            },
+            approvedPremisesApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withCrn(crn2)
+              withCreatedByUser(userEntity)
+              withCreatedAt(OffsetDateTime.now().minusDays(3))
+              withArrivalDate(OffsetDateTime.now().plusDays(26))
+              withRiskRatings(
+                PersonRisksFactory().withTier(
+                  RiskWithStatus(
+                    RiskTier("B", LocalDate.now()),
+                  ),
+                ).produce(),
+              )
+            },
+            approvedPremisesApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withName(name)
+              withCreatedByUser(userEntity)
+              withCreatedAt(OffsetDateTime.now().minusDays(12))
+              withArrivalDate(OffsetDateTime.now().plusDays(9))
+              withRiskRatings(
+                PersonRisksFactory().withTier(
+                  RiskWithStatus(
+                    RiskTier("G", LocalDate.now()),
+                  ),
+                ).produce(),
+              )
+            },
+          )
+
+          ApprovedPremisesApplicationStatus.entries.forEach {
+            allApplications.add(
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withApplicationSchema(applicationSchema)
+                withCreatedByUser(userEntity)
+                withStatus(it)
+                withCreatedAt(OffsetDateTime.now().minusDays(Random.nextLong(1, 25)))
+                withArrivalDate(OffsetDateTime.now().plusDays(Random.nextLong(1, 25)))
+                withRiskRatings(
+                  PersonRisksFactory().withTier(
+                    RiskWithStatus(
+                      RiskTier(('A'..'Z').random().toString(), LocalDate.now()),
+                    ),
+                  ).produce(),
+                )
+              },
+            )
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `findAllApprovedPremisesSummaries returns all applications`() {
+    allApplications.sortBy { it.createdAt }
+    val chunkedApplications = allApplications.chunked(10)
+
+    chunkedApplications.forEachIndexed { page, chunk ->
+      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(page + 1, null, null, null, null, null)
+
+      assertThat(metadata).isNotNull()
+      assertThat(metadata!!.currentPage).isEqualTo(page + 1)
+      assertThat(metadata.totalPages).isEqualTo(chunkedApplications.size)
+      assertThat(metadata.totalResults).isEqualTo(allApplications.size.toLong())
+      assertThat(metadata.pageSize).isEqualTo(10)
+
+      result.forEachIndexed { index, summary ->
+        assertThat(summary.matches(chunk[index]))
+      }
+    }
+  }
+
+  @Test
+  fun `findAllApprovedPremisesSummaries filters by CRN`() {
+    val expectedApplications = allApplications.filter { it.crn == crn1 }
+    val result = applicationService.getAllApprovedPremisesApplications(1, crn1, null, null, null, null)
+
+    result.first.forEachIndexed { index, summary ->
+      assertThat(summary.matches(expectedApplications[index]))
+    }
+  }
+
+  @Test
+  fun `findAllApprovedPremisesSummaries filters by name`() {
+    val expectedApplications = allApplications.filter { it.name == name }
+    val result = applicationService.getAllApprovedPremisesApplications(1, name, null, null, null, null)
+
+    result.first.forEachIndexed { index, summary ->
+      assertThat(summary.matches(expectedApplications[index]))
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(ApprovedPremisesApplicationStatus::class)
+  fun `findAllApprovedPremisesSummaries filters by status`(status: ApprovedPremisesApplicationStatus) {
+    val expectedApplications = allApplications.filter { it.status == status }
+
+    val result = applicationService.getAllApprovedPremisesApplications(1, null, null, status, null, null)
+
+    result.first.forEachIndexed { index, summary ->
+      assertThat(summary.matches(expectedApplications[index]))
+    }
+  }
+
+  @Test
+  fun `findAllApprovedPremisesSummaries handles pagination`() {
+    allApplications.forEachIndexed { index, application ->
+      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(index + 1, null, null, null, null, 1)
+
+      assertThat(metadata).isNotNull()
+      assertThat(metadata!!.currentPage).isEqualTo(index + 1)
+      assertThat(metadata.totalPages).isEqualTo(allApplications.size)
+      assertThat(metadata.totalResults).isEqualTo(allApplications.size.toLong())
+      assertThat(metadata.pageSize).isEqualTo(1)
+
+      assertThat(result.size).isEqualTo(1)
+      assertThat(result[0].matches(application))
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(ApplicationSortField::class)
+  fun `findAllApprovedPremisesSummaries sorts by a given field in ascending order`(sortField: ApplicationSortField) {
+    allApplications.sort(SortDirection.asc, sortField)
+    val chunkedApplications = allApplications.chunked(10)
+
+    chunkedApplications.forEachIndexed { page, chunk ->
+      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(page + 1, null, SortDirection.asc, null, sortField, null)
+
+      assertThat(metadata).isNotNull()
+      assertThat(metadata!!.currentPage).isEqualTo(page + 1)
+      assertThat(metadata.totalPages).isEqualTo(chunkedApplications.size)
+      assertThat(metadata.totalResults).isEqualTo(allApplications.size.toLong())
+      assertThat(metadata.pageSize).isEqualTo(10)
+
+      result.forEachIndexed { index, summary ->
+        assertThat(summary.matches(chunk[index]))
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(ApplicationSortField::class)
+  fun `findAllApprovedPremisesSummaries sorts by a given field in descending order`(sortField: ApplicationSortField) {
+    allApplications.sort(SortDirection.desc, sortField)
+    val chunkedApplications = allApplications.chunked(10)
+
+    chunkedApplications.forEachIndexed { page, chunk ->
+      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(page + 1, null, SortDirection.desc, null, sortField, null)
+
+      assertThat(metadata).isNotNull()
+      assertThat(metadata!!.currentPage).isEqualTo(page + 1)
+      assertThat(metadata.totalPages).isEqualTo(chunkedApplications.size)
+      assertThat(metadata.totalResults).isEqualTo(allApplications.size.toLong())
+      assertThat(metadata.pageSize).isEqualTo(10)
+
+      result.forEachIndexed { index, summary ->
+        assertThat(summary.matches(chunk[index]))
+      }
+    }
+  }
+
+  private fun List<ApprovedPremisesApplicationEntity>.sort(sortDirection: SortDirection, sortField: ApplicationSortField): List<ApprovedPremisesApplicationEntity> {
+    val comparator = Comparator<ApprovedPremisesApplicationEntity> { a, b ->
+      val ascendingCompare = when (sortField) {
+        ApplicationSortField.createdAt -> compareValues(a.createdAt, b.createdAt)
+        ApplicationSortField.arrivalDate -> compareValues(a.arrivalDate, b.arrivalDate)
+        ApplicationSortField.tier -> compareValues(a.riskRatings?.tier?.status, b.riskRatings?.tier?.status)
+      }
+
+      when (sortDirection) {
+        SortDirection.asc, null -> ascendingCompare
+        SortDirection.desc -> -ascendingCompare
+      }
+    }
+
+    return this.sortedWith(comparator)
+  }
+
+  private fun ApprovedPremisesApplicationSummary.matches(applicationEntity: ApprovedPremisesApplicationEntity): Boolean {
+    return this.getIsWomensApplication() == applicationEntity.isWomensApplication &&
+      (this.getIsEmergencyApplication() == (applicationEntity.noticeType == Cas1ApplicationTimelinessCategory.emergency)) &&
+      (this.getIsEsapApplication() == applicationEntity.isEsapApplication) &&
+      (this.getIsPipeApplication() == applicationEntity.isPipeApplication) &&
+      (this.getArrivalDate() == Timestamp(Instant.parse(applicationEntity.arrivalDate.toString()).toEpochMilli())) &&
+      (this.getRiskRatings() == objectMapper.writeValueAsString(applicationEntity.riskRatings)) &&
+      (this.getId() == applicationEntity.id) &&
+      (this.getCrn() == applicationEntity.crn) &&
+      (this.getCreatedByUserId() == applicationEntity.createdByUser.id) &&
+      (this.getCreatedAt() == Timestamp(Instant.parse(applicationEntity.createdAt.toString()).toEpochMilli())) &&
+      (this.getSubmittedAt() == Timestamp(Instant.parse(applicationEntity.submittedAt.toString()).toEpochMilli())) &&
+      this.getTier() == applicationEntity.riskRatings?.tier?.value.toString() &&
+      this.getStatus() == applicationEntity.status.toString() &&
+      this.getIsWithdrawn() == applicationEntity.isWithdrawn &&
+      this.getReleaseType() == applicationEntity.releaseType.toString()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DbExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DbExtension.kt
@@ -38,9 +38,19 @@ class DbExtension : BeforeAllCallback, BeforeEachCallback {
       val dataSource = getDatasource(applicationContext)
       getInitialDatabaseState(dataSource)
     }
+
+    if (isPerClass(context)) {
+      setupDatabase(context)
+    }
   }
 
   override fun beforeEach(context: ExtensionContext?) {
+    if (!isPerClass(context)) {
+      setupDatabase(context)
+    }
+  }
+
+  private fun setupDatabase(context: ExtensionContext?) {
     val applicationContext = SpringExtension.getApplicationContext(context!!)
     val dataSource = getDatasource(applicationContext)
     cleanDatabase(dataSource)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/IsPerClass.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/IsPerClass.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtensionContext
+
+fun isPerClass(context: ExtensionContext?) = context?.testInstanceLifecycle?.get() == TestInstance.Lifecycle.PER_CLASS


### PR DESCRIPTION
Now we want to show users applications that are still awaiting a placement request, we need to be able to filter applications by AP Area (I imagine this will be a requirement more generally anyway, now we've rolled out nationally).

As well as adding the AP Area filtering I've also made the long-wished for (at least by me!) ability to share database context between tests. Previously testing the database has meant we've had to have a ton of tests that have setup/teardown steps that run before every test and mean adding new functionality will add more latency to an already slow test suite. 

I haven't yet deleted the old application search tests (we'll still need some as the new tests run directly on the service), but I will do that assuming we're happy with this new approach.