### PR TITLE
(APS-685) Add person to personal timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -259,7 +259,7 @@ class PeopleController(
           .map { it as ApprovedPremisesApplicationEntity }
           .associateWith { applicationService.getApplicationTimeline(it.id) }
 
-        personalTimelineTransformer.transformApplicationsAndTimelineEvents(applicationsAndTimelineEvents)
+        personalTimelineTransformer.transformApplicationsAndTimelineEvents(personInfo, applicationsAndTimelineEvents)
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
@@ -6,14 +6,18 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonalTimeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 
 @Component
 class PersonalTimelineTransformer(
   private val userTransformer: UserTransformer,
+  private val personTransformer: PersonTransformer,
 ) {
   fun transformApplicationsAndTimelineEvents(
+    personInfoResult: PersonInfoResult,
     applicationsAndTimelineEvents: Map<ApprovedPremisesApplicationEntity, List<TimelineEvent>>,
   ) = PersonalTimeline(
+    person = personTransformer.transformModelToPersonApi(personInfoResult),
     applications = applicationsAndTimelineEvents.map { transformApplication(it.key, it.value) },
   )
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3455,11 +3455,14 @@ components:
     PersonalTimeline:
       type: object
       properties:
+        person:
+          $ref: '#/components/schemas/Person'
         applications:
           type: array
           items:
             $ref: '#/components/schemas/ApplicationTimeline'
       required:
+        - person
         - applications
     ApplicationTimeline:
       type: object

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7993,11 +7993,14 @@ components:
     PersonalTimeline:
       type: object
       properties:
+        person:
+          $ref: '#/components/schemas/Person'
         applications:
           type: array
           items:
             $ref: '#/components/schemas/ApplicationTimeline'
       required:
+        - person
         - applications
     ApplicationTimeline:
       type: object

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4020,11 +4020,14 @@ components:
     PersonalTimeline:
       type: object
       properties:
+        person:
+          $ref: '#/components/schemas/Person'
         applications:
           type: array
           items:
             $ref: '#/components/schemas/ApplicationTimeline'
       required:
+        - person
         - applications
     ApplicationTimeline:
       type: object

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3546,11 +3546,14 @@ components:
     PersonalTimeline:
       type: object
       properties:
+        person:
+          $ref: '#/components/schemas/Person'
         applications:
           type: array
           items:
             $ref: '#/components/schemas/ApplicationTimeline'
       required:
+        - person
         - applications
     ApplicationTimeline:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonalTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonalTimelineTransformerTest.kt
@@ -2,17 +2,22 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimeline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApprovedPremisesUserFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.TimelineEventFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonalTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
@@ -20,8 +25,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesAp
 
 class PersonalTimelineTransformerTest {
   private val userTransformer = mockk<UserTransformer>()
+  private val personTransformer = mockk<PersonTransformer>()
 
-  private val personalTimelineTransformer = PersonalTimelineTransformer(userTransformer)
+  private val personalTimelineTransformer = PersonalTimelineTransformer(userTransformer, personTransformer)
 
   companion object {
     private fun assertApplicationMatches(
@@ -80,13 +86,23 @@ class PersonalTimelineTransformerTest {
       .take(4)
       .toList()
 
+    val offenderDetailSummary = OffenderDetailsSummaryFactory().produce()
+    val personInfoResult = PersonInfoResult.Success.Full(
+      crn = offenderDetailSummary.otherIds.crn,
+      offenderDetailSummary = offenderDetailSummary,
+      inmateDetail = null,
+    )
+    val mockPerson = mockk<Person>()
+
     every { userTransformer.transformJpaToApi(application0.createdByUser, ServiceName.approvedPremises) } returns user0
     every { userTransformer.transformJpaToApi(application1.createdByUser, ServiceName.approvedPremises) } returns user1
     every { userTransformer.transformJpaToApi(application2.createdByUser, ServiceName.approvedPremises) } returns user2
     every { userTransformer.transformJpaToApi(application3.createdByUser, ServiceName.approvedPremises) } returns user3
 
+    every { personTransformer.transformModelToPersonApi(personInfoResult) } returns mockPerson
+
     val transformedPersonalTimeline = personalTimelineTransformer
-      .transformApplicationsAndTimelineEvents(applicationsAndTimelineEvents)
+      .transformApplicationsAndTimelineEvents(personInfoResult, applicationsAndTimelineEvents)
 
     assertThat(transformedPersonalTimeline.applications).hasSize(4)
 
@@ -94,5 +110,9 @@ class PersonalTimelineTransformerTest {
     assertApplicationMatches(transformedPersonalTimeline.applications[1], application1, user1, timelineEvents1)
     assertApplicationMatches(transformedPersonalTimeline.applications[2], application2, user2, timelineEvents2)
     assertApplicationMatches(transformedPersonalTimeline.applications[3], application3, user3, timelineEvents3)
+
+    assertThat(transformedPersonalTimeline.person).isEqualTo(mockPerson)
+
+    verify(exactly = 1) { personTransformer.transformModelToPersonApi(personInfoResult) }
   }
 }


### PR DESCRIPTION
This adds a person object to the personal timeline endpoint, allowing us to display information about an offender alongside the timeline info.