### PR TITLE
CAS2-413 remove the person field on application summaries and use bulk search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
@@ -55,7 +56,7 @@ class ApplicationsController(
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),
-    ).body(applications.map { getPersonDetailAndTransformToSummary(it, user) })
+    ).body(getPersonNamesAndTransformToSummaries(applications))
   }
 
   override fun applicationsApplicationIdGet(applicationId: UUID):
@@ -136,15 +137,15 @@ class ApplicationsController(
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication, user))
   }
 
-  private fun getPersonDetailAndTransformToSummary(
-    application: uk.gov.justice.digital
-    .hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary,
-    user: NomisUserEntity,
-  ):
-    ModelCas2ApplicationSummary {
-    val personInfo = offenderService.getInfoForPersonOrThrowInternalServerError(application.getCrn())
+  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummary>):
+    List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary> {
+    val crns = applicationSummaries.map { it.getCrn() }
 
-    return applicationsTransformer.transformJpaSummaryToSummary(application, personInfo)
+    val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
+
+    return applicationSummaries.map { application ->
+      applicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.getCrn()]!!)
+    }
   }
 
   private fun getPersonDetailAndTransform(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -26,15 +26,15 @@ const val SUBMITTED_APPLICATION_SUMMARY_FIELDS =
   """
     ,
     a.hdc_eligibility_date as hdcEligibilityDate,
-    a.noms_number as nomsNumber,
     asu.label as latestStatusUpdateLabel,
     CAST(asu.status_id AS TEXT) as latestStatusUpdateStatusId
   """
 
-const val UNSUBMITTED_APPLICATION_SUMMARY_FIELDS =
+const val DEFAULT_APPLICATION_SUMMARY_FIELDS =
   """
     CAST(a.id AS TEXT) as id,
     a.crn,
+    a.noms_number as nomsNumber,
     CAST(a.created_by_user_id AS TEXT) as createdByUserId,
     nu.name as createdByUserName,
     a.created_at as createdAt,
@@ -42,7 +42,7 @@ const val UNSUBMITTED_APPLICATION_SUMMARY_FIELDS =
   """
 
 const val ALL_APPLICATION_SUMMARY_FIELDS =
-  UNSUBMITTED_APPLICATION_SUMMARY_FIELDS + SUBMITTED_APPLICATION_SUMMARY_FIELDS
+  DEFAULT_APPLICATION_SUMMARY_FIELDS + SUBMITTED_APPLICATION_SUMMARY_FIELDS
 
 @Suppress("TooManyFunctions")
 @Repository
@@ -159,7 +159,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    $UNSUBMITTED_APPLICATION_SUMMARY_FIELDS
+    $DEFAULT_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.created_by_user_id = :userId
@@ -174,7 +174,7 @@ ORDER BY createdAt DESC
   @Query(
     """
 SELECT
-    $UNSUBMITTED_APPLICATION_SUMMARY_FIELDS
+    $DEFAULT_APPLICATION_SUMMARY_FIELDS
 FROM cas_2_applications a
 JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.referring_prison_code = :prisonCode

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -41,13 +41,11 @@ class ApplicationsTransformer(
 
   fun transformJpaSummaryToSummary(
     jpaSummary: Cas2ApplicationSummary,
-    personInfo:
-      PersonInfoResult.Success,
+    personName: String,
   ): uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary {
     return uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
       .Cas2ApplicationSummary(
         id = jpaSummary.getId(),
-        person = personTransformer.transformModelToPersonApi(personInfo),
         createdByUserId = jpaSummary.getCreatedByUserId(),
         createdByUserName = jpaSummary.getCreatedByUserName(),
         createdAt = jpaSummary.getCreatedAt().toInstant(),
@@ -58,8 +56,7 @@ class ApplicationsTransformer(
         hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
         crn = jpaSummary.getCrn(),
         nomsNumber = jpaSummary.getNomsNumber(),
-        personName = (personInfo as PersonInfoResult.Success.Full).offenderDetailSummary.firstName +
-          " " + personInfo.offenderDetailSummary.surname,
+        personName = personName,
       )
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1871,33 +1871,48 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            createdByUserName:
-              type: string
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-            personName:
-              type: string
-            crn:
-              type: string
-            nomsNumber:
-              type: string
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        createdByUserName:
+          type: string
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
+        - personName
+        - crn
+        - nomsNumber
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6478,33 +6478,48 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            createdByUserName:
-              type: string
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-            personName:
-              type: string
-            crn:
-              type: string
-            nomsNumber:
-              type: string
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        createdByUserName:
+          type: string
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
+        - personName
+        - crn
+        - nomsNumber
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2436,33 +2436,48 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            createdByUserName:
-              type: string
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-            personName:
-              type: string
-            crn:
-              type: string
-            nomsNumber:
-              type: string
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        createdByUserName:
+          type: string
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
+        - personName
+        - crn
+        - nomsNumber
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1962,33 +1962,48 @@ components:
             - createdByUserId
             - status
     Cas2ApplicationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ApplicationSummary'
-        - type: object
-          properties:
-            createdByUserId:
-              type: string
-              format: uuid
-            createdByUserName:
-              type: string
-            status:
-              $ref: '#/components/schemas/ApplicationStatus'
-            latestStatusUpdate:
-              $ref: '#/components/schemas/LatestCas2StatusUpdate'
-            risks:
-              $ref: '#/components/schemas/PersonRisks'
-            hdcEligibilityDate:
-              type: string
-              format: date
-            personName:
-              type: string
-            crn:
-              type: string
-            nomsNumber:
-              type: string
-          required:
-            - createdByUserId
-            - status
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        createdByUserName:
+          type: string
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
+        - personName
+        - crn
+        - nomsNumber
     NewCas2ApplicationNote:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
@@ -165,14 +164,9 @@ class ApplicationsTransformerTest {
 
       every { mockStatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns null
 
-      val mockPersonInfo = mockk<PersonInfoResult.Success.Full>()
-
-      every { mockPersonInfo.offenderDetailSummary.firstName } returns "firstName"
-      every { mockPersonInfo.offenderDetailSummary.surname } returns "surname"
-
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockPersonInfo,
+        "firstName surname",
       )
 
       assertThat(result.id).isEqualTo(application.getId())
@@ -206,14 +200,9 @@ class ApplicationsTransformerTest {
         label = application.getLatestStatusUpdateLabel(),
       )
 
-      val mockPersonInfo = mockk<PersonInfoResult.Success.Full>()
-
-      every { mockPersonInfo.offenderDetailSummary.firstName } returns "firstName"
-      every { mockPersonInfo.offenderDetailSummary.surname } returns "surname"
-
       val result = applicationsTransformer.transformJpaSummaryToSummary(
         application,
-        mockPersonInfo,
+        "firstName surname",
       )
 
       assertThat(result.id).isEqualTo(application.getId())


### PR DESCRIPTION
Ref: JIRA ticket [CAS2-413](https://dsdmoj.atlassian.net/browse/CAS2-413)

This PR contains the work required for the third sub task of [CAS2-401](https://dsdmoj.atlassian.net/browse/CAS2-401)

Tasks:
- API: remove the Person field on application summaries and use the bulk search for getMapOfPersonNamesAndCrns to get CRNs

We currently return for ApplicationSummaries a full Person result, which includes a lot of data, and causes issues with how we handle whether the person has been found/is restricted.

We propose that we follow the standard set for /submissions and just return a personName which will be ‘Unknown’ if person not found or restricted.

This will mean we can then do a bulk search with the CRNs more easily, and just get the person’s name.

[CAS2-401]: https://dsdmoj.atlassian.net/browse/CAS2-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CAS2-412]: https://dsdmoj.atlassian.net/browse/CAS2-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CAS2-413]: https://dsdmoj.atlassian.net/browse/CAS2-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ