### PR TITLE
(APS-673) Add a has domain event field to clarification notes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -422,6 +422,8 @@ data class AssessmentClarificationNoteEntity(
   var response: String?,
 
   var responseReceivedOn: LocalDate?,
+
+  var hasDomainEvent: Boolean = false,
 )
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -924,7 +924,9 @@ class ApplicationService(
 
   private fun getAllAssessmentClarificationNoteTimeLineEventsForApplication(applicationId: UUID): List<TimelineEvent> {
     val assessments = applicationRepository.findAllAssessmentsById(applicationId)
-    val allClarifications = assessments.flatMap { it.clarificationNotes }
+    val allClarifications = assessments
+      .flatMap { it.clarificationNotes }
+      .filter { !it.hasDomainEvent }
     return allClarifications.map {
       assessmentClarificationNoteTransformer.transformToTimelineEvent(it)
     }

--- a/src/main/resources/db/migration/all/20240424102921__add_has_domain_event_field_to_assessment_clarification_notes.sql
+++ b/src/main/resources/db/migration/all/20240424102921__add_has_domain_event_field_to_assessment_clarification_notes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."assessment_clarification_notes" ADD COLUMN "has_domain_event" BOOLEAN DEFAULT FALSE NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -19,6 +19,7 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
   private var query: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var response: Yielded<String?> = { null }
   private var responseReceivedOn: Yielded<LocalDate?> = { null }
+  private var hasDomainEvent: Yielded<Boolean> = { false }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -48,6 +49,10 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     this.responseReceivedOn = { responseReceivedOn }
   }
 
+  fun withHasDomainEvent(hasDomainEvent: Boolean) = apply {
+    this.hasDomainEvent = { hasDomainEvent }
+  }
+
   override fun produce(): AssessmentClarificationNoteEntity = AssessmentClarificationNoteEntity(
     id = this.id(),
     assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
@@ -56,5 +61,6 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     query = this.query(),
     response = this.response(),
     responseReceivedOn = this.responseReceivedOn(),
+    hasDomainEvent = this.hasDomainEvent(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2797,6 +2797,9 @@ class ApplicationTest : IntegrationTestBase() {
           )
         }
 
+        // Create a clarification note that already has a domain event
+        createAssessmentClarificationNote(assessment, user, 3, true)
+
         val allSummaries = summaries + informationRequestSummaries
         val expectedJson = objectMapper.writeValueAsString(
           allSummaries,
@@ -3023,6 +3026,7 @@ class ApplicationTest : IntegrationTestBase() {
       assessment: ApprovedPremisesAssessmentEntity,
       user: UserEntity,
       dayOfMonth: Int,
+      hasDomainEvent: Boolean = false,
     ): AssessmentClarificationNoteEntity {
       return assessmentClarificationNoteEntityFactory.produceAndPersist {
         withAssessment(assessment)
@@ -3030,6 +3034,7 @@ class ApplicationTest : IntegrationTestBase() {
           LocalDate.of(year, month, dayOfMonth).toLocalDateTime(),
         )
         withCreatedBy(user)
+        withHasDomainEvent(hasDomainEvent)
       }
     }
 


### PR DESCRIPTION
We will shortly be introducing a proper domain event for when information requests are created. To ensure we don't double up events in the timeline, this adds a `hasDomainEvent` boolean to the `AssessmentClarificationNoteEntity`, which defaults to `false`. We then filter out any entities which has this set to `true`. This will allow us to create new domain events without timelines doubling up, and also will allow us to find all notes which don't have a domain event when we're backfilling.