### PR TITLE
APS-687 Withdrawal emails are now sent if triggered by seed jobs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
@@ -46,7 +46,7 @@ class ApprovedPremisesBookingCancelSeedJob(
       notes = null,
       otherReason = null,
       withdrawalContext = WithdrawalContext(
-        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob(),
+        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob,
         triggeringEntityType = WithdrawableEntityType.Booking,
         triggeringEntityId = booking.id,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingCancelSeedJob.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import java.time.LocalDate
 import java.util.UUID
 
@@ -45,7 +46,7 @@ class ApprovedPremisesBookingCancelSeedJob(
       notes = null,
       otherReason = null,
       withdrawalContext = WithdrawalContext(
-        triggeringUser = null,
+        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob(),
         triggeringEntityType = WithdrawableEntityType.Booking,
         triggeringEntityId = booking.id,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromNestedAuthorisableValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
@@ -245,7 +246,7 @@ class ApprovedPremisesBookingSeedJob(
           notes = row.cancellationNotes,
           otherReason = null,
           withdrawalContext = WithdrawalContext(
-            triggeringUser = null,
+            withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob(),
             triggeringEntityType = WithdrawableEntityType.Booking,
             triggeringEntityId = createdBooking.id,
           ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApprovedPremisesBookingSeedJob.kt
@@ -246,7 +246,7 @@ class ApprovedPremisesBookingSeedJob(
           notes = row.cancellationNotes,
           otherReason = null,
           withdrawalContext = WithdrawalContext(
-            withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob(),
+            withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob,
             triggeringEntityType = WithdrawableEntityType.Booking,
             triggeringEntityId = createdBooking.id,
           ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1WithdrawPlacementRequestSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1WithdrawPlacementRequestSeedJob.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.javaConstantNameToSentence
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
@@ -45,10 +46,9 @@ class Cas1WithdrawPlacementRequestSeedJob(
       placementRequestId = id,
       userProvidedReason = row.withdrawalReason,
       withdrawalContext = WithdrawalContext(
-        triggeringUser = null,
+        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob(),
         triggeringEntityType = WithdrawableEntityType.PlacementRequest,
         triggeringEntityId = row.placementRequestId,
-        triggeredBySeedJob = true,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1WithdrawPlacementRequestSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1WithdrawPlacementRequestSeedJob.kt
@@ -46,7 +46,7 @@ class Cas1WithdrawPlacementRequestSeedJob(
       placementRequestId = id,
       userProvidedReason = row.withdrawalReason,
       withdrawalContext = WithdrawalContext(
-        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob(),
+        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob,
         triggeringEntityType = WithdrawableEntityType.PlacementRequest,
         triggeringEntityId = row.placementRequestId,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -245,7 +245,7 @@ class PlacementApplicationService(
     cas1PlacementApplicationEmailService.placementApplicationWithdrawn(
       placementApplication = placementApplication,
       wasBeingAssessedBy = wasBeingAssessedBy,
-      withdrawingUser = withdrawalContext.triggeringUser,
+      withdrawalTriggeredBy = withdrawalContext.withdrawalTriggeredBy,
     )
 
     return CasResult.Success(savedApplication)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Placeme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
@@ -350,12 +351,12 @@ class PlacementRequestService(
 
     placementRequestRepository.save(placementRequest)
 
-    if (!withdrawalContext.triggeredBySeedJob) {
+    if (withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
       val isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.PlacementRequest
       updateApplicationStatusOnWithdrawal(placementRequest, isUserRequestedWithdrawal)
     }
 
-    cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest, withdrawalContext.triggeringUser)
+    cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest, withdrawalContext.withdrawalTriggeredBy)
     cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext)
 
     return CasResult.Success(toPlacementRequestAndCancellations(placementRequest))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -53,14 +52,14 @@ class Cas1BookingEmailService(
   fun bookingWithdrawn(
     application: ApprovedPremisesApplicationEntity,
     booking: BookingEntity,
-    withdrawingUser: UserEntity?,
+    withdrawalTriggeredBy: WithdrawalTriggeredBy?,
   ) {
     val allPersonalisation =
       buildCommonPersonalisation(application, booking).toMutableMap()
 
     allPersonalisation += "region" to booking.premises.probationRegion.name
-    if (withdrawingUser != null) {
-      allPersonalisation["withdrawnBy"] = withdrawingUser.name
+    if (withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
+      allPersonalisation["withdrawnBy"] = withdrawalTriggeredBy.user.name
     }
 
     val template = notifyConfig.templates.bookingWithdrawnV2

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -52,15 +52,13 @@ class Cas1BookingEmailService(
   fun bookingWithdrawn(
     application: ApprovedPremisesApplicationEntity,
     booking: BookingEntity,
-    withdrawalTriggeredBy: WithdrawalTriggeredBy?,
+    withdrawalTriggeredBy: WithdrawalTriggeredBy,
   ) {
     val allPersonalisation =
       buildCommonPersonalisation(application, booking).toMutableMap()
 
     allPersonalisation += "region" to booking.premises.probationRegion.name
-    if (withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
-      allPersonalisation["withdrawnBy"] = withdrawalTriggeredBy.user.name
-    }
+    allPersonalisation["withdrawnBy"] = withdrawalTriggeredBy.getName()
 
     val template = notifyConfig.templates.bookingWithdrawnV2
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -88,7 +88,8 @@ class Cas1PlacementApplicationDomainEventService(
   }
 
   fun placementApplicationWithdrawn(placementApplication: PlacementApplicationEntity, withdrawalContext: WithdrawalContext) {
-    val user = requireNotNull(withdrawalContext.triggeringUser)
+    require(withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser)
+    val user = withdrawalContext.withdrawalTriggeredBy.user
 
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = Instant.now()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -88,7 +88,7 @@ class Cas1PlacementApplicationDomainEventService(
   }
 
   fun placementApplicationWithdrawn(placementApplication: PlacementApplicationEntity, withdrawalContext: WithdrawalContext) {
-    require(withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser)
+    require(withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser) { "Only withdrawals triggered by users are supported" }
     val user = withdrawalContext.withdrawalTriggeredBy.user
 
     val domainEventId = UUID.randomUUID()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
@@ -63,12 +63,12 @@ class Cas1PlacementApplicationEmailService(
   fun placementApplicationWithdrawn(
     placementApplication: PlacementApplicationEntity,
     wasBeingAssessedBy: UserEntity?,
-    withdrawingUser: UserEntity?,
+    withdrawalTriggeredBy: WithdrawalTriggeredBy,
   ) {
     val personalisation = getCommonPersonalisation(placementApplication)
 
-    if (withdrawingUser != null) {
-      personalisation["withdrawnBy"] = withdrawingUser.name
+    if (withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
+      personalisation["withdrawnBy"] = withdrawalTriggeredBy.user.name
     }
 
     val template = notifyConfig.templates.placementRequestWithdrawnV2

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
@@ -67,9 +67,7 @@ class Cas1PlacementApplicationEmailService(
   ) {
     val personalisation = getCommonPersonalisation(placementApplication)
 
-    if (withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
-      personalisation["withdrawnBy"] = withdrawalTriggeredBy.user.name
-    }
+    personalisation["withdrawnBy"] = withdrawalTriggeredBy.getName()
 
     val template = notifyConfig.templates.placementRequestWithdrawnV2
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
@@ -94,7 +94,7 @@ class Cas1PlacementRequestDomainEventService(
       return
     }
 
-    require(withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser)
+    require(withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser) { "Only withdrawals triggered by users are supported" }
     val user = withdrawalContext.withdrawalTriggeredBy.user
 
     val domainEventId = UUID.randomUUID()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
@@ -94,7 +94,8 @@ class Cas1PlacementRequestDomainEventService(
       return
     }
 
-    val user = requireNotNull(withdrawalContext.triggeringUser)
+    require(withdrawalContext.withdrawalTriggeredBy is WithdrawalTriggeredByUser)
+    val user = withdrawalContext.withdrawalTriggeredBy.user
 
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = Instant.now()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 
@@ -17,7 +16,7 @@ class Cas1PlacementRequestEmailService(
 ) {
   fun placementRequestWithdrawn(
     placementRequest: PlacementRequestEntity,
-    withdrawingUser: UserEntity?,
+    withdrawalTriggeredBy: WithdrawalTriggeredBy,
   ) {
     val application = placementRequest.application
 
@@ -31,8 +30,8 @@ class Cas1PlacementRequestEmailService(
       "additionalDatesSet" to "no",
     )
 
-    if (withdrawingUser != null) {
-      personalisation["withdrawnBy"] = withdrawingUser.name
+    if (withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
+      personalisation["withdrawnBy"] = withdrawalTriggeredBy.user.name
     }
 
     if (placementRequest.isForApplicationsArrivalDate()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -28,11 +28,8 @@ class Cas1PlacementRequestEmailService(
       "startDate" to placementRequest.expectedArrival.toString(),
       "endDate" to placementRequest.expectedDeparture().toString(),
       "additionalDatesSet" to "no",
+      "withdrawnBy" to withdrawalTriggeredBy.getName(),
     )
-
-    if (withdrawalTriggeredBy is WithdrawalTriggeredByUser) {
-      personalisation["withdrawnBy"] = withdrawalTriggeredBy.user.name
-    }
 
     if (placementRequest.isForApplicationsArrivalDate()) {
       /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -68,7 +68,7 @@ class WithdrawableService(
     }
 
     val withdrawalContext = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Application,
       triggeringEntityId = applicationId,
     )
@@ -91,7 +91,7 @@ class WithdrawableService(
       ?: return CasResult.NotFound()
 
     val withdrawalContext = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.PlacementRequest,
       triggeringEntityId = placementRequestId,
     )
@@ -114,7 +114,7 @@ class WithdrawableService(
       ?: return CasResult.NotFound()
 
     val withdrawalContext = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.PlacementApplication,
       triggeringEntityId = placementApplicationId,
     )
@@ -137,7 +137,7 @@ class WithdrawableService(
     otherReason: String?,
   ): CasResult<CancellationEntity> {
     val withdrawalContext = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Booking,
       triggeringEntityId = booking.id,
     )
@@ -187,17 +187,15 @@ class WithdrawableService(
 }
 
 data class WithdrawalContext(
-  /**
-   * Ideally this would not be nullable, but we have seed jobs that cancel bookings
-   * that don't have an associated user. This would be an issue if seed jobs cancel
-   * any elements that can cascade withdrawals, as we assume the user is provided
-   * in these cases
-   */
-  val triggeringUser: UserEntity?,
+  val withdrawalTriggeredBy: WithdrawalTriggeredBy,
   val triggeringEntityType: WithdrawableEntityType,
   val triggeringEntityId: UUID,
-  val triggeredBySeedJob: Boolean = false,
 )
+
+sealed interface WithdrawalTriggeredBy
+
+data class WithdrawalTriggeredByUser(val user: UserEntity) : WithdrawalTriggeredBy
+class WithdrawalTriggeredBySeedJob : WithdrawalTriggeredBy
 
 data class WithdrawableEntity(
   val type: WithdrawableEntityType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -192,10 +192,17 @@ data class WithdrawalContext(
   val triggeringEntityId: UUID,
 )
 
-sealed interface WithdrawalTriggeredBy
+sealed interface WithdrawalTriggeredBy {
+  fun getName(): String
+}
 
-data class WithdrawalTriggeredByUser(val user: UserEntity) : WithdrawalTriggeredBy
-class WithdrawalTriggeredBySeedJob : WithdrawalTriggeredBy
+data class WithdrawalTriggeredByUser(val user: UserEntity) : WithdrawalTriggeredBy {
+  override fun getName() = user.name
+}
+
+data object WithdrawalTriggeredBySeedJob : WithdrawalTriggeredBy {
+  override fun getName() = "Application Support"
+}
 
 data class WithdrawableEntity(
   val type: WithdrawableEntityType,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -135,6 +135,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
 import java.time.Instant
 import java.time.LocalDate
@@ -2146,7 +2147,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2175,7 +2176,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2208,7 +2209,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2241,7 +2242,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2270,7 +2271,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2310,7 +2311,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = "Other reason",
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2362,7 +2363,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
       every { mockApplicationService.updateApprovedPremisesApplicationStatus(any(), any()) } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledAt = LocalDate.parse("2022-08-25")
       val notes = "notes"
@@ -2374,7 +2375,7 @@ class BookingServiceTest {
         notes = notes,
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2451,7 +2452,7 @@ class BookingServiceTest {
 
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
       every { mockApplicationService.updateApprovedPremisesApplicationStatus(any(), any()) } returns Unit
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledAt = LocalDate.parse("2022-08-25")
       val notes = "notes"
@@ -2463,7 +2464,7 @@ class BookingServiceTest {
         notes = notes,
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2471,7 +2472,7 @@ class BookingServiceTest {
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
 
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) }
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) }
     }
 
     @Test
@@ -2513,7 +2514,7 @@ class BookingServiceTest {
         notes = notes,
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2596,7 +2597,7 @@ class BookingServiceTest {
         notes = notes,
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2685,7 +2686,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2741,7 +2742,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           triggeringEntity,
           bookingEntity.id,
         ),
@@ -2788,7 +2789,7 @@ class BookingServiceTest {
         )
       } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledBooking1 = BookingEntityFactory()
         .withPremises(premises)
@@ -2834,7 +2835,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2883,7 +2884,7 @@ class BookingServiceTest {
         )
       } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledBooking1 = BookingEntityFactory()
         .withPremises(premises)
@@ -2917,7 +2918,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Booking,
           bookingEntity.id,
         ),
@@ -2960,7 +2961,7 @@ class BookingServiceTest {
           ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT,
         )
       } returns Unit
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, user) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
 
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
 
@@ -2971,7 +2972,7 @@ class BookingServiceTest {
         notes = "notes",
         otherReason = null,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementApplication,
           bookingEntity.id,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -52,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Placeme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
@@ -790,7 +791,7 @@ class PlacementApplicationServiceTest {
         .produce()
 
       val withdrawalContext = WithdrawalContext(
-        user,
+        WithdrawalTriggeredByUser(user),
         WithdrawableEntityType.PlacementApplication,
         placementApplication.id,
       )
@@ -811,7 +812,7 @@ class PlacementApplicationServiceTest {
 
       assertThat(entity.decision).isEqualTo(PlacementApplicationDecision.WITHDRAW)
 
-      verify { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(placementApplication, allocatedTo, user) }
+      verify { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(placementApplication, allocatedTo, WithdrawalTriggeredByUser(user)) }
     }
 
     @Test
@@ -833,7 +834,7 @@ class PlacementApplicationServiceTest {
         placementApplication.id,
         PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Application,
           placementApplication.id,
         ),
@@ -864,7 +865,7 @@ class PlacementApplicationServiceTest {
           placementApplication.id,
           PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED,
           withdrawalContext = WithdrawalContext(
-            user,
+            WithdrawalTriggeredByUser(user),
             triggeringEntity,
             placementApplication.id,
           ),
@@ -887,7 +888,7 @@ class PlacementApplicationServiceTest {
         placementApplication.id,
         PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -866,7 +866,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          WithdrawalTriggeredBySeedJob(),
+          WithdrawalTriggeredBySeedJob,
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -76,6 +76,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Placeme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
 import java.time.LocalDate
@@ -662,7 +664,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
         ),
@@ -689,7 +691,7 @@ class PlacementRequestServiceTest {
       every { cancellationRepository.getCancellationsForApplicationId(any()) } returns emptyList()
 
       val withdrawalContext = WithdrawalContext(
-        user,
+        WithdrawalTriggeredByUser(user),
         WithdrawableEntityType.PlacementRequest,
         placementRequestId,
       )
@@ -712,7 +714,7 @@ class PlacementRequestServiceTest {
         )
       }
 
-      verify { cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest, user) }
+      verify { cas1PlacementRequestEmailService.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(user)) }
       verify { cas1PlacementRequestDomainEventService.placementRequestWithdrawn(placementRequest, withdrawalContext) }
     }
 
@@ -745,7 +747,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
         ),
@@ -790,7 +792,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
         ),
@@ -827,7 +829,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.Application,
           placementRequestId,
         ),
@@ -864,10 +866,9 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredBySeedJob(),
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
-          triggeredBySeedJob = true,
         ),
       )
 
@@ -890,7 +891,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         providedReason,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           triggeringEntity,
           placementRequestId,
         ),
@@ -942,7 +943,7 @@ class PlacementRequestServiceTest {
           placementRequestId,
           providedReason,
           WithdrawalContext(
-            user,
+            WithdrawalTriggeredByUser(user),
             triggeringEntity,
             placementRequestId,
           ),
@@ -962,7 +963,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.WITHDRAWN_BY_PP,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
         ),
@@ -990,7 +991,7 @@ class PlacementRequestServiceTest {
         placementRequestId,
         PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST,
         WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementRequest,
           placementRequestId,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1BookingEmailServiceTest.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1BookingEmailServiceTest.TestConstants.AP_AREA_EMAIL
@@ -271,6 +272,60 @@ class Cas1BookingEmailServiceTest {
       service.bookingWithdrawn(application, booking, WithdrawalTriggeredByUser(withdrawingUser))
 
       mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `bookingWithdrawn sends email when triggered by seed job`() {
+      val applicant = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .withEmail(APPLICANT_EMAIL)
+        .produce()
+
+      val (application, booking) = createApplicationAndBooking(
+        applicant,
+        premises,
+        arrivalDate = LocalDate.of(2023, 2, 1),
+        departureDate = LocalDate.of(2023, 2, 14),
+        caseManagerNotApplicant = true,
+      )
+
+      service.bookingWithdrawn(application, booking, WithdrawalTriggeredBySeedJob)
+
+      val expectedPersonalisation = mapOf(
+        "apName" to PREMISES_NAME,
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "applicationTimelineUrl" to "http://frontend/applications/${application.id}?tab=timeline",
+        "crn" to CRN,
+        "startDate" to "2023-02-01",
+        "endDate" to "2023-02-14",
+        "region" to REGION_NAME,
+        "withdrawnBy" to "Application Support",
+      )
+
+      mockEmailNotificationService.assertEmailRequestCount(4)
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.bookingWithdrawnV2,
+        expectedPersonalisation,
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        CASE_MANAGER_EMAIL,
+        notifyConfig.templates.bookingWithdrawnV2,
+        expectedPersonalisation,
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        PREMISES_EMAIL,
+        notifyConfig.templates.bookingWithdrawnV2,
+        expectedPersonalisation,
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        AP_AREA_EMAIL,
+        notifyConfig.templates.bookingWithdrawnV2,
+        expectedPersonalisation,
+      )
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1BookingEmailServiceTest.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1BookingEmailServiceTest.TestConstants.AP_AREA_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1BookingEmailServiceTest.TestConstants.CASE_MANAGER_EMAIL
@@ -206,7 +207,7 @@ class Cas1BookingEmailServiceTest {
         caseManagerNotApplicant = true,
       )
 
-      service.bookingWithdrawn(application, booking, withdrawingUser)
+      service.bookingWithdrawn(application, booking, WithdrawalTriggeredByUser(withdrawingUser))
 
       val expectedPersonalisation = mapOf(
         "apName" to PREMISES_NAME,
@@ -267,7 +268,7 @@ class Cas1BookingEmailServiceTest {
         departureDate = LocalDate.of(2023, 2, 14),
       )
 
-      service.bookingWithdrawn(application, booking, withdrawingUser)
+      service.bookingWithdrawn(application, booking, WithdrawalTriggeredByUser(withdrawingUser))
 
       mockEmailNotificationService.assertNoEmailsRequested()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationDomainEventServiceTest.TestConstants.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationDomainEventServiceTest.TestConstants.USERNAME
@@ -157,7 +158,7 @@ class Cas1PlacementApplicationDomainEventServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationDomainEventServiceTest.TestConstants.CRN
@@ -133,16 +135,34 @@ class Cas1PlacementApplicationDomainEventServiceTest {
   @Nested
   inner class PlacementApplicationWithdrawn {
 
+    val placementApplication = PlacementApplicationEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
+      .withDecision(null)
+      .withCreatedByUser(user)
+      .withWithdrawalReason(PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED)
+      .produce()
+
+    @Test
+    fun `it errors if triggered by seed job`() {
+      val withdrawnBy = WithdrawnByFactory().produce()
+      every { domainEventTransformer.toWithdrawnBy(user) } returns withdrawnBy
+      every { domainEventService.savePlacementApplicationWithdrawnEvent(any()) } returns Unit
+
+      assertThatThrownBy {
+        service.placementApplicationWithdrawn(
+          placementApplication,
+          withdrawalContext = WithdrawalContext(
+            WithdrawalTriggeredBySeedJob,
+            WithdrawableEntityType.PlacementApplication,
+            placementApplication.id,
+          ),
+        )
+      }.hasMessage("Only withdrawals triggered by users are supported")
+    }
+
     @Test
     fun `it creates a domain event`() {
-      val placementApplication = PlacementApplicationEntityFactory()
-        .withApplication(application)
-        .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
-        .withDecision(null)
-        .withCreatedByUser(user)
-        .withWithdrawalReason(PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED)
-        .produce()
-
       placementApplication.placementDates = mutableListOf(
         PlacementDateEntityFactory()
           .withPlacementApplication(placementApplication)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationEmailServiceTest.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationEmailServiceTest.TestConstants.AREA_NAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationEmailServiceTest.TestConstants.ASSESSOR_EMAIL
@@ -368,7 +369,7 @@ class Cas1PlacementApplicationEmailServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
         wasBeingAssessedBy = assessor,
-        withdrawingUser = withdrawnByUser,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
       )
 
       mockEmailNotificationService.assertNoEmailsRequested()
@@ -395,7 +396,7 @@ class Cas1PlacementApplicationEmailServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
         wasBeingAssessedBy = null,
-        withdrawingUser = withdrawnByUser,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
       )
 
       mockEmailNotificationService.assertEmailRequestCount(1)
@@ -440,7 +441,7 @@ class Cas1PlacementApplicationEmailServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
         wasBeingAssessedBy = null,
-        withdrawingUser = withdrawnByUser,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
       )
 
       mockEmailNotificationService.assertEmailRequestCount(1)
@@ -484,7 +485,7 @@ class Cas1PlacementApplicationEmailServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
         wasBeingAssessedBy = null,
-        withdrawingUser = withdrawnByUser,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
       )
 
       mockEmailNotificationService.assertEmailRequestCount(2)
@@ -537,7 +538,7 @@ class Cas1PlacementApplicationEmailServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
         wasBeingAssessedBy = assessor,
-        withdrawingUser = withdrawnByUser,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
       )
 
       mockEmailNotificationService.assertEmailRequestCount(1)
@@ -589,7 +590,7 @@ class Cas1PlacementApplicationEmailServiceTest {
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
         wasBeingAssessedBy = assessor,
-        withdrawingUser = withdrawnByUser,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
       )
 
       mockEmailNotificationService.assertEmailRequestCount(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.DatePeriod
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestDomainEventServiceTest.TestConstants.CRN
@@ -135,6 +137,24 @@ class Cas1PlacementRequestDomainEventServiceTest {
 
   @Nested
   inner class PlacementRequestWithdrawn {
+
+    @Test
+    fun `it errors if triggered by seed job`() {
+      val withdrawnBy = WithdrawnByFactory().produce()
+      every { domainEventTransformer.toWithdrawnBy(user) } returns withdrawnBy
+      every { domainEventService.saveMatchRequestWithdrawnEvent(any()) } returns Unit
+
+      assertThatThrownBy {
+        service.placementRequestWithdrawn(
+          placementRequest,
+          withdrawalContext = WithdrawalContext(
+            WithdrawalTriggeredBySeedJob,
+            WithdrawableEntityType.PlacementApplication,
+            placementRequest.id,
+          ),
+        )
+      }.hasMessage("Only withdrawals triggered by users are supported")
+    }
 
     @Test
     fun `it creates a domain event if for the applications arrival date`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestDomainEventServiceTest.TestConstants.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -144,7 +145,7 @@ class Cas1PlacementRequestDomainEventServiceTest {
       service.placementRequestWithdrawn(
         placementRequest,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementApplication,
           placementRequest.id,
         ),
@@ -218,7 +219,7 @@ class Cas1PlacementRequestDomainEventServiceTest {
       service.placementRequestWithdrawn(
         placementRequest,
         withdrawalContext = WithdrawalContext(
-          user,
+          WithdrawalTriggeredByUser(user),
           WithdrawableEntityType.PlacementApplication,
           placementRequest.id,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.AREA_NAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.CASE_MANAGER_EMAIL
@@ -55,7 +56,7 @@ class Cas1PlacementRequestEmailServiceTest {
     val application = createApplication(apAreaEmail = null)
     val placementRequest = createPlacementRequest(application, booking = null)
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertNoEmailsRequested()
   }
@@ -69,7 +70,7 @@ class Cas1PlacementRequestEmailServiceTest {
       .produce()
     val placementRequest = createPlacementRequest(application, booking)
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertNoEmailsRequested()
   }
@@ -79,7 +80,7 @@ class Cas1PlacementRequestEmailServiceTest {
     val application = createApplication(apAreaEmail = CRU_EMAIL)
     val placementRequest = createPlacementRequest(application, booking = null)
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertEmailRequestCount(1)
 
@@ -114,7 +115,7 @@ class Cas1PlacementRequestEmailServiceTest {
       hasPlacementApplication = false,
     )
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertNoEmailsRequested()
   }
@@ -136,7 +137,7 @@ class Cas1PlacementRequestEmailServiceTest {
       hasPlacementApplication = true,
     )
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertNoEmailsRequested()
   }
@@ -157,7 +158,7 @@ class Cas1PlacementRequestEmailServiceTest {
       hasPlacementApplication = false,
     )
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertEmailRequestCount(1)
     mockEmailNotificationService.assertEmailRequested(
@@ -193,7 +194,7 @@ class Cas1PlacementRequestEmailServiceTest {
       hasPlacementApplication = false,
     )
 
-    service.placementRequestWithdrawn(placementRequest, withdrawingUser)
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredByUser(withdrawingUser))
 
     mockEmailNotificationService.assertEmailRequestCount(2)
     mockEmailNotificationService.assertEmailRequested(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.APPLICANT_EMAIL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementRequestEmailServiceTest.TestConstants.AREA_NAME
@@ -143,7 +144,7 @@ class Cas1PlacementRequestEmailServiceTest {
   }
 
   @Test
-  fun `placementRequestWithdrawn sends placement request withdrawn email to applicant if placement request not linked to placement application `() {
+  fun `placementRequestWithdrawn sends placement request withdrawn email to applicant if placement request not linked to placement application`() {
     val application = createApplication(
       applicantEmail = APPLICANT_EMAIL,
     )
@@ -222,6 +223,41 @@ class Cas1PlacementRequestEmailServiceTest {
         "startDate" to placementRequest.expectedArrival.toString(),
         "endDate" to placementRequest.expectedDeparture().toString(),
         "withdrawnBy" to WITHDRAWING_USER_NAME,
+        "additionalDatesSet" to "no",
+      ),
+    )
+  }
+
+  @Test
+  fun `placementRequestWithdrawn uses hard coded withdrawn by if triggered by seed job`() {
+    val application = createApplication(
+      applicantEmail = APPLICANT_EMAIL,
+    )
+    val booking = BookingEntityFactory()
+      .withApplication(application)
+      .withDefaultPremises()
+      .produce()
+
+    val placementRequest = createPlacementRequest(
+      application,
+      booking,
+      hasPlacementApplication = false,
+    )
+
+    service.placementRequestWithdrawn(placementRequest, WithdrawalTriggeredBySeedJob)
+
+    mockEmailNotificationService.assertEmailRequestCount(1)
+    mockEmailNotificationService.assertEmailRequested(
+      APPLICANT_EMAIL,
+      notifyConfig.templates.placementRequestWithdrawnV2,
+      mapOf(
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "applicationTimelineUrl" to "http://frontend/applications/${application.id}?tab=timeline",
+        "crn" to TestConstants.CRN,
+        "applicationArea" to AREA_NAME,
+        "startDate" to placementRequest.expectedArrival.toString(),
+        "endDate" to placementRequest.expectedDeparture().toString(),
+        "withdrawnBy" to "Application Support",
         "additionalDatesSet" to "no",
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Withdrawabl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableTreeNode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -277,7 +278,7 @@ class Cas1WithdrawableServiceTest {
       every {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(
           tree,
-          WithdrawalContext(user, WithdrawableEntityType.Application, application.id),
+          WithdrawalContext(WithdrawalTriggeredByUser(user), WithdrawableEntityType.Application, application.id),
         )
       } returns Unit
 
@@ -297,7 +298,7 @@ class Cas1WithdrawableServiceTest {
       verify {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(
           tree,
-          WithdrawalContext(user, WithdrawableEntityType.Application, application.id),
+          WithdrawalContext(WithdrawalTriggeredByUser(user), WithdrawableEntityType.Application, application.id),
         )
       }
     }
@@ -422,7 +423,7 @@ class Cas1WithdrawableServiceTest {
         ),
       )
 
-      val context = WithdrawalContext(user, WithdrawableEntityType.PlacementRequest, placementRequest.id)
+      val context = WithdrawalContext(WithdrawalTriggeredByUser(user), WithdrawableEntityType.PlacementRequest, placementRequest.id)
 
       every {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(tree, context)
@@ -538,7 +539,7 @@ class Cas1WithdrawableServiceTest {
         placementApplicationService.withdrawPlacementApplication(any(), any(), any())
       } returns CasResult.Success(placementApplication)
 
-      val context = WithdrawalContext(user, WithdrawableEntityType.PlacementApplication, placementApplication.id)
+      val context = WithdrawalContext(WithdrawalTriggeredByUser(user), WithdrawableEntityType.PlacementApplication, placementApplication.id)
 
       every {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(tree, context)
@@ -654,7 +655,7 @@ class Cas1WithdrawableServiceTest {
         bookingService.createCas1Cancellation(any(), any(), any(), any(), any(), any())
       } returns CasResult.Success(CancellationEntityFactory().withDefaults().withBooking(booking).produce())
 
-      val context = WithdrawalContext(user, WithdrawableEntityType.Booking, booking.id)
+      val context = WithdrawalContext(WithdrawalTriggeredByUser(user), WithdrawableEntityType.Booking, booking.id)
 
       every {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(tree, context)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Withdrawabl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableTreeNode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import java.util.UUID
 
 class Cas1WithdrawableTreeOperationsTest {
@@ -160,7 +161,7 @@ class Cas1WithdrawableTreeOperationsTest {
     )
 
     val context = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Application,
       triggeringEntityId = application.id,
     )
@@ -334,7 +335,7 @@ class Cas1WithdrawableTreeOperationsTest {
     )
 
     val context = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Application,
       triggeringEntityId = application.id,
     )
@@ -478,7 +479,7 @@ class Cas1WithdrawableTreeOperationsTest {
     )
 
     val context = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Application,
       triggeringEntityId = application.id,
     )
@@ -625,7 +626,7 @@ class Cas1WithdrawableTreeOperationsTest {
     )
 
     val context = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Application,
       triggeringEntityId = application.id,
     )
@@ -661,7 +662,7 @@ class Cas1WithdrawableTreeOperationsTest {
     )
 
     val context = WithdrawalContext(
-      triggeringUser = user,
+      withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
       triggeringEntityType = WithdrawableEntityType.Application,
       triggeringEntityId = application.id,
     )


### PR DESCRIPTION
To address APS-687 we added a seed job to withdraw match requests (placement_requests) via a seed job.

When tested in pre-prod we saw an error sending the email due to:

`Status code: 400 {"errors":[{"error":"BadRequestError","message":"Missing personalisation: withdrawnBy"}],"status_code":400}`

This PR refactors how the Withdrawal Context model to provide a more consistent approach to identifying who or what triggered withdrawal of the entity. This is then subsequently leveraged to ensure we can always a determine a 'withdrawn by' value for withdrawal emails, regardless of whether it was triggered by a user or a seed job.