### PR TITLE
Speed up CAS3 E2Es

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,7 @@ jobs:
           channel: << pipeline.parameters.alerts-slack-channel >>
           template: basic_fail_1
   cas3_e2e_tests:
-    parallelism: 4
+    parallelism: 5
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     environment:
       CYPRESS_SKIP_AXE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,8 @@ jobs:
   cas3_e2e_tests:
     parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    environment:
+      CYPRESS_SKIP_AXE: 1
     docker:
       - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
     parameters:


### PR DESCRIPTION
When we’re running the E2Es against after an API deploy, it’s extremely unlikely any accessibility issues will be found, so let’s add an option to skip these in the API pipeline. I've also added another container to the parallel run, which cuts the runtime further to about 7 minutes in total.