### PR TITLE
CAS2-410: Return `hdcEligibilityDate` on ApplicationSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -25,6 +25,7 @@ import javax.persistence.Table
 const val SUBMITTED_APPLICATION_SUMMARY_FIELDS =
   """
     ,
+    a.hdc_eligibility_date as hdcEligibilityDate,
     a.noms_number as nomsNumber,
     asu.label as latestStatusUpdateLabel,
     CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -22,20 +22,34 @@ import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.Table
 
+const val SUBMITTED_APPLICATION_SUMMARY_FIELDS =
+  """
+    ,
+    a.noms_number as nomsNumber,
+    asu.label as latestStatusUpdateLabel,
+    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
+  """
+
+const val UNSUBMITTED_APPLICATION_SUMMARY_FIELDS =
+  """
+    CAST(a.id AS TEXT) as id,
+    a.crn,
+    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    a.created_at as createdAt,
+    a.submitted_at as submittedAt
+  """
+
+const val ALL_APPLICATION_SUMMARY_FIELDS =
+  UNSUBMITTED_APPLICATION_SUMMARY_FIELDS + SUBMITTED_APPLICATION_SUMMARY_FIELDS
+
 @Suppress("TooManyFunctions")
 @Repository
 interface Cas2ApplicationRepository : JpaRepository<Cas2ApplicationEntity, UUID> {
 
   @Query(
     """
-SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt,
-    asu.label as latestStatusUpdateLabel,
-    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
+SELECT 
+    $ALL_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 LEFT JOIN
     (SELECT DISTINCT ON (application_id) su.application_id, 
@@ -60,13 +74,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt,
-    asu.label as latestStatusUpdateLabel,
-    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
+    $ALL_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
     LEFT JOIN
         (SELECT DISTINCT ON (application_id) su.application_id, 
@@ -91,13 +99,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt,
-    asu.label as latestStatusUpdateLabel,
-    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
+    $ALL_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 LEFT JOIN
     (SELECT DISTINCT ON (application_id) su.application_id, 
@@ -124,13 +126,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt,
-    asu.label as latestStatusUpdateLabel,
-    CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
+    $ALL_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 LEFT JOIN
     (SELECT DISTINCT ON (application_id) su.application_id, 
@@ -157,11 +153,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    $UNSUBMITTED_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 WHERE a.created_by_user_id = :userId
 AND a.submitted_at IS NULL
@@ -175,11 +167,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    $UNSUBMITTED_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 WHERE a.referring_prison_code = :prisonCode
 AND a.submitted_at IS NULL
@@ -193,13 +181,14 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    CAST(a.id AS TEXT) as id,
-    a.crn,
-    a.noms_number as nomsNumber,
-    CAST(a.created_by_user_id AS TEXT) as createdByUserId,
-    a.created_at as createdAt,
-    a.submitted_at as submittedAt
+    $ALL_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
+LEFT JOIN
+    (SELECT DISTINCT ON (application_id) su.application_id, 
+      su.label, su.status_id
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+ON a.id = asu.application_id
 WHERE a.submitted_at IS NOT NULL
 """,
     countQuery =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -34,6 +35,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var notes: Yielded<MutableList<Cas2ApplicationNoteEntity>> = { mutableListOf() }
   private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
   private var referringPrisonCode: Yielded<String?> = { null }
+  private var hdcEligibilityDate: Yielded<LocalDate?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -99,6 +101,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.referringPrisonCode = { referringPrisonCode }
   }
 
+  fun withHdcEligibilityDate(hdcEligibilityDate: LocalDate) = apply {
+    this.hdcEligibilityDate = { hdcEligibilityDate }
+  }
+
   override fun produce(): Cas2ApplicationEntity = Cas2ApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -115,5 +121,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     notes = this.notes(),
     assessment = this.assessment(),
     referringPrisonCode = this.referringPrisonCode(),
+    hdcEligibilityDate = this.hdcEligibilityDate(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.math.sign
@@ -189,6 +190,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withCrn(offenderDetails.otherIds.crn)
               withData("{}")
               withCreatedAt(OffsetDateTime.parse("2024-01-03T16:10:00+01:00"))
+              withHdcEligibilityDate(LocalDate.now().plusMonths(3))
             }
 
             val secondApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CAS2-410

Previously we had added the `getHdcEligibilityDate` to the ApplicationSummary interface, but not returned the field from the database query. This fixes that issue, and introduces some refactoring that might help us avoid this in future.