### PR TITLE
(Chore) Add Configuration class for Domain Event URLs

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -44,6 +44,13 @@
     <ID>TooGenericExceptionThrown:DomainEventsController.kt$DomainEventsController$throw RuntimeException("Only CAS1 events are supported")</ID>
     <ID>TooGenericExceptionThrown:DomainEventServiceTest.kt$DomainEventServiceTest$throw RuntimeException("Cannot find EventType for $type")</ID>
     <ID>TooGenericExceptionThrown:DomainEventServiceTest.kt$DomainEventServiceTest$throw RuntimeException("Domain even type $type not supported")</ID>
+    <ID>UseCheckOrError:DomainEventUrlConfig.kt$DomainEventUrlConfig$throw IllegalStateException("")</ID>
+    <ID>UseCheckOrError:DomainEventUrlConfig.kt$DomainEventUrlConfig$throw IllegalStateException("Missing CAS1 Url Config")</ID>
+    <ID>CyclomaticComplexMethod:DomainEventUrlConfig.kt$DomainEventUrlConfig$fun getUrlForDomainEventType(domainEventType: DomainEventType): String</ID>
+    <ID>UseCheckOrError:DomainEventUrlConfig.kt$DomainEventUrlConfig$throw IllegalStateException("Missing URL for $domainEventType")</ID>
+    <ID>CyclomaticComplexMethod:DomainEventUrlConfig.kt$DomainEventUrlConfig$fun getUrlForDomainEventType(domainEventType: DomainEventType): UrlTemplate</ID>
+    <ID>CyclomaticComplexMethod:DomainEventUrlConfig.kt$DomainEventUrlConfig$fun getUrlForDomainEventType(domainEventType: DomainEventType, eventId: UUID): String</ID>
+    <ID>CyclomaticComplexMethod:DomainEventUrlConfig.kt$DomainEventUrlConfig$fun getUrlForDomainEventId(domainEventType: DomainEventType, eventId: UUID): String</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.util.UUID
+
+@Configuration
+@ConfigurationProperties(prefix = "url-templates.api")
+class DomainEventUrlConfig {
+  lateinit var cas1: Map<String, UrlTemplate>
+  lateinit var cas2: Map<String, UrlTemplate>
+  lateinit var cas3: Map<String, UrlTemplate>
+
+  fun getUrlForDomainEventId(domainEventType: DomainEventType, eventId: UUID): String {
+    val template = when (domainEventType) {
+      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> cas1["application-submitted-event-detail"]
+      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> cas1["application-assessed-event-detail"]
+      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> cas1["booking-made-event-detail"]
+      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> cas1["person-arrived-event-detail"]
+      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> cas1["person-not-arrived-event-detail"]
+      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> cas1["person-departed-event-detail"]
+      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> cas1["booking-not-made-event-detail"]
+      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> cas1["booking-cancelled-event-detail"]
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> cas1["booking-changed-event-detail"]
+      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> cas1["application-withdrawn-event-detail"]
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> cas1["assessment-appealed-event-detail"]
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> cas1["assessment-allocated-event-detail"]
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> cas1["placement-application-withdrawn-event-detail"]
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED -> cas1["placement-application-allocated-event-detail"]
+      DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> cas1["match-request-withdrawn-event-detail"]
+      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> cas1["request-for-placement-created-event-detail"]
+      DomainEventType.CAS2_APPLICATION_SUBMITTED -> cas2["application-submitted-event-detail"]
+      DomainEventType.CAS2_APPLICATION_STATUS_UPDATED -> cas2["application-status-updated-event-detail"]
+      DomainEventType.CAS3_BOOKING_CANCELLED -> cas3["booking-cancelled-event-detail"]
+      DomainEventType.CAS3_BOOKING_CONFIRMED -> cas3["booking-confirmed-event-detail"]
+      DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE -> cas3["booking-provisionally-made-event-detail"]
+      DomainEventType.CAS3_PERSON_ARRIVED -> cas3["person-arrived-event-detail"]
+      DomainEventType.CAS3_PERSON_ARRIVED_UPDATED -> cas3["person-arrived-updated-event-detail"]
+      DomainEventType.CAS3_PERSON_DEPARTED -> cas3["person-departed-event-detail"]
+      DomainEventType.CAS3_REFERRAL_SUBMITTED -> cas3["referral-submitted-event-detail"]
+      DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED -> cas3["person-departure-updated-event-detail"]
+      DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED -> cas3["booking-cancelled-updated-event-detail"]
+    } ?: throw IllegalStateException("Missing URL for $domainEventType")
+
+    return template.resolve("eventId", eventId.toString())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationAllocatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
@@ -29,7 +30,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -42,22 +42,7 @@ class DomainEventService(
   val domainEventWorker: ConfiguredDomainEventWorker,
   private val userService: UserService,
   @Value("\${domain-events.cas1.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
-  @Value("\${url-templates.api.cas1.application-submitted-event-detail}") private val applicationSubmittedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.application-assessed-event-detail}") private val applicationAssessedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.booking-made-event-detail}") private val bookingMadeDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.person-arrived-event-detail}") private val personArrivedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.person-not-arrived-event-detail}") private val personNotArrivedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.person-departed-event-detail}") private val personDepartedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.booking-not-made-event-detail}") private val bookingNotMadeDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.booking-cancelled-event-detail}") private val bookingCancelledDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.booking-changed-event-detail}") private val bookingChangedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.application-withdrawn-event-detail}") private val applicationWithdrawnDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.assessment-appealed-event-detail}") private val assessmentAppealedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas1.placement-application-withdrawn-event-detail}") private val placementApplicationWithdrawnDetailUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.api.cas1.placement-application-allocated-event-detail}") private val placementApplicationAllocatedDetailUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.api.cas1.match-request-withdrawn-event-detail}") private val matchRequestWithdrawnDetailUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.api.cas1.assessment-allocated-event-detail}") private val assessmentAllocatedUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.api.cas1.request-for-placement-created-event-detail}") private val requestForPlacementCreatedUrlTemplate: UrlTemplate,
+  private val domainEventUrlConfig: DomainEventUrlConfig,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -89,7 +74,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
-      detailUrl = applicationSubmittedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -99,7 +83,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
-      detailUrl = applicationAssessedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -109,7 +92,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
-      detailUrl = bookingMadeDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
@@ -120,7 +102,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-      detailUrl = personArrivedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
@@ -132,7 +113,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
-      detailUrl = personNotArrivedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
@@ -144,7 +124,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-      detailUrl = personDepartedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
@@ -156,7 +135,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
-      detailUrl = bookingNotMadeDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -166,7 +144,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
-      detailUrl = bookingCancelledDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
@@ -177,7 +154,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
-      detailUrl = bookingChangedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       bookingId = domainEvent.bookingId,
@@ -188,7 +164,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-      detailUrl = applicationWithdrawnDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
@@ -199,7 +174,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
-      detailUrl = assessmentAppealedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -209,7 +183,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
-      detailUrl = placementApplicationWithdrawnDetailUrlTemplate.resolve("eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -219,7 +192,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
-      detailUrl = placementApplicationAllocatedDetailUrlTemplate.resolve("eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -229,7 +201,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
-      detailUrl = matchRequestWithdrawnDetailUrlTemplate.resolve("eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -239,7 +210,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
-      detailUrl = requestForPlacementCreatedUrlTemplate.resolve("eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
@@ -250,7 +220,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-      detailUrl = assessmentAllocatedUrlTemplate.resolve("eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -262,12 +231,12 @@ class DomainEventService(
   fun saveAndEmit(
     domainEvent: DomainEvent<*>,
     eventType: DomainEventType,
-    detailUrl: String,
     crn: String,
     nomsNumber: String,
     bookingId: UUID? = null,
     emit: Boolean = true,
   ) {
+    val detailUrl = domainEventUrlConfig.getUrlForDomainEventId(eventType, domainEvent.id)
     val typeName = eventType.typeName
     val typeDescription = eventType.typeDescription
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3PersonDepartureUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3ReferralSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
@@ -46,15 +47,7 @@ class DomainEventService(
   private val domainEventBuilder: DomainEventBuilder,
   private val hmppsQueueService: HmppsQueueService,
   @Value("\${domain-events.cas3.emit-enabled}") private val emitDomainEventsEnabled: List<EventType>,
-  @Value("\${url-templates.api.cas3.booking-cancelled-event-detail}") private val bookingCancelledDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.booking-cancelled-updated-event-detail}") private val bookingCancelledUpdatedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.booking-confirmed-event-detail}") private val bookingConfirmedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.booking-provisionally-made-event-detail}") private val bookingProvisionallyMadeDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.person-arrived-event-detail}") private val personArrivedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.person-departed-event-detail}") private val personDepartedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.referral-submitted-event-detail}") private val referralSubmittedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.person-departure-updated-event-detail}") private val personDepartureUpdatedDetailUrlTemplate: String,
-  @Value("\${url-templates.api.cas3.person-arrived-updated-event-detail}") private val personArrivedUpdatedDetailUrlTemplate: String,
+  private val domainEventUrlConfig: DomainEventUrlConfig,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -105,7 +98,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = bookingCancelledDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -117,7 +109,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = bookingConfirmedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -129,7 +120,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = bookingProvisionallyMadeDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -141,7 +131,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = personArrivedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -153,7 +142,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = personArrivedUpdatedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -165,7 +153,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = personDepartedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -177,7 +164,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = referralSubmittedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -189,7 +175,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = personDepartureUpdatedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
@@ -197,13 +182,13 @@ class DomainEventService(
 
   private fun <T : CAS3Event> saveAndEmit(
     domainEvent: DomainEvent<T>,
-    detailUrl: String,
     crn: String,
     nomsNumber: String?,
   ) {
     val enumType = enumTypeFromDataType(domainEvent.data::class)
     val typeName = enumType.typeName
     val typeDescription = enumType.typeDescription
+    val detailUrl = domainEventUrlConfig.getUrlForDomainEventId(enumType, domainEvent.id)
 
     domainEventRepository.save(
       DomainEventEntity(
@@ -276,7 +261,6 @@ class DomainEventService(
 
     saveAndEmit(
       domainEvent = domainEvent,
-      detailUrl = bookingCancelledUpdatedDetailUrlTemplate.replace("#eventId", domainEvent.id.toString()),
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )


### PR DESCRIPTION
This adds a new `DomainEventUrlConfig` class that allows us to get url templates for a domain event type directly, instead of having to pass them as `@Value` annotated strings in our service classes, which is getting unweildy. It also allows us to easily map domain events to URL templates elsewhere in our code.