### PR TITLE
CAS2-408: return author's name on ApplicationSummaries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -36,6 +36,7 @@ const val UNSUBMITTED_APPLICATION_SUMMARY_FIELDS =
     CAST(a.id AS TEXT) as id,
     a.crn,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
+    nu.name as createdByUserName,
     a.created_at as createdAt,
     a.submitted_at as submittedAt
   """
@@ -58,6 +59,7 @@ LEFT JOIN
     FROM cas_2_status_updates su
     ORDER BY su.application_id, su.created_at DESC) as asu
 ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.created_by_user_id = :userId
 ORDER BY createdAt DESC
 """,
@@ -83,6 +85,7 @@ FROM cas_2_applications a
         FROM cas_2_status_updates su
         ORDER BY su.application_id, su.created_at DESC) as asu
 ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.referring_prison_code = :prisonCode
 ORDER BY createdAt DESC
 """,
@@ -108,6 +111,7 @@ LEFT JOIN
     FROM cas_2_status_updates su
     ORDER BY su.application_id, su.created_at DESC) as asu
 ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.created_by_user_id = :userId
 AND a.submitted_at IS NOT NULL
 ORDER BY createdAt DESC
@@ -135,6 +139,7 @@ LEFT JOIN
     FROM cas_2_status_updates su
     ORDER BY su.application_id, su.created_at DESC) as asu
 ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.referring_prison_code = :prisonCode
 AND a.submitted_at IS NOT NULL
 ORDER BY createdAt DESC
@@ -156,6 +161,7 @@ ORDER BY createdAt DESC
 SELECT
     $UNSUBMITTED_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.created_by_user_id = :userId
 AND a.submitted_at IS NULL
 ORDER BY createdAt DESC
@@ -170,6 +176,7 @@ ORDER BY createdAt DESC
 SELECT
     $UNSUBMITTED_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.referring_prison_code = :prisonCode
 AND a.submitted_at IS NULL
 ORDER BY createdAt DESC
@@ -190,6 +197,7 @@ LEFT JOIN
     FROM cas_2_status_updates su
     ORDER BY su.application_id, su.created_at DESC) as asu
 ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.submitted_at IS NOT NULL
 """,
     countQuery =
@@ -276,6 +284,7 @@ interface AppSummary {
   fun getCrn(): String
   fun getNomsNumber(): String
   fun getCreatedByUserId(): UUID
+  fun getCreatedByUserName(): String
   fun getCreatedAt(): Timestamp
   fun getSubmittedAt(): Timestamp?
   fun getHdcEligibilityDate(): LocalDate?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -49,6 +49,7 @@ class ApplicationsTransformer(
         id = jpaSummary.getId(),
         person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = jpaSummary.getCreatedByUserId(),
+        createdByUserName = jpaSummary.getCreatedByUserName(),
         createdAt = jpaSummary.getCreatedAt().toInstant(),
         submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
         status = getStatusFromSummary(jpaSummary),

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1878,6 +1878,8 @@ components:
             createdByUserId:
               type: string
               format: uuid
+            createdByUserName:
+              type: string
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6485,6 +6485,8 @@ components:
             createdByUserId:
               type: string
               format: uuid
+            createdByUserName:
+              type: string
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2443,6 +2443,8 @@ components:
             createdByUserId:
               type: string
               format: uuid
+            createdByUserName:
+              type: string
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1969,6 +1969,8 @@ components:
             createdByUserId:
               type: string
               format: uuid
+            createdByUserName:
+              type: string
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             latestStatusUpdate:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -235,7 +235,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 firstApplicationEntity.createdAt.toInstant() == it.createdAt &&
                 firstApplicationEntity.createdByUser.id == it.createdByUserId &&
                 firstApplicationEntity.submittedAt?.toInstant() == it.submittedAt &&
-                firstApplicationEntity.hdcEligibilityDate == it.hdcEligibilityDate
+                firstApplicationEntity.hdcEligibilityDate == it.hdcEligibilityDate &&
+                firstApplicationEntity.createdByUser.name == it.createdByUserName
             }
 
             Assertions.assertThat(responseBody).noneMatch {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -84,6 +84,7 @@ class ApplicationServiceTest {
         override fun getCrn() = randomStringMultiCaseWithNumbers(6)
         override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+        override fun getCreatedByUserName() = "first last"
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
@@ -130,6 +131,7 @@ class ApplicationServiceTest {
       override fun getCrn() = randomStringMultiCaseWithNumbers(6)
       override fun getNomsNumber() = randomStringMultiCaseWithNumbers(6)
       override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+      override fun getCreatedByUserName() = "first last"
       override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
       override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
       override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -155,6 +155,7 @@ class ApplicationsTransformerTest {
         override fun getCrn() = "CRNNUM"
         override fun getNomsNumber() = "NOMNUM"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+        override fun getCreatedByUserName() = "first last"
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = null
         override fun getHdcEligibilityDate() = null
@@ -182,6 +183,7 @@ class ApplicationsTransformerTest {
       assertThat(result.nomsNumber).isEqualTo(application.getNomsNumber())
       assertThat(result.hdcEligibilityDate).isNull()
       assertThat(result.latestStatusUpdate).isNull()
+      assertThat(result.createdByUserName).isEqualTo("first last")
     }
 
     @Test
@@ -191,6 +193,7 @@ class ApplicationsTransformerTest {
         override fun getCrn() = "CRNNUM"
         override fun getNomsNumber() = "NOMNUM"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+        override fun getCreatedByUserName() = "first last"
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
@@ -221,6 +224,7 @@ class ApplicationsTransformerTest {
       assertThat(result.nomsNumber).isEqualTo(application.getNomsNumber())
       assertThat(result.latestStatusUpdate?.label).isEqualTo("my latest status update")
       assertThat(result.latestStatusUpdate?.statusId).isEqualTo(UUID.fromString("ae544aee-7170-4794-99fb-703090cbc7db"))
+      assertThat(result.createdByUserName).isEqualTo("first last")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -125,6 +125,7 @@ class SubmissionsTransformerTest {
         override fun getCrn() = "CRN123"
         override fun getNomsNumber() = "NOMS456"
         override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
+        override fun getCreatedByUserName() = "first last"
         override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
         override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
         override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")


### PR DESCRIPTION
Our dashboard for displaying lists of applications to referrers needs the author's name - this PR gets the name from the `nomis_users` table in the sql queries that return `ApplicationSummaries` and adds it to the API model.

Note: the ApplicationSummary is shared across the models on `/applications` and `/submissions` [(we are aware this is a bit of tech debt we need to address) ](https://dsdmoj.atlassian.net/browse/CAS2-325) - the submissions end point does not need to see this author name atm, so I'm not currently returning it in the SubmissionsTransformer.