### PR TITLE
(APS-677) Add a `hasRequestsForPlacement` field to an Application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -61,7 +61,11 @@ SELECT
     apa.status as status,
     apa.risk_ratings -> 'tier' -> 'value' ->> 'level' as tier,
     apa.is_withdrawn as isWithdrawn,
-    apa.release_type as releaseType
+    apa.release_type as releaseType,
+    (
+        (select count(1) from placement_applications where application_id = a.id) > 0 OR 
+        (select count(1) from placement_requests where application_id = a.id) > 0
+    ) as hasRequestsForPlacement
 FROM approved_premises_applications apa
 LEFT JOIN applications a ON a.id = apa.id
 WHERE apa.is_inapplicable IS NOT TRUE 
@@ -173,7 +177,11 @@ SELECT
     apa.arrival_date as arrivalDate,
     apa.status as status,
     CAST(apa.risk_ratings AS TEXT) as riskRatings,
-    apa.is_withdrawn as isWithdrawn
+    apa.is_withdrawn as isWithdrawn,
+    (
+        (select count(1) from placement_applications where application_id = a.id) > 0 OR 
+        (select count(1) from placement_requests where application_id = a.id) > 0
+    ) as hasRequestsForPlacement
 FROM approved_premises_applications apa
 LEFT JOIN applications a ON a.id = apa.id
 WHERE a.created_by_user_id = :userId 
@@ -495,6 +503,7 @@ interface ApprovedPremisesApplicationSummary : ApplicationSummary {
   fun getStatus(): String
   fun getIsWithdrawn(): Boolean
   fun getReleaseType(): String?
+  fun getHasRequestsForPlacement(): Boolean
 }
 
 interface TemporaryAccommodationApplicationSummary : ApplicationSummary {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -131,6 +131,7 @@ class ApplicationsTransformer(
         tier = domain.getTier(),
         isWithdrawn = domain.getIsWithdrawn(),
         releaseType = domain.getReleaseType()?.let { ReleaseTypeOption.valueOf(it) },
+        hasRequestsForPlacement = domain.getHasRequestsForPlacement(),
       )
     }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1847,10 +1847,13 @@ components:
               type: boolean
             releaseType:
               $ref: '#/components/schemas/ReleaseTypeOption'
+            hasRequestsForPlacement:
+              type: boolean
           required:
             - createdByUserId
             - status
             - isWithdrawn
+            - hasRequestsForPlacement
     TemporaryAccommodationApplicationSummary:
       allOf:
         - $ref: '#/components/schemas/ApplicationSummary'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6385,10 +6385,13 @@ components:
               type: boolean
             releaseType:
               $ref: '#/components/schemas/ReleaseTypeOption'
+            hasRequestsForPlacement:
+              type: boolean
           required:
             - createdByUserId
             - status
             - isWithdrawn
+            - hasRequestsForPlacement
     TemporaryAccommodationApplicationSummary:
       allOf:
         - $ref: '#/components/schemas/ApplicationSummary'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2412,10 +2412,13 @@ components:
               type: boolean
             releaseType:
               $ref: '#/components/schemas/ReleaseTypeOption'
+            hasRequestsForPlacement:
+              type: boolean
           required:
             - createdByUserId
             - status
             - isWithdrawn
+            - hasRequestsForPlacement
     TemporaryAccommodationApplicationSummary:
       allOf:
         - $ref: '#/components/schemas/ApplicationSummary'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1938,10 +1938,13 @@ components:
               type: boolean
             releaseType:
               $ref: '#/components/schemas/ReleaseTypeOption'
+            hasRequestsForPlacement:
+              type: boolean
           required:
             - createdByUserId
             - status
             - isWithdrawn
+            - hasRequestsForPlacement
     TemporaryAccommodationApplicationSummary:
       allOf:
         - $ref: '#/components/schemas/ApplicationSummary'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -520,6 +520,7 @@ class ApplicationTest : IntegrationTestBase() {
                 ),
                 submittedAt = null,
                 isWithdrawn = false,
+                hasRequestsForPlacement = false,
               ),
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -191,6 +191,7 @@ class ApplicationServiceTest {
         override fun getStatus(): String = ApprovedPremisesApplicationStatus.started.toString()
         override fun getIsWithdrawn(): Boolean = false
         override fun getReleaseType(): String = ReleaseTypeOption.licence.toString()
+        override fun getHasRequestsForPlacement(): Boolean = false
       },
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -346,6 +346,7 @@ class ApplicationsTransformerTest {
       override fun getStatus(): String = jpaStatus.toString()
       override fun getIsWithdrawn(): Boolean = true
       override fun getReleaseType(): String = ReleaseTypeOption.licence.toString()
+      override fun getHasRequestsForPlacement(): Boolean = true
     }
     every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockPerson
 
@@ -366,6 +367,7 @@ class ApplicationsTransformerTest {
     assertThat(result.type).isEqualTo("CAS1")
     assertThat(result.tier).isEqualTo(application.getTier())
     assertThat(result.isWithdrawn).isEqualTo(true)
+    assertThat(result.hasRequestsForPlacement).isEqualTo(true)
   }
 
   @ParameterizedTest
@@ -391,6 +393,7 @@ class ApplicationsTransformerTest {
       override fun getStatus(): String = ApprovedPremisesApplicationStatus.SUBMITTED.toString()
       override fun getIsWithdrawn(): Boolean = true
       override fun getReleaseType(): String? = releaseTypeOption?.let { releaseTypeOption.toString() }
+      override fun getHasRequestsForPlacement(): Boolean = true
     }
 
     every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockPerson


### PR DESCRIPTION
This adds a boolean to indicate is an application has any associated placement requests or applications. To test this, I’ve created a placement application and placement request for two applications and added their IDs to a list - `applicationIdsWithRequestsForPlacement`

When validating if a returned summary matches the application, we can then check if the application’s ID is contained in the `applicationIdsWithRequestsForPlacement` list - if it does, we know the expected value should be true, otherwise it’s false.