### PR TITLE
CAS2-398 add prisonCode query param

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -51,18 +51,7 @@ class ApplicationsController(
 
     val pageCriteria = PageCriteria("created_at", SortDirection.desc, page)
 
-    val (applications, metadata) = when (prisonCode) {
-      null -> when (isSubmitted) {
-        true -> applicationService.getSubmittedApplicationsForUser(user, pageCriteria)
-        false -> applicationService.getUnsubmittedApplicationsForUser(user, pageCriteria)
-        null -> applicationService.getAllApplicationsForUser(user, pageCriteria)
-      }
-      else -> when (isSubmitted) {
-        true -> applicationService.getSubmittedApplicationsByPrison(prisonCode, pageCriteria)
-        false -> applicationService.getUnsubmittedApplicationsByPrison(prisonCode, pageCriteria)
-        null -> applicationService.getAllApplicationsByPrison(prisonCode, pageCriteria)
-      }
-    }
+    val (applications, metadata) = applicationService.getApplications(prisonCode, isSubmitted, user, pageCriteria)
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -47,6 +47,26 @@ class ApplicationService(
   @Value("\${url-templates.frontend.cas2.submitted-application-overview}") private val submittedApplicationUrlTemplate: String,
 ) {
 
+  fun getApplications(
+    prisonCode: String?,
+    isSubmitted: Boolean?,
+    user: NomisUserEntity,
+    pageCriteria: PageCriteria<String>,
+  ): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    return when (prisonCode) {
+      null -> when (isSubmitted) {
+        true -> getSubmittedApplicationsForUser(user, pageCriteria)
+        false -> getUnsubmittedApplicationsForUser(user, pageCriteria)
+        null -> getAllApplicationsForUser(user, pageCriteria)
+      }
+      else -> when (isSubmitted) {
+        true -> getSubmittedApplicationsByPrison(prisonCode, pageCriteria)
+        false -> getUnsubmittedApplicationsByPrison(prisonCode, pageCriteria)
+        null -> getAllApplicationsByPrison(prisonCode, pageCriteria)
+      }
+    }
+  }
+
   fun getAllApplicationsForUser(user: NomisUserEntity, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
     val response = applicationRepository.findAllCas2ApplicationSummariesCreatedByUser(user.id, getPageable(pageCriteria))
     val metadata = getMetadata(response, pageCriteria)
@@ -61,6 +81,24 @@ class ApplicationService(
 
   fun getUnsubmittedApplicationsForUser(user: NomisUserEntity, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
     val response = applicationRepository.findUnsubmittedCas2ApplicationSummariesCreatedByUser(user.id, getPageable(pageCriteria))
+    val metadata = getMetadata(response, pageCriteria)
+    return Pair(response.content, metadata)
+  }
+
+  fun getAllApplicationsByPrison(prisonCode: String, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val response = applicationRepository.findAllCas2ApplicationSummariesByPrison(prisonCode, getPageable(pageCriteria))
+    val metadata = getMetadata(response, pageCriteria)
+    return Pair(response.content, metadata)
+  }
+
+  fun getSubmittedApplicationsByPrison(prisonCode: String, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val response = applicationRepository.findSubmittedCas2ApplicationSummariesByPrison(prisonCode, getPageable(pageCriteria))
+    val metadata = getMetadata(response, pageCriteria)
+    return Pair(response.content, metadata)
+  }
+
+  fun getUnsubmittedApplicationsByPrison(prisonCode: String, pageCriteria: PageCriteria<String>): Pair<MutableList<Cas2ApplicationSummary>, PaginationMetadata?> {
+    val response = applicationRepository.findUnsubmittedCas2ApplicationSummariesByPrison(prisonCode, getPageable(pageCriteria))
     val metadata = getMetadata(response, pageCriteria)
     return Pair(response.content, metadata)
   }

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -58,6 +58,11 @@ paths:
           description: Page number of results to return.  If blank, returns all results
           schema:
             type: integer
+        - name: prisonCode
+          in: query
+          description: Prison code of applications to return.  If blank, returns all results.
+          schema:
+            type: string
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -60,6 +60,11 @@ paths:
           description: Page number of results to return.  If blank, returns all results
           schema:
             type: integer
+        - name: prisonCode
+          in: query
+          description: Prison code of applications to return.  If blank, returns all results.
+          schema:
+            type: string
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
The frontend would like to start sending this query param to this existing endpoint /cas2/applications?prisonCode="AB"

When a prison code is provided to our existing endpoint as a query param, we should now include all application summaries where the user's active case load ID matches the application’s referring prison code.