### PR TITLE
(Chore) Attempt to fix Wiremock ports

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -237,7 +237,7 @@ import java.util.TimeZone
 import java.util.UUID
 
 object WiremockPortHolder {
-  private val possiblePorts = 57830..57880
+  private val possiblePorts = (57830..57880).shuffled()
 
   private var port: Int? = null
   private var channel: FileChannel? = null


### PR DESCRIPTION
This attempts to fix the occasional issues with Wiremock port collisions due to race conditions by shuffling the list of possible ports, as well as improving the logging so we can see what has happened if / when it goes wrong again.