### PR TITLE
APS-573 Add seed job to remove assessment details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
@@ -22,7 +22,7 @@ data class ApplicationTimelineNoteEntity(
   val applicationId: UUID,
   @ManyToOne
   @JoinColumn(name = "created_by_user_id")
-  val createdBy: UserEntity,
+  val createdBy: UserEntity?,
   val createdAt: OffsetDateTime,
   val body: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1RedactAssessmentDetailsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1RedactAssessmentDetailsSeedJob.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.util.UUID
+
+class Cas1RemoveAssessmentDetailsSeedJob(
+  fileName: String,
+  private val assessmentRepository: AssessmentRepository,
+  private val objectMapper: ObjectMapper,
+) : SeedJob<Cas1RemoveAssessmentDetailsSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "assessment_id",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1RemoveAssessmentDetailsSeedCsvRow(
+    assessmentId = columns["assessment_id"]!!.trim(),
+  )
+
+  override fun processRow(row: Cas1RemoveAssessmentDetailsSeedCsvRow) {
+    val assessment = assessmentRepository.findByIdOrNull(UUID.fromString(row.assessmentId))
+      ?: error("Assessment with identifier '${row.assessmentId}' does not exist")
+
+    assessment.data = removeAllButSufficientInformation(assessment.data)
+    assessment.document = removeAllButSufficientInformation(assessment.document)
+
+    assessmentRepository.save(assessment)
+
+    log.info("Updated JSON for assessment ${assessment.id}")
+  }
+
+  fun removeAllButSufficientInformation(json: String?): String? {
+    if (json == null) {
+      return null
+    }
+
+    val dataModel: JsonNode = objectMapper.readTree(json)
+
+    dataModel.removeAll {
+      it.isObject && !it.has("sufficient-information")
+    }
+
+    return objectMapper.writeValueAsString(dataModel)
+  }
+}
+
+data class Cas1RemoveAssessmentDetailsSeedCsvRow(
+  val assessmentId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -940,7 +940,7 @@ class ApplicationService(
   fun addNoteToApplication(
     applicationId: UUID,
     note: String,
-    user: UserEntity,
+    user: UserEntity?,
   ): ApplicationTimelineNote {
     val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, note, user)
     return applicationTimelineNoteTransformer.transformJpaToApi(savedNote)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
@@ -15,7 +15,7 @@ class ApplicationTimelineNoteService(
   fun getApplicationTimelineNotesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity> =
     applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
 
-  fun saveApplicationTimelineNote(applicationId: UUID, note: String, user: UserEntity):
+  fun saveApplicationTimelineNote(applicationId: UUID, note: String, user: UserEntity?):
     ApplicationTimelineNoteEntity {
     return applicationTimelineNoteRepository.save(
       ApplicationTimelineNoteEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import org.apache.commons.io.FileUtils
 import org.springframework.context.ApplicationContext
@@ -48,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingAdhocPropertySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
@@ -233,6 +235,12 @@ class SeedService(
         SeedFileType.approvedPremisesAssessmentMoreInfoBugFix -> Cas1FurtherInfoBugFixSeedJob(
           filename,
           applicationContext.getBean(AssessmentRepository::class.java),
+        )
+
+        SeedFileType.approvedPremisesRedactAssessmentDetails -> Cas1RemoveAssessmentDetailsSeedJob(
+          filename,
+          applicationContext.getBean(AssessmentRepository::class.java),
+          applicationContext.getBean(ObjectMapper::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -58,7 +58,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findRootCause
 import java.io.File
 import java.io.IOException
+import java.nio.file.Path
 import javax.annotation.PostConstruct
+import kotlin.io.path.absolutePathString
 
 @Service
 class SeedService(
@@ -241,6 +243,7 @@ class SeedService(
           filename,
           applicationContext.getBean(AssessmentRepository::class.java),
           applicationContext.getBean(ObjectMapper::class.java),
+          applicationContext.getBean(ApplicationService::class.java),
         )
       }
 
@@ -256,6 +259,7 @@ class SeedService(
     // During processing, the CSV file is processed one row at a time to avoid OOM issues.
     // It is preferable to fail fast rather than processing half of a file before stopping,
     // so we first do a full pass but only deserializing each row
+    seedLogger.info("Processing CSV file ${Path.of(job.resolveCsvPath()).absolutePathString()}")
     enforcePresenceOfRequiredHeaders(job, resolveCsvPath)
     ensureCsvCanBeDeserialized(job, resolveCsvPath)
     processCsv(job, resolveCsvPath)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
@@ -15,7 +15,7 @@ class ApplicationTimelineNoteTransformer(
   fun transformJpaToApi(jpa: ApplicationTimelineNoteEntity) = ApplicationTimelineNote(
     id = jpa.id,
     createdAt = jpa.createdAt.toInstant(),
-    createdByUser = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
+    createdByUser = jpa.createdBy?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
     note = jpa.body,
   )
 
@@ -24,7 +24,7 @@ class ApplicationTimelineNoteTransformer(
     id = jpa.id.toString(),
     occurredAt = jpa.createdAt.toInstant(),
     content = jpa.body,
-    createdBy = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
+    createdBy = jpa.createdBy?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
     associatedUrls = emptyList(),
   )
 }

--- a/src/main/resources/db/migration/all/20240415124848__make_timeline_note_user_nullable.sql
+++ b/src/main/resources/db/migration/all/20240415124848__make_timeline_note_user_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE application_timeline_notes ALTER COLUMN created_by_user_id DROP NOT NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3549,6 +3549,7 @@ components:
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
         - approved_premises_assessment_more_info_bug_fix
+        - approved_premises_redact_assessment_details
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8058,6 +8058,7 @@ components:
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
         - approved_premises_assessment_more_info_bug_fix
+        - approved_premises_redact_assessment_details
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4109,6 +4109,7 @@ components:
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
         - approved_premises_assessment_more_info_bug_fix
+        - approved_premises_redact_assessment_details
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3640,6 +3640,7 @@ components:
         - approved_premises_ap_area_email_addresses
         - approved_premises_booking_adhoc_property
         - approved_premises_assessment_more_info_bug_fix
+        - approved_premises_redact_assessment_details
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
-  private var createdBy: Yielded<UserEntity>? = null
+  private var createdBy: Yielded<UserEntity?>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var body: Yielded<String> = { randomStringUpperCase(12) }
 
@@ -24,7 +24,7 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
     this.applicationId = { applicationId }
   }
 
-  fun withCreatedBy(createdBy: UserEntity) = apply {
+  fun withCreatedBy(createdBy: UserEntity?) = apply {
     this.createdBy = { createdBy }
   }
 
@@ -39,7 +39,7 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
   override fun produce(): ApplicationTimelineNoteEntity = ApplicationTimelineNoteEntity(
     id = this.id(),
     applicationId = this.applicationId(),
-    createdBy = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy User"),
+    createdBy = this.createdBy?.invoke(),
     createdAt = this.createdAt(),
     body = this.body(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentEntityFactory.kt
@@ -48,7 +48,7 @@ class ApprovedPremisesAssessmentEntityFactory : Factory<ApprovedPremisesAssessme
     this.data = { data }
   }
 
-  fun withDocument(document: String) = apply {
+  fun withDocument(document: String?) = apply {
     this.document = { document }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedCsvRow
+import java.time.OffsetDateTime
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
+
+  @Test
+  fun `Updates required assessments leaving others unmodified`() {
+    val sampleJson = """{
+      "review-application":{"review":{"reviewed":"yes"}},
+      "sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}},
+      "suitability-assessment":{"suitability-assessment":{"riskFactors":"yes","riskFactorsComments":"asd","riskManagement":"yes","riskManagementComments":"","locationOfPlacement":"yes","locationOfPlacementComments":"","moveOnPlan":"yes","moveOnPlanComments":""}},
+      "required-actions":{"required-actions":{"additionalActions":"no","additionalActionsComments":"","curfewsOrSignIns":"no","curfewsOrSignInsComments":"","concernsOfUnmanagableRisk":"no","concernsOfUnmanagableRiskComments":"","additionalRecommendations":"no","additionalRecommendationsComments":"","nameOfAreaManager":"","dateOfDiscussion-year":"","dateOfDiscussion-month":"","dateOfDiscussion-day":"","outlineOfDiscussion":""}},
+      "make-a-decision":{"make-a-decision":{"decision":"accept","decisionRationale":""}},"matching-information":{"matching-information":{"apType":"normal","lengthOfStayAgreed":"yes","lengthOfStayWeeks":"","lengthOfStayDays":"","cruInformation":"asd","isWheelchairDesignated":"notRelevant","isArsonDesignated":"notRelevant","isSingle":"notRelevant","isCatered":"essential","isSuitedForSexOffenders":"notRelevant","isStepFreeDesignated":"notRelevant","hasEnSuite":"notRelevant","isSuitableForVulnerable":"notRelevant","acceptsSexOffenders":"notRelevant","acceptsChildSexOffenders":"notRelevant","acceptsNonSexualChildOffenders":"notRelevant","acceptsHateCrimeOffenders":"notRelevant","isArsonSuitable":"notRelevant"}},
+      "check-your-answers":{"check-your-answers":{"reviewed":"1"}}
+    }"""
+
+    val assessment1NoJson = createAssessment(data = null)
+    val assessment2HasJson = createAssessment(data = sampleJson)
+    val assessment3Unmodified = createAssessment(data = sampleJson)
+
+    withCsv(
+      "valid-csv",
+      rowsToCsv(
+        listOf(
+          Cas1RemoveAssessmentDetailsSeedCsvRow(assessment1NoJson.id.toString()),
+          Cas1RemoveAssessmentDetailsSeedCsvRow(assessment2HasJson.id.toString()),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesRedactAssessmentDetails, "valid-csv")
+
+    val expectedJson = """{"sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}}}"""
+
+    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.data).isNull()
+    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.document).isNull()
+
+    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.data).isEqualTo(expectedJson)
+    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.document).isEqualTo(expectedJson)
+
+    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.data).isEqualTo(sampleJson)
+    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.document).isEqualTo(sampleJson)
+  }
+
+  fun removeLineBreaks(input: String) = input.replace(Regex("""(\r\n)|\n"""), "")
+
+  private fun createAssessment(data: String?): AssessmentEntity {
+    val (user) = `Given a User`()
+    val (offenderDetails) = `Given an Offender`()
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+      withAddedAt(OffsetDateTime.now())
+    }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCrn(offenderDetails.otherIds.crn)
+      withCreatedByUser(user)
+      withApplicationSchema(applicationSchema)
+    }
+
+    return approvedPremisesAssessmentEntityFactory.produceAndPersist {
+      withAllocatedToUser(user)
+      withApplication(application)
+      withAssessmentSchema(assessmentSchema)
+      withData(data)
+      withDocument(data)
+    }
+  }
+
+  private fun rowsToCsv(rows: List<Cas1RemoveAssessmentDetailsSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "assessment_id",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.assessmentId)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
@@ -45,17 +45,30 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
 
     val expectedJson = """{"sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}}}"""
 
-    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.data).isNull()
-    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.document).isNull()
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.data).isNull()
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.document).isNull()
+    assertThat(
+      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(assessment1NoJson.id).none {
+        it.body == "Assessment details redacted"
+      },
+    )
 
-    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.data).isEqualTo(expectedJson)
-    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.document).isEqualTo(expectedJson)
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.data).isEqualTo(expectedJson)
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.document).isEqualTo(expectedJson)
+    assertThat(
+      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(assessment2HasJson.id).any {
+        it.body == "Assessment details redacted"
+      },
+    )
 
-    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.data).isEqualTo(sampleJson)
-    Assertions.assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.document).isEqualTo(sampleJson)
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.data).isEqualTo(sampleJson)
+    assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.document).isEqualTo(sampleJson)
+    assertThat(
+      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(assessment3Unmodified.id).none {
+        it.body == "Assessment details redacted"
+      },
+    )
   }
-
-  fun removeLineBreaks(input: String) = input.replace(Regex("""(\r\n)|\n"""), "")
 
   private fun createAssessment(data: String?): AssessmentEntity {
     val (user) = `Given a User`()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
+
+class Cas1RedactAssessmentDetailsSeedJobTest {
+
+  val service = Cas1RemoveAssessmentDetailsSeedJob(
+    fileName = "theFileName",
+    assessmentRepository = mockk<AssessmentRepository>(),
+    objectMapper = ObjectMapper(),
+  )
+
+  @SuppressWarnings("MaxLineLength")
+  @Test
+  fun removeAllButSufficientInformation() {
+    val originalJson = """{"review-application":{"review":{"reviewed":"yes"}},
+      |"sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}},
+      |"suitability-assessment":{"suitability-assessment":
+      |{"riskFactors":"yes","riskFactorsComments":"asd","riskManagement":"yes","riskManagementComments":"","locationOfPlacement":"yes","locationOfPlacementComments":"","moveOnPlan":"yes","moveOnPlanComments":""}},"required-actions":{"required-actions":{"additionalActions":"no","additionalActionsComments":"","curfewsOrSignIns":"no","curfewsOrSignInsComments":"","concernsOfUnmanagableRisk":"no","concernsOfUnmanagableRiskComments":"","additionalRecommendations":"no","additionalRecommendationsComments":"","nameOfAreaManager":"","dateOfDiscussion-year":"","dateOfDiscussion-month":"","dateOfDiscussion-day":"","outlineOfDiscussion":""}},
+      |"make-a-decision":{"make-a-decision":{"decision":"accept","decisionRationale":""}},"matching-information":{"matching-information":{"apType":"normal","lengthOfStayAgreed":"yes","lengthOfStayWeeks":"","lengthOfStayDays":"","cruInformation":"asd","isWheelchairDesignated":"notRelevant","isArsonDesignated":"notRelevant","isSingle":"notRelevant","isCatered":"essential","isSuitedForSexOffenders":"notRelevant","isStepFreeDesignated":"notRelevant","hasEnSuite":"notRelevant","isSuitableForVulnerable":"notRelevant","acceptsSexOffenders":"notRelevant","acceptsChildSexOffenders":"notRelevant","acceptsNonSexualChildOffenders":"notRelevant","acceptsHateCrimeOffenders":"notRelevant","isArsonSuitable":"notRelevant"}},
+      |"check-your-answers":{"check-your-answers":{"reviewed":"1"}}}
+    """.trimMargin()
+    val updatedJson = service.removeAllButSufficientInformation(originalJson)
+
+    assertThat(updatedJson).isEqualTo(
+      """{"sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}}}""",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 
 class Cas1RedactAssessmentDetailsSeedJobTest {
 
@@ -13,6 +14,7 @@ class Cas1RedactAssessmentDetailsSeedJobTest {
     fileName = "theFileName",
     assessmentRepository = mockk<AssessmentRepository>(),
     objectMapper = ObjectMapper(),
+    applicationService = mockk<ApplicationService>(),
   )
 
   @SuppressWarnings("MaxLineLength")


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-573

This is required for a specific assessment in production where we want to remove all elements of the assessment data/document except for ‘sufficient-information-confirm’