### PR TITLE
(APS-691) Return information requests in timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentClarificationNoteTransformer.kt
@@ -22,5 +22,6 @@ class AssessmentClarificationNoteTransformer {
     type = TimelineEventType.approvedPremisesInformationRequest,
     occurredAt = jpa.createdAt.toInstant(),
     associatedUrls = emptyList(),
+    content = jpa.query,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2792,6 +2792,7 @@ class ApplicationTest : IntegrationTestBase() {
             it.id.toString(),
             it.createdAt.toInstant(),
             associatedUrls = emptyList(),
+            content = it.query,
           )
         }
 


### PR DESCRIPTION
A user has reported that once they have made an information request, it's impossible to see what the initial request was. I've added the ability to review it in the assess screen in https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1742, but I think it'll be useful to show this information in the timeline too for audit purposes.