### PR TITLE
CAS-319 Check and update user PDU when logging in the portal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
@@ -16,6 +16,8 @@ interface ProbationDeliveryUnitRepository : JpaRepository<ProbationDeliveryUnitE
   fun findByIdAndProbationRegion_Id(id: UUID, probationRegionId: UUID): ProbationDeliveryUnitEntity?
 
   fun findByNameAndProbationRegion_Id(name: String, probationRegionId: UUID): ProbationDeliveryUnitEntity?
+
+  fun findByDeliusCode(deliusCode: String): ProbationDeliveryUnitEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -257,6 +257,8 @@ data class UserEntity(
   @ManyToOne
   var probationRegion: ProbationRegionEntity,
   @ManyToOne
+  var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
+  @ManyToOne
   @JoinColumn(name = "ap_area_id")
   var apArea: ApAreaEntity?,
   @Convert(converter = StringListConverter::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualificat
 @Component
 class UserTransformer(
   private val probationRegionTransformer: ProbationRegionTransformer,
+  private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
   private val apAreaTransformer: ApAreaTransformer,
 ) {
 
@@ -64,6 +65,7 @@ class UserTransformer(
       isActive = jpa.isActive,
       roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformTemporaryAccommodationRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
+      probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
       service = ServiceName.temporaryAccommodation.value,
     )
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")

--- a/src/main/resources/db/migration/all/20240412134527__add_pdu_id_to_users.sql
+++ b/src/main/resources/db/migration/all/20240412134527__add_pdu_id_to_users.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+ADD COLUMN probation_delivery_unit_id UUID;
+ALTER TABLE users
+ADD FOREIGN KEY (probation_delivery_unit_id) REFERENCES probation_delivery_units(id);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2879,6 +2879,8 @@ components:
           type: boolean
         region:
           $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
       discriminator:
         propertyName: service
         mapping:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7417,6 +7417,8 @@ components:
           type: boolean
         region:
           $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
       discriminator:
         propertyName: service
         mapping:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3444,6 +3444,8 @@ components:
           type: boolean
         region:
           $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
       discriminator:
         propertyName: service
         mapping:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2970,6 +2970,8 @@ components:
           type: boolean
         region:
           $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
       discriminator:
         propertyName: service
         mapping:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
@@ -25,6 +26,7 @@ class UserEntityFactory : Factory<UserEntity> {
   private var applications: Yielded<MutableList<ApplicationEntity>> = { mutableListOf() }
   private var qualifications: Yielded<MutableList<UserQualificationAssignmentEntity>> = { mutableListOf() }
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
+  private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
   private var isActive: Yielded<Boolean> = { true }
   private var apArea: Yielded<ApAreaEntity?> = { null }
   private var teamCodes: Yielded<List<String>?> = { null }
@@ -79,6 +81,10 @@ class UserEntityFactory : Factory<UserEntity> {
     this.probationRegion = probationRegion
   }
 
+  fun withProbationDeliveryUnit(probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>) = apply {
+    this.probationDeliveryUnit = probationDeliveryUnit
+  }
+
   fun withDefaults() = withDefaultProbationRegion()
   fun withDefaultProbationRegion() =
     withYieldedProbationRegion {
@@ -128,6 +134,7 @@ class UserEntityFactory : Factory<UserEntity> {
     roles = mutableListOf(),
     qualifications = this.qualifications(),
     probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("A probation region must be provided"),
+    probationDeliveryUnit = this.probationDeliveryUnit?.invoke(),
     isActive = this.isActive(),
     apArea = this.apArea(),
     teamCodes = this.teamCodes(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addQualificationForUnitTest
@@ -40,9 +41,10 @@ import java.util.UUID.randomUUID
 
 class UserTransformerTest {
   private val probationRegionTransformer = mockk<ProbationRegionTransformer>()
+  private val probationDeliveryUnitTransformer = mockk<ProbationDeliveryUnitTransformer>()
   private val apAreaTransformer = mockk<ApAreaTransformer>()
 
-  private val userTransformer = UserTransformer(probationRegionTransformer, apAreaTransformer)
+  private val userTransformer = UserTransformer(probationRegionTransformer, probationDeliveryUnitTransformer, apAreaTransformer)
 
   private val apArea = ApArea(randomUUID(), "someIdentifier", "someName")
 


### PR DESCRIPTION
This PR [CAS-319](https://dsdmoj.atlassian.net/browse/CAS-319) includes:

- Add a new column PDU to the users table

- When the user logged in the portal part of the process is to get the user details from nDelius we will check the PDU assigned to this user. 
   - If there is no PDU assigned to the user then it will updated with the PDU from nDelius
   - If the user have a PDU but is different from the PDU in nDelius will be updated with the PDU from nDelius



[CAS-319]: https://dsdmoj.atlassian.net/browse/CAS-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ