### PR TITLE
(APS-643) Set information requested status correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
@@ -23,7 +23,9 @@ class AssessmentListener {
 
   @PreUpdate
   fun preUpdate(assessment: ApprovedPremisesAssessmentEntity) {
-    if (assessment.decision == null && assessment.data != null) {
+    if ((assessment.application as ApprovedPremisesApplicationEntity).status == ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION) {
+      return
+    } else if (assessment.decision == null && assessment.data != null) {
       (assessment.application as ApprovedPremisesApplicationEntity).status =
         ApprovedPremisesApplicationStatus.ASSESSMENT_IN_PROGRESS
     } else if (assessment.decision == AssessmentDecision.ACCEPTED) {

--- a/src/main/resources/db/migration/all/20240425143644__update_information_request_statuses.sql
+++ b/src/main/resources/db/migration/all/20240425143644__update_information_request_statuses.sql
@@ -1,0 +1,20 @@
+UPDATE
+    approved_premises_applications
+SET
+    status = 'REQUESTED_FURTHER_INFORMATION'
+WHERE
+        id IN (
+        SELECT
+            application_id
+        from
+            assessments
+        where
+                id IN (
+                SELECT
+                    assessment_id
+                from
+                    assessment_clarification_notes
+                where
+                    response is null
+            )
+    );

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -167,6 +167,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
     startAssessment()
 
     requestFurtherInformation()
+    updateAssessment()
     assertApplicationStatus(ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION)
 
     updateFurtherInformation()
@@ -278,6 +279,8 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
       .expectStatus()
       .isOk
   }
+
+  private fun updateAssessment() = startAssessment()
 
   private fun approveAssessment() {
     val application = realApplicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity


### PR DESCRIPTION
We’ve noticed that assessments with a status of `REQUESTED_FURTHER_INFORMATION` were not showing correctly. After some investigation I discovered that the status was getting set, but then immediately being set back to `ASSESSMENT_IN_PROGRESS` with a subsequent update, which is obviously not what we want.

I’ve updated the AssessmentListener to immediately short circuit if the application’s status is `REQUESTED_FURTHER_INFORMATION`, as well as updated the tests to give a more realistic scenario.

I’ve also added a simple SQL query that gets all assessments with pending clarification notes, then updates their associated application’s status to `REQUESTED_FURTHER_INFORMATION`. I could have added a seed job, but this seemed like overkill.