### PR TITLE
CAS-340 Add referral rejection reasons Api end point

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NonArrivalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationDeliveryUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralRejectionReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
@@ -37,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCatego
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ReferralRejectionReasonTransformer
 import java.util.UUID
 
 @Service
@@ -51,6 +54,7 @@ class ReferenceDataController(
   private val probationRegionRepository: ProbationRegionRepository,
   private val nonArrivalReasonRepository: NonArrivalReasonRepository,
   private val probationDeliveryUnitRepository: ProbationDeliveryUnitRepository,
+  private val referralRejectionReasonRepository: ReferralRejectionReasonRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
   private val destinationProviderTransformer: DestinationProviderTransformer,
@@ -61,6 +65,7 @@ class ReferenceDataController(
   private val probationRegionTransformer: ProbationRegionTransformer,
   private val nonArrivalReasonTransformer: NonArrivalReasonTransformer,
   private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
+  private val referralRejectionReasonTransformer: ReferralRejectionReasonTransformer,
   private val apAreaRepository: ApAreaRepository,
   private val apAreaTransformer: ApAreaTransformer,
 ) : ReferenceDataApiDelegate {
@@ -171,5 +176,16 @@ class ReferenceDataController(
     }
 
     return ResponseEntity.ok(probationDeliveryUnits.map(probationDeliveryUnitTransformer::transformJpaToApi))
+  }
+
+  override fun referenceDataReferralRejectionReasonsGet(
+    xServiceName: ServiceName?,
+  ): ResponseEntity<List<ReferralRejectionReason>> {
+    val referralRejectionReasons = when (xServiceName != null) {
+      true -> referralRejectionReasonRepository.findAllByServiceScope(xServiceName.value)
+      else -> referralRejectionReasonRepository.findAll()
+    }
+
+    return ResponseEntity.ok(referralRejectionReasons.map(referralRejectionReasonTransformer::transformJpaToApi))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReferralRejectionReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReferralRejectionReasonEntity.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface ReferralRejectionReasonRepository : JpaRepository<ReferralRejectionReasonEntity, UUID> {
+  @Query("SELECT m FROM ReferralRejectionReasonEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*'")
+  fun findAllByServiceScope(serviceName: String): List<ReferralRejectionReasonEntity>
+
+  @Query("SELECT m FROM ReferralRejectionReasonEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*' AND m.isActive = true")
+  fun findActiveByServiceScope(serviceName: String): List<ReferralRejectionReasonEntity>
+
+  @Query("SELECT m FROM ReferralRejectionReasonEntity m WHERE m.isActive = true")
+  fun findActive(): List<ReferralRejectionReasonEntity>
+}
+
+@Entity
+@Table(name = "referral_rejection_reasons")
+data class ReferralRejectionReasonEntity(
+  @Id
+  val id: UUID,
+  val name: String,
+  val isActive: Boolean,
+  val serviceScope: String,
+) {
+  override fun toString() = "ReferralRejectionReasonEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ReferralRejectionReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ReferralRejectionReasonTransformer.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralRejectionReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonEntity
+
+@Component
+class ReferralRejectionReasonTransformer {
+  fun transformJpaToApi(jpa: ReferralRejectionReasonEntity) = ReferralRejectionReason(
+    id = jpa.id,
+    name = jpa.name,
+    isActive = jpa.isActive,
+    serviceScope = jpa.serviceScope,
+  )
+}

--- a/src/main/resources/db/migration/all/20240423171511__referral_rejection_reasons_table.sql
+++ b/src/main/resources/db/migration/all/20240423171511__referral_rejection_reasons_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE referral_rejection_reasons (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    is_active BOOL NOT NULL,
+    service_scope TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (name)
+);
+
+INSERT INTO referral_rejection_reasons(id,name,is_active,service_scope) VALUES
+    ('21b8569c-ef2e-4059-8676-323098d16aa5','They have no recourse to public funds (NRPF)',true,'temporary-accommodation'),
+    ('11506230-49a8-48b5-bdf5-20f51324e8a5','They’re not eligible (not because of NRPF)',true,'temporary-accommodation'),
+    ('a1c7d402-77b5-4335-a67b-eba6a71c70bf','There was not enough time to place them',true,'temporary-accommodation'),
+    ('88c3b8d5-77c8-4c52-84f0-ec9073e4df50','There was not enough time on their licence or post-sentence supervision (PSS)',true,'temporary-accommodation'),
+    ('90e9d919-9a39-45cd-b405-7039b5640668','Their risk or needs cannot be safely managed in CAS3',true,'temporary-accommodation'),
+    ('155ee6dc-ac2a-40d2-a350-90b63fb34a06','There’s no capacity',true,'temporary-accommodation'),
+    ('85799bf8-8b64-4903-9ab8-b08a77f1a9d3','Other (please add)',true,'temporary-accommodation');

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4384,6 +4384,24 @@ components:
       required:
         - id
         - name
+    ReferralRejectionReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2877,6 +2877,33 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /reference-data/referral-rejection-reasons:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all referral rejection reasons
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only referral rejection reasons for this service will be returned
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/ReferralRejectionReason'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /tasks:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2879,6 +2879,33 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/referral-rejection-reasons:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all referral rejection reasons
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only referral rejection reasons for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReferralRejectionReason'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /tasks:
     get:
       tags:
@@ -8991,6 +9018,24 @@ components:
       required:
         - id
         - name
+    ReferralRejectionReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4949,6 +4949,24 @@ components:
       required:
         - id
         - name
+    ReferralRejectionReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4475,6 +4475,24 @@ components:
       required:
         - id
         - name
+    ReferralRejectionReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ReferralRejectionReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ReferralRejectionReasonEntityFactory.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class ReferralRejectionReasonEntityFactory : Factory<ReferralRejectionReasonEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var isActive: Yielded<Boolean> = { true }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withIsActive(isActive: Boolean) = apply {
+    this.isActive = { isActive }
+  }
+
+  fun withServiceScope(serviceScope: String) = apply {
+    this.serviceScope = { serviceScope }
+  }
+
+  override fun produce(): ReferralRejectionReasonEntity = ReferralRejectionReasonEntity(
+    id = this.id(),
+    name = this.name(),
+    isActive = this.isActive(),
+    serviceScope = this.serviceScope(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -83,6 +83,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PostCodeDistrict
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationAreaProbationRegionMappingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ReferralRejectionReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationJsonSchemaEntityFactory
@@ -156,6 +157,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationAreaProbationRegionMappingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -516,6 +519,9 @@ abstract class IntegrationTestBase {
   lateinit var cas1ApplicationUserDetailsRepository: Cas1ApplicationUserDetailsRepository
 
   @Autowired
+  lateinit var referralRejectionReasonRepository: ReferralRejectionReasonRepository
+
+  @Autowired
   lateinit var emailAsserter: EmailNotificationAsserter
 
   @Autowired
@@ -587,6 +593,7 @@ abstract class IntegrationTestBase {
   lateinit var applicationTimelineNoteEntityFactory: PersistedFactory<ApplicationTimelineNoteEntity, UUID, ApplicationTimelineNoteEntityFactory>
   lateinit var appealEntityFactory: PersistedFactory<AppealEntity, UUID, AppealEntityFactory>
   lateinit var cas1ApplicationUserDetailsEntityFactory: PersistedFactory<Cas1ApplicationUserDetailsEntity, UUID, Cas1ApplicationUserDetailsEntityFactory>
+  lateinit var referralRejectionReasonEntityFactory: PersistedFactory<ReferralRejectionReasonEntity, UUID, ReferralRejectionReasonEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -687,6 +694,7 @@ abstract class IntegrationTestBase {
     applicationTimelineNoteEntityFactory = PersistedFactory({ ApplicationTimelineNoteEntityFactory() }, applicationTimelineNoteRepository)
     appealEntityFactory = PersistedFactory({ AppealEntityFactory() }, appealTestRepository)
     cas1ApplicationUserDetailsEntityFactory = PersistedFactory({ Cas1ApplicationUserDetailsEntityFactory() }, cas1ApplicationUserDetailsRepository)
+    referralRejectionReasonEntityFactory = PersistedFactory({ ReferralRejectionReasonEntityFactory() }, referralRejectionReasonRepository)
   }
 
   fun mockClientCredentialsJwtRequest(


### PR DESCRIPTION
This PR [CAS-340](https://dsdmoj.atlassian.net/browse/CAS-340) is to add and end point for the Referral Rejection Reasons `/reference-data/referral-rejection-reasons` for temporary accommodation

[CAS-340]: https://dsdmoj.atlassian.net/browse/CAS-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ