### PR TITLE
Rename ignoreLao to ignoreLaoRestrictions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -94,8 +94,8 @@ class AssessmentController(
       .body(summaries)
   }
 
-  private fun transformDomainToApi(user: UserEntity, summaries: List<DomainAssessmentSummary>, ignoreLao: Boolean = false) = summaries.map {
-    val personInfo = offenderService.getInfoForPerson(it.crn, user.deliusUsername, ignoreLao)
+  private fun transformDomainToApi(user: UserEntity, summaries: List<DomainAssessmentSummary>, ignoreLaoRestrictions: Boolean = false) = summaries.map {
+    val personInfo = offenderService.getInfoForPerson(it.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     assessmentTransformer.transformDomainToApiSummary(
       it,
@@ -113,9 +113,9 @@ class AssessmentController(
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
     }
 
-    val ignoreLao = (assessment.application is ApprovedPremisesApplicationEntity) && user.hasQualification(UserQualification.LAO)
+    val ignoreLaoRestrictions = (assessment.application is ApprovedPremisesApplicationEntity) && user.hasQualification(UserQualification.LAO)
 
-    val personInfo = offenderService.getInfoForPerson(assessment.application.crn, user.deliusUsername, ignoreLao)
+    val personInfo = offenderService.getInfoForPerson(assessment.application.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     return ResponseEntity.ok(
       assessmentTransformer.transformJpaToApi(assessment, personInfo),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -83,7 +83,7 @@ class PeopleController(
   }
 
   override fun peopleCrnPrisonCaseNotesGet(crn: String): ResponseEntity<List<PrisonCaseNote>> {
-    val offenderDetails = getOffenderDetailsIgnoringLaoQualification(crn)
+    val offenderDetails = getOffenderDetails(crn)
 
     if (offenderDetails.otherIds.nomsNumber == null) {
       throw NotFoundProblem(crn, "Case Notes")
@@ -102,7 +102,7 @@ class PeopleController(
   }
 
   override fun peopleCrnAdjudicationsGet(crn: String): ResponseEntity<List<Adjudication>> {
-    val offenderDetails = getOffenderDetailsIgnoringLaoQualification(crn)
+    val offenderDetails = getOffenderDetails(crn)
 
     if (offenderDetails.otherIds.nomsNumber == null) {
       throw NotFoundProblem(crn, "Adjudications")
@@ -121,7 +121,7 @@ class PeopleController(
   }
 
   override fun peopleCrnAcctAlertsGet(crn: String): ResponseEntity<List<PersonAcctAlert>> {
-    val offenderDetails = getOffenderDetailsIgnoringLaoQualification(crn)
+    val offenderDetails = getOffenderDetails(crn)
 
     if (offenderDetails.otherIds.nomsNumber == null) {
       throw NotFoundProblem(crn, "ACCT Alerts")
@@ -271,13 +271,19 @@ class PeopleController(
   }
 
   private fun ensureUserCanAccessOffenderInfo(crn: String) {
-    getOffenderDetailsIgnoringLaoQualification(crn)
+    getOffenderDetails(crn)
   }
 
-  private fun getOffenderDetailsIgnoringLaoQualification(crn: String): OffenderDetailSummary {
+  private fun getOffenderDetails(crn: String): OffenderDetailSummary {
     val user = userService.getUserForRequest()
 
-    val offenderDetails = when (val offenderDetailsResult = offenderService.getOffenderByCrn(crn, user.deliusUsername, false)) {
+    val offenderDetails = when (
+      val offenderDetailsResult = offenderService.getOffenderByCrn(
+        crn = crn,
+        userDistinguishedName = user.deliusUsername,
+        ignoreLaoRestrictions = false,
+      )
+    ) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(crn, "Person")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.Success -> offenderDetailsResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -214,7 +214,7 @@ class PlacementRequestsController(
     val personInfo = offenderService.getInfoForPerson(
       placementRequestAndCancellations.placementRequest.application.crn,
       forUser.deliusUsername,
-      ignoreLao = false,
+      ignoreLaoRestrictions = false,
     )
 
     return placementRequestDetailTransformer.transformJpaToApi(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateApplicationOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateApplicationOffenderNameJob.kt
@@ -70,7 +70,7 @@ class Cas3UpdateApplicationOffenderNameJob(
   private fun splitAndRetrievePersonInfo(crns: Set<String>, deliusUsername: String): Map<String, PersonSummaryInfoResult> {
     val crnMap = ListUtils.partition(crns.toList(), pageSize)
       .stream().map { crns ->
-        offenderService.getOffenderSummariesByCrns(crns.toSet(), deliusUsername, ignoreLao = true).associateBy { it.crn }
+        offenderService.getOffenderSummariesByCrns(crns.toSet(), deliusUsername, ignoreLaoRestrictions = true).associateBy { it.crn }
       }.collect(Collectors.toList())
 
     return crnMap.flatMap { it.toList() }.toMap()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
@@ -71,7 +71,7 @@ class BookingSearchService(
     val offenderSummaries = offenderService.getOffenderSummariesByCrns(
       bookingSearchResultDtos.map { it.personCrn }.toSet(),
       user.deliusUsername,
-      ignoreLao = false,
+      ignoreLaoRestrictions = false,
       forceApDeliusContextApi = false,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CalendarServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CalendarServiceTest.kt
@@ -71,7 +71,7 @@ class CalendarServiceTest {
     )
 
     every { calendarRepositoryMock.getCalendarInfo(premisesId, startDate, endDate) } returns repositoryResults
-    every { offenderServiceMock.getOffenderSummariesByCrns(emptySet(), user.deliusUsername, ignoreLao = false, forceApDeliusContextApi = false) } returns emptyList()
+    every { offenderServiceMock.getOffenderSummariesByCrns(emptySet(), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns emptyList()
 
     val result = calendarService.getCalendarInfo(user, premisesId, startDate, endDate)
 
@@ -119,7 +119,7 @@ class CalendarServiceTest {
       )
     }
 
-    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLao = false, forceApDeliusContextApi = false) } returns
+    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns
       listOf(PersonSummaryInfoResult.NotFound(crn))
 
     every { offenderServiceMock.getOffenderByCrn(crn, user.deliusUsername) } returns AuthorisableActionResult.NotFound()
@@ -182,7 +182,7 @@ class CalendarServiceTest {
       )
     }
 
-    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLao = false, forceApDeliusContextApi = false) } returns
+    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns
       listOf(PersonSummaryInfoResult.Success.Restricted(crn, "noms"))
 
     val result = calendarService.getCalendarInfo(user, premisesId, startDate, endDate)
@@ -243,7 +243,7 @@ class CalendarServiceTest {
       )
     }
 
-    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLao = false, forceApDeliusContextApi = false) } returns
+    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full(
           crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -128,7 +128,7 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `getOffenderByCrn does not enforce LAO when ignoreLao is enabled (because user has LAO qualification)`() {
+  fun `getOffenderByCrn does not enforce LAO when ignoreLaoRestrictions is enabled (because user has LAO qualification)`() {
     val resultBody = OffenderDetailsSummaryFactory()
       .withCrn("a-crn")
       .withFirstName("Bob")
@@ -141,7 +141,7 @@ class OffenderServiceTest {
     every { mockOffenderDetailsDataSource.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)
 
-    assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name", true) is AuthorisableActionResult.Success).isTrue
+    assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name", ignoreLaoRestrictions = true) is AuthorisableActionResult.Success).isTrue
   }
 
   @Test
@@ -707,7 +707,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Restricted for LAO Offender where user does not pass check and ignoreLao is false`() {
+    fun `returns Restricted for LAO Offender where user does not pass check and ignoreLaoRestrictions is false`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -732,7 +732,7 @@ class OffenderServiceTest {
         ),
       )
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, ignoreLaoRestrictions = false)
 
       assertThat(result is PersonInfoResult.Success.Restricted).isTrue
       result as PersonInfoResult.Success.Restricted
@@ -740,7 +740,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Full for LAO Offender where user does pass check and ignoreLao is false`() {
+    fun `returns Full for LAO Offender where user does pass check and ignoreLaoRestrictions is false`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -774,7 +774,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Full for LAO Offender where user does not pass check but ignoreLao is true`() {
+    fun `returns Full for LAO Offender where user does not pass check but ignoreLaoRestrictions is true`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -802,7 +802,7 @@ class OffenderServiceTest {
         ),
       )
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, true)
+      val result = offenderService.getInfoForPerson(crn, deliusUsername, ignoreLaoRestrictions = true)
 
       assertThat(result is PersonInfoResult.Success.Full).isTrue
       result as PersonInfoResult.Success.Full
@@ -991,7 +991,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `it ignores LAO when ignoreLao is set to true (forceApDeliusContextApi = true)`() {
+    fun `it ignores LAO when ignoreLaoRestrictions is set to true (forceApDeliusContextApi = true)`() {
       val caseAccess = listOf(
         CaseAccessFactory()
           .withCrn(crns[0])
@@ -1024,7 +1024,7 @@ class OffenderServiceTest {
         ),
       )
 
-      val result = offenderService.getOffenderSummariesByCrns(crns.toSet(), user.deliusUsername, true, true)
+      val result = offenderService.getOffenderSummariesByCrns(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions = true, true)
 
       assertThat(result[0]).isEqualTo(PersonSummaryInfoResult.Success.Full(crns[0], caseSummariesByCrn[crns[0]]!!))
       assertThat(result[1]).isEqualTo(PersonSummaryInfoResult.Success.Full(crns[1], caseSummariesByCrn[crns[1]]!!))
@@ -1132,7 +1132,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `it ignores LAO when ignoreLao is set to true (forceApDeliusContextApi = false)`() {
+    fun `it ignores LAO when ignoreLaoRestrictions is set to true (forceApDeliusContextApi = false)`() {
       every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(crns) } returns offenderSummaryResultsByCrn
 
       every {
@@ -1151,7 +1151,7 @@ class OffenderServiceTest {
           ),
       )
 
-      val result = offenderService.getOffenderSummariesByCrns(crns.toSet(), user.deliusUsername, true, false)
+      val result = offenderService.getOffenderSummariesByCrns(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions = true, false)
 
       assertThat(result[0]).isEqualTo(PersonSummaryInfoResult.Success.Full(crns[0], caseSummariesByCrn[crns[0]]!!))
       assertThat(result[1]).isEqualTo(PersonSummaryInfoResult.Success.Full(crns[1], caseSummariesByCrn[crns[1]]!!))


### PR DESCRIPTION
In several places we have an ignoreLao boolean parameter in the code. The intention of this is to indicate that restrictions on viewing LAO offenders can be ignored (otherwise an unathorised access problem will be returned). I often misread this as ‘don’t return offenders with LAO’, which is incorrect. I’ve renamed this variable for clarity