### PR TITLE
(APS-673) Add a job to create info request domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -399,6 +399,13 @@ enum class AssessmentDecision {
 @Repository
 interface AssessmentClarificationNoteRepository : JpaRepository<AssessmentClarificationNoteEntity, UUID> {
   fun findByAssessmentIdAndId(assessmentId: UUID, id: UUID): AssessmentClarificationNoteEntity?
+
+  @Query("SELECT a from AssessmentClarificationNoteEntity a WHERE a.hasDomainEvent = false")
+  fun findAllWhereHasDomainEventFalse(page: Pageable): Slice<AssessmentClarificationNoteEntity>
+
+  @Modifying
+  @Query("UPDATE AssessmentClarificationNoteEntity a SET a.hasDomainEvent = true WHERE a.id = :id")
+  fun updateHasDomainEvent(id: UUID)
 }
 
 @EntityListeners(AssessmentClarificationNoteListener::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1InformationReceivedMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1InformationReceivedMigrationJob.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
+import javax.persistence.EntityManager
+
+class Cas1InformationReceivedMigrationJob(
+  private val cas1AssessmentDomainEventService: Cas1AssessmentDomainEventService,
+  private val clarificationNoteRepository: AssessmentClarificationNoteRepository,
+  private val entityManager: EntityManager,
+  private val migrationLogger: MigrationLogger,
+  private val transactionTemplate: TransactionTemplate,
+  private val pageSize: Int,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+
+  override fun process() {
+    var page = 1
+    var hasNext = true
+    var slice: Slice<AssessmentClarificationNoteEntity>
+
+    while (hasNext) {
+      migrationLogger.info("Getting page $page for max page size $pageSize")
+      slice = clarificationNoteRepository.findAllWhereHasDomainEventFalse(PageRequest.of(0, pageSize))
+
+      slice.content.forEach { clarificationNote ->
+        transactionTemplate.executeWithoutResult {
+          try {
+            migrationLogger.info("Creating domain event for ${clarificationNote.id}")
+            cas1AssessmentDomainEventService.furtherInformationRequested(clarificationNote.assessment, clarificationNote, false)
+            clarificationNoteRepository.updateHasDomainEvent(clarificationNote.id)
+          } catch (e: IllegalStateException) {
+            migrationLogger.error(e.message ?: "An unknown error occurred")
+          }
+        }
+      }
+
+      entityManager.clear()
+      hasNext = slice.hasNext()
+      page += 1
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigratio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.BookingStatusMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1BackfillUserApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1InformationReceivedMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateApplicationOffenderNameJob
@@ -35,6 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersPduFromCommunityApiJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
 import javax.persistence.EntityManager
 
 @Service
@@ -130,6 +133,15 @@ class MigrationJobService(
           applicationContext.getBean(UserRepository::class.java),
           applicationContext.getBean(UserService::class.java),
           applicationContext.getBean(MigrationLogger::class.java),
+        )
+
+        MigrationJobType.informationReceivedDomainEvents -> Cas1InformationReceivedMigrationJob(
+          applicationContext.getBean(Cas1AssessmentDomainEventService::class.java),
+          applicationContext.getBean(AssessmentClarificationNoteRepository::class.java),
+          applicationContext.getBean(EntityManager::class.java),
+          applicationContext.getBean(MigrationLogger::class.java),
+          applicationContext.getBean(TransactionTemplate::class.java),
+          pageSize,
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3638,6 +3638,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_all_users_pdu_from_community_api
+        - update_information_received_domain_events
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8245,6 +8245,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_all_users_pdu_from_community_api
+        - update_information_received_domain_events
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4203,6 +4203,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_all_users_pdu_from_community_api
+        - update_information_received_domain_events
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3729,6 +3729,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_all_users_pdu_from_community_api
+        - update_information_received_domain_events
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas1InformationReceivedMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas1InformationReceivedMigrationJobTest.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.FurtherInformationRequestedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+
+class Cas1InformationReceivedMigrationJobTest : IntegrationTestBase() {
+  lateinit var applicationSchema: ApprovedPremisesApplicationJsonSchemaEntity
+  lateinit var assessmentSchema: ApprovedPremisesAssessmentJsonSchemaEntity
+  lateinit var user: UserEntity
+
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @BeforeEach
+  fun setup() {
+    val userArgs = `Given a User`()
+    user = userArgs.first
+
+    applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+  }
+
+  @Test
+  fun `All information received notes have an associated domain event created`() {
+    val clarificationNotesWithoutDomainEvents = (0..6).map { createClarificationNote(false) }
+    val clarificationNotesWithDomainEvents = (0..4).map { createClarificationNote(true) }
+
+    migrationJobService.runMigrationJob(MigrationJobType.informationReceivedDomainEvents, 1)
+
+    val domainEvents = domainEventRepository.findAll().map {
+      it.toDomainEvent<FurtherInformationRequestedEnvelope>(objectMapper)
+    }
+
+    clarificationNotesWithoutDomainEvents.forEach {
+      val updatedNote = assessmentClarificationNoteRepository.findByIdOrNull(it.id)!!
+      assertThat(updatedNote.hasDomainEvent).isTrue()
+
+      val domainEvent = domainEvents.find { domainEvent -> domainEvent.data.eventDetails.requestId == it.id }
+
+      assertThat(domainEvent).isNotNull
+    }
+
+    // Confirm that the events that already have domain events have not been touched
+    // In reality, they'd have domain events, but the absence of domain events here
+    // confirms the job hasn't created a domain even for these clarification notes
+    clarificationNotesWithDomainEvents.forEach {
+      val domainEvent = domainEvents.find { domainEvent -> domainEvent.data.eventDetails.requestId == it.id }
+      assertThat(domainEvent).isNull()
+    }
+  }
+
+  private fun createClarificationNote(hasDomainEvent: Boolean): AssessmentClarificationNoteEntity {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(applicationSchema)
+      withCreatedByUser(user)
+    }
+
+    val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
+      withApplication(application)
+      withAllocatedToUser(user)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    return assessmentClarificationNoteEntityFactory.produceAndPersist {
+      withCreatedBy(user)
+      withAssessment(assessment)
+      withHasDomainEvent(hasDomainEvent)
+    }
+  }
+}


### PR DESCRIPTION
This fetches all info requests with a `hasDomainEvent` of false, creates a domain event and then sets the `hasDomainEvent` value to true