### PR TITLE
APS-727 applications/all supports filtering on statuses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -104,7 +104,7 @@ class ApplicationsController(
     page: Int?,
     crnOrName: String?,
     sortDirection: SortDirection?,
-    status: ApprovedPremisesApplicationStatus?,
+    status: List<ApprovedPremisesApplicationStatus>?,
     sortBy: ApplicationSortField?,
     apAreaId: UUID?,
   ): ResponseEntity<List<ApplicationSummary>> {
@@ -112,7 +112,7 @@ class ApplicationsController(
       throw ForbiddenProblem()
     }
     val user = userService.getUserForRequest()
-    val statusTransformed = status?.let { DomainApprovedPremisesApplicationStatus.valueOf(it) }
+    val statusTransformed = status?.map { DomainApprovedPremisesApplicationStatus.valueOf(it) } ?: emptyList()
 
     val (applications, metadata) =
       applicationService.getAllApprovedPremisesApplications(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -76,7 +76,7 @@ AND (
       )
 )
 AND (
-    :status IS NULL OR (apa.status = :#{#status?.toString()})
+    :statusProvided is false OR apa.status IN (:status)
 )
 AND (
     (CAST(:apAreaId AS uuid) IS NULL) OR (apa.ap_area_id = :apAreaId)
@@ -94,7 +94,7 @@ AND (
         )
       )
       AND (
-          :status IS NULL OR (apa.status = :#{#status?.toString()})
+          :statusProvided is false OR apa.status IN (:status)
       )
       AND (
           (CAST(:apAreaId AS uuid) IS NULL) OR (apa.ap_area_id = :apAreaId)
@@ -105,7 +105,8 @@ AND (
   fun findAllApprovedPremisesSummaries(
     pageable: Pageable?,
     crnOrName: String?,
-    status: ApprovedPremisesApplicationStatus?,
+    statusProvided: Boolean,
+    status: List<String>,
     apAreaId: UUID?,
   ): Page<ApprovedPremisesApplicationSummary>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
@@ -37,7 +37,7 @@ enum class ApprovedPremisesApplicationStatus(val apiValue: ApiApprovedPremisesAp
   ;
 
   companion object {
-    fun valueOf(apiValue: ApiApprovedPremisesApplicationStatus): ApprovedPremisesApplicationStatus? =
-      ApprovedPremisesApplicationStatus.entries.firstOrNull { it.apiValue == apiValue }
+    fun valueOf(apiValue: ApiApprovedPremisesApplicationStatus): ApprovedPremisesApplicationStatus =
+      ApprovedPremisesApplicationStatus.entries.first { it.apiValue == apiValue }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -120,7 +120,7 @@ class ApplicationService(
     page: Int?,
     crnOrName: String?,
     sortDirection: SortDirection?,
-    status: ApprovedPremisesApplicationStatus?,
+    status: List<ApprovedPremisesApplicationStatus>,
     sortBy: ApplicationSortField?,
     apAreaId: UUID?,
     pageSize: Int? = 10,
@@ -133,11 +133,14 @@ class ApplicationService(
     }
     val pageable = getPageable(sortField, sortDirection, page, pageSize)
 
+    val statusNames = status.map { it.name }
+
     val response = applicationRepository.findAllApprovedPremisesSummaries(
-      pageable,
-      crnOrName,
-      status,
-      apAreaId,
+      pageable = pageable,
+      crnOrName = crnOrName,
+      statusProvided = statusNames.isNotEmpty(),
+      status = statusNames,
+      apAreaId = apAreaId,
     )
 
     return Pair(response.content, getMetadata(response, page, pageSize))

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1758,9 +1758,11 @@ paths:
             $ref: '_shared.yml#/components/schemas/SortDirection'
         - name: status
           in: query
-          description: The application status
+          description: Application statuses to filter on. If none provided, all will be returned
           schema:
-            $ref: '_shared.yml#/components/schemas/ApprovedPremisesApplicationStatus'
+            type: array
+            items:
+              $ref: '_shared.yml#/components/schemas/ApprovedPremisesApplicationStatus'
         - name: sortBy
           in: query
           description: The field to sort the results by.

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1760,9 +1760,11 @@ paths:
             $ref: '#/components/schemas/SortDirection'
         - name: status
           in: query
-          description: The application status
+          description: Application statuses to filter on. If none provided, all will be returned
           schema:
-            $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+            type: array
+            items:
+              $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
         - name: sortBy
           in: query
           description: The field to sort the results by.


### PR DESCRIPTION
previously the endpoint only allowed filtering on one status, now multiple statuses can be provided