### PR TITLE
fix returning latest status update on all applicatons

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -196,6 +196,13 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withCrn(offenderDetails.otherIds.crn)
               withData("{}")
               withCreatedAt(OffsetDateTime.parse("2024-02-29T09:00:00+01:00"))
+              withSubmittedAt(OffsetDateTime.now())
+            }
+
+            val statusUpdate = cas2StatusUpdateEntityFactory.produceAndPersist {
+              withLabel("older status update")
+              withApplication(secondApplicationEntity)
+              withAssessor(externalUserEntityFactory.produceAndPersist())
             }
 
             val otherCas2ApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
@@ -234,6 +241,9 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
             Assertions.assertThat(responseBody[0].createdAt)
               .isEqualTo(secondApplicationEntity.createdAt.toInstant())
+
+            Assertions.assertThat(responseBody[0].latestStatusUpdate!!.label)
+              .isEqualTo(statusUpdate.label)
 
             Assertions.assertThat(responseBody[1].createdAt)
               .isEqualTo(firstApplicationEntity.createdAt.toInstant())


### PR DESCRIPTION
Previous work was done to add latest status updates to the submitted applications query [1].

This query would not work if pagination was
required, I think because it wasn't
able to work out the left join. This rewrites the
psql query to only do the left join after the
applications have been selected - I think what
happens now is that the query goes and gets the
first page of applications as it's sub SELECT, and only then tries to do the LEFT JOIN.

I've also now added the query to the method that
returns all applications for a user.

[1] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1710