### PR TITLE
return latest status update on all applicatons query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -32,8 +32,16 @@ SELECT
     a.crn,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    a.submitted_at as submittedAt,
+    asu.label as latestStatusUpdateLabel,
+    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
 FROM cas_2_applications a
+LEFT JOIN
+    (SELECT DISTINCT ON (application_id) su.application_id, 
+      su.label, su.status_id
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+ON a.id = asu.application_id
 WHERE a.created_by_user_id = :userId
 ORDER BY createdAt DESC
 """,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -196,6 +196,13 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withCrn(offenderDetails.otherIds.crn)
               withData("{}")
               withCreatedAt(OffsetDateTime.parse("2024-02-29T09:00:00+01:00"))
+              withSubmittedAt(OffsetDateTime.now())
+            }
+
+            val statusUpdate = cas2StatusUpdateEntityFactory.produceAndPersist {
+              withLabel("older status update")
+              withApplication(secondApplicationEntity)
+              withAssessor(externalUserEntityFactory.produceAndPersist())
             }
 
             val otherCas2ApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
@@ -234,6 +241,9 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
             Assertions.assertThat(responseBody[0].createdAt)
               .isEqualTo(secondApplicationEntity.createdAt.toInstant())
+
+            Assertions.assertThat(responseBody[0].latestStatusUpdate!!.label)
+              .isEqualTo(statusUpdate.label)
 
             Assertions.assertThat(responseBody[1].createdAt)
               .isEqualTo(firstApplicationEntity.createdAt.toInstant())


### PR DESCRIPTION
Previous work was done to add latest status updates to the submitted applications query [1]. This adds the SQL needed to return them on the query for all applications.

[1] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1710