### PR TITLE
SUPERSEDED CAS2-401 refactor application summaries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -5,11 +5,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.ApplicationsCas2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
@@ -44,7 +44,7 @@ class ApplicationsController(
     isSubmitted: Boolean?,
     page: Int?,
     prisonCode: String?,
-  ): ResponseEntity<List<ApplicationSummary>> {
+  ): ResponseEntity<List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary>> {
     val user = userService.getUserForRequest()
 
     prisonCode?.let { if (prisonCode != user.activeCaseloadId) throw ForbiddenProblem() }
@@ -55,7 +55,7 @@ class ApplicationsController(
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),
-    ).body(applications.map { getPersonDetailAndTransformToSummary(it, user) })
+    ).body(getPersonNamesAndTransformToSummaries(applications))
   }
 
   override fun applicationsApplicationIdGet(applicationId: UUID):
@@ -136,15 +136,15 @@ class ApplicationsController(
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication, user))
   }
 
-  private fun getPersonDetailAndTransformToSummary(
-    application: uk.gov.justice.digital
-    .hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary,
-    user: NomisUserEntity,
-  ):
-    ApplicationSummary {
-    val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
+  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummary>):
+    List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary> {
+    val crns = applicationSummaries.map { it.getCrn() }
 
-    return applicationsTransformer.transformJpaSummaryToSummary(application, personInfo)
+    val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
+
+    return applicationSummaries.map { application ->
+      applicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.getCrn()]!!)
+    }
   }
 
   private fun getPersonDetailAndTransform(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -41,13 +41,11 @@ class ApplicationsTransformer(
 
   fun transformJpaSummaryToSummary(
     jpaSummary: Cas2ApplicationSummary,
-    personInfo:
-      PersonInfoResult.Success,
+    personName: String,
   ): uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary {
     return uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
       .Cas2ApplicationSummary(
         id = jpaSummary.getId(),
-        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = jpaSummary.getCreatedByUserId(),
         createdAt = jpaSummary.getCreatedAt().toInstant(),
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
@@ -55,6 +53,7 @@ class ApplicationsTransformer(
         latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
         type = "CAS2",
         hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
+        personName = personName,
       )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1867,25 +1867,39 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -71,7 +71,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '_shared.yml#/components/schemas/ApplicationSummary'
+                  $ref: '_shared.yml#/components/schemas/Cas2ApplicationSummary'
           headers:
             X-Pagination-CurrentPage:
               $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6405,25 +6405,39 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -73,7 +73,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ApplicationSummary'
+                  $ref: '#/components/schemas/Cas2ApplicationSummary'
           headers:
             X-Pagination-CurrentPage:
               $ref: '#/components/headers/X-Pagination-CurrentPage'
@@ -2432,25 +2432,39 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1958,25 +1958,39 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -166,12 +166,13 @@ class ApplicationsTransformerTest {
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockk(),
+        "person name",
       )
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
+      assertThat(result.personName).isEqualTo("person name")
       assertThat(result.hdcEligibilityDate).isNull()
       assertThat(result.latestStatusUpdate).isNull()
     }
@@ -197,12 +198,13 @@ class ApplicationsTransformerTest {
 
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockk(),
+        "person name",
       )
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
       assertThat(result.hdcEligibilityDate).isEqualTo("2023-04-29")
+      assertThat(result.personName).isEqualTo("person name")
       assertThat(result.latestStatusUpdate?.label).isEqualTo("my latest status update")
       assertThat(result.latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("ae544aee-7170-4794-99fb-703090cbc7db"))
     }


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS2-401

We currently return for ApplicationSummaries a full Person result, which includes a lot of data, and causes issues with how we handle whether the person has been found/is restricted.

I propose that we follow the standard set for /submissions and just return a personName which will be ‘Unknown’ if person not found or restricted.

This will mean we can then do a bulk search with the CRNs more easily, and just get the person’s name.
 
Tasks:
* API: add personName as field to Cas2ApplicationSummary
* UI: start using personName on the applications dashboard
* API: remove the Person field on application summaries and use the bulk search for getMapOfPersonNamesAndCrns to get CRNs