### PR TITLE
CAS2-407:  fix status updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -114,6 +114,13 @@ WHERE a.referring_prison_code = :prisonCode
 AND a.submitted_at IS NOT NULL
 ORDER BY createdAt DESC
 """,
+    countQuery =
+    """
+    SELECT COUNT(*)
+      FROM cas_2_applications a
+    WHERE a.referring_prison_code = :prisonCode
+    AND a.submitted_at IS NOT NULL
+    """,
     nativeQuery = true,
   )
   fun findSubmittedCas2ApplicationSummariesByPrison(prisonCode: String, pageable: Pageable?):

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -81,6 +81,13 @@ WHERE a.created_by_user_id = :userId
 AND a.submitted_at IS NOT NULL
 ORDER BY createdAt DESC
 """,
+    countQuery =
+    """
+    SELECT COUNT(*)
+      FROM cas_2_applications a
+    WHERE a.created_by_user_id = :userId
+    AND a.submitted_at IS NOT NULL
+    """,
     nativeQuery = true,
   )
   fun findSubmittedCas2ApplicationSummariesCreatedByUser(userId: UUID, pageable: Pageable?):

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -64,11 +64,25 @@ SELECT
     a.crn,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    a.submitted_at as submittedAt,
+    asu.label as latestStatusUpdateLabel,
+    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
 FROM cas_2_applications a
+    LEFT JOIN
+        (SELECT DISTINCT ON (application_id) su.application_id, 
+          su.label, su.status_id
+        FROM cas_2_status_updates su
+        ORDER BY su.application_id, su.created_at DESC) as asu
+ON a.id = asu.application_id
 WHERE a.referring_prison_code = :prisonCode
 ORDER BY createdAt DESC
 """,
+    countQuery =
+    """
+    SELECT COUNT(*)
+      FROM cas_2_applications a
+    WHERE a.referring_prison_code = :prisonCode
+    """,
     nativeQuery = true,
   )
   fun findAllCas2ApplicationSummariesByPrison(prisonCode: String, pageable: Pageable?):

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -33,11 +33,25 @@ SELECT
     a.crn,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    a.submitted_at as submittedAt,
+    asu.label as latestStatusUpdateLabel,
+    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
 FROM cas_2_applications a
+LEFT JOIN
+    (SELECT DISTINCT ON (application_id) su.application_id, 
+      su.label, su.status_id
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+ON a.id = asu.application_id
 WHERE a.created_by_user_id = :userId
 ORDER BY createdAt DESC
 """,
+    countQuery =
+    """
+    SELECT COUNT(*)
+      FROM cas_2_applications a
+    WHERE a.created_by_user_id = :userId
+    """,
     nativeQuery = true,
   )
   fun findAllCas2ApplicationSummariesCreatedByUser(userId: UUID, pageable: Pageable?):

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -414,84 +414,104 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     inner class WithPrisonCode {
       @Test
       fun `Get all applications using prisonCode returns 200 with correct body`() {
-        `Given a CAS2 User` { userAPrisonA, jwt ->
-          `Given an Offender` { offenderDetails, _ ->
-            cas2ApplicationJsonSchemaRepository.deleteAll()
+        `Given a CAS2 Assessor` { assessor, _ ->
+          `Given a CAS2 User` { userAPrisonA, jwt ->
+            `Given an Offender` { offenderDetails, _ ->
+              cas2ApplicationJsonSchemaRepository.deleteAll()
 
-            val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
-              withAddedAt(OffsetDateTime.now())
-              withId(UUID.randomUUID())
-            }
+              val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withAddedAt(OffsetDateTime.now())
+                withId(UUID.randomUUID())
+              }
 
-            val userAPrisonAApplicationIds = mutableListOf<UUID>()
+              val userAPrisonAApplicationIds = mutableListOf<UUID>()
 
-            repeat(5) {
-              userAPrisonAApplicationIds.add(
-                cas2ApplicationEntityFactory.produceAndPersist {
-                  withApplicationSchema(applicationSchema)
-                  withCreatedByUser(userAPrisonA)
-                  withCrn(offenderDetails.otherIds.crn)
-                  withData("{}")
-                  withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
-                  withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
-                }.id,
+              repeat(5) {
+                userAPrisonAApplicationIds.add(
+                  cas2ApplicationEntityFactory.produceAndPersist {
+                    withApplicationSchema(applicationSchema)
+                    withCreatedByUser(userAPrisonA)
+                    withCrn(offenderDetails.otherIds.crn)
+                    withData("{}")
+                    withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
+                    withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
+                  }.id,
+                )
+              }
+
+              val userBPrisonA = nomisUserEntityFactory.produceAndPersist {
+                withActiveCaseloadId(userAPrisonA.activeCaseloadId!!)
+              }
+
+              val userBPrisonAApplicationIds = mutableListOf<UUID>()
+
+              repeat(6) {
+                userBPrisonAApplicationIds.add(
+                  cas2ApplicationEntityFactory.produceAndPersist {
+                    withApplicationSchema(applicationSchema)
+                    withCreatedByUser(userBPrisonA)
+                    withCrn(offenderDetails.otherIds.crn)
+                    withData("{}")
+                    withCreatedAt(OffsetDateTime.now().minusDays(it.toLong()))
+                    withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
+                    withSubmittedAt(OffsetDateTime.now().minusDays(it.toLong()))
+                  }.id,
+                )
+              }
+
+              // add two status updates to the first submitted application
+              cas2StatusUpdateEntityFactory.produceAndPersist {
+                withLabel("older status update")
+                withApplication(cas2ApplicationRepository.findById(userBPrisonAApplicationIds.first()).get())
+                withAssessor(assessor)
+              }
+              // this is the one that should be returned as lastStatusUpdate
+              cas2StatusUpdateEntityFactory.produceAndPersist {
+                withStatusId(UUID.fromString("c74c3e54-52d8-4aa2-86f6-05190985efee"))
+                withLabel("more recent status update")
+                withApplication(cas2ApplicationRepository.findById(userBPrisonAApplicationIds.first()).get())
+                withAssessor(assessor)
+              }
+
+              val userCPrisonB = nomisUserEntityFactory.produceAndPersist {
+                withActiveCaseloadId("another prison")
+              }
+
+              val otherPrisonApplication = cas2ApplicationEntityFactory.produceAndPersist {
+                withApplicationSchema(applicationSchema)
+                withCreatedByUser(userCPrisonB)
+                withCrn(offenderDetails.otherIds.crn)
+                withData("{}")
+                withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
+                withReferringPrisonCode(userCPrisonB.activeCaseloadId!!)
+              }
+
+              val rawResponseBody = webTestClient.get()
+                .uri("/cas2/applications?prisonCode=${userAPrisonA.activeCaseloadId}")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.cas2.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .returnResult<String>()
+                .responseBody
+                .blockFirst()
+
+              val responseBody =
+                objectMapper.readValue(rawResponseBody, object : TypeReference<List<Cas2ApplicationSummary>>() {})
+
+              val returnedApplicationIds = responseBody.map { it.id }.toSet()
+
+              Assertions.assertThat(returnedApplicationIds).isEqualTo(
+                userAPrisonAApplicationIds.toSet().union(userBPrisonAApplicationIds.toSet()),
               )
-            }
 
-            val userBPrisonA = nomisUserEntityFactory.produceAndPersist {
-              withActiveCaseloadId(userAPrisonA.activeCaseloadId!!)
-            }
+              Assertions.assertThat(responseBody).noneMatch {
+                otherPrisonApplication.id == it.id
+              }
 
-            val userBPrisonAApplicationIds = mutableListOf<UUID>()
-
-            repeat(6) {
-              userBPrisonAApplicationIds.add(
-                cas2ApplicationEntityFactory.produceAndPersist {
-                  withApplicationSchema(applicationSchema)
-                  withCreatedByUser(userBPrisonA)
-                  withCrn(offenderDetails.otherIds.crn)
-                  withData("{}")
-                  withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
-                  withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
-                }.id,
-              )
-            }
-
-            val userCPrisonB = nomisUserEntityFactory.produceAndPersist {
-              withActiveCaseloadId("another prison")
-            }
-
-            val otherPrisonApplication = cas2ApplicationEntityFactory.produceAndPersist {
-              withApplicationSchema(applicationSchema)
-              withCreatedByUser(userCPrisonB)
-              withCrn(offenderDetails.otherIds.crn)
-              withData("{}")
-              withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
-              withReferringPrisonCode(userCPrisonB.activeCaseloadId!!)
-            }
-
-            val rawResponseBody = webTestClient.get()
-              .uri("/cas2/applications?prisonCode=${userAPrisonA.activeCaseloadId}")
-              .header("Authorization", "Bearer $jwt")
-              .header("X-Service-Name", ServiceName.cas2.value)
-              .exchange()
-              .expectStatus()
-              .isOk
-              .returnResult<String>()
-              .responseBody
-              .blockFirst()
-
-            val responseBody =
-              objectMapper.readValue(rawResponseBody, object : TypeReference<List<Cas2ApplicationSummary>>() {})
-
-            val returnedApplicationIds = responseBody.map { it.id }.toSet()
-
-            Assertions.assertThat(returnedApplicationIds).isEqualTo(
-              userAPrisonAApplicationIds.toSet().union(userBPrisonAApplicationIds.toSet()),
-            )
-
-            Assertions.assertThat(responseBody).noneMatch {
-              otherPrisonApplication.id == it.id
+              Assertions.assertThat(responseBody[0].latestStatusUpdate?.label).isEqualTo("more recent status update")
+              Assertions.assertThat(responseBody[0].latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("c74c3e54-52d8-4aa2-86f6-05190985efee"))
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -196,6 +196,13 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withCrn(offenderDetails.otherIds.crn)
               withData("{}")
               withCreatedAt(OffsetDateTime.parse("2024-02-29T09:00:00+01:00"))
+              withSubmittedAt(OffsetDateTime.now())
+            }
+
+            val statusUpdate = cas2StatusUpdateEntityFactory.produceAndPersist {
+              withLabel("older status update")
+              withApplication(secondApplicationEntity)
+              withAssessor(externalUserEntityFactory.produceAndPersist())
             }
 
             val otherCas2ApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
@@ -234,6 +241,9 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
             Assertions.assertThat(responseBody[0].createdAt)
               .isEqualTo(secondApplicationEntity.createdAt.toInstant())
+
+            Assertions.assertThat(responseBody[0].latestStatusUpdate!!.label)
+              .isEqualTo(statusUpdate.label)
 
             Assertions.assertThat(responseBody[1].createdAt)
               .isEqualTo(firstApplicationEntity.createdAt.toInstant())


### PR DESCRIPTION
This contains two main changes/fixes:

1. The `findSubmittedCas2ApplicationSummariesCreatedByUser` query was failing when a pageable object was passed in - from debugging the hibernate/sql going on, it looks like it was failing
when trying to do the count query, when there was a LEFT JOIN in place.
This adds a [custom countQuery](https://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa/repository/Query.html#countQuery()) that is much simpler than
the select query. 
I've added in custom `countQueries` wherever I think they could simplify things.

2. Return `latestStatusUpdate` on `findAllCas2ApplicationSummariesByPrison` and `findAllCas2ApplicationSummariesCreatedByUser` - we should return these fields on any query that potentially returns submitted applications



