### PR TITLE
APS-712 Add domain_events.noms_number to support replay

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -86,6 +86,7 @@ data class DomainEventEntity(
   val data: String,
   val service: String,
   val triggeredByUserId: UUID?,
+  val nomsNumber: String?,
 ) {
   final inline fun <reified T> toDomainEvent(objectMapper: ObjectMapper): DomainEvent<T> {
     val data = when {
@@ -132,6 +133,7 @@ data class DomainEventEntity(
       id = this.id,
       applicationId = this.applicationId,
       crn = this.crn,
+      nomsNumber = this.nomsNumber,
       occurredAt = this.occurredAt.toInstant(),
       data = data,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -9,6 +9,7 @@ data class DomainEvent<T> (
   val assessmentId: UUID? = null,
   val bookingId: UUID? = null,
   val crn: String,
+  val nomsNumber: String?,
   val occurredAt: Instant,
   val data: T,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -473,6 +473,7 @@ class AssessmentService(
         applicationId = application.id,
         assessmentId = assessment.id,
         crn = application.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
         occurredAt = acceptedAt.toInstant(),
         data = ApplicationAssessedEnvelope(
           id = domainEventId,
@@ -594,6 +595,7 @@ class AssessmentService(
           applicationId = application.id,
           assessmentId = assessment.id,
           crn = application.crn,
+          nomsNumber = offenderDetails?.otherIds?.nomsNumber,
           occurredAt = rejectedAt.toInstant(),
           data = ApplicationAssessedEnvelope(
             id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -553,6 +553,7 @@ class BookingService(
         id = domainEventId,
         applicationId = applicationId,
         crn = booking.crn,
+        nomsNumber = offenderDetails?.otherIds?.nomsNumber,
         occurredAt = bookingCreatedAt.toInstant(),
         bookingId = booking.id,
         data = BookingMadeEnvelope(
@@ -621,6 +622,7 @@ class BookingService(
         id = domainEventId,
         applicationId = applicationId,
         crn = booking.crn,
+        nomsNumber = offenderDetails?.otherIds?.nomsNumber,
         occurredAt = bookingChangedAt.toInstant(),
         bookingId = booking.id,
         data = BookingChangedEnvelope(
@@ -883,6 +885,7 @@ class BookingService(
           id = domainEventId,
           applicationId = applicationId,
           crn = booking.crn,
+          nomsNumber = offenderDetails?.otherIds?.nomsNumber,
           occurredAt = arrivalDateTime,
           bookingId = booking.id,
           data = PersonArrivedEnvelope(
@@ -1084,6 +1087,7 @@ class BookingService(
           id = domainEventId,
           applicationId = applicationId,
           crn = booking.crn,
+          nomsNumber = offenderDetails.otherIds.nomsNumber,
           occurredAt = date.toLocalDateTime().toInstant(),
           bookingId = booking.id,
           data = PersonNotArrivedEnvelope(
@@ -1305,6 +1309,7 @@ class BookingService(
         id = domainEventId,
         applicationId = applicationId,
         crn = booking.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
         occurredAt = dateTime.toInstant(),
         bookingId = booking.id,
         data = BookingCancelledEnvelope(
@@ -1537,6 +1542,7 @@ class BookingService(
           id = domainEventId,
           applicationId = applicationId,
           crn = booking.crn,
+          nomsNumber = offenderDetails.otherIds.nomsNumber,
           occurredAt = dateTime.toInstant(),
           bookingId = booking.id,
           data = PersonDepartedEnvelope(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -76,7 +76,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -84,7 +83,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -92,7 +90,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -100,7 +97,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
 
@@ -109,7 +105,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
 
@@ -118,7 +113,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
 
@@ -127,7 +121,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -135,7 +128,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -143,7 +135,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -151,7 +142,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
 
@@ -160,7 +150,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -168,7 +157,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -176,7 +164,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -184,7 +171,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -192,7 +178,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
 
@@ -201,7 +186,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
   @Transactional
@@ -209,7 +193,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
-      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
 
@@ -220,7 +203,6 @@ class DomainEventService(
   fun saveAndEmit(
     domainEvent: DomainEvent<*>,
     eventType: DomainEventType,
-    nomsNumber: String,
     emit: Boolean = true,
   ) {
     domainEventRepository.save(
@@ -236,19 +218,19 @@ class DomainEventService(
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS1",
         triggeredByUserId = userService.getUserForRequestOrNull()?.id,
-        nomsNumber = nomsNumber,
+        nomsNumber = domainEvent.nomsNumber,
       ),
     )
 
     if (emit) {
-      emit(eventType, domainEvent, nomsNumber)
+      emit(eventType, domainEvent, domainEvent.nomsNumber)
     }
   }
 
   private fun emit(
     eventType: DomainEventType,
     domainEvent: DomainEvent<*>,
-    nomsNumber: String,
+    nomsNumber: String?,
   ) {
     if (!emitDomainEventsEnabled) {
       log.info("Not emitting SNS event for domain event because domain-events.cas1.emit-enabled is not enabled")
@@ -273,7 +255,7 @@ class DomainEventService(
         personReference = SnsEventPersonReferenceCollection(
           identifiers = listOf(
             SnsEventPersonReference("CRN", crn),
-            SnsEventPersonReference("NOMS", nomsNumber),
+            SnsEventPersonReference("NOMS", nomsNumber ?: "Unknown NOMS Number"),
           ),
         ),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -76,7 +76,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -85,7 +84,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -94,7 +92,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -103,7 +100,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
@@ -113,7 +109,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
@@ -123,7 +118,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
@@ -133,7 +127,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -142,7 +135,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -151,7 +143,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -160,7 +151,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
@@ -170,7 +160,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -179,7 +168,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -188,7 +176,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -197,7 +184,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -206,7 +192,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
@@ -216,7 +201,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
     )
 
@@ -237,13 +221,13 @@ class DomainEventService(
   fun saveAndEmit(
     domainEvent: DomainEvent<*>,
     eventType: DomainEventType,
-    crn: String,
     nomsNumber: String,
     emit: Boolean = true,
   ) {
     val detailUrl = domainEventUrlConfig.getUrlForDomainEventId(eventType, domainEvent.id)
     val typeName = eventType.typeName
     val typeDescription = eventType.typeDescription
+    val crn = domainEvent.crn
 
     domainEventRepository.save(
       DomainEventEntity(
@@ -251,7 +235,7 @@ class DomainEventService(
         applicationId = domainEvent.applicationId,
         assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
-        crn = domainEvent.crn,
+        crn = crn,
         type = eventType,
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -96,7 +96,6 @@ class DomainEventService(
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
-      bookingId = domainEvent.bookingId,
     )
 
   @Transactional
@@ -106,7 +105,6 @@ class DomainEventService(
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
-      bookingId = domainEvent.bookingId,
       emit = emit,
     )
 
@@ -117,7 +115,6 @@ class DomainEventService(
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
-      bookingId = domainEvent.bookingId,
       emit = emit,
     )
 
@@ -128,7 +125,6 @@ class DomainEventService(
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
-      bookingId = domainEvent.bookingId,
       emit = emit,
     )
 
@@ -148,7 +144,6 @@ class DomainEventService(
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
-      bookingId = domainEvent.bookingId,
     )
 
   @Transactional
@@ -158,7 +153,6 @@ class DomainEventService(
       eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
       crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
-      bookingId = domainEvent.bookingId,
     )
 
   @Transactional
@@ -245,7 +239,6 @@ class DomainEventService(
     eventType: DomainEventType,
     crn: String,
     nomsNumber: String,
-    bookingId: UUID? = null,
     emit: Boolean = true,
   ) {
     val detailUrl = domainEventUrlConfig.getUrlForDomainEventId(eventType, domainEvent.id)
@@ -257,7 +250,7 @@ class DomainEventService(
         id = domainEvent.id,
         applicationId = domainEvent.applicationId,
         assessmentId = domainEvent.assessmentId,
-        bookingId = bookingId,
+        bookingId = domainEvent.bookingId,
         crn = domainEvent.crn,
         type = eventType,
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -209,7 +209,6 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
-      crn = domainEvent.data.eventDetails.personReference.crn,
       nomsNumber = domainEvent.data.eventDetails.personReference.noms,
       emit = emit,
     )
@@ -237,6 +236,7 @@ class DomainEventService(
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS1",
         triggeredByUserId = userService.getUserForRequestOrNull()?.id,
+        nomsNumber = nomsNumber,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -440,6 +440,7 @@ class PlacementRequestService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
         occurredAt = bookingNotCreatedAt.toInstant(),
         data = BookingNotMadeEnvelope(
           id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
@@ -40,6 +40,7 @@ class Cas1AppealDomainEventService(
         assessmentId = null,
         bookingId = null,
         crn = appeal.application.crn,
+        nomsNumber = appeal.application.nomsNumber,
         occurredAt = timestamp,
         data = AssessmentAppealedEnvelope(
           id = id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -96,6 +96,7 @@ class Cas1ApplicationDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
         occurredAt = eventOccurredAt.toInstant(),
         data = ApplicationSubmittedEnvelope(
           id = domainEventId,
@@ -126,6 +127,7 @@ class Cas1ApplicationDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
         data = ApplicationWithdrawnEnvelope(
           id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -49,6 +49,7 @@ class Cas1AssessmentDomainEventService(
         applicationId = assessment.application.id,
         assessmentId = assessment.id,
         crn = assessment.application.crn,
+        nomsNumber = assessment.application.nomsNumber,
         occurredAt = occurredAt,
         data = AssessmentAllocatedEnvelope(
           id = id,
@@ -113,6 +114,7 @@ class Cas1AssessmentDomainEventService(
       applicationId = assessment.application.id,
       assessmentId = assessment.id,
       crn = assessment.application.crn,
+      nomsNumber = assessment.application.nomsNumber,
       occurredAt = occurredAt,
       data = data,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -76,6 +76,7 @@ class Cas1PlacementApplicationDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
         data = RequestForPlacementCreatedEnvelope(
           id = domainEventId,
@@ -121,6 +122,7 @@ class Cas1PlacementApplicationDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
         data = PlacementApplicationWithdrawnEnvelope(
           id = domainEventId,
@@ -164,6 +166,7 @@ class Cas1PlacementApplicationDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
         data = PlacementApplicationAllocatedEnvelope(
           id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
@@ -67,6 +67,7 @@ class Cas1PlacementRequestDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
         data = RequestForPlacementCreatedEnvelope(
           id = domainEventId,
@@ -126,6 +127,7 @@ class Cas1PlacementRequestDomainEventService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
         data = MatchRequestWithdrawnEnvelope(
           id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -305,6 +305,7 @@ class ApplicationService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt.toInstant(),
         data = Cas2ApplicationSubmittedEvent(
           id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
@@ -64,6 +64,7 @@ class DomainEventService(
       crn = domainEventEntity.crn,
       occurredAt = domainEventEntity.occurredAt.toInstant(),
       data = data,
+      nomsNumber = domainEventEntity.nomsNumber,
     )
   }
 
@@ -97,6 +98,7 @@ class DomainEventService(
         assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
         crn = domainEvent.crn,
+        nomsNumber = domainEvent.nomsNumber,
         type = enumTypeFromDataType(domainEvent.data::class),
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -142,6 +142,7 @@ class StatusUpdateService(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
+        nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt.toInstant(),
         data = Cas2ApplicationStatusUpdatedEvent(
           id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
@@ -52,6 +52,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = cancellation.createdAt.toInstant(),
       data = CAS3BookingCancelledEvent(
         id = domainEventId,
@@ -75,6 +76,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = booking.createdAt.toInstant(),
       data = CAS3BookingConfirmedEvent(
         id = domainEventId,
@@ -110,6 +112,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = booking.createdAt.toInstant(),
       data = CAS3BookingProvisionallyMadeEvent(
         id = domainEventId,
@@ -146,6 +149,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = arrival.arrivalDateTime,
       data = CAS3PersonArrivedEvent(
         id = domainEventId,
@@ -170,6 +174,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = departure.dateTime.toInstant(),
       data = CAS3PersonDepartedEvent(
         id = domainEventId,
@@ -190,6 +195,7 @@ class DomainEventBuilder(
       applicationId = application.id,
       bookingId = null,
       crn = application.crn,
+      nomsNumber = application.nomsNumber,
       occurredAt = application.createdAt.toInstant(),
       data = CAS3ReferralSubmittedEvent(
         id = domainEventId,
@@ -221,6 +227,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = departure.dateTime.toInstant(),
       data = CAS3PersonDepartureUpdatedEvent(
         id = domainEventId,
@@ -241,6 +248,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = cancellation.createdAt.toInstant(),
       data = CAS3BookingCancelledUpdatedEvent(
         id = domainEventId,
@@ -264,6 +272,7 @@ class DomainEventBuilder(
       applicationId = application?.id,
       bookingId = booking.id,
       crn = booking.crn,
+      nomsNumber = booking.nomsNumber,
       occurredAt = arrival.arrivalDateTime,
       data = CAS3PersonArrivedUpdatedEvent(
         id = domainEventId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -87,6 +87,7 @@ class DomainEventService(
       applicationId = domainEventEntity.applicationId,
       bookingId = domainEventEntity.bookingId,
       crn = domainEventEntity.crn,
+      nomsNumber = domainEventEntity.nomsNumber,
       occurredAt = domainEventEntity.occurredAt.toInstant(),
       data = data,
     )
@@ -197,6 +198,7 @@ class DomainEventService(
         assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
         crn = domainEvent.crn,
+        nomsNumber = domainEvent.nomsNumber,
         type = enumTypeFromDataType(domainEvent.data::class),
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),

--- a/src/main/resources/db/migration/all/20240424153917__add_domain_event_noms_number.sql
+++ b/src/main/resources/db/migration/all/20240424153917__add_domain_event_noms_number.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events ADD COLUMN noms_number text NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -24,6 +24,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var data: Yielded<String> = { "{}" }
   private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS3")) }
   private var triggeredByUserId: Yielded<UUID?> = { null }
+  private var nomsNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -79,6 +80,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.triggeredByUserId = { userId }
   }
 
+  fun withNomsNumber(nomsNumber: String?) = apply {
+    this.nomsNumber = { nomsNumber }
+  }
+
   override fun produce(): DomainEventEntity = DomainEventEntity(
     id = this.id(),
     applicationId = this.applicationId(),
@@ -91,5 +96,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     data = this.data(),
     service = this.service(),
     triggeredByUserId = this.triggeredByUserId(),
+    nomsNumber = this.nomsNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas2/Cas2DomainEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas2/Cas2DomainEventFactory.kt
@@ -22,6 +22,7 @@ class Cas2DomainEventFactory<T : Cas2Event, D : Any>(
   private var occurredAt: Yielded<Instant> = { Instant.now() }
   private var timestamp: Yielded<Instant> = { Instant.now() }
   private var data: Yielded<D?> = { null }
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(8) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -55,6 +56,7 @@ class Cas2DomainEventFactory<T : Cas2Event, D : Any>(
       id = this.id(),
       applicationId = this.applicationId(),
       crn = this.crn(),
+      nomsNumber = this.nomsNumber(),
       occurredAt = this.occurredAt(),
       data = dataConstructor(
         this.data() ?: throw RuntimeException("Must provide event data"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3DomainEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3DomainEventFactory.kt
@@ -27,6 +27,7 @@ class CAS3DomainEventFactory<T : CAS3Event, D : Any>(
   private var occurredAt: Yielded<Instant> = { Instant.now() }
   private var timestamp: Yielded<Instant> = { Instant.now() }
   private var data: Yielded<D?> = { null }
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(8) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -60,6 +61,7 @@ class CAS3DomainEventFactory<T : CAS3Event, D : Any>(
       id = this.id(),
       applicationId = this.applicationId(),
       crn = this.crn(),
+      nomsNumber = this.nomsNumber(),
       occurredAt = this.occurredAt(),
       data = dataConstructor(
         this.data() ?: throw RuntimeException("Must provide event data"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -599,6 +599,7 @@ class DomainEventDescriberTest {
       id = id,
       applicationId = applicationId,
       crn = "SOME-CRN",
+      nomsNumber = "theNomsNumber",
       occurredAt = Instant.now(),
       data = builder(id),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1460,6 +1460,7 @@ class AssessmentServiceTest {
           it.applicationId == assessment.application.id &&
             it.assessmentId == assessment.id &&
             it.crn == assessment.application.crn &&
+            it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
             data.applicationId == assessment.application.id &&
             data.applicationUrl == "http://frontend/applications/${assessment.application.id}" &&
             data.personReference == PersonReference(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -29,7 +29,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.DestinationProvider
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
@@ -645,6 +644,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == bookingEntity.id
             data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -731,6 +731,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
@@ -821,6 +822,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == bookingEntity.id
             data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -1331,6 +1333,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.occurredAt == arrivalDateTime &&
               it.bookingId == bookingEntity.id &&
               data.applicationId == application.id &&
@@ -1414,6 +1417,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.occurredAt == arrivalDateTime &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -1507,6 +1511,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.occurredAt == arrivalDateTime &&
               it.bookingId == bookingEntity.id &&
               data.applicationId == application.id &&
@@ -1883,11 +1888,12 @@ class BookingServiceTest {
         mockDomainEventService.savePersonNotArrivedEvent(
           emit = true,
           domainEvent = match {
-            val data = (it.data as PersonNotArrivedEnvelope).eventDetails
+            val data = it.data.eventDetails
             val approvedPremises = bookingEntity.premises as ApprovedPremisesEntity
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == bookingEntity.id &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -1975,11 +1981,12 @@ class BookingServiceTest {
         mockDomainEventService.savePersonNotArrivedEvent(
           emit = true,
           domainEvent = match {
-            val data = (it.data as PersonNotArrivedEnvelope).eventDetails
+            val data = it.data.eventDetails
             val approvedPremises = bookingEntity.premises as ApprovedPremisesEntity
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
@@ -2072,11 +2079,12 @@ class BookingServiceTest {
         mockDomainEventService.savePersonNotArrivedEvent(
           emit = false,
           domainEvent = match {
-            val data = (it.data as PersonNotArrivedEnvelope).eventDetails
+            val data = it.data.eventDetails
             val approvedPremises = bookingEntity.premises as ApprovedPremisesEntity
 
             it.applicationId == application.id &&
               it.crn == bookingEntity.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == bookingEntity.id &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -2395,6 +2403,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
@@ -2534,6 +2543,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
@@ -3641,10 +3651,11 @@ class BookingServiceTest {
       verify(exactly = 1) {
         mockDomainEventService.saveBookingChangedEvent(
           match {
-            val data = (it.data as BookingChangedEnvelope).eventDetails
+            val data = it.data.eventDetails
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == bookingEntity.id &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -3715,10 +3726,11 @@ class BookingServiceTest {
       verify(exactly = 1) {
         mockDomainEventService.saveBookingChangedEvent(
           match {
-            val data = (it.data as BookingChangedEnvelope).eventDetails
+            val data = it.data.eventDetails
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == bookingEntity.id &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -4357,10 +4369,11 @@ class BookingServiceTest {
       verify(exactly = 1) {
         mockDomainEventService.saveBookingMadeDomainEvent(
           match {
-            val data = (it.data as BookingMadeEnvelope).eventDetails
+            val data = (it.data).eventDetails
 
             it.applicationId == application.id &&
               it.crn == crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
@@ -4419,10 +4432,11 @@ class BookingServiceTest {
       verify(exactly = 1) {
         mockDomainEventService.saveBookingMadeDomainEvent(
           match {
-            val data = (it.data as BookingMadeEnvelope).eventDetails
+            val data = it.data.eventDetails
 
             it.applicationId == existingApplication.id &&
               it.crn == crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == existingApplication.id &&
               data.applicationUrl == "http://frontend/applications/${existingApplication.id}" &&
               data.personReference == PersonReference(
@@ -4484,6 +4498,7 @@ class BookingServiceTest {
 
             it.applicationId == existingApplication.id &&
               it.crn == crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == existingApplication.id &&
               data.applicationUrl == "http://frontend/applications/${existingApplication.id}" &&
               data.personReference == PersonReference(
@@ -7316,10 +7331,11 @@ class BookingServiceTest {
       verify(exactly = 1) {
         mockDomainEventService.saveBookingChangedEvent(
           match {
-            val data = (it.data as BookingChangedEnvelope).eventDetails
+            val data = it.data.eventDetails
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == booking.id &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
@@ -7397,6 +7413,7 @@ class BookingServiceTest {
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               it.bookingId == booking.id &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -157,22 +157,23 @@ class DomainEventServiceTest {
       crn = crn,
       occurredAt = occurredAt,
       data = data,
+      bookingId = bookingId,
     )
 
     every { domainEventWorkerMock.emitEvent(any(), any()) } returns Unit
 
-    domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, true)
+    domainEventService.saveAndEmit(domainEventToSave, domainEventType, nomsNumber, true)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
-        match {
-          it.id == domainEventToSave.id &&
-            it.type == domainEventType &&
-            it.crn == domainEventToSave.crn &&
-            it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == user.id &&
-            it.bookingId == bookingId
+        withArg {
+          assertThat(it.id).isEqualTo(id)
+          assertThat(it.type).isEqualTo(domainEventType)
+          assertThat(it.crn).isEqualTo(crn)
+          assertThat(it.occurredAt.toInstant()).isEqualTo(occurredAt)
+          assertThat(it.data).isEqualTo(objectMapper.writeValueAsString(domainEventToSave.data))
+          assertThat(it.triggeredByUserId).isEqualTo(user.id)
+          assertThat(it.bookingId).isEqualTo(bookingId)
         },
       )
     }
@@ -220,18 +221,18 @@ class DomainEventServiceTest {
       bookingId = bookingId,
     )
 
-    domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, false)
+    domainEventService.saveAndEmit(domainEventToSave, domainEventType, nomsNumber, false)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
-        match {
-          it.id == domainEventToSave.id &&
-            it.type == domainEventType &&
-            it.crn == domainEventToSave.crn &&
-            it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
-            it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == user.id &&
-            it.bookingId == bookingId
+        withArg {
+          assertThat(it.id).isEqualTo(id)
+          assertThat(it.type).isEqualTo(domainEventType)
+          assertThat(it.crn).isEqualTo(crn)
+          assertThat(it.occurredAt.toInstant()).isEqualTo(occurredAt)
+          assertThat(it.data).isEqualTo(objectMapper.writeValueAsString(domainEventToSave.data))
+          assertThat(it.triggeredByUserId).isEqualTo(user.id)
+          assertThat(it.bookingId).isEqualTo(bookingId)
         },
       )
     }
@@ -264,16 +265,16 @@ class DomainEventServiceTest {
     )
 
     try {
-      domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, true)
+      domainEventService.saveAndEmit(domainEventToSave, domainEventType, nomsNumber, true)
     } catch (_: Exception) {
     }
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
-        match {
+        withArg {
           it.id == domainEventToSave.id &&
             it.type == domainEventType &&
-            it.crn == domainEventToSave.crn &&
+            it.crn == crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == user.id &&
@@ -309,7 +310,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -337,7 +337,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -357,7 +356,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingMadeDomainEvent(domainEvent)
 
@@ -365,7 +364,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -386,7 +384,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonArrivedEvent(domainEvent, emit)
 
@@ -394,7 +392,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
         emit,
       )
@@ -416,7 +413,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonNotArrivedEvent(domainEvent, emit)
 
@@ -424,7 +421,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
         emit,
       )
@@ -446,7 +442,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonDepartedEvent(domainEvent, emit)
 
@@ -454,7 +450,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
         emit,
       )
@@ -483,7 +478,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -504,7 +498,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingCancelledEvent(domainEvent)
 
@@ -512,7 +506,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -532,7 +525,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingChangedEvent(domainEvent)
 
@@ -540,7 +533,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -561,7 +553,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveApplicationWithdrawnEvent(domainEvent, emit)
 
@@ -569,7 +561,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
         emit,
       )
@@ -590,7 +581,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveAssessmentAppealedEvent(domainEvent)
 
@@ -598,7 +589,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -618,7 +608,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.savePlacementApplicationWithdrawnEvent(domainEvent)
 
@@ -626,7 +616,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -646,7 +635,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.savePlacementApplicationAllocatedEvent(domainEvent)
 
@@ -654,7 +643,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -674,7 +662,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveMatchRequestWithdrawnEvent(domainEvent)
 
@@ -682,7 +670,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }
@@ -703,7 +690,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveRequestForPlacementCreatedEvent(domainEvent, emit)
 
@@ -711,7 +698,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
         emit,
       )
@@ -732,7 +718,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveAssessmentAllocatedEvent(domainEvent)
 
@@ -740,7 +726,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -166,7 +166,7 @@ class DomainEventServiceTest {
 
     every { domainEventWorkerMock.emitEvent(any(), any()) } returns Unit
 
-    domainEventService.saveAndEmit(domainEventToSave, domainEventType, nomsNumber, true)
+    domainEventService.saveAndEmit(domainEventToSave, domainEventType, true)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
@@ -227,7 +227,7 @@ class DomainEventServiceTest {
       bookingId = bookingId,
     )
 
-    domainEventService.saveAndEmit(domainEventToSave, domainEventType, nomsNumber, false)
+    domainEventService.saveAndEmit(domainEventToSave, domainEventType, false)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
@@ -273,7 +273,7 @@ class DomainEventServiceTest {
     )
 
     try {
-      domainEventService.saveAndEmit(domainEventToSave, domainEventType, nomsNumber, true)
+      domainEventService.saveAndEmit(domainEventToSave, domainEventType, true)
     } catch (_: Exception) {
     }
 
@@ -311,7 +311,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveApplicationSubmittedDomainEvent(domainEvent)
 
@@ -319,7 +319,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -338,7 +337,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveApplicationAssessedDomainEvent(domainEvent)
 
@@ -346,7 +345,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -365,7 +363,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingMadeDomainEvent(domainEvent)
 
@@ -373,7 +371,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -393,7 +390,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonArrivedEvent(domainEvent, emit)
 
@@ -401,7 +398,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-        nomsNumber = eventDetails.personReference.noms,
         emit,
       )
     }
@@ -422,7 +418,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonNotArrivedEvent(domainEvent, emit)
 
@@ -430,7 +426,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
-        nomsNumber = eventDetails.personReference.noms,
         emit,
       )
     }
@@ -451,7 +446,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonDepartedEvent(domainEvent, emit)
 
@@ -459,7 +454,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-        nomsNumber = eventDetails.personReference.noms,
         emit,
       )
     }
@@ -479,7 +473,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingNotMadeEvent(domainEvent)
 
@@ -487,7 +481,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -495,7 +488,6 @@ class DomainEventServiceTest {
   @Test
   fun `saveBookingCancelledEvent sends correct arguments to saveAndEmit`() {
     val id = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
 
     val eventDetails = BookingCancelledFactory().produce()
     val domainEventEnvelope = mockk<BookingCancelledEnvelope>()
@@ -507,7 +499,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingCancelledEvent(domainEvent)
 
@@ -515,7 +507,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -534,7 +525,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
     domainEventServiceSpy.saveBookingChangedEvent(domainEvent)
 
@@ -542,7 +533,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -562,7 +552,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveApplicationWithdrawnEvent(domainEvent, emit)
 
@@ -570,7 +560,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-        nomsNumber = eventDetails.personReference.noms,
         emit,
       )
     }
@@ -590,7 +579,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
     domainEventServiceSpy.saveAssessmentAppealedEvent(domainEvent)
 
@@ -598,7 +587,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -617,7 +605,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
     domainEventServiceSpy.savePlacementApplicationWithdrawnEvent(domainEvent)
 
@@ -625,7 +613,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -644,7 +631,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
     domainEventServiceSpy.savePlacementApplicationAllocatedEvent(domainEvent)
 
@@ -652,7 +639,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -671,7 +657,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
     domainEventServiceSpy.saveMatchRequestWithdrawnEvent(domainEvent)
 
@@ -679,7 +665,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -699,7 +684,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveRequestForPlacementCreatedEvent(domainEvent, emit)
 
@@ -707,7 +692,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
-        nomsNumber = eventDetails.personReference.noms,
         emit,
       )
     }
@@ -735,7 +719,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-        nomsNumber = eventDetails.personReference.noms,
       )
     }
   }
@@ -755,7 +738,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveFurtherInformationRequestedEvent(domainEvent, emit)
 
@@ -763,7 +746,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
-        nomsNumber = eventDetails.personReference.noms,
         emit = emit,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -161,7 +161,7 @@ class DomainEventServiceTest {
 
     every { domainEventWorkerMock.emitEvent(any(), any()) } returns Unit
 
-    domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, bookingId, true)
+    domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, true)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
@@ -171,7 +171,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == user.id
+            it.triggeredByUserId == user.id &&
+            it.bookingId == bookingId
         },
       )
     }
@@ -216,9 +217,10 @@ class DomainEventServiceTest {
       crn = crn,
       occurredAt = occurredAt,
       data = data,
+      bookingId = bookingId,
     )
 
-    domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, bookingId, false)
+    domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, false)
 
     verify(exactly = 1) {
       domainEventRespositoryMock.save(
@@ -228,7 +230,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == user.id
+            it.triggeredByUserId == user.id &&
+            it.bookingId == bookingId
         },
       )
     }
@@ -257,10 +260,11 @@ class DomainEventServiceTest {
       crn = crn,
       occurredAt = occurredAt,
       data = data,
+      bookingId = bookingId,
     )
 
     try {
-      domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, bookingId, true)
+      domainEventService.saveAndEmit(domainEventToSave, domainEventType, crn, nomsNumber, true)
     } catch (_: Exception) {
     }
 
@@ -272,7 +276,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == user.id
+            it.triggeredByUserId == user.id &&
+            it.bookingId == bookingId
         },
       )
     }
@@ -341,14 +346,12 @@ class DomainEventServiceTest {
   @Test
   fun `saveBookingMadeDomainEvent sends correct arguments to saveAndEmit`() {
     val id = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
 
     val eventDetails = BookingMadeFactory().produce()
     val domainEventEnvelope = mockk<BookingMadeEnvelope>()
     val domainEvent = mockk<DomainEvent<BookingMadeEnvelope>>()
 
     every { domainEvent.id } returns id
-    every { domainEvent.bookingId } returns bookingId
     every { domainEvent.data } returns domainEventEnvelope
     every { domainEventEnvelope.eventDetails } returns eventDetails
 
@@ -364,7 +367,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = bookingId,
       )
     }
   }
@@ -373,20 +375,18 @@ class DomainEventServiceTest {
   @ValueSource(booleans = [true, false])
   fun `savePersonArrivedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
     val id = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
 
     val eventDetails = PersonArrivedFactory().produce()
     val domainEventEnvelope = mockk<PersonArrivedEnvelope>()
     val domainEvent = mockk<DomainEvent<PersonArrivedEnvelope>>()
 
     every { domainEvent.id } returns id
-    every { domainEvent.bookingId } returns bookingId
     every { domainEvent.data } returns domainEventEnvelope
     every { domainEventEnvelope.eventDetails } returns eventDetails
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonArrivedEvent(domainEvent, emit)
 
@@ -396,7 +396,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = bookingId,
         emit,
       )
     }
@@ -406,20 +405,18 @@ class DomainEventServiceTest {
   @ValueSource(booleans = [true, false])
   fun `savePersonNotArrivedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
     val id = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
 
     val eventDetails = PersonNotArrivedFactory().produce()
     val domainEventEnvelope = mockk<PersonNotArrivedEnvelope>()
     val domainEvent = mockk<DomainEvent<PersonNotArrivedEnvelope>>()
 
     every { domainEvent.id } returns id
-    every { domainEvent.bookingId } returns bookingId
     every { domainEvent.data } returns domainEventEnvelope
     every { domainEventEnvelope.eventDetails } returns eventDetails
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonNotArrivedEvent(domainEvent, emit)
 
@@ -429,7 +426,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = bookingId,
         emit,
       )
     }
@@ -439,20 +435,18 @@ class DomainEventServiceTest {
   @ValueSource(booleans = [true, false])
   fun `savePersonDepartedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
     val id = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
 
     val eventDetails = PersonDepartedFactory().produce()
     val domainEventEnvelope = mockk<PersonDepartedEnvelope>()
     val domainEvent = mockk<DomainEvent<PersonDepartedEnvelope>>()
 
     every { domainEvent.id } returns id
-    every { domainEvent.bookingId } returns bookingId
     every { domainEvent.data } returns domainEventEnvelope
     every { domainEventEnvelope.eventDetails } returns eventDetails
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.savePersonDepartedEvent(domainEvent, emit)
 
@@ -462,7 +456,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = bookingId,
         emit,
       )
     }
@@ -506,7 +499,6 @@ class DomainEventServiceTest {
     val domainEvent = mockk<DomainEvent<BookingCancelledEnvelope>>()
 
     every { domainEvent.id } returns id
-    every { domainEvent.bookingId } returns bookingId
     every { domainEvent.data } returns domainEventEnvelope
     every { domainEventEnvelope.eventDetails } returns eventDetails
 
@@ -522,7 +514,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = bookingId,
       )
     }
   }
@@ -530,14 +521,12 @@ class DomainEventServiceTest {
   @Test
   fun `saveBookingChangedEvent sends correct arguments to saveAndEmit`() {
     val id = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
 
     val eventDetails = BookingChangedFactory().produce()
     val domainEventEnvelope = mockk<BookingChangedEnvelope>()
     val domainEvent = mockk<DomainEvent<BookingChangedEnvelope>>()
 
     every { domainEvent.id } returns id
-    every { domainEvent.bookingId } returns bookingId
     every { domainEvent.data } returns domainEventEnvelope
     every { domainEventEnvelope.eventDetails } returns eventDetails
 
@@ -553,7 +542,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = bookingId,
       )
     }
   }
@@ -573,7 +561,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), null, emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveApplicationWithdrawnEvent(domainEvent, emit)
 
@@ -583,7 +571,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        null,
         emit,
       )
     }
@@ -716,7 +703,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), any(), emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveRequestForPlacementCreatedEvent(domainEvent, emit)
 
@@ -726,7 +713,6 @@ class DomainEventServiceTest {
         eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
         crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
-        bookingId = null,
         emit,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -112,6 +112,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.randomUUID()
     val occurredAt = OffsetDateTime.now()
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val method = fetchGetterForType(domainEventType)
     val data = createDomainEventOfType(domainEventType)
@@ -120,6 +121,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(domainEventType)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -132,6 +134,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = crn,
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -145,9 +148,9 @@ class DomainEventServiceTest {
     val applicationId = UUID.randomUUID()
     val bookingId = UUID.randomUUID()
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
     val occurredAt = Instant.now()
     val data = createDomainEventOfType(domainEventType)
-    val nomsNumber = "123"
 
     every { domainEventRespositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -155,6 +158,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = occurredAt,
       data = data,
       bookingId = bookingId,
@@ -170,6 +174,7 @@ class DomainEventServiceTest {
           assertThat(it.id).isEqualTo(id)
           assertThat(it.type).isEqualTo(domainEventType)
           assertThat(it.crn).isEqualTo(crn)
+          assertThat(it.nomsNumber).isEqualTo(nomsNumber)
           assertThat(it.occurredAt.toInstant()).isEqualTo(occurredAt)
           assertThat(it.data).isEqualTo(objectMapper.writeValueAsString(domainEventToSave.data))
           assertThat(it.triggeredByUserId).isEqualTo(user.id)
@@ -206,9 +211,9 @@ class DomainEventServiceTest {
     val applicationId = UUID.randomUUID()
     val bookingId = UUID.randomUUID()
     val crn = "CRN"
+    val nomsNumber = "123"
     val occurredAt = Instant.now()
     val data = createDomainEventOfType(domainEventType)
-    val nomsNumber = "123"
 
     every { domainEventRespositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -216,6 +221,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = occurredAt,
       data = data,
       bookingId = bookingId,
@@ -229,6 +235,7 @@ class DomainEventServiceTest {
           assertThat(it.id).isEqualTo(id)
           assertThat(it.type).isEqualTo(domainEventType)
           assertThat(it.crn).isEqualTo(crn)
+          assertThat(it.nomsNumber).isEqualTo(nomsNumber)
           assertThat(it.occurredAt.toInstant()).isEqualTo(occurredAt)
           assertThat(it.data).isEqualTo(objectMapper.writeValueAsString(domainEventToSave.data))
           assertThat(it.triggeredByUserId).isEqualTo(user.id)
@@ -249,9 +256,9 @@ class DomainEventServiceTest {
     val applicationId = UUID.randomUUID()
     val bookingId = UUID.randomUUID()
     val crn = "CRN"
+    val nomsNumber = "123"
     val occurredAt = Instant.now()
     val data = createDomainEventOfType(domainEventType)
-    val nomsNumber = "123"
 
     every { domainEventRespositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -259,6 +266,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = occurredAt,
       data = data,
       bookingId = bookingId,
@@ -275,6 +283,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == domainEventType &&
             it.crn == crn &&
+            it.nomsNumber == nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == user.id &&
@@ -746,7 +755,7 @@ class DomainEventServiceTest {
 
     val domainEventServiceSpy = spyk(domainEventService)
 
-    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any(), null, emit) } returns Unit
+    every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), emit) } returns Unit
 
     domainEventServiceSpy.saveFurtherInformationRequestedEvent(domainEvent, emit)
 
@@ -754,7 +763,6 @@ class DomainEventServiceTest {
       domainEventServiceSpy.saveAndEmit(
         domainEvent = domainEvent,
         eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
-        crn = eventDetails.personReference.crn,
         nomsNumber = eventDetails.personReference.noms,
         emit = emit,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
@@ -17,12 +17,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.retry.backoff.FixedBackOffPolicy
 import org.springframework.retry.policy.SimpleRetryPolicy
 import org.springframework.retry.support.RetryTemplate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationAssessedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationSubmittedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
@@ -32,9 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomain
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SyncDomainEventWorker
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
-import java.time.Instant
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import java.util.UUID
 
 @Suppress("SwallowedException")
@@ -116,27 +108,14 @@ class DomainEventWorkerTest {
 
     every { asyncDomainEventWorker.domainTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
 
-    val domainEventToSave = DomainEvent(
-      id = id,
-      applicationId = applicationId,
-      crn = crn,
-      occurredAt = Instant.now(),
-      data = ApplicationAssessedEnvelope(
-        id = id,
-        timestamp = occurredAt.toInstant(),
-        eventType = EventType.applicationAssessed,
-        eventDetails = ApplicationAssessedFactory().produce(),
-      ),
-    )
-
     val snsEvent = SnsEvent(
       eventType = "",
       version = 1,
       description = "",
       detailUrl = "detailUrl",
-      occurredAt = domainEventToSave.occurredAt.atOffset(ZoneOffset.UTC),
+      occurredAt = occurredAt,
       additionalInformation = SnsEventAdditionalInformation(
-        applicationId = domainEventToSave.applicationId,
+        applicationId = applicationId,
       ),
       personReference = SnsEventPersonReferenceCollection(
         identifiers = listOf(
@@ -157,7 +136,7 @@ class DomainEventWorkerTest {
       retryTemplate.setBackOffPolicy(backOffPolicy)
       retryTemplate.setRetryPolicy(retryPolicy)
       asyncDomainEventWorker.retryTemplate = retryTemplate
-      asyncDomainEventWorker.emitEvent(snsEvent, domainEventToSave.id)
+      asyncDomainEventWorker.emitEvent(snsEvent, id)
     } catch (error: RuntimeException) {
       verify(exactly = AsyncDomainEventWorker.MAX_ATTEMPTS_RETRY) {
         asyncDomainEventWorker.domainTopic.snsClient.publish(
@@ -176,27 +155,14 @@ class DomainEventWorkerTest {
 
     every { asyncDomainEventWorker.domainTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
 
-    val domainEventToSave = DomainEvent(
-      id = id,
-      applicationId = applicationId,
-      crn = crn,
-      occurredAt = Instant.now(),
-      data = ApplicationAssessedEnvelope(
-        id = id,
-        timestamp = occurredAt.toInstant(),
-        eventType = EventType.applicationAssessed,
-        eventDetails = ApplicationAssessedFactory().produce(),
-      ),
-    )
-
     val snsEvent = SnsEvent(
       eventType = "",
       version = 1,
       description = "",
       detailUrl = "detailUrl",
-      occurredAt = domainEventToSave.occurredAt.atOffset(ZoneOffset.UTC),
+      occurredAt = occurredAt,
       additionalInformation = SnsEventAdditionalInformation(
-        applicationId = domainEventToSave.applicationId,
+        applicationId = applicationId,
       ),
       personReference = SnsEventPersonReferenceCollection(
         identifiers = listOf(
@@ -234,27 +200,14 @@ class DomainEventWorkerTest {
 
     every { syncDomainEventWorker.domainTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
 
-    val domainEventToSave = DomainEvent(
-      id = id,
-      applicationId = applicationId,
-      crn = crn,
-      occurredAt = Instant.now(),
-      data = ApplicationAssessedEnvelope(
-        id = id,
-        timestamp = occurredAt.toInstant(),
-        eventType = EventType.applicationAssessed,
-        eventDetails = ApplicationAssessedFactory().produce(),
-      ),
-    )
-
     val snsEvent = SnsEvent(
       eventType = "",
       version = 1,
       description = "",
       detailUrl = "detailUrl",
-      occurredAt = domainEventToSave.occurredAt.atOffset(ZoneOffset.UTC),
+      occurredAt = occurredAt,
       additionalInformation = SnsEventAdditionalInformation(
-        applicationId = domainEventToSave.applicationId,
+        applicationId = applicationId,
       ),
       personReference = SnsEventPersonReferenceCollection(
         identifiers = listOf(
@@ -282,27 +235,14 @@ class DomainEventWorkerTest {
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
 
-    val domainEventToSave = DomainEvent(
-      id = id,
-      applicationId = applicationId,
-      crn = crn,
-      occurredAt = Instant.now(),
-      data = ApplicationSubmittedEnvelope(
-        id = id,
-        timestamp = occurredAt.toInstant(),
-        eventType = EventType.applicationSubmitted,
-        eventDetails = ApplicationSubmittedFactory().produce(),
-      ),
-    )
-
     val snsEvent = SnsEvent(
       eventType = "approved-premises.application.submitted",
       version = 1,
       description = "An application has been submitted for an Approved Premises placement",
       detailUrl = "http://api/events/application-submitted/$id",
-      occurredAt = domainEventToSave.occurredAt.atOffset(ZoneOffset.UTC),
+      occurredAt = occurredAt,
       additionalInformation = SnsEventAdditionalInformation(
-        applicationId = domainEventToSave.applicationId,
+        applicationId = applicationId,
       ),
       personReference = SnsEventPersonReferenceCollection(
         identifiers = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -552,6 +552,7 @@ class PlacementRequestServiceTest {
 
           it.applicationId == application.id &&
             it.crn == application.crn &&
+            it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
             data.applicationId == application.id &&
             data.applicationUrl == "http://frontend/applications/${application.id}" &&
             data.personReference == PersonReference(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationDomainEventServiceTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmitted
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedSubmittedBy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Ldu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
@@ -83,6 +82,7 @@ class Cas1ApplicationDomainEventServiceTest {
   @Nested
   inner class ApplicationSubmitted {
 
+    @SuppressWarnings("CyclomaticComplexMethod")
     @Test
     fun `applicationSubmitted success`() {
       val situation = SituationOption.bailSentence
@@ -188,10 +188,11 @@ class Cas1ApplicationDomainEventServiceTest {
       verify(exactly = 1) {
         mockDomainEventService.saveApplicationSubmittedDomainEvent(
           match {
-            val data = (it.data as ApplicationSubmittedEnvelope).eventDetails
+            val data = it.data.eventDetails
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == offenderDetails.otherIds.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(
@@ -275,6 +276,7 @@ class Cas1ApplicationDomainEventServiceTest {
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == application.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.personReference == PersonReference(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -111,7 +111,8 @@ class Cas1AssessmentDomainEventServiceTest {
             val rootDomainEventDataMatches = (
               it.assessmentId == assessment.id &&
                 it.applicationId == assessment.application.id &&
-                it.crn == assessment.application.crn
+                it.crn == assessment.application.crn &&
+                it.nomsNumber == assessment.application.nomsNumber
               )
 
             val envelopeMatches = envelope.eventType == EventType.assessmentAllocated
@@ -212,7 +213,8 @@ class Cas1AssessmentDomainEventServiceTest {
             val rootDomainEventDataMatches = (
               it.assessmentId == assessment.id &&
                 it.applicationId == assessment.application.id &&
-                it.crn == assessment.application.crn
+                it.crn == assessment.application.crn &&
+                it.nomsNumber == assessment.application.nomsNumber
               )
 
             val envelopeMatches = envelope.eventType == EventType.informationRequestMade

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -111,6 +111,7 @@ class Cas1PlacementApplicationDomainEventServiceTest {
             assertThat(it.id).isNotNull()
             assertThat(it.applicationId).isEqualTo(application.id)
             assertThat(it.crn).isEqualTo(CRN)
+            assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
             assertThat(it.occurredAt).isWithinTheLastMinute()
 
             val eventDetails = it.data.eventDetails
@@ -190,6 +191,7 @@ class Cas1PlacementApplicationDomainEventServiceTest {
             assertThat(it.id).isNotNull()
             assertThat(it.applicationId).isEqualTo(application.id)
             assertThat(it.crn).isEqualTo(CRN)
+            assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
             assertThat(it.occurredAt).isWithinTheLastMinute()
 
             val eventDetails = it.data.eventDetails
@@ -343,6 +345,7 @@ class Cas1PlacementApplicationDomainEventServiceTest {
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == application.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.placementApplicationId == placementApplication.id &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestDomainEventServiceTest.kt
@@ -114,6 +114,7 @@ class Cas1PlacementRequestDomainEventServiceTest {
             assertThat(it.id).isNotNull()
             assertThat(it.applicationId).isEqualTo(application.id)
             assertThat(it.crn).isEqualTo(CRN)
+            assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
             assertThat(it.occurredAt).isWithinTheLastMinute()
 
             val eventDetails = it.data.eventDetails
@@ -178,6 +179,7 @@ class Cas1PlacementRequestDomainEventServiceTest {
 
             it.applicationId == application.id &&
               it.crn == application.crn &&
+              it.nomsNumber == application.nomsNumber &&
               data.applicationId == application.id &&
               data.applicationUrl == "http://frontend/applications/${application.id}" &&
               data.matchRequestId == placementRequest.id &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
@@ -77,6 +77,7 @@ class DomainEventServiceTest {
       fun `returns event`() {
         val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
+        val nomsNumber = "theNomsNumber"
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
 
@@ -94,6 +95,7 @@ class DomainEventServiceTest {
           .withType(DomainEventType.CAS2_APPLICATION_SUBMITTED)
           .withData(objectMapper.writeValueAsString(data))
           .withOccurredAt(occurredAt)
+          .withNomsNumber(nomsNumber)
           .produce()
 
         val event = domainEventService.getCas2ApplicationSubmittedDomainEvent(id)
@@ -104,6 +106,7 @@ class DomainEventServiceTest {
             crn = "CRN",
             occurredAt = occurredAt.toInstant(),
             data = data,
+            nomsNumber = nomsNumber,
           ),
         )
       }
@@ -117,6 +120,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -128,6 +132,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
+          nomsNumber = nomsNumber,
           occurredAt = occurredAt.toInstant(),
           data = Cas2ApplicationSubmittedEvent(
             id = id,
@@ -148,6 +153,7 @@ class DomainEventServiceTest {
               it.id == domainEventToSave.id &&
                 it.type == DomainEventType.CAS2_APPLICATION_SUBMITTED &&
                 it.crn == domainEventToSave.crn &&
+                it.nomsNumber == domainEventToSave.nomsNumber &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
                 it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
                 it.triggeredByUserId == null
@@ -183,6 +189,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -194,6 +201,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
+          nomsNumber = nomsNumber,
           occurredAt = Instant.now(),
           data = Cas2ApplicationSubmittedEvent(
             id = id,
@@ -215,6 +223,7 @@ class DomainEventServiceTest {
               it.id == domainEventToSave.id &&
                 it.type == DomainEventType.CAS2_APPLICATION_SUBMITTED &&
                 it.crn == domainEventToSave.crn &&
+                it.nomsNumber == domainEventToSave.nomsNumber &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
                 it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
                 it.triggeredByUserId == null
@@ -241,6 +250,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -252,6 +262,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
+          nomsNumber = nomsNumber,
           occurredAt = Instant.now(),
           data = Cas2ApplicationSubmittedEvent(
             id = id,
@@ -269,6 +280,7 @@ class DomainEventServiceTest {
               it.id == domainEventToSave.id &&
                 it.type == DomainEventType.CAS2_APPLICATION_SUBMITTED &&
                 it.crn == domainEventToSave.crn &&
+                it.nomsNumber == domainEventToSave.nomsNumber &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
                 it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
                 it.triggeredByUserId == null
@@ -294,6 +306,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -305,6 +318,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
+          nomsNumber = nomsNumber,
           occurredAt = Instant.now(),
           data = Cas2ApplicationStatusUpdatedEvent(
             id = id,
@@ -325,6 +339,7 @@ class DomainEventServiceTest {
               it.id == domainEventToSave.id &&
                 it.type == DomainEventType.CAS2_APPLICATION_STATUS_UPDATED &&
                 it.crn == domainEventToSave.crn &&
+                it.nomsNumber == domainEventToSave.nomsNumber &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
                 it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
                 it.triggeredByUserId == null
@@ -368,6 +383,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -379,6 +395,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
+          nomsNumber = nomsNumber,
           occurredAt = Instant.now(),
           data = Cas2ApplicationStatusUpdatedEvent(
             id = id,
@@ -396,6 +413,7 @@ class DomainEventServiceTest {
               it.id == domainEventToSave.id &&
                 it.type == DomainEventType.CAS2_APPLICATION_STATUS_UPDATED &&
                 it.crn == domainEventToSave.crn &&
+                it.nomsNumber == domainEventToSave.nomsNumber &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
                 it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
                 it.triggeredByUserId == null
@@ -414,6 +432,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -425,6 +444,7 @@ class DomainEventServiceTest {
           id = id,
           applicationId = applicationId,
           crn = crn,
+          nomsNumber = nomsNumber,
           occurredAt = Instant.now(),
           data = Cas2ApplicationStatusUpdatedEvent(
             id = id,
@@ -446,6 +466,7 @@ class DomainEventServiceTest {
               it.id == domainEventToSave.id &&
                 it.type == DomainEventType.CAS2_APPLICATION_STATUS_UPDATED &&
                 it.crn == domainEventToSave.crn &&
+                it.nomsNumber == domainEventToSave.nomsNumber &&
                 it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
                 it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
                 it.triggeredByUserId == null
@@ -476,6 +497,7 @@ class DomainEventServiceTest {
         val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
         val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
         val crn = "CRN"
+        val nomsNumber = "theNomsNumber"
 
         val data = Cas2ApplicationStatusUpdatedEvent(
           id = id,
@@ -488,6 +510,7 @@ class DomainEventServiceTest {
           .withId(id)
           .withApplicationId(applicationId)
           .withCrn(crn)
+          .withNomsNumber(nomsNumber)
           .withType(DomainEventType.CAS2_APPLICATION_STATUS_UPDATED)
           .withData(objectMapper.writeValueAsString(data))
           .withOccurredAt(occurredAt)
@@ -499,6 +522,7 @@ class DomainEventServiceTest {
             id = id,
             applicationId = applicationId,
             crn = "CRN",
+            nomsNumber = nomsNumber,
             occurredAt = occurredAt.toInstant(),
             data = data,
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
+@SuppressWarnings("CyclomaticComplexMethod")
 class DomainEventBuilderTest {
   private val domainEventBuilder = DomainEventBuilder(
     applicationUrlTemplate = "http://api/applications/#applicationId",
@@ -86,6 +87,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.bookingId == booking.id &&
@@ -151,6 +153,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.bookingId == booking.id &&
@@ -204,6 +207,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.bookingId == booking.id &&
@@ -258,6 +262,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.bookingId == booking.id &&
@@ -320,6 +325,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
@@ -389,6 +395,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.noms == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
         data.bookingId == booking.id &&
@@ -461,6 +468,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
@@ -540,6 +548,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
@@ -577,6 +586,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == null &&
         it.crn == application.crn &&
+        it.nomsNumber == application.nomsNumber &&
         data.personReference.crn == application.crn &&
         data.personReference.noms == application.nomsNumber &&
         data.applicationId == application.id &&
@@ -699,6 +709,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.personReference.crn == booking.crn &&
         data.personReference.noms == booking.nomsNumber &&
         data.bookingId == booking.id &&
@@ -758,6 +769,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
         data.applicationId == application.id &&
         data.applicationUrl.toString() == "http://api/applications/${application.id}" &&
@@ -820,6 +832,7 @@ class DomainEventBuilderTest {
       it.applicationId == application.id &&
         it.bookingId == booking.id &&
         it.crn == booking.crn &&
+        it.nomsNumber == booking.nomsNumber &&
         data.deliusEventNumber == application.eventNumber &&
         data.applicationId == application.id &&
         data.applicationUrl.toString() == "http://api/applications/${application.id}" &&
@@ -861,6 +874,7 @@ class DomainEventBuilderTest {
 
     return eventData.bookingId == booking.id &&
       eventData.crn == booking.crn &&
+      eventData.nomsNumber == booking.nomsNumber &&
       data.personReference.crn == booking.crn &&
       data.personReference.noms == booking.nomsNumber &&
       data.bookingId == booking.id &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
@@ -110,6 +110,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingCancelledEvent(
       id = id,
@@ -122,6 +123,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_CANCELLED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -132,7 +134,8 @@ class DomainEventServiceTest {
       DomainEvent(
         id = id,
         applicationId = applicationId,
-        crn = "CRN",
+        crn = crn,
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -145,6 +148,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingCancelledEvent(
       id = id,
@@ -159,6 +163,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_CANCELLED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -170,6 +175,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -182,6 +188,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -193,6 +200,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingCancelledEvent(
         id = id,
@@ -251,6 +259,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -262,6 +271,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingCancelledEvent(
         id = id,
@@ -303,6 +313,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -314,6 +325,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingCancelledEvent(
         id = id,
@@ -366,6 +378,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingConfirmedEvent(
       id = id,
@@ -378,6 +391,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_CONFIRMED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -389,6 +403,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -401,6 +416,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingConfirmedEvent(
       id = id,
@@ -415,6 +431,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_CONFIRMED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -426,6 +443,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -438,6 +456,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -449,6 +468,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingConfirmedEvent(
         id = id,
@@ -508,6 +528,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -519,6 +540,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingConfirmedEvent(
         id = id,
@@ -561,6 +583,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -572,6 +595,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingConfirmedEvent(
         id = id,
@@ -624,6 +648,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingProvisionallyMadeEvent(
       id = id,
@@ -636,6 +661,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -647,6 +673,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -659,6 +686,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingProvisionallyMadeEvent(
       id = id,
@@ -673,6 +701,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -684,6 +713,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -696,6 +726,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -707,6 +738,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingProvisionallyMadeEvent(
         id = id,
@@ -733,6 +765,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -768,6 +801,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -779,6 +813,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingProvisionallyMadeEvent(
         id = id,
@@ -805,6 +840,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -823,6 +859,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -834,6 +871,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingProvisionallyMadeEvent(
         id = id,
@@ -861,6 +899,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_BOOKING_PROVISIONALLY_MADE &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -888,6 +927,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3PersonArrivedEvent(
       id = id,
@@ -900,6 +940,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_PERSON_ARRIVED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -911,6 +952,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -923,6 +965,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3PersonArrivedEvent(
       id = id,
@@ -937,6 +980,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_PERSON_ARRIVED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -948,6 +992,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -960,6 +1005,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -971,6 +1017,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3PersonArrivedEvent(
         id = id,
@@ -995,6 +1042,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_ARRIVED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1030,6 +1078,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -1041,6 +1090,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3PersonArrivedEvent(
         id = id,
@@ -1065,6 +1115,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_ARRIVED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1083,6 +1134,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -1094,6 +1146,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3PersonArrivedEvent(
         id = id,
@@ -1119,6 +1172,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_ARRIVED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1146,6 +1200,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3PersonDepartedEvent(
       id = id,
@@ -1158,6 +1213,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_PERSON_DEPARTED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -1169,6 +1225,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -1181,6 +1238,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -1192,6 +1250,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3PersonDepartedEvent(
         id = id,
@@ -1216,6 +1275,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1251,6 +1311,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -1262,6 +1323,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3PersonDepartedEvent(
         id = id,
@@ -1286,6 +1348,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1304,6 +1367,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -1315,6 +1379,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3PersonDepartedEvent(
         id = id,
@@ -1340,6 +1405,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1367,6 +1433,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3ReferralSubmittedEvent(
       id = id,
@@ -1379,6 +1446,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_REFERRAL_SUBMITTED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -1390,6 +1458,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -1402,6 +1471,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -1413,6 +1483,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3ReferralSubmittedEvent(
         id = id,
@@ -1448,6 +1519,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_REFERRAL_SUBMITTED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1483,6 +1555,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -1494,6 +1567,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3ReferralSubmittedEvent(
         id = id,
@@ -1529,6 +1603,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_REFERRAL_SUBMITTED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1547,6 +1622,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
@@ -1558,6 +1634,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3ReferralSubmittedEvent(
         id = id,
@@ -1594,6 +1671,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_REFERRAL_SUBMITTED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1612,7 +1690,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
     val mockHmppsTopic = mockk<HmppsTopic>()
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -1629,6 +1708,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1664,7 +1744,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
     val mockHmppsTopic = mockk<HmppsTopic>()
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
@@ -1682,6 +1763,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1699,7 +1781,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
     val mockHmppsTopic = mockk<HmppsTopic>()
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -1717,6 +1800,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1760,6 +1844,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
     val data = CAS3PersonDepartureUpdatedEvent(
       id = id,
       timestamp = occurredAt.toInstant(),
@@ -1770,6 +1855,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -1782,6 +1868,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -1794,7 +1881,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCAS3DepartureUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
     val mockHmppsTopic = mockk<HmppsTopic>()
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -1809,6 +1897,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1827,7 +1916,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, occurredAt, StaffMemberFactory().produce())
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, nomsNumber, occurredAt, StaffMemberFactory().produce())
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     val mockHmppsTopic = mockk<HmppsTopic>()
@@ -1845,6 +1935,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1880,7 +1971,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, occurredAt, null)
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, nomsNumber, occurredAt, null)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     val mockHmppsTopic = mockk<HmppsTopic>()
@@ -1898,6 +1990,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1933,7 +2026,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, occurredAt, StaffMemberFactory().produce())
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, nomsNumber, occurredAt, StaffMemberFactory().produce())
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     val mockHmppsTopic = mockk<HmppsTopic>()
@@ -1949,6 +2043,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -1967,7 +2062,8 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
-    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, occurredAt, StaffMemberFactory().produce())
+    val nomsNumber = "theNomsNumber"
+    val domainEventToSave = createCancelledUpdatedEventEntity(id, applicationId, crn, nomsNumber, occurredAt, StaffMemberFactory().produce())
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     val mockHmppsTopic = mockk<HmppsTopic>()
@@ -2011,6 +2107,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3BookingCancelledUpdatedEvent(
       id = id,
@@ -2023,6 +2120,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -2034,6 +2132,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -2046,8 +2145,9 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
     val mockHmppsTopic = mockk<HmppsTopic>()
-    val domainEventToSave = createArrivedUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val domainEventToSave = createArrivedUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -2064,7 +2164,8 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_ARRIVED_UPDATED &&
             it.crn == domainEventToSave.crn &&
-            it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
+            it.nomsNumber == domainEventToSave.nomsNumber
+          it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
         },
@@ -2099,8 +2200,9 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
     val mockHmppsTopic = mockk<HmppsTopic>()
-    val domainEventToSave = createArrivedUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val domainEventToSave = createArrivedUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -2117,6 +2219,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_ARRIVED_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -2132,8 +2235,9 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
     val mockHmppsTopic = mockk<HmppsTopic>()
-    val domainEventToSave = createArrivedUpdatedDomainEvent(id, applicationId, crn, occurredAt)
+    val domainEventToSave = createArrivedUpdatedDomainEvent(id, applicationId, crn, nomsNumber, occurredAt)
     val bookingEntity = createTemporaryAccommodationPremisesBookingEntity()
 
     every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
@@ -2149,6 +2253,7 @@ class DomainEventServiceTest {
           it.id == domainEventToSave.id &&
             it.type == DomainEventType.CAS3_PERSON_ARRIVED_UPDATED &&
             it.crn == domainEventToSave.crn &&
+            it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
             it.triggeredByUserId == null
@@ -2173,6 +2278,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3PersonArrivedUpdatedEvent(
       id = id,
@@ -2185,6 +2291,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_PERSON_ARRIVED_UPDATED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -2196,6 +2303,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -2208,6 +2316,7 @@ class DomainEventServiceTest {
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
     val crn = "CRN"
+    val nomsNumber = "theNomsNumber"
 
     val data = CAS3PersonArrivedUpdatedEvent(
       id = id,
@@ -2222,6 +2331,7 @@ class DomainEventServiceTest {
       .withId(id)
       .withApplicationId(applicationId)
       .withCrn(crn)
+      .withNomsNumber(nomsNumber)
       .withType(DomainEventType.CAS3_PERSON_ARRIVED_UPDATED)
       .withData(objectMapper.writeValueAsString(data))
       .withOccurredAt(occurredAt)
@@ -2233,6 +2343,7 @@ class DomainEventServiceTest {
         id = id,
         applicationId = applicationId,
         crn = "CRN",
+        nomsNumber = nomsNumber,
         occurredAt = occurredAt.toInstant(),
         data = data,
       ),
@@ -2243,11 +2354,13 @@ class DomainEventServiceTest {
     id: UUID,
     applicationId: UUID?,
     crn: String,
+    nomsNumber: String,
     occurredAt: OffsetDateTime,
   ) = DomainEvent(
     id = id,
     applicationId = applicationId,
     crn = crn,
+    nomsNumber = nomsNumber,
     occurredAt = Instant.now(),
     data = CAS3PersonArrivedUpdatedEvent(
       id = id,
@@ -2288,11 +2401,13 @@ class DomainEventServiceTest {
     id: UUID,
     applicationId: UUID?,
     crn: String,
+    nomsNumber: String,
     occurredAt: OffsetDateTime,
   ) = DomainEvent(
     id = id,
     applicationId = applicationId,
     crn = crn,
+    nomsNumber = nomsNumber,
     occurredAt = Instant.now(),
     data = CAS3PersonDepartureUpdatedEvent(
       id = id,
@@ -2302,10 +2417,12 @@ class DomainEventServiceTest {
     ),
   )
 
+  @SuppressWarnings("LongParameterList")
   private fun createCancelledUpdatedEventEntity(
     id: UUID,
     applicationId: UUID?,
     crn: String,
+    nomsNumber: String,
     occurredAt: OffsetDateTime,
     staffMember: StaffMember?,
   ): DomainEvent<CAS3BookingCancelledUpdatedEvent> {
@@ -2313,6 +2430,7 @@ class DomainEventServiceTest {
       id = id,
       applicationId = applicationId,
       crn = crn,
+      nomsNumber = nomsNumber,
       occurredAt = Instant.now(),
       data = CAS3BookingCancelledUpdatedEvent(
         id = id,


### PR DESCRIPTION
To replay a domain event (i.e. adding the necessary information in an SNS message) we need its corresponding noms number, if defined.

Currently the noms number is only stored in the domain event JSON, which is difficult to extract programmatically. This is because we don’t have a common hierarchy for the ‘domain event envelope’ classes as they’re generated from open api specs. This means we’d need ‘type specific’ code to extract the noms number for each domain event type which would be cumbersome.

For that reason, this commit introduces a nullable ‘first class property’ for the noms number on the DomainEventEntity, populating wherever there is a noms number relevant to the domain event for CAS1, 2 and 3

Evidence from local testing showing noms number being populated, and assessment id/booking id unaffected by refactoring:

![Screenshot 2024-04-25 at 11 06 12](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/01dbc204-e125-4b80-9bc8-b4432e917b2d)
