### PR TITLE
CAS2-401 refactor application summaries (add personName)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.ApplicationsCas2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
@@ -26,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import java.net.URI
 import java.util.UUID
 import javax.transaction.Transactional
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary as ModelCas2ApplicationSummary
 
 @Service(
   "uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2" +
@@ -44,7 +44,7 @@ class ApplicationsController(
     isSubmitted: Boolean?,
     page: Int?,
     prisonCode: String?,
-  ): ResponseEntity<List<ApplicationSummary>> {
+  ): ResponseEntity<List<ModelCas2ApplicationSummary>> {
     val user = userService.getUserForRequest()
 
     prisonCode?.let { if (prisonCode != user.activeCaseloadId) throw ForbiddenProblem() }
@@ -141,7 +141,7 @@ class ApplicationsController(
     .hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary,
     user: NomisUserEntity,
   ):
-    ApplicationSummary {
+    ModelCas2ApplicationSummary {
     val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
 
     return applicationsTransformer.transformJpaSummaryToSummary(application, personInfo)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -55,6 +55,8 @@ class ApplicationsTransformer(
         latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
         type = "CAS2",
         hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
+        crn = jpaSummary.getCrn(),
+        nomsNumber = jpaSummary.getNomsNumber(),
         personName = (personInfo as PersonInfoResult.Success.Full).offenderDetailSummary.firstName +
           " " + personInfo.offenderDetailSummary.surname,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -55,6 +55,8 @@ class ApplicationsTransformer(
         latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
         type = "CAS2",
         hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
+        personName = (personInfo as PersonInfoResult.Success.Full).offenderDetailSummary.firstName +
+          " " + personInfo.offenderDetailSummary.surname,
       )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1887,6 +1887,8 @@ components:
             hdcEligibilityDate:
               type: string
               format: date
+            personName:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1889,6 +1889,10 @@ components:
               format: date
             personName:
               type: string
+            crn:
+              type: string
+            nomsNumber:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -71,7 +71,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '_shared.yml#/components/schemas/ApplicationSummary'
+                  $ref: '_shared.yml#/components/schemas/Cas2ApplicationSummary'
           headers:
             X-Pagination-CurrentPage:
               $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6425,6 +6425,8 @@ components:
             hdcEligibilityDate:
               type: string
               format: date
+            personName:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6427,6 +6427,10 @@ components:
               format: date
             personName:
               type: string
+            crn:
+              type: string
+            nomsNumber:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2454,6 +2454,10 @@ components:
               format: date
             personName:
               type: string
+            crn:
+              type: string
+            nomsNumber:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -73,7 +73,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ApplicationSummary'
+                  $ref: '#/components/schemas/Cas2ApplicationSummary'
           headers:
             X-Pagination-CurrentPage:
               $ref: '#/components/headers/X-Pagination-CurrentPage'
@@ -2452,6 +2452,8 @@ components:
             hdcEligibilityDate:
               type: string
               format: date
+            personName:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1980,6 +1980,10 @@ components:
               format: date
             personName:
               type: string
+            crn:
+              type: string
+            nomsNumber:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1978,6 +1978,8 @@ components:
             hdcEligibilityDate:
               type: string
               format: date
+            personName:
+              type: string
           required:
             - createdByUserId
             - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
@@ -153,8 +152,8 @@ class ApplicationsTransformerTest {
     () {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
-        override fun getCrn() = randomStringMultiCaseWithNumbers(6)
-        override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
+        override fun getCrn() = "CRNNUM"
+        override fun getNomsNumber() = "NOMNUM"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
@@ -179,6 +178,8 @@ class ApplicationsTransformerTest {
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
       assertThat(result.personName).isEqualTo("firstName surname")
+      assertThat(result.crn).isEqualTo(application.getCrn())
+      assertThat(result.nomsNumber).isEqualTo(application.getNomsNumber())
       assertThat(result.hdcEligibilityDate).isNull()
       assertThat(result.latestStatusUpdate).isNull()
     }
@@ -187,8 +188,8 @@ class ApplicationsTransformerTest {
     fun `transforms a submitted CAS2 application correctly`() {
       val application = object : Cas2ApplicationSummary {
         override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
-        override fun getCrn() = randomStringMultiCaseWithNumbers(6)
-        override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
+        override fun getCrn() = "CRNNUM"
+        override fun getNomsNumber() = "NOMNUM"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
@@ -216,6 +217,8 @@ class ApplicationsTransformerTest {
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
       assertThat(result.hdcEligibilityDate).isEqualTo("2023-04-29")
       assertThat(result.personName).isEqualTo("firstName surname")
+      assertThat(result.crn).isEqualTo(application.getCrn())
+      assertThat(result.nomsNumber).isEqualTo(application.getNomsNumber())
       assertThat(result.latestStatusUpdate?.label).isEqualTo("my latest status update")
       assertThat(result.latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("ae544aee-7170-4794-99fb-703090cbc7db"))
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
@@ -164,14 +165,20 @@ class ApplicationsTransformerTest {
 
       every { mockStatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns null
 
+      val mockPersonInfo = mockk<PersonInfoResult.Success.Full>()
+
+      every { mockPersonInfo.offenderDetailSummary.firstName } returns "firstName"
+      every { mockPersonInfo.offenderDetailSummary.surname } returns "surname"
+
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockk(),
+        mockPersonInfo,
       )
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.createdByUserId).isEqualTo(application.getCreatedByUserId())
       assertThat(result.risks).isNull()
+      assertThat(result.personName).isEqualTo("firstName surname")
       assertThat(result.hdcEligibilityDate).isNull()
       assertThat(result.latestStatusUpdate).isNull()
     }
@@ -195,14 +202,20 @@ class ApplicationsTransformerTest {
         label = application.getLatestStatusUpdateLabel(),
       )
 
+      val mockPersonInfo = mockk<PersonInfoResult.Success.Full>()
+
+      every { mockPersonInfo.offenderDetailSummary.firstName } returns "firstName"
+      every { mockPersonInfo.offenderDetailSummary.surname } returns "surname"
+
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockk(),
+        mockPersonInfo,
       )
 
       assertThat(result.id).isEqualTo(application.getId())
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
       assertThat(result.hdcEligibilityDate).isEqualTo("2023-04-29")
+      assertThat(result.personName).isEqualTo("firstName surname")
       assertThat(result.latestStatusUpdate?.label).isEqualTo("my latest status update")
       assertThat(result.latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("ae544aee-7170-4794-99fb-703090cbc7db"))
     }


### PR DESCRIPTION
This PR contains the work required for the first bullet point of [CAS2-401](https://dsdmoj.atlassian.net/browse/CAS2-401)

Tasks:
* API: add personName as field to Cas2ApplicationSummary

We currently return for ApplicationSummaries a full Person result, which includes a lot of data, and causes issues with how we handle whether the person has been found/is restricted.

We propose that we follow the standard set for /submissions and just return a personName which will be ‘Unknown’ if person not found or restricted.

This will mean we can then do a bulk search with the CRNs more easily, and just get the person’s name.

[CAS2-401]: https://dsdmoj.atlassian.net/browse/CAS2-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ