### PR TITLE
CAS2-417: Add Licence Case Admins to CAS2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -59,6 +59,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/internal/room/*", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
+        authorize(HttpMethod.GET, "/cas2/applications/**", hasAnyRole("POM", "LICENCE_CA"))
         authorize(HttpMethod.PUT, "/cas2/assessments/**", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/assessments/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("POM", "CAS2_ASSESSOR"))
@@ -66,8 +67,8 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM"))
         authorize(HttpMethod.GET, "/cas2/reports/**", hasRole("CAS2_MI"))
-        authorize(HttpMethod.GET, "/cas3-api.yml", permitAll)
         authorize("/cas2/**", hasAuthority("ROLE_POM"))
+        authorize(HttpMethod.GET, "/cas3-api.yml", permitAll)
         authorize(anyRequest, hasAuthority("ROLE_PROBATION"))
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHourOfDay
@@ -84,7 +84,7 @@ class Cas2ApplicationNotesTest(
     fun `assessors create note returns 201`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      `Given a CAS2 User` { referrer, _ ->
+      `Given a CAS2 POM User` { referrer, _ ->
         `Given a CAS2 Assessor` { assessor, jwt ->
           val applicationSchema =
             cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -161,7 +161,7 @@ class Cas2ApplicationNotesTest(
         @Test
         fun `referrer create note returns 201`() {
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
-          `Given a CAS2 User` { referrer, jwt ->
+          `Given a CAS2 POM User` { referrer, jwt ->
             val applicationSchema =
               cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
                 withAddedAt(OffsetDateTime.now())
@@ -235,7 +235,7 @@ class Cas2ApplicationNotesTest(
           fun `referrer cannot create note`() {
             val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-            `Given a CAS2 User` { referrer, jwt ->
+            `Given a CAS2 POM User` { referrer, jwt ->
               val applicationSchema =
                 cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
                   withAddedAt(OffsetDateTime.now())
@@ -280,7 +280,7 @@ class Cas2ApplicationNotesTest(
 
           @Test
           fun `referrer can create a note for an application they did not create`() {
-            `Given a CAS2 User` { referrer, jwt ->
+            `Given a CAS2 POM User` { referrer, jwt ->
               val applicationSchema =
                 cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
                   withAddedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockNotFoundInmateDetailsCall
@@ -174,8 +174,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get all applications returns 200 with correct body`() {
-      `Given a CAS2 User` { userEntity, jwt ->
-        `Given a CAS2 User` { otherUser, _ ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
+        `Given a CAS2 POM User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -261,8 +261,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Get all applications with pagination returns 200 with correct body and header`() {
-      `Given a CAS2 User` { userEntity, jwt ->
-        `Given a CAS2 User` { otherUser, _ ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
+        `Given a CAS2 POM User` { otherUser, _ ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -329,7 +329,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `When a person is not found, returns 200 with placeholder text`() {
-      `Given a CAS2 User`() { userEntity, jwt ->
+      `Given a CAS2 POM User`() { userEntity, jwt ->
         val crn = "X1234"
 
         produceAndPersistBasicApplication(crn, userEntity)
@@ -376,7 +376,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       @Test
       fun `Get all applications using prisonCode returns 200 with correct body`() {
         `Given a CAS2 Assessor` { assessor, _ ->
-          `Given a CAS2 User` { userAPrisonA, jwt ->
+          `Given a CAS2 POM User` { userAPrisonA, jwt ->
             `Given an Offender` { offenderDetails, _ ->
               cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -469,7 +469,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       @Test
       fun `Get all submitted applications using prisonCode returns 200 with correct body`() {
         `Given a CAS2 Assessor` { assessor, _ ->
-          `Given a CAS2 User` { userAPrisonA, jwt ->
+          `Given a CAS2 POM User` { userAPrisonA, jwt ->
             `Given an Offender` { offenderDetails, _ ->
               cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -541,7 +541,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
       @Test
       fun `Get all unsubmitted applications using prisonCode returns 200 with correct body`() {
-        `Given a CAS2 User` { userAPrisonA, jwt ->
+        `Given a CAS2 POM User` { userAPrisonA, jwt ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -608,7 +608,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
       @Test
       fun `Get applications using another prisonCode returns Forbidden 403`() {
-        `Given a CAS2 User` { userAPrisonA, jwt ->
+        `Given a CAS2 POM User` { userAPrisonA, jwt ->
           val rawResponseBody = webTestClient.get()
             .uri("/cas2/applications?prisonCode=${userAPrisonA.activeCaseloadId!!.reversed()}")
             .header("Authorization", "Bearer $jwt")
@@ -646,8 +646,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     @BeforeEach
     fun setup() {
       `Given a CAS2 Assessor` { assessor, _ ->
-        `Given a CAS2 User` { userEntity, jwt ->
-          `Given a CAS2 User` { otherUser, _ ->
+        `Given a CAS2 POM User` { userEntity, jwt ->
+          `Given a CAS2 POM User` { otherUser, _ ->
             `Given an Offender` { offenderDetails, _ ->
               cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -802,7 +802,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       // When the application requested was created by the logged-in user
       @Test
       fun `Get single in progress application returns 200 with correct body`() {
-        `Given a CAS2 User` { userEntity, jwt ->
+        `Given a CAS2 POM User` { userEntity, jwt ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -853,7 +853,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
       @Test
       fun `Get single application returns successfully when the offender cannot be fetched from the prisons API`() {
-        `Given a CAS2 User` { userEntity, jwt ->
+        `Given a CAS2 POM User` { userEntity, jwt ->
           val crn = "X1234"
 
           `Given an Offender`(
@@ -899,7 +899,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
       @Test
       fun `Get single submitted application returns 200 with timeline events`() {
-        `Given a CAS2 User` { userEntity, jwt ->
+        `Given a CAS2 POM User` { userEntity, jwt ->
           `Given an Offender` { offenderDetails, inmateDetails ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -949,7 +949,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       inner class WhenDifferentPrison {
         @Test
         fun `Get single submitted application is forbidden`() {
-          `Given a CAS2 User` { userEntity, jwt ->
+          `Given a CAS2 POM User` { userEntity, jwt ->
             `Given an Offender` { offenderDetails, inmateDetails ->
               cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -990,7 +990,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       inner class WhenSamePrison {
         @Test
         fun `Get single submitted application returns 200 with timeline events`() {
-          `Given a CAS2 User` { userEntity, jwt ->
+          `Given a CAS2 POM User` { userEntity, jwt ->
             `Given an Offender` { offenderDetails, inmateDetails ->
               cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -1044,7 +1044,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
   inner class PostToCreate {
     @Test
     fun `Create new application for CAS-2 returns 201 with correct body and Location header`() {
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         `Given an Offender` { offenderDetails, _ ->
           val applicationSchema =
             cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -1080,7 +1080,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Create new application returns 404 when a person cannot be found`() {
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         val crn = "X1234"
 
         CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
@@ -1112,7 +1112,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
   inner class PutToUpdate {
     @Test
     fun `Update existing CAS2 application returns 200 with correct body`() {
-      `Given a CAS2 User` { submittingUser, jwt ->
+      `Given a CAS2 POM User` { submittingUser, jwt ->
         `Given an Offender` { offenderDetails, _ ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2AssessmentTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Asse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Admin`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
@@ -90,7 +90,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
     fun `assessors create note returns 201`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      `Given a CAS2 User` { referrer, _ ->
+      `Given a CAS2 POM User` { referrer, _ ->
         `Given a CAS2 Assessor` { assessor, jwt ->
           val submittedApplication = createSubmittedApplication(applicationId, referrer)
 
@@ -199,7 +199,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
     fun `assessors update assessment returns 200`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      `Given a CAS2 User` { referrer, _ ->
+      `Given a CAS2 POM User` { referrer, _ ->
         `Given a CAS2 Assessor` { assessor, jwt ->
           val submittedApplication = createSubmittedApplication(applicationId, referrer)
 
@@ -234,7 +234,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
     fun `admins get assessment returns 200`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      `Given a CAS2 User` { referrer, _ ->
+      `Given a CAS2 POM User` { referrer, _ ->
         `Given a CAS2 Admin` { admin, jwt ->
           val submittedApplication = createSubmittedApplication(applicationId, referrer)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateAssessmentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateAssessmentsTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
@@ -35,7 +35,7 @@ class Cas2MigrateAssessmentsTest : MigrationJobTestBase() {
 
   @Test
   fun `Should create assessments for CAS2 Applications that are submitted and returns 202 response`() {
-    `Given a CAS2 User` { userEntity, _ ->
+    `Given a CAS2 POM User` { userEntity, _ ->
       val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
         withAddedAt(OffsetDateTime.now())
         withId(UUID.randomUUID())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRiskToSelfTest.kt
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulOffenceDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulRiskToTheIndividualCall
@@ -60,7 +60,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
 
   @Test
   fun `Getting Risk To Self for a CRN that does not exist returns 404`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
@@ -77,7 +77,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
 
   @Test
   fun `Getting Risk to Self for a CRN returns OK with correct body`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val offenceDetails = OffenceDetailsFactory().produce()
         APOASysContext_mockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
@@ -106,7 +106,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
 
   @Test
   fun `Getting Risk to Self when upstream times out returns 404`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val risksToTheIndividual = RiskToTheIndividualFactory().produce()
         APOASysContext_mockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, risksToTheIndividual, 2500)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRoshTest.kt
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulOffenceDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulRoSHSummaryCall
@@ -59,7 +59,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
 
   @Test
   fun `Getting Rosh for a CRN that does not exist returns 404`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
@@ -76,7 +76,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
 
   @Test
   fun `Getting RoSH for a CRN returns OK with correct body`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val offenceDetails = OffenceDetailsFactory().produce()
         APOASysContext_mockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
@@ -105,7 +105,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
 
   @Test
   fun `Getting RoSH when upstream times out returns 404`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         val rosh = RoshSummaryFactory().produce()
         APOASysContext_mockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, rosh, 2500)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonRisksTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
@@ -61,7 +61,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
 
   @Test
   fun `Getting risks for a CRN that does not exist returns 404`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
@@ -78,7 +78,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
 
   @Test
   fun `Getting risks for a CRN returns OK with correct body`() {
-    `Given a CAS2 User` { userEntity, jwt ->
+    `Given a CAS2 POM User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
         APOASysContext_mockSuccessfulRoshRatingsCall(
           offenderDetails.otherIds.crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOffenderDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockNotFoundSearchCall
@@ -69,7 +69,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
     fun `Searching for a NOMIS ID that does not exist returns 404`() {
       mockClientCredentialsJwtRequest()
 
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         wiremockServer.stubFor(
           get(WireMock.urlEqualTo("/search?nomsNumber=nomsNumber"))
             .willReturn(
@@ -89,7 +89,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a NOMIS ID returns OK with correct body`() {
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         val offender = ProbationOffenderDetailFactory()
           .withOtherIds(IDs(crn = "CRN", nomsNumber = "NOMS321", pncNumber = "PNC123"))
           .withFirstName("James")
@@ -146,7 +146,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized`() {
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall()
 
         webTestClient.get()
@@ -160,7 +160,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a NOMIS ID returns Unauthorised error when it is not found`() {
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         ProbationOffenderSearchAPI_mockNotFoundSearchCall()
 
         webTestClient.get()
@@ -174,7 +174,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a NOMIS ID returns server error when there is a server error`() {
-      `Given a CAS2 User` { userEntity, jwt ->
+      `Given a CAS2 POM User` { userEntity, jwt ->
         ProbationOffenderSearchAPI_mockServerErrorSearchCall()
 
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
@@ -80,7 +80,7 @@ class Cas2StatusUpdateTest(
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
       `Given a CAS2 Assessor`() { _, jwt ->
-        `Given a CAS2 User` { applicant, _ ->
+        `Given a CAS2 POM User` { applicant, _ ->
           val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
           val application = cas2ApplicationEntityFactory.produceAndPersist {
             withId(applicationId)
@@ -144,7 +144,7 @@ class Cas2StatusUpdateTest(
     @Test
     fun `Create status update returns 400 when new status NOT valid`() {
       `Given a CAS2 Assessor`() { _, jwt ->
-        `Given a CAS2 User` { applicant, _ ->
+        `Given a CAS2 POM User` { applicant, _ ->
           val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
           val application = cas2ApplicationEntityFactory.produceAndPersist {
             withCreatedByUser(applicant)
@@ -175,7 +175,7 @@ class Cas2StatusUpdateTest(
         val submittedAt = OffsetDateTime.now()
 
         `Given a CAS2 Assessor`() { _, jwt ->
-          `Given a CAS2 User` { applicant, _ ->
+          `Given a CAS2 POM User` { applicant, _ ->
             val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
             val application = cas2ApplicationEntityFactory.produceAndPersist {
               withId(applicationId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserDeta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Admin`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ManageUsers_mockSuccessfulExternalUsersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
@@ -193,7 +193,7 @@ class Cas2SubmissionTest(
     @Test
     fun `Assessor can view ALL submitted applications`() {
       `Given a CAS2 Assessor` { _externalUserEntity, jwt ->
-        `Given a CAS2 User` { user, _ ->
+        `Given a CAS2 POM User` { user, _ ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -370,7 +370,7 @@ class Cas2SubmissionTest(
     @Test
     fun `Assessor can view single submitted application`() {
       `Given a CAS2 Assessor` { assessor, jwt ->
-        `Given a CAS2 User` { user, _ ->
+        `Given a CAS2 POM User` { user, _ ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -491,7 +491,7 @@ class Cas2SubmissionTest(
     @Test
     fun `Assessor can NOT view single in-progress application`() {
       `Given a CAS2 Assessor` { _, jwt ->
-        `Given a CAS2 User` { user, _ ->
+        `Given a CAS2 POM User` { user, _ ->
           `Given an Offender` { offenderDetails, _ ->
             cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -527,7 +527,7 @@ class Cas2SubmissionTest(
       fun `Admin can view single submitted application`() {
         `Given a CAS2 Assessor` { assessor, _ ->
           `Given a CAS2 Admin` { admin, jwt ->
-            `Given a CAS2 User` { user, _ ->
+            `Given a CAS2 POM User` { user, _ ->
               `Given an Offender` { offenderDetails, _ ->
                 cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -617,7 +617,7 @@ class Cas2SubmissionTest(
       @Test
       fun `Admin can NOT view single in-progress application`() {
         `Given a CAS2 Admin` { _, jwt ->
-          `Given a CAS2 User` { user, _ ->
+          `Given a CAS2 POM User` { user, _ ->
             `Given an Offender` { offenderDetails, _ ->
               cas2ApplicationJsonSchemaRepository.deleteAll()
 
@@ -657,7 +657,7 @@ class Cas2SubmissionTest(
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
       val telephoneNumber = "123 456 7891"
 
-      `Given a CAS2 User`() { submittingUser, jwt ->
+      `Given a CAS2 POM User`() { submittingUser, jwt ->
         `Given an Offender`(
           inmateDetailsConfigBlock = {
             withAssignedLivingUnit(
@@ -748,7 +748,7 @@ class Cas2SubmissionTest(
 
     @Test
     fun `When several concurrent submit application requests occur, only one is successful, all others return 400`() {
-      `Given a CAS2 User`() { submittingUser, jwt ->
+      `Given a CAS2 POM User`() { submittingUser, jwt ->
         `Given an Offender`(
           inmateDetailsConfigBlock = {
             withAssignedLivingUnit(
@@ -828,7 +828,7 @@ class Cas2SubmissionTest(
 
     @Test
     fun `When there's an error fetching the referred person's prison code, the application is not saved`() {
-      `Given a CAS2 User`() { submittingUser, jwt ->
+      `Given a CAS2 POM User`() { submittingUser, jwt ->
         `Given an Offender`(mockNotFoundErrorForPrisonApi = true) { offenderDetails, _ ->
           val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -102,7 +102,7 @@ fun IntegrationTestBase.`Given a User`(
   return block(user, jwt)
 }
 
-fun IntegrationTestBase.`Given a CAS2 User`(
+fun IntegrationTestBase.`Given a CAS2 POM User`(
   id: UUID = UUID.randomUUID(),
   nomisUserDetailsConfigBlock: (NomisUserDetailFactory.() -> Unit)? = null,
   block: (nomisUserEntity: NomisUserEntity, jwt: String) -> Unit,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -130,6 +130,34 @@ fun IntegrationTestBase.`Given a CAS2 POM User`(
   block(user, jwt)
 }
 
+fun IntegrationTestBase.`Given a CAS2 Licence Case Admin User`(
+  id: UUID = UUID.randomUUID(),
+  nomisUserDetailsConfigBlock: (NomisUserDetailFactory.() -> Unit)? = null,
+  block: (nomisUserEntity: NomisUserEntity, jwt: String) -> Unit,
+) {
+  val nomisUserDetailsFactory = NomisUserDetailFactory()
+
+  if (nomisUserDetailsConfigBlock != null) {
+    nomisUserDetailsConfigBlock(nomisUserDetailsFactory)
+  }
+
+  val nomisUserDetails = nomisUserDetailsFactory.produce()
+
+  val user = nomisUserEntityFactory.produceAndPersist {
+    withId(id)
+    withNomisUsername(nomisUserDetails.username)
+    withEmail(nomisUserDetails.primaryEmail)
+    withName("${nomisUserDetails.firstName} ${nomisUserDetails.lastName}")
+    withActiveCaseloadId(nomisUserDetails.activeCaseloadId!!)
+  }
+
+  val jwt = jwtAuthHelper.createValidNomisAuthorisationCodeJwt(nomisUserDetails.username, listOf("ROLE_LICENCE_CA"))
+
+  NomisUserRoles_mockSuccessfulGetUserDetailsCall(jwt, nomisUserDetails)
+
+  block(user, jwt)
+}
+
 fun IntegrationTestBase.`Given a CAS2 Assessor`(
   id: UUID = UUID.randomUUID(),
   block: (externalUserEntity: ExternalUserEntity, jwt: String) -> Unit,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -63,11 +63,11 @@ class JwtAuthHelper {
           .compact()
       }
 
-  internal fun createValidNomisAuthorisationCodeJwt(username: String = "username") =
+  internal fun createValidNomisAuthorisationCodeJwt(username: String = "username", roles: List<String>? = listOf("ROLE_POM")) =
     createAuthorizationCodeJwt(
       subject = username,
       authSource = "nomis",
-      roles = listOf("ROLE_POM"),
+      roles = roles,
     )
 
   internal fun createValidExternalAuthorisationCodeJwt(username: String = "username") =


### PR DESCRIPTION
We would like to allow Nomis users with the
'Licence Case Admin' (LICENCE_CA) role to be able
to have READ permissions for CAS2 applications
from their prison.

This change adds the LICENCE_CA role,
alongside POM, to GET requests for `/applications`

The only role-based configuration on the API for
CAS2 is via the
`OAuth2ResourceServerSecurityConfiguration` file -
once users get past this configuration they are
dealt with as Nomis or External Users regardless
of specific role. Therefore I think our current
integration tests should mostly give us confidence
that LICENCE CA should not have elevated
permissions - the same rules affecting POMs (e.g.
won't see applications from other prisons, won't
be able to see content of unsubmitted
applications) will apply, and we can test that
they do cannot do WRITE actions alongside the
other user roles.