### PR TITLE
(Chore) Save test results correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,14 @@ jobs:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/unitTest/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
       - store_test_results:
-          path: build/test-results
+          path: ~/test-results
       - store_artifacts:
           path: build/reports/tests
   integration_test:
@@ -238,8 +244,14 @@ jobs:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/integrationTest/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
       - store_test_results:
-          path: build/test-results
+          path: ~/test-results
       - store_artifacts:
           path: build/reports/tests
   cas1_e2e_tests:


### PR DESCRIPTION
This should hopefully allow us to keep timing data correctly and allow the node balancing on CircleCI to split the tests more effectively.