### PR TITLE
(Chore) Attempt to improve build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
             - gradle-
       - run:
           name: Build project
-          command: ./gradlew assemble --build-cache && ./gradlew assemble testClasses --build-cache
+          command: ./gradlew assemble testClasses --build-cache
       - save_cache:
           paths:
             - ~/.gradle

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -39,6 +39,7 @@
     <ID>CyclomaticComplexMethod:GetAllApprovedPremisesApplicationsTest.kt$GetAllApprovedPremisesApplicationsTest$private fun ApprovedPremisesApplicationSummary.matches(applicationEntity: ApprovedPremisesApplicationEntity): Boolean</ID>
     <ID>MaxLineLength:AssessmentServiceTest.kt$AssessmentServiceTest.ReallocateAssessment$fun</ID>
     <ID>ReturnCount:PlacementRequestService.kt$PlacementRequestService$fun reallocatePlacementRequest( assigneeUser: UserEntity, id: UUID, ): AuthorisableActionResult&lt;ValidatableActionResult&lt;PlacementRequestEntity>></ID>
+    <ID>LongMethod:UserAllocationsEngineTest.kt$UserAllocationsEngineTest$@BeforeAll fun setup()</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,12 @@
+# Set sensible defaults for memory usage
 org.gradle.jvmargs=-Xms256M -Xmx4g -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvmargs=-Xmx2g
+# Enable Kotlin incremental builds
+kotlin.incremental.useClasspathSnapshot=true
+# Enable Gradle Daemon
+org.gradle.daemon=true
+# Enable Configure on demand
+org.gradle.configureondemand=true
+# Enable parallel builds
+org.gradle.parallel=true
+# Enable simple gradle caching
+org.gradle.caching=true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserAllocationsEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserAllocationsEngineTest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.AllocationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UserAllocationsEngine
 import java.time.OffsetDateTime
 
-class UserAllocationsEngineTest : IntegrationTestBase() {
+class UserAllocationsEngineTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var realUserRepository: UserRepository
 
@@ -39,7 +39,7 @@ class UserAllocationsEngineTest : IntegrationTestBase() {
   lateinit var excludedAssessor: UserEntity
   lateinit var excludedPlacementApplicationMatcher: UserEntity
 
-  @BeforeEach
+  @BeforeAll
   fun setup() {
     applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
     assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist()


### PR DESCRIPTION
This is a grabbag of attempts to _try_ and improve build times. 

I started by changing the gradle.properties (which I think will only help us locally). There's a degree of cargo-culting there (see https://stackoverflow.com/questions/45327617/very-very-slow-gradle-build-on-android-studio), but it all seems to make sense.

I then noticed that the build was running twice, so have attempted to fix that, which shaves about a minute off the build time. I also noticed that the `UserAllocationsTest` had some expensive setup, so have shared the database context there.