### PR TITLE
[APS-587] Add API endpoints for Requests for Placement

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplicationTimelineNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApplication
@@ -51,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestForPlacementService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableService
@@ -84,6 +86,7 @@ class ApplicationsController(
   private val appealService: AppealService,
   private val appealTransformer: AppealTransformer,
   private val placementRequestService: PlacementRequestService,
+  private val requestForPlacementService: RequestForPlacementService,
 ) : ApplicationsApiDelegate {
 
   override fun applicationsGet(xServiceName: ServiceName?): ResponseEntity<List<ApplicationSummary>> {
@@ -331,6 +334,31 @@ class ApplicationsController(
     }
     val events = applicationService.getApplicationTimeline(applicationId)
     return ResponseEntity(events, HttpStatus.OK)
+  }
+
+  override fun applicationsApplicationIdRequestsForPlacementGet(applicationId: UUID): ResponseEntity<List<RequestForPlacement>> {
+    val requestsForPlacement = when (val result = requestForPlacementService.getRequestsForPlacementByApplication(applicationId)) {
+      is AuthorisableActionResult.Success -> result.entity
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(requestsForPlacement)
+  }
+
+  override fun applicationsApplicationIdRequestsForPlacementRequestForPlacementIdGet(
+    applicationId: UUID,
+    requestForPlacementId: UUID,
+  ): ResponseEntity<RequestForPlacement> {
+    val application = applicationService.getApplication(applicationId) ?: throw NotFoundProblem(applicationId, "Application")
+
+    val requestForPlacement = when (val result = requestForPlacementService.getRequestForPlacement(application, requestForPlacementId)) {
+      is AuthorisableActionResult.Success -> result.entity
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "RequestForPlacement")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(requestForPlacement)
   }
 
   override fun applicationsApplicationIdSubmissionPost(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -514,7 +514,7 @@ class ApplicationsController(
     } else { emptyList() }
 
     val placementApplicationEntities =
-      placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(applicationId)
+      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(applicationId)
     val additionalPlacementRequests = placementApplicationEntities.map {
       placementApplicationTransformer.transformJpaToApi(it)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Column
@@ -169,15 +170,21 @@ enum class PlacementApplicationDecision(val apiValue: ApiPlacementApplicationDec
   }
 }
 
-enum class PlacementApplicationWithdrawalReason {
-  DUPLICATE_PLACEMENT_REQUEST,
-  ALTERNATIVE_PROVISION_IDENTIFIED,
-  WITHDRAWN_BY_PP,
-  CHANGE_IN_CIRCUMSTANCES,
-  CHANGE_IN_RELEASE_DECISION,
-  NO_CAPACITY_DUE_TO_LOST_BED,
-  NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION,
-  NO_CAPACITY,
-  ERROR_IN_PLACEMENT_REQUEST,
-  RELATED_APPLICATION_WITHDRAWN,
+enum class PlacementApplicationWithdrawalReason(val apiValue: WithdrawPlacementRequestReason) {
+  DUPLICATE_PLACEMENT_REQUEST(WithdrawPlacementRequestReason.duplicatePlacementRequest),
+  ALTERNATIVE_PROVISION_IDENTIFIED(WithdrawPlacementRequestReason.alternativeProvisionIdentified),
+  WITHDRAWN_BY_PP(WithdrawPlacementRequestReason.withdrawnByPP),
+  CHANGE_IN_CIRCUMSTANCES(WithdrawPlacementRequestReason.changeInCircumstances),
+  CHANGE_IN_RELEASE_DECISION(WithdrawPlacementRequestReason.changeInReleaseDecision),
+  NO_CAPACITY_DUE_TO_LOST_BED(WithdrawPlacementRequestReason.noCapacityDueToLostBed),
+  NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION(WithdrawPlacementRequestReason.noCapacityDueToPlacementPrioritisation),
+  NO_CAPACITY(WithdrawPlacementRequestReason.noCapacity),
+  ERROR_IN_PLACEMENT_REQUEST(WithdrawPlacementRequestReason.errorInPlacementRequest),
+  RELATED_APPLICATION_WITHDRAWN(WithdrawPlacementRequestReason.relatedApplicationWithdrawn),
+  ;
+
+  companion object {
+    fun valueOf(apiValue: WithdrawPlacementRequestReason): PlacementApplicationWithdrawalReason? =
+      PlacementApplicationWithdrawalReason.entries.firstOrNull { it.apiValue == apiValue }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -44,6 +44,8 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
 
   fun findByApplication(application: ApplicationEntity): List<PlacementApplicationEntity>
 
+  fun findByApplicationId(applicationId: UUID): List<PlacementApplicationEntity>
+
   @Query("SELECT p from PlacementApplicationEntity p WHERE p.dueAt IS NULL AND p.submittedAt IS NOT NULL")
   fun findAllWithNullDueAt(pageable: Pageable?): Slice<PlacementApplicationEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -229,16 +230,22 @@ data class PlacementRequestEntity(
   fun isForApplicationsArrivalDate() = placementApplication == null
 }
 
-enum class PlacementRequestWithdrawalReason {
-  DUPLICATE_PLACEMENT_REQUEST,
-  ALTERNATIVE_PROVISION_IDENTIFIED,
-  WITHDRAWN_BY_PP,
-  CHANGE_IN_CIRCUMSTANCES,
-  CHANGE_IN_RELEASE_DECISION,
-  NO_CAPACITY_DUE_TO_LOST_BED,
-  NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION,
-  NO_CAPACITY,
-  ERROR_IN_PLACEMENT_REQUEST,
-  RELATED_APPLICATION_WITHDRAWN,
-  RELATED_PLACEMENT_APPLICATION_WITHDRAWN,
+enum class PlacementRequestWithdrawalReason(val apiValue: WithdrawPlacementRequestReason) {
+  DUPLICATE_PLACEMENT_REQUEST(WithdrawPlacementRequestReason.duplicatePlacementRequest),
+  ALTERNATIVE_PROVISION_IDENTIFIED(WithdrawPlacementRequestReason.alternativeProvisionIdentified),
+  WITHDRAWN_BY_PP(WithdrawPlacementRequestReason.withdrawnByPP),
+  CHANGE_IN_CIRCUMSTANCES(WithdrawPlacementRequestReason.changeInCircumstances),
+  CHANGE_IN_RELEASE_DECISION(WithdrawPlacementRequestReason.changeInReleaseDecision),
+  NO_CAPACITY_DUE_TO_LOST_BED(WithdrawPlacementRequestReason.noCapacityDueToLostBed),
+  NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION(WithdrawPlacementRequestReason.noCapacityDueToPlacementPrioritisation),
+  NO_CAPACITY(WithdrawPlacementRequestReason.noCapacity),
+  ERROR_IN_PLACEMENT_REQUEST(WithdrawPlacementRequestReason.errorInPlacementRequest),
+  RELATED_APPLICATION_WITHDRAWN(WithdrawPlacementRequestReason.relatedApplicationWithdrawn),
+  RELATED_PLACEMENT_APPLICATION_WITHDRAWN(WithdrawPlacementRequestReason.relatedPlacementApplicationWithdrawn),
+  ;
+
+  companion object {
+    fun valueOf(apiValue: WithdrawPlacementRequestReason): PlacementRequestWithdrawalReason? =
+      PlacementRequestWithdrawalReason.entries.firstOrNull { it.apiValue == apiValue }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -56,6 +56,10 @@ class PlacementApplicationService(
 
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
+  fun getAllPlacementApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
+    return placementApplicationRepository.findByApplicationId(applicationId)
+  }
+
   fun getAllActivePlacementApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
     return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(
       applicationId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -56,7 +56,7 @@ class PlacementApplicationService(
 
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
-  fun getAllPlacementApplicationEntitiesForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
+  fun getAllActivePlacementApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
     return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(
       applicationId,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RequestForPlacementService.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
+import java.util.UUID
+
+@Component
+class RequestForPlacementService(
+  private val applicationService: ApplicationService,
+  private val placementApplicationService: PlacementApplicationService,
+  private val placementRequestService: PlacementRequestService,
+  private val requestForPlacementTransformer: RequestForPlacementTransformer,
+) {
+  fun getRequestsForPlacementByApplication(applicationId: UUID): AuthorisableActionResult<List<RequestForPlacement>> {
+    if (applicationService.getApplication(applicationId) == null) {
+      return AuthorisableActionResult.NotFound("Application", applicationId.toString())
+    }
+
+    val placementApplications = placementApplicationService.getAllPlacementApplicationsForApplicationId(applicationId)
+    val placementRequests = placementRequestService.getPlacementRequestForInitialApplicationDates(applicationId)
+
+    val result = placementApplications.map(requestForPlacementTransformer::transformPlacementApplicationEntityToApi) +
+      placementRequests.map(requestForPlacementTransformer::transformPlacementRequestEntityToApi)
+
+    return AuthorisableActionResult.Success(result)
+  }
+
+  fun getRequestForPlacement(application: ApplicationEntity, requestForPlacementId: UUID): AuthorisableActionResult<RequestForPlacement> {
+    val placementApplication = placementApplicationService.getApplicationOrNull(requestForPlacementId)
+    val placementRequest = placementRequestService.getPlacementRequestOrNull(requestForPlacementId)
+
+    return when {
+      placementApplication == null && placementRequest == null ->
+        AuthorisableActionResult.NotFound("RequestForPlacement", requestForPlacementId.toString())
+
+      placementApplication != null && placementRequest != null ->
+        throw RequestForPlacementServiceException.AmbiguousRequestForPlacementId()
+
+      placementApplication != null -> when (placementApplication.application) {
+        application ->
+          AuthorisableActionResult.Success(requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication))
+
+        else ->
+          AuthorisableActionResult.NotFound("RequestForPlacement", requestForPlacementId.toString())
+      }
+
+      else -> when (placementRequest!!.application) {
+        application ->
+          AuthorisableActionResult.Success(requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest))
+
+        else ->
+          AuthorisableActionResult.NotFound("RequestForPlacement", requestForPlacementId.toString())
+      }
+    }
+  }
+
+  private sealed class RequestForPlacementServiceException(message: String) : RuntimeException(message) {
+    class AmbiguousRequestForPlacementId : RequestForPlacementServiceException("A placement application and placement request could not be distinguished as they share the same UUID")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -41,7 +41,7 @@ class Cas1WithdrawableTreeBuilder(
       children.add(treeForPlacementReq(it, user))
     }
 
-    placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(application.id).forEach {
+    placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id).forEach {
       children.add(treeForPlacementApp(it, user))
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+
+@Component
+class RequestForPlacementTransformer(
+  private val objectMapper: ObjectMapper,
+) {
+  fun transformPlacementApplicationEntityToApi(
+    placementApplicationEntity: PlacementApplicationEntity,
+  ) = RequestForPlacement(
+    id = placementApplicationEntity.id,
+    createdByUserId = placementApplicationEntity.createdByUser.id,
+    createdAt = placementApplicationEntity.createdAt.toInstant(),
+    isWithdrawn = placementApplicationEntity.isWithdrawn(),
+    type = RequestForPlacementType.manual,
+    placementDates = placementApplicationEntity.placementDates.map { it.toPlacementDates() },
+    submittedAt = placementApplicationEntity.submittedAt?.toInstant(),
+    requestReviewedAt = placementApplicationEntity.decisionMadeAt?.toInstant(),
+    document = placementApplicationEntity.document?.let(objectMapper::readTree),
+    withdrawalReason = placementApplicationEntity.withdrawalReason?.apiValue,
+  )
+
+  fun transformPlacementRequestEntityToApi(
+    placementRequestEntity: PlacementRequestEntity,
+  ) = RequestForPlacement(
+    id = placementRequestEntity.id,
+    createdByUserId = placementRequestEntity.application.createdByUser.id,
+    createdAt = placementRequestEntity.createdAt.toInstant(),
+    isWithdrawn = placementRequestEntity.isWithdrawn,
+    type = RequestForPlacementType.automatic,
+    placementDates = listOf(
+      PlacementDates(
+        expectedArrival = placementRequestEntity.expectedArrival,
+        duration = placementRequestEntity.duration,
+      ),
+    ),
+    submittedAt = placementRequestEntity.createdAt.toInstant(),
+    requestReviewedAt = placementRequestEntity.assessment.submittedAt?.toInstant(),
+    document = null,
+    withdrawalReason = placementRequestEntity.withdrawalReason?.apiValue,
+  )
+
+  private fun PlacementDateEntity.toPlacementDates() = PlacementDates(
+    expectedArrival = expectedArrival,
+    duration = duration,
+  )
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3785,6 +3785,54 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
+    RequestForPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the `PlacementApplication` ID.
+            If `type` is `"automatic"` this field provides a `PlacementRequest` ID.
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        requestReviewedAt:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the value of `PlacementApplication.decisionMadeAt`.
+            If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
+          format: date-time
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        isWithdrawn:
+          type: boolean
+        withdrawalReason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+        type:
+          $ref: '#/components/schemas/RequestForPlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+      required:
+        - id
+        - createdByUserId
+        - createdAt
+        - isWithdrawn
+        - type
+        - placementDates
+    RequestForPlacementType:
+      type: string
+      enum:
+        - manual
+        - automatic
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2348,6 +2348,75 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /applications/{applicationId}/requests-for-placement:
+    get:
+      summary: Returns a list of Requests for Placement for the given application.
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/RequestForPlacement'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /applications/{applicationId}/requests-for-placement/{requestForPlacementId}:
+    get:
+      summary: Returns the specified Request for Placement.
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application which the Request for Placement enacts.
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: requestForPlacementId
+          in: path
+          description: ID of the Request for Placement.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/RequestForPlacement'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /beds/search:
     post:
       summary: Searches for available Beds within the given parameters

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2350,6 +2350,75 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/requests-for-placement:
+    get:
+      summary: Returns a list of Requests for Placement for the given application.
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RequestForPlacement'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/requests-for-placement/{requestForPlacementId}:
+    get:
+      summary: Returns the specified Request for Placement.
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application which the Request for Placement enacts.
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: requestForPlacementId
+          in: path
+          description: ID of the Request for Placement.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/RequestForPlacement'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /beds/search:
     post:
       summary: Searches for available Beds within the given parameters
@@ -8323,6 +8392,54 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
+    RequestForPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the `PlacementApplication` ID.
+            If `type` is `"automatic"` this field provides a `PlacementRequest` ID.
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        requestReviewedAt:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the value of `PlacementApplication.decisionMadeAt`.
+            If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
+          format: date-time
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        isWithdrawn:
+          type: boolean
+        withdrawalReason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+        type:
+          $ref: '#/components/schemas/RequestForPlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+      required:
+        - id
+        - createdByUserId
+        - createdAt
+        - isWithdrawn
+        - type
+        - placementDates
+    RequestForPlacementType:
+      type: string
+      enum:
+        - manual
+        - automatic
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4350,6 +4350,54 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
+    RequestForPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the `PlacementApplication` ID.
+            If `type` is `"automatic"` this field provides a `PlacementRequest` ID.
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        requestReviewedAt:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the value of `PlacementApplication.decisionMadeAt`.
+            If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
+          format: date-time
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        isWithdrawn:
+          type: boolean
+        withdrawalReason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+        type:
+          $ref: '#/components/schemas/RequestForPlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+      required:
+        - id
+        - createdByUserId
+        - createdAt
+        - isWithdrawn
+        - type
+        - placementDates
+    RequestForPlacementType:
+      type: string
+      enum:
+        - manual
+        - automatic
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3876,6 +3876,54 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
+    RequestForPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the `PlacementApplication` ID.
+            If `type` is `"automatic"` this field provides a `PlacementRequest` ID.
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        requestReviewedAt:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the value of `PlacementApplication.decisionMadeAt`.
+            If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
+          format: date-time
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        isWithdrawn:
+          type: boolean
+        withdrawalReason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+        type:
+          $ref: '#/components/schemas/RequestForPlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+      required:
+        - id
+        - createdByUserId
+        - createdAt
+        - isWithdrawn
+        - type
+        - placementDates
+    RequestForPlacementType:
+      type: string
+      enum:
+        - manual
+        - automatic
     PlacementRequest:
       allOf:
         - $ref: '#/components/schemas/PlacementRequirements'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/RequestsForPlacementTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/RequestsForPlacementTest.kt
@@ -1,0 +1,214 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class RequestsForPlacementTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var requestForPlacementTransformer: RequestForPlacementTransformer
+
+  @Nested
+  inner class AllRequestsForPlacementForApplication {
+    @Test
+    fun `Get all Requests for Placement for an application without a JWT returns a 401 response`() {
+      webTestClient.get()
+        .uri("/applications/${UUID.randomUUID()}/requests-for-placement")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get all Requests for Placement for an application that could not be found returns a 404 response`() {
+      `Given a User` { _, jwt ->
+        webTestClient.get()
+          .uri("/applications/${UUID.randomUUID()}/requests-for-placement")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @Test
+    fun `Get all Requests for Placement for an application returns a 200 response with the expected value`() {
+      `Given a User` { user, jwt ->
+        `Given an Assessment for Approved Premises`(
+          allocatedToUser = null,
+          createdByUser = user,
+        ) { assessment, application ->
+          val schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist()
+
+          val placementApplication = placementApplicationFactory.produceAndPersist {
+            withApplication(application)
+            withSchemaVersion(schema)
+            withCreatedByUser(user)
+          }
+
+          val postCodeDistrict = postCodeDistrictFactory.produceAndPersist()
+
+          val placementRequirements = placementRequirementsFactory.produceAndPersist {
+            withApplication(application)
+            withAssessment(assessment)
+            withPostcodeDistrict(postCodeDistrict)
+            withEssentialCriteria(listOf())
+            withDesirableCriteria(listOf())
+          }
+
+          val placementRequest = placementRequestFactory.produceAndPersist {
+            withApplication(application)
+            withAssessment(assessment)
+            withPlacementRequirements(placementRequirements)
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+          }
+
+          webTestClient.get()
+            .uri("/applications/${application.id}/requests-for-placement")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                listOf(
+                  requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication),
+                  requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest),
+                ),
+              ),
+            )
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class SpecificRequestForPlacement {
+    @Test
+    fun `Get a Request for Placement for an application without a JWT returns a 401 response`() {
+      webTestClient.get()
+        .uri("/applications/${UUID.randomUUID()}/requests-for-placement/${UUID.randomUUID()}")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get a Request for Placement for an application that could not be found returns a 404 response`() {
+      `Given a User` { _, jwt ->
+        webTestClient.get()
+          .uri("/applications/${UUID.randomUUID()}/requests-for-placement/${UUID.randomUUID()}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @Test
+    fun `Get a Request for Placement that does not exist returns a 404 response`() {
+      `Given a User` { user, jwt ->
+        `Given an Application`(user) { wrongApplication ->
+          webTestClient.get()
+            .uri("/applications/${wrongApplication.id}/requests-for-placement/${UUID.randomUUID()}")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isNotFound
+        }
+      }
+    }
+
+    @Test
+    fun `Get a Request for Placement for an application that is not the application it belongs to returns a 404 response`() {
+      `Given a User` { user, jwt ->
+        `Given an Application`(user) { wrongApplication ->
+          `Given a Placement Request`(
+            placementRequestAllocatedTo = null,
+            assessmentAllocatedTo = user,
+            createdByUser = user,
+          ) { placementRequest, _ ->
+            webTestClient.get()
+              .uri("/applications/${wrongApplication.id}/requests-for-placement/${placementRequest.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isNotFound
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get a Request for Placement for an application returns a 200 response with the expected placement request`() {
+      `Given a User` { user, jwt ->
+        `Given an Assessment for Approved Premises`(
+          allocatedToUser = null,
+          createdByUser = user,
+        ) { assessment, application ->
+          val postCodeDistrict = postCodeDistrictFactory.produceAndPersist()
+
+          val placementRequirements = placementRequirementsFactory.produceAndPersist {
+            withApplication(application)
+            withAssessment(assessment)
+            withPostcodeDistrict(postCodeDistrict)
+            withEssentialCriteria(listOf())
+            withDesirableCriteria(listOf())
+          }
+
+          val placementRequest = placementRequestFactory.produceAndPersist {
+            withApplication(application)
+            withAssessment(assessment)
+            withPlacementRequirements(placementRequirements)
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+          }
+
+          webTestClient.get()
+            .uri("/applications/${application.id}/requests-for-placement/${placementRequest.id}")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest),
+              ),
+            )
+        }
+      }
+    }
+
+    @Test
+    fun `Get a Request for Placement for an application returns a 200 response with the expected placement application`() {
+      `Given a User` { user, jwt ->
+        val schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist()
+
+        `Given a Placement Application`(createdByUser = user, schema = schema) { placementApplication ->
+          webTestClient.get()
+            .uri("/applications/${placementApplication.application.id}/requests-for-placement/${placementApplication.id}")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication),
+              ),
+            )
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementApplicationEntityTest.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision as ApiPlacementApplicationDecision
 
 class PlacementApplicationEntityTest {
@@ -31,5 +33,43 @@ class PlacementApplicationEntityTest {
   )
   fun `PlacementApplicationDecision#valueOf gets the enum value from the API value`(apiDecision: ApiPlacementApplicationDecision, decision: PlacementApplicationDecision) {
     assertThat(PlacementApplicationDecision.valueOf(apiDecision)).isEqualTo(decision)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "DUPLICATE_PLACEMENT_REQUEST,duplicatePlacementRequest",
+      "ALTERNATIVE_PROVISION_IDENTIFIED,alternativeProvisionIdentified",
+      "WITHDRAWN_BY_PP,withdrawnByPP",
+      "CHANGE_IN_CIRCUMSTANCES,changeInCircumstances",
+      "CHANGE_IN_RELEASE_DECISION,changeInReleaseDecision",
+      "NO_CAPACITY_DUE_TO_LOST_BED,noCapacityDueToLostBed",
+      "NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION,noCapacityDueToPlacementPrioritisation",
+      "NO_CAPACITY,noCapacity",
+      "ERROR_IN_PLACEMENT_REQUEST,errorInPlacementRequest",
+      "RELATED_APPLICATION_WITHDRAWN,relatedApplicationWithdrawn",
+    ],
+  )
+  fun `PlacementApplicationWithdrawalReason#apiValue converts to the API enum values correctly`(withdrawalReason: PlacementApplicationWithdrawalReason, apiReason: WithdrawPlacementRequestReason) {
+    assertThat(withdrawalReason.apiValue).isEqualTo(apiReason)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "DUPLICATE_PLACEMENT_REQUEST,duplicatePlacementRequest",
+      "ALTERNATIVE_PROVISION_IDENTIFIED,alternativeProvisionIdentified",
+      "WITHDRAWN_BY_PP,withdrawnByPP",
+      "CHANGE_IN_CIRCUMSTANCES,changeInCircumstances",
+      "CHANGE_IN_RELEASE_DECISION,changeInReleaseDecision",
+      "NO_CAPACITY_DUE_TO_LOST_BED,noCapacityDueToLostBed",
+      "NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION,noCapacityDueToPlacementPrioritisation",
+      "NO_CAPACITY,noCapacity",
+      "ERROR_IN_PLACEMENT_REQUEST,errorInPlacementRequest",
+      "RELATED_APPLICATION_WITHDRAWN,relatedApplicationWithdrawn",
+    ],
+  )
+  fun `PlacementApplicationWithdrawalReason#valueOf gets the enum value from the API value`(withdrawalReason: PlacementApplicationWithdrawalReason, apiReason: WithdrawPlacementRequestReason) {
+    assertThat(PlacementApplicationWithdrawalReason.valueOf(apiReason)).isEqualTo(withdrawalReason)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementRequestEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementRequestEntityTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+
+class PlacementRequestEntityTest {
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "DUPLICATE_PLACEMENT_REQUEST,duplicatePlacementRequest",
+      "ALTERNATIVE_PROVISION_IDENTIFIED,alternativeProvisionIdentified",
+      "WITHDRAWN_BY_PP,withdrawnByPP",
+      "CHANGE_IN_CIRCUMSTANCES,changeInCircumstances",
+      "CHANGE_IN_RELEASE_DECISION,changeInReleaseDecision",
+      "NO_CAPACITY_DUE_TO_LOST_BED,noCapacityDueToLostBed",
+      "NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION,noCapacityDueToPlacementPrioritisation",
+      "NO_CAPACITY,noCapacity",
+      "ERROR_IN_PLACEMENT_REQUEST,errorInPlacementRequest",
+      "RELATED_APPLICATION_WITHDRAWN,relatedApplicationWithdrawn",
+      "RELATED_PLACEMENT_APPLICATION_WITHDRAWN,relatedPlacementApplicationWithdrawn",
+    ],
+  )
+  fun `PlacementRequestWithdrawalReason#apiValue converts to the API enum values correctly`(withdrawalReason: PlacementRequestWithdrawalReason, apiReason: WithdrawPlacementRequestReason) {
+    assertThat(withdrawalReason.apiValue).isEqualTo(apiReason)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "DUPLICATE_PLACEMENT_REQUEST,duplicatePlacementRequest",
+      "ALTERNATIVE_PROVISION_IDENTIFIED,alternativeProvisionIdentified",
+      "WITHDRAWN_BY_PP,withdrawnByPP",
+      "CHANGE_IN_CIRCUMSTANCES,changeInCircumstances",
+      "CHANGE_IN_RELEASE_DECISION,changeInReleaseDecision",
+      "NO_CAPACITY_DUE_TO_LOST_BED,noCapacityDueToLostBed",
+      "NO_CAPACITY_DUE_TO_PLACEMENT_PRIORITISATION,noCapacityDueToPlacementPrioritisation",
+      "NO_CAPACITY,noCapacity",
+      "ERROR_IN_PLACEMENT_REQUEST,errorInPlacementRequest",
+      "RELATED_APPLICATION_WITHDRAWN,relatedApplicationWithdrawn",
+      "RELATED_PLACEMENT_APPLICATION_WITHDRAWN,relatedPlacementApplicationWithdrawn",
+    ],
+  )
+  fun `PlacementRequestWithdrawalReason#valueOf gets the enum value from the API value`(withdrawalReason: PlacementRequestWithdrawalReason, apiReason: WithdrawPlacementRequestReason) {
+    assertThat(PlacementRequestWithdrawalReason.valueOf(apiReason)).isEqualTo(withdrawalReason)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/RequestForPlacementServiceTest.kt
@@ -1,0 +1,209 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestForPlacementService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+class RequestForPlacementServiceTest {
+  private val applicationService = mockk<ApplicationService>()
+  private val placementApplicationService = mockk<PlacementApplicationService>()
+  private val placementRequestService = mockk<PlacementRequestService>()
+  private val requestForPlacementTransformer = mockk<RequestForPlacementTransformer>()
+
+  private val requestForPlacementService = RequestForPlacementService(
+    applicationService,
+    placementApplicationService,
+    placementRequestService,
+    requestForPlacementTransformer,
+  )
+
+  @BeforeEach
+  fun setupRequestForPlacementTransformerMock() {
+    every { requestForPlacementTransformer.transformPlacementApplicationEntityToApi(any()) } returns mockk()
+    every { requestForPlacementTransformer.transformPlacementRequestEntityToApi(any()) } returns mockk()
+  }
+
+  companion object {
+    private val user = UserEntityFactory()
+      .withDefaults()
+      .produce()
+  }
+
+  @Nested
+  inner class GetRequestsForPlacementByApplication {
+    @Test
+    fun `Returns NotFound result if no application with the specified ID was found`() {
+      every { applicationService.getApplication(any()) } returns null
+
+      val result = requestForPlacementService.getRequestsForPlacementByApplication(UUID.randomUUID())
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+    }
+
+    @Test
+    fun `Returns all placement applications attached to the application with the specified ID`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementApplications = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .produceMany()
+        .take(5)
+        .toList()
+
+      every { applicationService.getApplication(application.id) } returns application
+
+      every {
+        placementApplicationService.getAllPlacementApplicationsForApplicationId(application.id)
+      } returns placementApplications
+
+      every {
+        placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
+      } returns listOf()
+
+      val result = requestForPlacementService.getRequestsForPlacementByApplication(application.id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).hasSize(placementApplications.size)
+      placementApplications.forEach {
+        verify(exactly = 1) { requestForPlacementTransformer.transformPlacementApplicationEntityToApi(it) }
+      }
+    }
+
+    @Test
+    fun `Returns all placement requests attached to the application with the specified ID`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val placementRequests = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .produceMany()
+        .take(5)
+        .toList()
+
+      every { applicationService.getApplication(application.id) } returns application
+
+      every {
+        placementApplicationService.getAllPlacementApplicationsForApplicationId(application.id)
+      } returns listOf()
+
+      every {
+        placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
+      } returns placementRequests
+
+      val result = requestForPlacementService.getRequestsForPlacementByApplication(application.id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      result as AuthorisableActionResult.Success
+      assertThat(result.entity).hasSize(placementRequests.size)
+      placementRequests.forEach {
+        verify(exactly = 1) { requestForPlacementTransformer.transformPlacementRequestEntityToApi(it) }
+      }
+    }
+  }
+
+  @Nested
+  inner class GetRequestForPlacement {
+    @Test
+    fun `Returns NotFound result if neither a placement application nor a placement request with the specified ID was found`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      every { placementApplicationService.getApplicationOrNull(any()) } returns null
+      every { placementRequestService.getPlacementRequestOrNull(any()) } returns null
+
+      val result = requestForPlacementService.getRequestForPlacement(application, UUID.randomUUID())
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+    }
+
+    @Test
+    fun `Returns the placement application with the specified ID`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .produce()
+
+      every { placementApplicationService.getApplicationOrNull(placementApplication.id) } returns placementApplication
+      every { placementRequestService.getPlacementRequestOrNull(any()) } returns null
+
+      val result = requestForPlacementService.getRequestForPlacement(application, placementApplication.id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+
+      verify(exactly = 1) { requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication) }
+    }
+
+    @Test
+    fun `Returns the placement request with the specified ID`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .produce()
+
+      every { placementApplicationService.getApplicationOrNull(any()) } returns null
+      every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
+
+      val result = requestForPlacementService.getRequestForPlacement(application, placementRequest.id)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+
+      verify(exactly = 1) { requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest) }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
@@ -101,7 +101,7 @@ class Cas1WithdrawableTreeBuilderTest {
     setupWithdrawableState(placementApplication2, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true))
 
     every {
-      placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(application.id)
+      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
     } returns listOf(placementApp1, placementApplication2)
 
     val adhocBooking1 = createBooking(adhoc = true)
@@ -166,7 +166,7 @@ Application(), withdrawable:Y, mayDirectlyWithdraw:Y, BLOCKED
     setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
 
     every {
-      placementApplicationService.getAllPlacementApplicationEntitiesForApplicationId(application.id)
+      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
     } returns listOf(placementApp1, placementApp2)
 
     every { bookingService.getAllAdhocOrUnknownForApplication(application) } returns emptyList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -1,0 +1,133 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+
+class RequestForPlacementTransformerTest {
+  private val objectMapper = mockk<ObjectMapper>()
+
+  private val requestForPlacementTransformer = RequestForPlacementTransformer(objectMapper)
+
+  @BeforeEach
+  fun setupObjectMapperMock() {
+    every { objectMapper.readTree(any<String>()) } returns mockk()
+  }
+
+  companion object {
+    private val user = UserEntityFactory()
+      .withDefaults()
+      .produce()
+
+    private fun assertPlacementDatesMatchPlacementDateEntities(
+      actual: List<PlacementDates>,
+      expected: List<PlacementDateEntity>,
+    ) {
+      assertThat(actual).hasSize(expected.size)
+      actual.zip(expected).forEach { (a, e) -> assertPlacementDateMatchesPlacementDateEntity(a, e) }
+    }
+
+    private fun assertPlacementDateMatchesPlacementDateEntity(
+      actual: PlacementDates,
+      expected: PlacementDateEntity,
+    ) {
+      assertThat(actual.expectedArrival).isEqualTo(expected.expectedArrival)
+      assertThat(actual.duration).isEqualTo(expected.duration)
+    }
+  }
+
+  @Nested
+  inner class TransformPlacementApplicationEntityToApi {
+    @Test
+    fun `Transforms the placement application correctly`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .withDecisionMadeAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .withWithdrawalReason(randomOf(PlacementApplicationWithdrawalReason.entries))
+        .produce()
+
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+
+      assertThat(result.id).isEqualTo(placementApplication.id)
+      assertThat(result.createdByUserId).isEqualTo(placementApplication.createdByUser.id)
+      assertThat(result.createdAt).isEqualTo(placementApplication.createdAt.toInstant())
+      assertThat(result.isWithdrawn).isEqualTo(placementApplication.isWithdrawn())
+      assertThat(result.type).isEqualTo(RequestForPlacementType.manual)
+      assertPlacementDatesMatchPlacementDateEntities(result.placementDates, placementApplication.placementDates)
+      assertThat(result.submittedAt).isEqualTo(placementApplication.submittedAt?.toInstant())
+      assertThat(result.requestReviewedAt).isEqualTo(placementApplication.decisionMadeAt?.toInstant())
+      assertThat(result.document).isNotNull
+      assertThat(result.withdrawalReason).isEqualTo(placementApplication.withdrawalReason?.apiValue)
+
+      verify(exactly = 1) { objectMapper.readTree(placementApplication.document) }
+    }
+  }
+
+  @Nested
+  inner class TransformPlacementRequestEntityToApi {
+    @Test
+    fun `Transforms the placement request correctly`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .withWithdrawalReason(randomOf(PlacementRequestWithdrawalReason.entries))
+        .produce()
+
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+
+      assertThat(result.id).isEqualTo(placementRequest.id)
+      assertThat(result.createdByUserId).isEqualTo(placementRequest.application.createdByUser.id)
+      assertThat(result.createdAt).isEqualTo(placementRequest.createdAt.toInstant())
+      assertThat(result.isWithdrawn).isEqualTo(placementRequest.isWithdrawn)
+      assertThat(result.type).isEqualTo(RequestForPlacementType.automatic)
+      assertThat(result.placementDates).hasSize(1)
+      assertThat(result.placementDates[0].expectedArrival).isEqualTo(placementRequest.expectedArrival)
+      assertThat(result.placementDates[0].duration).isEqualTo(placementRequest.duration)
+      assertThat(result.submittedAt).isEqualTo(placementRequest.createdAt.toInstant())
+      assertThat(result.requestReviewedAt).isEqualTo(placementRequest.assessment.submittedAt?.toInstant())
+      assertThat(result.document).isNull()
+      assertThat(result.withdrawalReason).isEqualTo(placementRequest.withdrawalReason?.apiValue)
+    }
+  }
+}


### PR DESCRIPTION
> See [APS-587 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-587).

This PR introduces the `GET /applications/{applicationId}/requests-for-placement` and `GET /applications/{applicationId}/requests-for-placement/{requestForPlacementId}` endpoints, which can be used to retrieve a list of requests for placement and a specific request respectively.

These endpoints use the newly-introduced `RequestForPlacement` schema, which provides a unified abstraction over both placement applications and placement requests. In the future both of these will be fully merged into the request for placement concept.