### PR TITLE
Increase use of InitialiseDatabasePerClassTestBase

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -30,7 +30,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
 
-class AppealsTest : IntegrationTestBase() {
+class AppealsTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Get appeal without JWT returns 401`() {
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Co
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
 import java.time.LocalDateTime
 
-class ApplicationDocumentsTest : IntegrationTestBase() {
+class ApplicationDocumentsTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var documentTransformer: DocumentTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -16,9 +16,9 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
 
   @Test
   fun `findNonWithdrawnApprovedPremisesSummariesForUser query works as described`() {
-    `Given a User` { user, jwt ->
+    `Given a User` { user, _ ->
       `Given a User` { differentUser, _ ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
+        `Given an Offender` { offenderDetails, _ ->
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           }
@@ -111,8 +111,8 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
 
   @Test
   fun `findAllTemporaryAccommodationSummariesCreatedByUser query works as described`() {
-    `Given a User` { user, jwt ->
-      `Given an Offender` { offenderDetails, inmateDetails ->
+    `Given a User` { user, _ ->
+      `Given an Offender` { offenderDetails, _ ->
         val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
           withPermissiveSchema()
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelinessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelinessTest.kt
@@ -17,7 +17,7 @@ class ApplicationTimelinessTest : IntegrationTestBase() {
   @Autowired
   lateinit var applicationTimelinessEntityRepository: ApplicationTimelinessEntityRepository
 
-  @Test()
+  @Test
   fun `it returns application timeliness data`() {
     val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
       withPermissiveSchema()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AuthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AuthTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
 
-class AuthTest : IntegrationTestBase() {
+class AuthTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Providing no JWT to a secured endpoint returns 401`() {
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
@@ -11,28 +11,28 @@ class BedDetailQueryTest : IntegrationTestBase() {
 
   @Test
   fun `summary works as expected`() {
-    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
       withYieldedApArea {
         apAreaEntityFactory.produceAndPersist()
       }
     }
 
-    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
-    var premises = approvedPremisesEntityFactory.produceAndPersist {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
       withProbationRegion(probationRegion)
       withLocalAuthorityArea(localAuthorityArea)
     }
 
-    var room = roomEntityFactory.produceAndPersist {
+    val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
     }
 
-    var bed = bedEntityFactory.produceAndPersist {
+    val bed = bedEntityFactory.produceAndPersist {
       withRoom(room)
     }
 
-    var result = realBedRepository.getDetailById(bed.id)!!
+    val result = realBedRepository.getDetailById(bed.id)!!
 
     assertThat(result.id).isEqualTo(bed.id)
     assertThat(result.name).isEqualTo(bed.name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -19,13 +19,13 @@ class BedSummaryQueryTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
       withYieldedApArea {
         apAreaEntityFactory.produceAndPersist()
       }
     }
 
-    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
     this.premises = approvedPremisesEntityFactory.produceAndPersist {
       withProbationRegion(probationRegion)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
@@ -9,18 +9,18 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import java.time.LocalDate
 import java.util.UUID
 
-class BedSummaryTest : IntegrationTestBase() {
+class BedSummaryTest : InitialiseDatabasePerClassTestBase() {
   lateinit var premises: PremisesEntity
 
   @BeforeEach
   fun setup() {
-    var probationRegion = probationRegionEntityFactory.produceAndPersist {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
       withYieldedApArea {
         apAreaEntityFactory.produceAndPersist()
       }
     }
 
-    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
     this.premises = approvedPremisesEntityFactory.produceAndPersist {
       withProbationRegion(probationRegion)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CalendarTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CalendarTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.time.LocalDate
 
-class CalendarTest : IntegrationTestBase() {
+class CalendarTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Requesting Calendar without JWT returns 401`() {
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -949,6 +949,13 @@ abstract class IntegrationTestBase {
   fun loadPreemptiveCacheForInmateDetails(nomsNumber: String) = prisonsApiClient.getInmateDetailsWithCall(nomsNumber)
 }
 
+/**
+ * If an integration test extends this class instead of IntegrationTestBase,
+ * the database will only be populated once and will not be 'reset' between
+ * tests
+ *
+ * This should be used where possible as tests will run significantly faster
+ */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Tag("isPerClass")
 abstract class InitialiseDatabasePerClassTestBase : IntegrationTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MoveBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MoveBookingTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.util.UUID
 
-class MoveBookingTest : IntegrationTestBase() {
+class MoveBookingTest : InitialiseDatabasePerClassTestBase() {
 
   lateinit var premises: PremisesEntity
   lateinit var booking: BookingEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Co
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulAlertsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AlertTransformer
 
-class PersonAcctAlertsTest : IntegrationTestBase() {
+class PersonAcctAlertsTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var alertTransformer: AlertTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Co
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulAdjudicationsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AdjudicationTransformer
 
-class PersonAdjudicationsTest : IntegrationTestBase() {
+class PersonAdjudicationsTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var adjudicationTransformer: AdjudicationTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 
-class PersonOASysRiskToSelfTest : IntegrationTestBase() {
+class PersonOASysRiskToSelfTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var oaSysSectionsTransformer: OASysSectionsTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 
-class PersonOASysRoshTest : IntegrationTestBase() {
+class PersonOASysRoshTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var oaSysSectionsTransformer: OASysSectionsTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 
-class PersonOASysSectionsTest : IntegrationTestBase() {
+class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var oaSysSectionsTransformer: OASysSectionsTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSelectionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSelectionTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.AP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NeedsDetailsTransformer
 
-class PersonOASysSelectionTest : IntegrationTestBase() {
+class PersonOASysSelectionTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var needsDetailsTransformer: NeedsDetailsTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Co
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulConvictionsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ConvictionTransformer
 
-class PersonOffencesTest : IntegrationTestBase() {
+class PersonOffencesTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var convictionTransformer: ConvictionTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -34,7 +34,7 @@ import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.util.UUID
 
-class PersonRisksTest : IntegrationTestBase() {
+class PersonRisksTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Getting risks by CRN without a JWT returns 401`() {
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -108,7 +108,7 @@ class PersonSearchTest : IntegrationTestBase() {
 
   @Test
   fun `Searching for a CRN returns OK with correct body`() {
-    `Given a User` { userEntity, jwt ->
+    `Given a User` { _, jwt ->
       `Given an Offender`(
         offenderDetailsConfigBlock = {
           withCrn("CRN")
@@ -168,7 +168,7 @@ class PersonSearchTest : IntegrationTestBase() {
 
   @Test
   fun `Searching for a CRN without a NomsNumber returns OK with correct body`() {
-    `Given a User` { userEntity, jwt ->
+    `Given a User` { _, jwt ->
       `Given an Offender`(
         offenderDetailsConfigBlock = {
           withCrn("CRN")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementMetricsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementMetricsTest.kt
@@ -62,7 +62,7 @@ class PlacementMetricsTest : IntegrationTestBase() {
     }
   }
 
-  @Test()
+  @Test
   fun `it returns placement metrics`() {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { user, jwt ->
       val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
@@ -17,7 +17,7 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class ProblemResponsesTest : IntegrationTestBase() {
+class ProblemResponsesTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `An invalid request body will return a 400 when the expected body root is an object and an array is provided`() {
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.time.LocalDate
 import java.util.UUID
 
-class TurnaroundTest : IntegrationTestBase() {
+class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Create Turnaround returns 404 Not Found if the premises was not found`() {
     `Given a User` { _, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransfor
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
 
-class UsersTest : IntegrationTestBase() {
+class UsersTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var userTransformer: UserTransformer
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
@@ -45,7 +45,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class ApplicationStateTest : IntegrationTestBase() {
+class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var realApplicationRepository: ApplicationRepository
 


### PR DESCRIPTION
I’ve picked some ‘low hanging fruit’ to migrate to the new InitialiseDatabasePerClassTestBase, where it’s clear there won’t be any issues retaining the database state between tests. These are typically tests where all but one tests are checking calls fail if permisisons are missing.