### PR TITLE
Catch RuntimeExceptions in InformationReceived job

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -55,6 +55,7 @@
     <ID>CyclomaticComplexMethod:DomainEventUrlConfig.kt$DomainEventUrlConfig$fun getUrlForDomainEventId(domainEventType: DomainEventType, eventId: UUID): String</ID>
     <ID>TooGenericExceptionThrown:DomainEventDescriber.kt$DomainEventDescriber$throw RuntimeException("Clarification note with ID ${data.eventDetails.requestId} not found")</ID>
     <ID>CyclomaticComplexMethod:DomainEventHelpers.kt$fun createDomainEventOfType(type: DomainEventType, requestId: UUID = UUID.randomUUID()): Any</ID>
+    <ID>TooGenericExceptionCaught:Cas1InformationReceivedMigrationJob.kt$Cas1InformationReceivedMigrationJob$e: RuntimeException</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:BookingService.kt$BookingService$booking.service == ServiceName.approvedPremises.value &amp;&amp; booking.application != null &amp;&amp; user != null &amp;&amp; !arrivedAndDepartedDomainEventsDisabled</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1InformationReceivedMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1InformationReceivedMigrationJob.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
+import java.lang.RuntimeException
 import javax.persistence.EntityManager
 
 class Cas1InformationReceivedMigrationJob(
@@ -35,6 +36,9 @@ class Cas1InformationReceivedMigrationJob(
             clarificationNoteRepository.updateHasDomainEvent(clarificationNote.id)
           } catch (e: IllegalStateException) {
             migrationLogger.error(e.message ?: "An unknown error occurred")
+          } catch (e: RuntimeException) {
+            val errorMessage = e.message ?: "An unknown error occurred"
+            migrationLogger.error("Can't create domain event for ${clarificationNote.id} - $errorMessage", e)
           }
         }
       }


### PR DESCRIPTION
We hit a RuntimeException when running this in preprod, because a user doesn’t exist. We want to cleanly recover from this and continue.

I’m hoping that this issue won’t come up in prod, but I want to run this again in preprod and see how many errors we get. If there are only a handful, I think this will be safe to run in prod. If we get any errors in prod, we can note down which ones have come up and decide how to proceed from there.