### PR TITLE
Reports API date validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
@@ -128,8 +128,7 @@ class ReportsController(
   @SuppressWarnings("ThrowsCount")
   private fun validateRequestedDates(startDate: LocalDate, endDate: LocalDate) {
     when {
-      startDate.isEqual(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "sameAsEndDate"), errorDetail = "Start Date $startDate cannot be the same as End Date $endDate")
-      startDate.isAfter(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
+      startDate.isAfter(endDate) || startDate.isEqual(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
       endDate.isAfter(LocalDate.now()) -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "inFuture"), errorDetail = "End Date $endDate cannot be in the future")
       ChronoUnit.MONTHS.between(startDate, endDate)
         .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
@@ -128,7 +128,8 @@ class ReportsController(
   @SuppressWarnings("ThrowsCount")
   private fun validateRequestedDates(startDate: LocalDate, endDate: LocalDate) {
     when {
-      startDate.isAfter(endDate) || startDate.isEqual(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
+      startDate.isAfter(endDate) || startDate.isEqual(endDate) ->
+        throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
       endDate.isAfter(LocalDate.now()) -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "inFuture"), errorDetail = "End Date $endDate cannot be in the future")
       ChronoUnit.MONTHS.between(startDate, endDate)
         .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
@@ -128,14 +128,10 @@ class ReportsController(
   @SuppressWarnings("ThrowsCount")
   private fun validateRequestedDates(startDate: LocalDate, endDate: LocalDate) {
     when {
-      startDate.isAfter(endDate) || startDate.isEqual(endDate) ->
-        throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
-      endDate.isAfter(LocalDate.now()) -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "inFuture"), errorDetail = "End Date $endDate cannot be in the future")
+      startDate.isAfter(endDate) || startDate.isEqual(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"))
+      endDate.isAfter(LocalDate.now()) -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "inFuture"))
       ChronoUnit.MONTHS.between(startDate, endDate)
-        .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(
-        invalidParams = mapOf("$.endDate" to "rangeTooLarge"),
-        errorDetail = "End Date $endDate cannot be more than $MAXIMUM_REPORT_DURATION_IN_MONTHS months after Start Date $startDate",
-      )
+        .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "rangeTooLarge"))
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
@@ -127,9 +127,10 @@ class ReportsController(
 
   private fun validateRequestedDates(startDate: LocalDate, endDate: LocalDate) {
     when {
-      startDate.isAfter(endDate) -> throw BadRequestProblem(errorDetail = "Start Date $startDate cannot be after End Date $endDate")
+      startDate.isEqual(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "sameAsEndDate"), errorDetail = "Start Date $startDate cannot be the same as End Date $endDate")
+      startDate.isAfter(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
       ChronoUnit.MONTHS.between(startDate, endDate)
-        .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(errorDetail = "End Date $endDate cannot be more than 3 months after Start Date $startDate")
+        .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "rangeTooLarge"), errorDetail = "End Date $endDate cannot be more than $MAXIMUM_REPORT_DURATION_IN_MONTHS months after Start Date $startDate")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
@@ -125,12 +125,17 @@ class ReportsController(
     validateRequestedDates(startDate, endDate)
   }
 
+  @SuppressWarnings("ThrowsCount")
   private fun validateRequestedDates(startDate: LocalDate, endDate: LocalDate) {
     when {
       startDate.isEqual(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "sameAsEndDate"), errorDetail = "Start Date $startDate cannot be the same as End Date $endDate")
       startDate.isAfter(endDate) -> throw BadRequestProblem(invalidParams = mapOf("$.startDate" to "afterEndDate"), errorDetail = "Start Date $startDate cannot be after End Date $endDate")
+      endDate.isAfter(LocalDate.now()) -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "inFuture"), errorDetail = "End Date $endDate cannot be in the future")
       ChronoUnit.MONTHS.between(startDate, endDate)
-        .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(invalidParams = mapOf("$.endDate" to "rangeTooLarge"), errorDetail = "End Date $endDate cannot be more than $MAXIMUM_REPORT_DURATION_IN_MONTHS months after Start Date $startDate")
+        .toInt() > MAXIMUM_REPORT_DURATION_IN_MONTHS -> throw BadRequestProblem(
+        invalidParams = mapOf("$.endDate" to "rangeTooLarge"),
+        errorDetail = "End Date $endDate cannot be more than $MAXIMUM_REPORT_DURATION_IN_MONTHS months after Start Date $startDate",
+      )
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -182,8 +182,8 @@ class Cas3ReportsTest : IntegrationTestBase() {
         .expectStatus()
         .isBadRequest
         .expectBody()
-        .jsonPath("$.detail").isEqualTo("Start Date $startDate cannot be the same as End Date $endDate")
-        .jsonPath("invalid-params[0].errorType").isEqualTo("sameAsEndDate")
+        .jsonPath("$.detail").isEqualTo("Start Date $startDate cannot be after End Date $endDate")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("afterEndDate")
         .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.startDate")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -142,7 +142,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
         .expectStatus()
         .isBadRequest
         .expectBody()
-        .jsonPath("$.detail").isEqualTo("End Date $endDate cannot be more than 3 months after Start Date $startDate")
         .jsonPath("invalid-params[0].errorType").isEqualTo("rangeTooLarge")
         .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.endDate")
     }
@@ -162,7 +161,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
         .expectStatus()
         .isBadRequest
         .expectBody()
-        .jsonPath("$.detail").isEqualTo("Start Date $startDate cannot be after End Date $endDate")
         .jsonPath("invalid-params[0].errorType").isEqualTo("afterEndDate")
         .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.startDate")
     }
@@ -182,7 +180,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
         .expectStatus()
         .isBadRequest
         .expectBody()
-        .jsonPath("$.detail").isEqualTo("Start Date $startDate cannot be after End Date $endDate")
         .jsonPath("invalid-params[0].errorType").isEqualTo("afterEndDate")
         .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.startDate")
     }
@@ -203,7 +200,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
         .expectStatus()
         .isBadRequest
         .expectBody()
-        .jsonPath("$.detail").isEqualTo("End Date $endDate cannot be in the future")
         .jsonPath("invalid-params[0].errorType").isEqualTo("inFuture")
         .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.endDate")
     }


### PR DESCRIPTION

Adds additional Reports API request date validation and updates error details. It now also throws a bad request error if the start date is the same as the end date or the end date is after today's date.