### PR TITLE
CAS2 Gatling tests

### DIFF
--- a/doc/how-to/run_performance_tests.md
+++ b/doc/how-to/run_performance_tests.md
@@ -1,12 +1,15 @@
 # How to run performance tests
+
 Performance tests use [Gatling](https://gatling.io), which provides a Gradle plugin.
 This bundles up Gatling in a convenient way so that no additional tools need to be downloaded.
 
 ## Running against a local instance
+
 This requires the [ap-tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools)
 utility to be running.
 
 Once the API has started locally, just run:
+
 ```shell
 ./gradlew gatlingRun
 ```
@@ -18,7 +21,9 @@ To run a specific test define the FQN of the simulation:
 ```
 
 ## Running against a remote environment
+
 This requires some configuration, which can be done through environment variables:
+
 ```shell
 GATLING_BASE_URL="https://approved-premises-api-{env}.hmpps.service.justice.gov.uk" \
 GATLING_CAS3_USERNAME="{your username}" \
@@ -28,5 +33,6 @@ GATLING_HMPPS_AUTH_BASE_URL="https://sign-in-{env}.hmpps.service.justice.gov.uk"
 ```
 
 ## Results
+
 Once Gatling has finished, it will output reports into the `build/reports/gatling` folder.
 It will also provide a link in the terminal to open the report directly in the browser.

--- a/doc/how-to/run_performance_tests.md
+++ b/doc/how-to/run_performance_tests.md
@@ -1,11 +1,13 @@
 # How to run performance tests
 
-Performance tests use [Gatling](https://gatling.io), which provides a Gradle plugin.
-This bundles up Gatling in a convenient way so that no additional tools need to be downloaded.
+Performance tests use [Gatling](https://gatling.io), which provides a Gradle
+plugin. This bundles up Gatling in a convenient way so that no additional tools
+need to be downloaded.
 
 ## Running against a local instance
 
-This requires the [ap-tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools)
+This requires the
+[ap-tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools)
 utility to be running.
 
 Once the API has started locally, just run:
@@ -22,7 +24,8 @@ To run a specific test define the FQN of the simulation:
 
 ## Running against a remote environment
 
-This requires some configuration, which can be done through environment variables:
+This requires some configuration, which can be done through environment
+variables:
 
 ```shell
 GATLING_BASE_URL="https://approved-premises-api-{env}.hmpps.service.justice.gov.uk" \
@@ -34,5 +37,6 @@ GATLING_HMPPS_AUTH_BASE_URL="https://sign-in-{env}.hmpps.service.justice.gov.uk"
 
 ## Results
 
-Once Gatling has finished, it will output reports into the `build/reports/gatling` folder.
-It will also provide a link in the terminal to open the report directly in the browser.
+Once Gatling has finished, it will output reports into the
+`build/reports/gatling` folder. It will also provide a link in the terminal to
+open the report directly in the browser.

--- a/doc/how-to/run_performance_tests.md
+++ b/doc/how-to/run_performance_tests.md
@@ -21,8 +21,8 @@ To run a specific test define the FQN of the simulation:
 This requires some configuration, which can be done through environment variables:
 ```shell
 GATLING_BASE_URL="https://approved-premises-api-{env}.hmpps.service.justice.gov.uk" \
-GATLING_USERNAME="{your username}" \
-GATLING_PASSWORD="{your password}" \
+GATLING_CAS3_USERNAME="{your username}" \
+GATLING_CAS3_PASSWORD="{your password}" \
 GATLING_HMPPS_AUTH_BASE_URL="https://sign-in-{env}.hmpps.service.justice.gov.uk" \
 ./gradlew gatlingRun
 ```

--- a/doc/how-to/run_performance_tests.md
+++ b/doc/how-to/run_performance_tests.md
@@ -40,3 +40,8 @@ GATLING_HMPPS_AUTH_BASE_URL="https://sign-in-{env}.hmpps.service.justice.gov.uk"
 Once Gatling has finished, it will output reports into the
 `build/reports/gatling` folder. It will also provide a link in the terminal to
 open the report directly in the browser.
+
+NB. Gatling will not clear the data it's just created so you may be left with
+thousands of rows which slows your environment down. To clear this easily you
+can wipe your API database with `docker-compose down -v` from within the AP
+tools repo.

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas2/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas2/ApplyJourneyStressSimulation.kt
@@ -10,6 +10,7 @@ import io.gatling.javaapi.core.Simulation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.createCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.submitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.updateCas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.viewAllMyCas2Applications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
@@ -44,12 +45,16 @@ class ApplyJourneyStressSimulation : Simulation() {
     10.seconds.toJavaDuration(),
   )
 
+  private val viewAllMyCas2Applications = viewAllMyCas2Applications()
+    .pause(10.seconds.toJavaDuration())
+
   private val cas2ApplyJourney = scenario("Apply journey for CAS2")
     .exec(
       authorizeUser("cas2"),
       createCas2Application,
       updateCas2Application,
       submitCas2Application,
+      viewAllMyCas2Applications,
     )
 
   init {

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas2/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas2/ApplyJourneyStressSimulation.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations.cas2
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.repeat
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.CoreDsl.stressPeakUsers
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.core.Simulation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.createCas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.submitCas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2.updateCas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class ApplyJourneyStressSimulation : Simulation() {
+  private val applicationIdKey = "application_id"
+  private val getApplicationId = { session: Session -> session.getUUID(applicationIdKey) }
+
+  private val createCas2Application = createCas2Application(
+    saveApplicationIdAs = applicationIdKey,
+  ).exitHereIfFailed()
+    .pause(
+      1.seconds.toJavaDuration(),
+    )
+
+  private val updateCas2Application = repeat({ randomInt(1, 20) }, "n").on(
+    updateCas2Application(
+      applicationId = getApplicationId,
+    )
+      .pause(
+        5.seconds.toJavaDuration(),
+      ),
+  )
+
+  private val submitCas2Application = submitCas2Application(
+    applicationId = getApplicationId,
+  ).pause(
+    10.seconds.toJavaDuration(),
+  )
+
+  private val cas2ApplyJourney = scenario("Apply journey for CAS2")
+    .exec(
+      authorizeUser("cas2"),
+      createCas2Application,
+      updateCas2Application,
+      submitCas2Application,
+    )
+
+  init {
+    setUp(
+      cas2ApplyJourney.injectOpen(
+        constantUsersPerSec(50.0).during(2.minutes.toJavaDuration()).randomized(),
+        stressPeakUsers(5000).during(1.minutes.toJavaDuration()),
+      ),
+    ).assertions(
+      CoreDsl.global().responseTime().percentile(95.0).lt(40000),
+      CoreDsl.global().successfulRequests().percent().gte(100.0),
+    ).withAuthorizedUserHttpProtocol()
+  }
+}

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas2/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas2/ApplyJourneyStressSimulation.kt
@@ -46,7 +46,7 @@ class ApplyJourneyStressSimulation : Simulation() {
   )
 
   private val viewAllMyCas2Applications = viewAllMyCas2Applications()
-    .pause(10.seconds.toJavaDuration())
+    .pause(5.seconds.toJavaDuration())
 
   private val cas2ApplyJourney = scenario("Apply journey for CAS2")
     .exec(
@@ -60,11 +60,11 @@ class ApplyJourneyStressSimulation : Simulation() {
   init {
     setUp(
       cas2ApplyJourney.injectOpen(
-        constantUsersPerSec(50.0).during(2.minutes.toJavaDuration()).randomized(),
-        stressPeakUsers(5000).during(1.minutes.toJavaDuration()),
+        constantUsersPerSec(30.0).during(2.minutes.toJavaDuration()).randomized(),
+        stressPeakUsers(350).during(1.minutes.toJavaDuration()),
       ),
     ).assertions(
-      CoreDsl.global().responseTime().percentile(95.0).lt(40000),
+      CoreDsl.global().responseTime().max().lt(10000),
       CoreDsl.global().successfulRequests().percent().gte(100.0),
     ).withAuthorizedUserHttpProtocol()
   }

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas3/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas3/ApplyJourneyStressSimulation.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations.cas3
 
 import io.gatling.javaapi.core.CoreDsl
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
@@ -7,9 +7,9 @@ import io.gatling.javaapi.core.CoreDsl.scenario
 import io.gatling.javaapi.core.CoreDsl.stressPeakUsers
 import io.gatling.javaapi.core.Session
 import io.gatling.javaapi.core.Simulation
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.submitTemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.updateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.createTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.submitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.updateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
@@ -43,7 +43,7 @@ class ApplyJourneyStressSimulation : Simulation() {
 
   private val temporaryAccommodationApplyJourney = scenario("Apply journey for Temporary Accommodation")
     .exec(
-      authorizeUser(),
+      authorizeUser("cas3"),
       createTemporaryAccommodationApplication,
       updateTemporaryAccommodationApplication,
       submitTemporaryAccommodationApplication,

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas3/BookingsTimeSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/cas3/BookingsTimeSimulation.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations.cas3
 
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
 import io.gatling.javaapi.core.CoreDsl.exec
@@ -9,14 +9,14 @@ import io.gatling.javaapi.core.Simulation
 import io.gatling.javaapi.http.HttpDsl.http
 import io.gatling.javaapi.http.HttpDsl.status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationBooking
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationPremises
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.createTemporaryAccommodationRoom
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.getProbationDeliveryUnit
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.getUserProbationRegion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.submitTemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.updateTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.createTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.createTemporaryAccommodationBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.createTemporaryAccommodationPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.createTemporaryAccommodationRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.getProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.getUserProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.submitTemporaryAccommodationApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3.updateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.authorizeUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.getUUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.withAuthorizedUserHttpProtocol
@@ -106,7 +106,7 @@ class BookingsTimeSimulation : Simulation() {
 
   private val setupBooking = scenario("Setup booking")
     .exec(
-      authorizeUser(),
+      authorizeUser("cas3"),
       createArrivalDate,
       getUserProbationRegion,
       getProbationDeliveryUnit,
@@ -139,13 +139,13 @@ class BookingsTimeSimulation : Simulation() {
 
   private val bookingsSearchJourney = scenario("Bookings search journey")
     .exec(
-      authorizeUser(),
+      authorizeUser("cas3"),
       bookingSearch,
     )
 
   private val bookingsReportDownloadJourney = scenario("Bookings report journey")
     .exec(
-      authorizeUser(),
+      authorizeUser("cas3"),
       createReportDate,
       getUserProbationRegion,
       downloadBookingsReport,

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas2/Applications.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas2/Applications.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas2
+
+import io.gatling.javaapi.core.CoreDsl
+import io.gatling.javaapi.core.Session
+import io.gatling.javaapi.http.HttpDsl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.CRN
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util.toJson
+import java.time.LocalDate
+import java.util.UUID
+
+fun createCas2Application(
+  crn: (Session) -> String = { _ -> CRN },
+  saveApplicationIdAs: String? = null,
+) = CoreDsl.exec(
+  HttpDsl.http("Create CAS2 Application")
+    .post("/cas2/applications")
+    .header("X-Service-Name", ServiceName.cas2.value)
+    .body(
+      toJson { session ->
+        NewApplication(
+          crn = crn(session),
+          convictionId = 0L,
+          deliusEventNumber = "",
+          offenceId = "",
+        )
+      },
+    )
+    .check(HttpDsl.status().`is`(201))
+    .let {
+      when (saveApplicationIdAs) {
+        null -> it
+        else -> it.check(CoreDsl.jsonPath("$.id").saveAs(saveApplicationIdAs))
+      }
+    },
+)
+
+fun updateCas2Application(
+  applicationId: (Session) -> UUID,
+) = CoreDsl.exec(
+  HttpDsl.http("Update Application")
+    .put { session -> "/cas2/applications/${applicationId(session)}" }
+    .header("X-Service-Name", ServiceName.cas2.value)
+    .body(
+      toJson(
+        UpdateCas2Application(
+          type = UpdateApplicationType.CAS2,
+          data = mapOf(),
+        ),
+      ),
+    ),
+)
+
+fun submitCas2Application(
+  applicationId: (Session) -> UUID,
+) = CoreDsl.exec(
+  HttpDsl.http("Submit Application")
+    .post { session -> "/cas2/submissions" }
+    .header("X-Service-Name", ServiceName.cas2.value)
+    .body(
+      toJson { session ->
+        SubmitCas2Application(
+          applicationId = applicationId(session),
+          translatedDocument = {},
+          telephoneNumber = "123 456 7891",
+          preferredAreas = "Leeds | Bradford",
+          hdcEligibilityDate = LocalDate.parse("2023-03-30"),
+          conditionalReleaseDate = LocalDate.parse("2023-04-29"),
+        )
+      },
+    ),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas2/Applications.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas2/Applications.kt
@@ -74,3 +74,9 @@ fun submitCas2Application(
       },
     ),
 )
+
+fun viewAllMyCas2Applications() = CoreDsl.exec(
+  HttpDsl.http("Get Applications")
+    .get { session -> "/cas2/applications" }
+    .header("X-Service-Name", ServiceName.cas2.value),
+)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Applications.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Applications.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3
 
 import io.gatling.javaapi.core.CoreDsl
 import io.gatling.javaapi.core.Session

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Bookings.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Bookings.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3
 
 import io.gatling.javaapi.core.CoreDsl
 import io.gatling.javaapi.core.Session

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Premises.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Premises.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3
 
 import io.gatling.javaapi.core.CoreDsl
 import io.gatling.javaapi.core.Session

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/ReferenceData.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/ReferenceData.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3
 
 import io.gatling.javaapi.core.CoreDsl
 import io.gatling.javaapi.core.Session

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Users.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/steps/cas3/Users.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.steps.cas3
 
 import io.gatling.javaapi.core.CoreDsl
 import io.gatling.javaapi.http.HttpDsl

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt
@@ -12,8 +12,29 @@ import reactor.core.publisher.Mono
 import java.net.URLEncoder
 import java.nio.charset.Charset
 
-fun authorizeUser(): ChainBuilder {
-  val jwt = getJwt()
+fun authorizeUser(serviceName: String): ChainBuilder {
+  var username: String
+  var password: String
+
+  when (serviceName) {
+    "cas1" -> {
+      username = CAS1_USERNAME
+      password = CAS1_PASSWORD
+    }
+    "cas2" -> {
+      username = CAS2_USERNAME
+      password = CAS2_PASSWORD
+    }
+    "cas3" -> {
+      username = CAS3_USERNAME
+      password = CAS3_PASSWORD
+    }
+    else -> {
+      throw IllegalArgumentException("Invalid service name: $serviceName")
+    }
+  }
+
+  val jwt = getJwt(username, password)
 
   return exec { session ->
     session.set("access_token", jwt)
@@ -30,7 +51,7 @@ fun Simulation.SetUp.withAuthorizedUserHttpProtocol() = apply {
   this.protocols(protocol)
 }
 
-private fun getJwt(): String {
+private fun getJwt(username: String, password: String): String {
   println("Setting up auth ($HMPPS_AUTH_BASE_URL)...")
   val webClient = WebClient.create()
 
@@ -52,8 +73,8 @@ private fun getJwt(): String {
     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
     .bodyValue(
       "redirect_url=${URLEncoder.encode("http://example.org", Charset.defaultCharset())}" +
-        "&username=${URLEncoder.encode(USERNAME, Charset.defaultCharset())}" +
-        "&password=${URLEncoder.encode(PASSWORD, Charset.defaultCharset())}",
+        "&username=${URLEncoder.encode(username, Charset.defaultCharset())}" +
+        "&password=${URLEncoder.encode(password, Charset.defaultCharset())}",
     )
     .exchangeToMono {
       it.printIfError("sign in")

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Environment.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Environment.kt
@@ -7,8 +7,8 @@ val CRN = System.getenv("GATLING_CRN") ?: "X320741"
 val CAS1_USERNAME = System.getenv("GATLING_CAS1_USERNAME") ?: "JimSnowLdap"
 val CAS1_PASSWORD = System.getenv("GATLING_CAS1_PASSWORD") ?: "secret"
 
-val CAS2_USERNAME = System.getenv("GATLING_CAS2_USERNAME") ?: ""
-val CAS2_PASSWORD = System.getenv("GATLING_CAS2_PASSWORD") ?: ""
+val CAS2_USERNAME = System.getenv("GATLING_CAS2_USERNAME") ?: "POM_USER"
+val CAS2_PASSWORD = System.getenv("GATLING_CAS2_PASSWORD") ?: "password123456"
 
 val CAS3_USERNAME = System.getenv("GATLING_CAS3_USERNAME") ?: "JimSnowLdap"
 val CAS3_PASSWORD = System.getenv("GATLING_CAS3_PASSWORD") ?: "secret"

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Environment.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Environment.kt
@@ -1,7 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.util
 
 val BASE_URL = System.getenv("GATLING_BASE_URL") ?: "http://localhost:8080"
-val USERNAME = System.getenv("GATLING_USERNAME") ?: "JimSnowLdap"
-val PASSWORD = System.getenv("GATLING_PASSWORD") ?: "secret"
 val HMPPS_AUTH_BASE_URL = System.getenv("GATLING_HMPPS_AUTH_BASE_URL") ?: "http://localhost:9091"
 val CRN = System.getenv("GATLING_CRN") ?: "X320741"
+
+val CAS1_USERNAME = System.getenv("GATLING_CAS1_USERNAME") ?: "JimSnowLdap"
+val CAS1_PASSWORD = System.getenv("GATLING_CAS1_PASSWORD") ?: "secret"
+
+val CAS2_USERNAME = System.getenv("GATLING_CAS2_USERNAME") ?: ""
+val CAS2_PASSWORD = System.getenv("GATLING_CAS2_PASSWORD") ?: ""
+
+val CAS3_USERNAME = System.getenv("GATLING_CAS3_USERNAME") ?: "JimSnowLdap"
+val CAS3_PASSWORD = System.getenv("GATLING_CAS3_PASSWORD") ?: "secret"


### PR DESCRIPTION
## Changes

* We start with some refactoring of the old CAS3 tests to allow new CAS2 tests to clearly slot in 
* We add new CAS2 application tests
* These tests only work locally due to problems with the Nomis Roles API. There are three proposals to amend that service to support us [1](https://github.com/ministryofjustice/nomis-user-roles-api/pull/272), [2](https://github.com/ministryofjustice/nomis-user-roles-api/pull/270), [3](https://github.com/ministryofjustice/nomis-user-roles-api/pull/269). If these were merged into main we could be able to try running this on our real dev environment. Until then we are limited to using a patched local instance of Nomis Roles API with these changes applied. Notes will be included at the bottom for how to do that.

## Results

These results are limited to running on our local machines. This is not perfect but our hope is that it will give us an indication into the performance of some of our least efficient pages, highlighting any inefficient SQL queries.

![Screenshot 2024-04-24 at 12-25-33 Gatling Stats - Global Information](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/e30e3eb8-e5e7-43e1-9918-1d05c26f3d6a)

![Screenshot 2024-04-24 at 12-25-37 Gatling Stats - Create CAS2 Application](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/6d00c1c9-49c1-4318-bd97-0f5a228dc60d)

![Screenshot 2024-04-24 at 12-30-00 Gatling Stats - Update Application](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/5c467c2a-bb1c-4823-a69f-b7a4175081d2)

![Screenshot 2024-04-24 at 12-30-04 Gatling Stats - Submit Application](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/a1433a6c-a9bf-4606-a177-8c5dd1e63cb4)

![Screenshot 2024-04-24 at 12-30-08 Gatling Stats - Get Applications](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/1937297d-3137-4fb5-9d22-506a11c5365e)

We can see that 3957 applications for the same user were created. The 'Get Applications' endpoint is not paginated and is able to respond with a reassuring 99th percentile of 2358ms. We don't imagine a single referrer or group of referrers belonging to the same prison to have the number for a long time. Pagination is planned in to happen soon too so good news aside from the caveat this isn't run on a real environment.

## Running a patched Nomis Roles API

Why do we have to patch this? There is more detail in the linked pull requests but essentially we get a basic authentication JWT from HMPPS Auth which we use in our downstream requests. Outside the context of Gatling this JWT is expanded with additional data via the callback mechanism. Given we are in the context of Gatling, without a frontend that can receive a callback we cannot replicate it entirely. Nomis Roles API requires data to include a client_id for telemetery and a user_name (where it could look at the `sub`). The same strategy works for CAS3 so there is some hope we could find a way to get those proposals merged.

### Patching to run locally <a href="#user-content-patching" id="patching">#</a>

* Clone [the Nomis Roles API](https://github.com/ministryofjustice/nomis-user-roles-api)
* Apply the changes of each of these changes [1](https://github.com/ministryofjustice/nomis-user-roles-api/pull/272), [2](https://github.com/ministryofjustice/nomis-user-roles-api/pull/270), [3](https://github.com/ministryofjustice/nomis-user-roles-api/pull/269) to your branch 
* Edit your AP Tools docker-compose.yml file to use this version of Nomis Roles API with:
     ```
       nomis-user-roles-api:
       # image: quay.io/hmpps/nomis-user-roles-api:latest
       build:
         context: ../nomis-user-roles-api
         dockerfile: Dockerfile
     ```
* Start AP tools as normal
* Run Gatling tests from the CAS API `./gradlew gatlingRun-uk.gov.justice.digital.hmpps.approvedpremisesapi.gatling.simulations.cas2.ApplyJourneyStressSimulation`