### PR TITLE
Catch Kotlin RuntimeException

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1InformationReceivedMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1InformationReceivedMigrationJob.kt
@@ -6,7 +6,6 @@ import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
-import java.lang.RuntimeException
 import javax.persistence.EntityManager
 
 class Cas1InformationReceivedMigrationJob(


### PR DESCRIPTION
The RuntimeException that gets thrown when we can’t get things upstream is the default Kotlin `RuntimeException`, not the imported Java one