### PR TITLE
(APS-661) Ensure task cant be reallocated multiple times

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -37,6 +37,7 @@
     <ID>TooGenericExceptionThrown:TasksTest.kt$TasksTest.GetAllReallocatableTest$throw RuntimeException("Unexpected sortField $sortBy")</ID>
     <ID>LongParameterList:GivenAnAssessment.kt$( allocatedToUser: UserEntity?, createdByUser: UserEntity, crn: String = randomStringMultiCaseWithNumbers(8), reallocated: Boolean = false, data: String? = "{ \"some\": \"data\"}", createdAt: OffsetDateTime? = null, block: ((assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit)? = null, )</ID>
     <ID>CyclomaticComplexMethod:GetAllApprovedPremisesApplicationsTest.kt$GetAllApprovedPremisesApplicationsTest$private fun ApprovedPremisesApplicationSummary.matches(applicationEntity: ApprovedPremisesApplicationEntity): Boolean</ID>
+    <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.ReallocateAssessment$fun</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -38,6 +38,7 @@
     <ID>LongParameterList:GivenAnAssessment.kt$( allocatedToUser: UserEntity?, createdByUser: UserEntity, crn: String = randomStringMultiCaseWithNumbers(8), reallocated: Boolean = false, data: String? = "{ \"some\": \"data\"}", createdAt: OffsetDateTime? = null, block: ((assessment: AssessmentEntity, application: TemporaryAccommodationApplicationEntity) -> Unit)? = null, )</ID>
     <ID>CyclomaticComplexMethod:GetAllApprovedPremisesApplicationsTest.kt$GetAllApprovedPremisesApplicationsTest$private fun ApprovedPremisesApplicationSummary.matches(applicationEntity: ApprovedPremisesApplicationEntity): Boolean</ID>
     <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.ReallocateAssessment$fun</ID>
+    <ID>ReturnCount:PlacementRequestService.kt$PlacementRequestService$fun reallocatePlacementRequest( assigneeUser: UserEntity, id: UUID, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementRequestEntity>></ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -295,7 +295,7 @@ class ApprovedPremisesAssessmentEntity(
   schemaUpToDate: Boolean,
   isWithdrawn: Boolean,
   dueAt: OffsetDateTime?,
-  val createdFromAppeal: Boolean,
+  var createdFromAppeal: Boolean,
 ) : AssessmentEntity(
   id,
   application,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -699,6 +699,15 @@ class AssessmentService(
     val currentAssessment = assessmentRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
+    if (currentAssessment.reallocatedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.ConflictError(
+          currentAssessment.id,
+          "This assessment has already been reallocated",
+        ),
+      )
+    }
+
     return when (currentAssessment) {
       is ApprovedPremisesAssessmentEntity -> reallocateApprovedPremisesAssessment(assigneeUser, currentAssessment)
       is TemporaryAccommodationAssessmentEntity -> reallocateTemporaryAccommodationAssessment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -122,6 +122,15 @@ class PlacementApplicationService(
     val currentPlacementApplication = placementApplicationRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
+    if (currentPlacementApplication.reallocatedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.ConflictError(
+          currentPlacementApplication.id,
+          "This placement application has already been reallocated",
+        ),
+      )
+    }
+
     if (currentPlacementApplication.decision != null) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("This placement application has already been completed"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -148,6 +148,15 @@ class PlacementRequestService(
     val currentPlacementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 
+    if (currentPlacementRequest.reallocatedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.ConflictError(
+          currentPlacementRequest.id,
+          "This placement request has already been reallocated",
+        ),
+      )
+    }
+
     if (currentPlacementRequest.booking != null) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("This placement request has already been completed"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -189,21 +189,8 @@ class PlacementRequestServiceTest {
     verify { cas1PlacementRequestDomainEventService.placementRequestCreated(placementRequest, source) }
   }
 
-  @Test
-  fun `reallocatePlacementRequest returns General Validation Error when request already has an associated booking`() {
-    val premisesEntity = ApprovedPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
-
-    val booking = BookingEntityFactory()
-      .withYieldedPremises { premisesEntity }
-      .produce()
-
+  @Nested
+  inner class ReallocatePlacementRequest {
     val application = ApprovedPremisesApplicationEntityFactory()
       .withCreatedByUser(assigneeUser)
       .produce()
@@ -213,43 +200,7 @@ class PlacementRequestServiceTest {
       .withAllocatedToUser(assigneeUser)
       .produce()
 
-    val previousPlacementRequest = PlacementRequestEntityFactory()
-      .withPlacementRequirements(
-        PlacementRequirementsEntityFactory()
-          .withApplication(application)
-          .withAssessment(assessment)
-          .produce(),
-      )
-      .withApplication(application)
-      .withBooking(booking)
-      .withAssessment(assessment)
-      .withAllocatedToUser(previousUser)
-      .produce()
-
-    every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
-
-    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
-
-    assertThat(result is AuthorisableActionResult.Success).isTrue
-    val validationResult = (result as AuthorisableActionResult.Success).entity
-
-    assertThat(validationResult is ValidatableActionResult.GeneralValidationError).isTrue
-    validationResult as ValidatableActionResult.GeneralValidationError
-    assertThat(validationResult.message).isEqualTo("This placement request has already been completed")
-  }
-
-  @Test
-  fun `reallocatePlacementRequest returns Field Validation Error when user to assign to is not a MATCHER`() {
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(assigneeUser)
-      .produce()
-
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(assigneeUser)
-      .produce()
-
-    val previousPlacementRequest = PlacementRequestEntityFactory()
+    private val previousPlacementRequest = PlacementRequestEntityFactory()
       .withPlacementRequirements(
         PlacementRequirementsEntityFactory()
           .withApplication(application)
@@ -261,88 +212,98 @@ class PlacementRequestServiceTest {
       .withAllocatedToUser(previousUser)
       .produce()
 
-    every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
+    @Test
+    fun `reallocatePlacementRequest returns General Validation Error when request already has an associated booking`() {
+      val premisesEntity = ApprovedPremisesEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+        .produce()
 
-    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
+      val booking = BookingEntityFactory()
+        .withYieldedPremises { premisesEntity }
+        .produce()
 
-    assertThat(result is AuthorisableActionResult.Success).isTrue
-    val validationResult = (result as AuthorisableActionResult.Success).entity
-
-    assertThat(validationResult is ValidatableActionResult.FieldValidationError).isTrue
-    validationResult as ValidatableActionResult.FieldValidationError
-    assertThat(validationResult.validationMessages).containsEntry("$.userId", "lackingMatcherRole")
-  }
-
-  @Test
-  fun `reallocatePlacementRequest returns Success, deallocates old placementRequest and creates a new one`() {
-    val assigneeUser = UserEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
+      previousPlacementRequest.apply {
+        this.booking = booking
       }
-      .produce()
-      .apply {
+
+      every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
+
+      val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(validationResult is ValidatableActionResult.GeneralValidationError).isTrue
+      validationResult as ValidatableActionResult.GeneralValidationError
+      assertThat(validationResult.message).isEqualTo("This placement request has already been completed")
+    }
+
+    @Test
+    fun `reallocatePlacementRequest returns Field Validation Error when user to assign to is not a MATCHER`() {
+      assigneeUser.apply {
+        roles = mutableListOf()
+      }
+
+      every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
+
+      val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(validationResult is ValidatableActionResult.FieldValidationError).isTrue
+      validationResult as ValidatableActionResult.FieldValidationError
+      assertThat(validationResult.validationMessages).containsEntry("$.userId", "lackingMatcherRole")
+    }
+
+    @Test
+    fun `reallocatePlacementRequest returns Success, deallocates old placementRequest and creates a new one`() {
+      assigneeUser.apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
           .withRole(UserRole.CAS1_MATCHER)
           .produce()
       }
 
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(assigneeUser)
-      .produce()
+      val dueAt = OffsetDateTime.now()
 
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(assigneeUser)
-      .produce()
+      every { taskDeadlineServiceMock.getDeadline(any<PlacementRequestEntity>()) } returns dueAt
+      every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
 
-    val previousPlacementRequest = PlacementRequestEntityFactory()
-      .withPlacementRequirements(
-        PlacementRequirementsEntityFactory()
-          .withApplication(application)
-          .withAssessment(assessment)
-          .produce(),
-      )
-      .withApplication(application)
-      .withAssessment(assessment)
-      .withAllocatedToUser(previousUser)
-      .produce()
+      every { placementRequestRepository.save(previousPlacementRequest) } answers { it.invocation.args[0] as PlacementRequestEntity }
+      every { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementRequestEntity }
 
-    val dueAt = OffsetDateTime.now()
+      val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
 
-    every { taskDeadlineServiceMock.getDeadline(any<PlacementRequestEntity>()) } returns dueAt
-    every { placementRequestRepository.findByIdOrNull(previousPlacementRequest.id) } returns previousPlacementRequest
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      val validationResult = (result as AuthorisableActionResult.Success).entity
 
-    every { placementRequestRepository.save(previousPlacementRequest) } answers { it.invocation.args[0] as PlacementRequestEntity }
-    every { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) } answers { it.invocation.args[0] as PlacementRequestEntity }
+      assertThat(validationResult is ValidatableActionResult.Success).isTrue
+      validationResult as ValidatableActionResult.Success
 
-    val result = placementRequestService.reallocatePlacementRequest(assigneeUser, previousPlacementRequest.id)
+      assertThat(previousPlacementRequest.reallocatedAt).isNotNull
 
-    assertThat(result is AuthorisableActionResult.Success).isTrue
-    val validationResult = (result as AuthorisableActionResult.Success).entity
+      verify { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) }
 
-    assertThat(validationResult is ValidatableActionResult.Success).isTrue
-    validationResult as ValidatableActionResult.Success
+      val newPlacementRequest = validationResult.entity
 
-    assertThat(previousPlacementRequest.reallocatedAt).isNotNull
-
-    verify { placementRequestRepository.save(match { it.allocatedToUser == assigneeUser }) }
-
-    val newPlacementRequest = validationResult.entity
-
-    assertThat(newPlacementRequest.application).isEqualTo(application)
-    assertThat(newPlacementRequest.allocatedToUser).isEqualTo(assigneeUser)
-    assertThat(newPlacementRequest.placementRequirements.radius).isEqualTo(previousPlacementRequest.placementRequirements.radius)
-    assertThat(newPlacementRequest.placementRequirements.postcodeDistrict).isEqualTo(previousPlacementRequest.placementRequirements.postcodeDistrict)
-    assertThat(newPlacementRequest.placementRequirements.gender).isEqualTo(previousPlacementRequest.placementRequirements.gender)
-    assertThat(newPlacementRequest.expectedArrival).isEqualTo(previousPlacementRequest.expectedArrival)
-    assertThat(newPlacementRequest.placementRequirements.apType).isEqualTo(previousPlacementRequest.placementRequirements.apType)
-    assertThat(newPlacementRequest.duration).isEqualTo(previousPlacementRequest.duration)
-    assertThat(newPlacementRequest.placementRequirements.desirableCriteria).isEqualTo(previousPlacementRequest.placementRequirements.desirableCriteria)
-    assertThat(newPlacementRequest.placementRequirements.essentialCriteria).isEqualTo(previousPlacementRequest.placementRequirements.essentialCriteria)
-    assertThat(newPlacementRequest.dueAt).isEqualTo(dueAt)
+      assertThat(newPlacementRequest.application).isEqualTo(application)
+      assertThat(newPlacementRequest.allocatedToUser).isEqualTo(assigneeUser)
+      assertThat(newPlacementRequest.placementRequirements.radius).isEqualTo(previousPlacementRequest.placementRequirements.radius)
+      assertThat(newPlacementRequest.placementRequirements.postcodeDistrict).isEqualTo(previousPlacementRequest.placementRequirements.postcodeDistrict)
+      assertThat(newPlacementRequest.placementRequirements.gender).isEqualTo(previousPlacementRequest.placementRequirements.gender)
+      assertThat(newPlacementRequest.expectedArrival).isEqualTo(previousPlacementRequest.expectedArrival)
+      assertThat(newPlacementRequest.placementRequirements.apType).isEqualTo(previousPlacementRequest.placementRequirements.apType)
+      assertThat(newPlacementRequest.duration).isEqualTo(previousPlacementRequest.duration)
+      assertThat(newPlacementRequest.placementRequirements.desirableCriteria).isEqualTo(previousPlacementRequest.placementRequirements.desirableCriteria)
+      assertThat(newPlacementRequest.placementRequirements.essentialCriteria).isEqualTo(previousPlacementRequest.placementRequirements.essentialCriteria)
+      assertThat(newPlacementRequest.dueAt).isEqualTo(dueAt)
+    }
   }
 
   @Test


### PR DESCRIPTION
If a user reallocates a task and they attempt to reallocate a previously reallocated task again, this results in duplicate tasks, which has caused confusion in the past. 

This throws an error if the task has already been reallocated and the user attempts to reallocate it again.