### PR TITLE
APS-695 Exclude withdrawn tasks from pending task count

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -141,6 +141,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
           a.allocated_to_user_id = u.id
           and a.reallocated_at is null
           and a.submitted_at is null
+          and a.is_withdrawn != true
       ) as pendingAssessments,
       (
         SELECT
@@ -171,6 +172,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
           placement_application.allocated_to_user_id = u.id
           and placement_application.reallocated_at is null
           and placement_application.submitted_at is null
+          and placement_application.decision is null
       ) as pendingPlacementApplications,
       (
         SELECT
@@ -201,6 +203,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
           placement_request.allocated_to_user_id = u.id
           and placement_request.booking_id is null
           and placement_request.reallocated_at is null
+          and placement_request.is_withdrawn != true
       ) as pendingPlacementRequests,
       (
         SELECT

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -34,6 +34,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.ACCEPTED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.REJECTED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.WITHDRAW
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.WITHDRAWN_BY_PP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -1682,55 +1686,62 @@ class TasksTest {
                   crn = offenderDetails.otherIds.crn,
 
                 ) { placementApplication ->
+                  val crn = offenderDetails.otherIds.crn
                   val numAssessmentsPending = 3
                   repeat(numAssessmentsPending) {
-                    createAssessment(null, allocatableUser, user, offenderDetails.otherIds.crn)
+                    createAssessment(null, allocatableUser, user, crn)
                   }
+                  createAssessment(null, allocatableUser, user, crn, isWithdrawn = true)
 
                   val numPlacementApplicationsPending = 4
                   repeat(numPlacementApplicationsPending) {
-                    createPlacementApplication(null, allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementApplication(null, allocatableUser, user, crn)
                   }
+                  createPlacementApplication(null, allocatableUser, user, crn, decision = ACCEPTED)
+                  createPlacementApplication(null, allocatableUser, user, crn, decision = REJECTED)
+                  createPlacementApplication(null, allocatableUser, user, crn, decision = WITHDRAW)
+                  createPlacementApplication(null, allocatableUser, user, crn, decision = WITHDRAWN_BY_PP)
 
                   val numPlacementRequestsPending = 2
                   repeat(numPlacementRequestsPending) {
-                    createPlacementRequest(null, allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementRequest(null, allocatableUser, user, crn)
                   }
+                  createPlacementRequest(null, allocatableUser, user, crn, isWithdrawn = true)
 
                   val numAssessmentsCompletedBetween1And7DaysAgo = 4
                   repeat(numAssessmentsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createAssessment(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createAssessment(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numPlacementApplicationsCompletedBetween1And7DaysAgo = 2
                   repeat(numPlacementApplicationsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numPlacementRequestsCompletedBetween1And7DaysAgo = 1
                   repeat(numPlacementRequestsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numAssessmentsCompletedBetween8And30DaysAgo = 4
                   repeat(numAssessmentsCompletedBetween8And30DaysAgo) {
                     val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createAssessment(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createAssessment(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numPlacementApplicationsCompletedBetween8And30DaysAgo = 3
                   repeat(numPlacementApplicationsCompletedBetween8And30DaysAgo) {
                     val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numPlacementRequestsCompletedBetween8And30DaysAgo = 2
                   repeat(numPlacementRequestsCompletedBetween8And30DaysAgo) {
                     val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numPendingTasks = listOf(
@@ -1805,29 +1816,31 @@ class TasksTest {
       }
     }
 
-    private fun createAssessment(completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
-      if (completedAt != null) {
-        `Given an Assessment for Approved Premises`(
-          allocatedToUser = allocatedUser,
-          createdByUser = createdByUser,
-          crn = crn,
-          decision = null,
-          reallocated = false,
-          submittedAt = completedAt,
-        )
-      } else {
-        `Given an Assessment for Approved Premises`(
-          allocatedToUser = allocatedUser,
-          createdByUser = createdByUser,
-          crn = crn,
-          decision = null,
-          reallocated = false,
-          submittedAt = null,
-        )
-      }
+    private fun createAssessment(
+      completedAt: OffsetDateTime?,
+      allocatedUser: UserEntity,
+      createdByUser: UserEntity,
+      crn: String,
+      isWithdrawn: Boolean = false,
+    ) {
+      `Given an Assessment for Approved Premises`(
+        allocatedToUser = allocatedUser,
+        createdByUser = createdByUser,
+        crn = crn,
+        decision = null,
+        reallocated = false,
+        submittedAt = completedAt,
+        isWithdrawn = isWithdrawn,
+      )
     }
 
-    private fun createPlacementRequest(completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
+    private fun createPlacementRequest(
+      completedAt: OffsetDateTime?,
+      allocatedUser: UserEntity,
+      createdByUser: UserEntity,
+      crn: String,
+      isWithdrawn: Boolean = false,
+    ) {
       val booking = if (completedAt != null) {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1847,10 +1860,17 @@ class TasksTest {
         createdByUser = createdByUser,
         crn = crn,
         booking = booking,
+        isWithdrawn = isWithdrawn,
       )
     }
 
-    private fun createPlacementApplication(completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
+    private fun createPlacementApplication(
+      completedAt: OffsetDateTime?,
+      allocatedUser: UserEntity,
+      createdByUser: UserEntity,
+      crn: String,
+      decision: PlacementApplicationDecision? = null,
+    ) {
       `Given a Placement Application`(
         createdByUser = createdByUser,
         allocatedToUser = allocatedUser,
@@ -1859,6 +1879,7 @@ class TasksTest {
         },
         submittedAt = completedAt,
         crn = crn,
+        decision = decision,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -1684,53 +1684,53 @@ class TasksTest {
                 ) { placementApplication ->
                   val numAssessmentsPending = 3
                   repeat(numAssessmentsPending) {
-                    createTask(TaskType.assessment, null, allocatableUser, user, offenderDetails.otherIds.crn)
+                    createAssessment(null, allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPlacementApplicationsPending = 4
                   repeat(numPlacementApplicationsPending) {
-                    createTask(TaskType.placementApplication, null, allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementApplication(null, allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPlacementRequestsPending = 2
                   repeat(numPlacementRequestsPending) {
-                    createTask(TaskType.placementRequest, null, allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementRequest(null, allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numAssessmentsCompletedBetween1And7DaysAgo = 4
                   repeat(numAssessmentsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createTask(TaskType.assessment, OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createAssessment(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPlacementApplicationsCompletedBetween1And7DaysAgo = 2
                   repeat(numPlacementApplicationsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createTask(TaskType.placementApplication, OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPlacementRequestsCompletedBetween1And7DaysAgo = 1
                   repeat(numPlacementRequestsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createTask(TaskType.placementRequest, OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numAssessmentsCompletedBetween8And30DaysAgo = 4
                   repeat(numAssessmentsCompletedBetween8And30DaysAgo) {
                     val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createTask(TaskType.assessment, OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createAssessment(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPlacementApplicationsCompletedBetween8And30DaysAgo = 3
                   repeat(numPlacementApplicationsCompletedBetween8And30DaysAgo) {
                     val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createTask(TaskType.placementApplication, OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPlacementRequestsCompletedBetween8And30DaysAgo = 2
                   repeat(numPlacementRequestsCompletedBetween8And30DaysAgo) {
                     val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createTask(TaskType.placementRequest, OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
+                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, offenderDetails.otherIds.crn)
                   }
 
                   val numPendingTasks = listOf(
@@ -1805,68 +1805,61 @@ class TasksTest {
       }
     }
 
-    private fun createTask(taskType: TaskType, completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
-      (
-        when (taskType) {
-          TaskType.assessment -> {
-            if (completedAt != null) {
-              `Given an Assessment for Approved Premises`(
-                allocatedToUser = allocatedUser,
-                createdByUser = createdByUser,
-                crn = crn,
-                decision = null,
-                reallocated = false,
-                submittedAt = completedAt,
-              )
-            } else {
-              `Given an Assessment for Approved Premises`(
-                allocatedToUser = allocatedUser,
-                createdByUser = createdByUser,
-                crn = crn,
-                decision = null,
-                reallocated = false,
-                submittedAt = null,
-              )
-            }
-          }
-          TaskType.placementRequest -> {
-            val booking = if (completedAt != null) {
-              val premises = approvedPremisesEntityFactory.produceAndPersist {
-                withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                withProbationRegion(createdByUser.probationRegion)
-              }
-              bookingEntityFactory.produceAndPersist {
-                withPremises(premises)
-                withCreatedAt(completedAt)
-              }
-            } else {
-              null
-            }
-
-            `Given a Placement Request`(
-              placementRequestAllocatedTo = allocatedUser,
-              assessmentAllocatedTo = createdByUser,
-              createdByUser = createdByUser,
-              crn = crn,
-              booking = booking,
-            )
-          }
-          TaskType.placementApplication -> {
-            `Given a Placement Application`(
-              createdByUser = createdByUser,
-              allocatedToUser = allocatedUser,
-              schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                withPermissiveSchema()
-              },
-              submittedAt = completedAt,
-              crn = crn,
-            )
-          }
-          else -> {
-            null
-          }
-        }
+    private fun createAssessment(completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
+      if (completedAt != null) {
+        `Given an Assessment for Approved Premises`(
+          allocatedToUser = allocatedUser,
+          createdByUser = createdByUser,
+          crn = crn,
+          decision = null,
+          reallocated = false,
+          submittedAt = completedAt,
         )
+      } else {
+        `Given an Assessment for Approved Premises`(
+          allocatedToUser = allocatedUser,
+          createdByUser = createdByUser,
+          crn = crn,
+          decision = null,
+          reallocated = false,
+          submittedAt = null,
+        )
+      }
+    }
+
+    private fun createPlacementRequest(completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
+      val booking = if (completedAt != null) {
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withProbationRegion(createdByUser.probationRegion)
+        }
+        bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withCreatedAt(completedAt)
+        }
+      } else {
+        null
+      }
+
+      `Given a Placement Request`(
+        placementRequestAllocatedTo = allocatedUser,
+        assessmentAllocatedTo = createdByUser,
+        createdByUser = createdByUser,
+        crn = crn,
+        booking = booking,
+      )
+    }
+
+    private fun createPlacementApplication(completedAt: OffsetDateTime?, allocatedUser: UserEntity, createdByUser: UserEntity, crn: String) {
+      `Given a Placement Application`(
+        createdByUser = createdByUser,
+        allocatedToUser = allocatedUser,
+        schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        },
+        submittedAt = completedAt,
+        crn = crn,
+      )
     }
   }
 


### PR DESCRIPTION
This commit splits the createTask into separate private methods for readabiltiy, before adding an additional arg to optional mark as placement requests and placement applications as withdrawn