### PR TITLE
(APS-643) Add an `info_requested` task status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import java.time.Instant
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType as ApiPlacementType
@@ -116,6 +117,7 @@ class TaskTransformer(
   private fun getAssessmentStatus(entity: AssessmentEntity): TaskStatus = when {
     entity.data.isNullOrEmpty() -> TaskStatus.notStarted
     entity.decision !== null -> TaskStatus.complete
+    (entity.application as ApprovedPremisesApplicationEntity).status == ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION -> TaskStatus.infoRequested
     else -> TaskStatus.inProgress
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -297,6 +297,7 @@ components:
         - not_started
         - in_progress
         - complete
+        - info_requested
     TaskSortField:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4835,6 +4835,7 @@ components:
         - not_started
         - in_progress
         - complete
+        - info_requested
     TaskSortField:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -862,6 +862,7 @@ components:
         - not_started
         - in_progress
         - complete
+        - info_requested
     TaskSortField:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -388,6 +388,7 @@ components:
         - not_started
         - in_progress
         - complete
+        - info_requested
     TaskSortField:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
@@ -179,6 +180,22 @@ class TaskTransformerTest {
       assertThat(result.status).isEqualTo(TaskStatus.complete)
       assertThat(result.outcome).isEqualTo(apiDecision)
       assertThat(result.outcomeRecordedAt).isEqualTo(submittedAt.toInstant())
+    }
+
+    @Test
+    fun `Assessment awaiting information request is correctly transformed`() {
+      val application = applicationFactory
+        .withStatus(ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION)
+        .produce()
+      val assessment = assessmentFactory
+        .withDecision(null)
+        .withData("{\"test\": \"data\"}")
+        .withApplication(application)
+        .produce()
+
+      val result = taskTransformer.transformAssessmentToTask(assessment, "First Last")
+
+      assertThat(result.status).isEqualTo(TaskStatus.infoRequested)
     }
 
     @Test


### PR DESCRIPTION
This allows CRU managers to see at a glance what assessments are awaiting information requests from PPs.