### PR TITLE
[APS-707] Introduce additional sort fields for `GET /tasks` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestTaskOutcome
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -228,6 +229,20 @@ data class PlacementRequestEntity(
    * This property is used to identify such instances.
    */
   fun isForApplicationsArrivalDate() = placementApplication == null
+
+  fun getOutcomeDetails(): Pair<OffsetDateTime?, PlacementRequestTaskOutcome?> {
+    val bookingNotMades = this.bookingNotMades
+
+    if (bookingNotMades.size > 0) {
+      return Pair(bookingNotMades.last().createdAt, PlacementRequestTaskOutcome.unableToMatch)
+    }
+
+    if (this.hasActiveBooking()) {
+      return Pair(this.booking!!.createdAt, PlacementRequestTaskOutcome.matched)
+    }
+
+    return Pair(null, null)
+  }
 }
 
 enum class PlacementRequestWithdrawalReason(val apiValue: WithdrawPlacementRequestReason) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -245,6 +245,8 @@ data class Task(
   val type: TaskEntityType,
   val person: String,
   val allocatedTo: String?,
+  val completedAt: LocalDateTime?,
+  val decision: String?,
 )
 
 enum class TaskEntityType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -113,6 +113,7 @@ class TaskService(
           TaskSortField.dueAt -> "due_at"
           TaskSortField.allocatedTo -> "allocated_to"
           TaskSortField.person -> "person"
+          else -> throw NotImplementedError()
         },
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -113,7 +113,9 @@ class TaskService(
           TaskSortField.dueAt -> "due_at"
           TaskSortField.allocatedTo -> "allocated_to"
           TaskSortField.person -> "person"
-          else -> throw NotImplementedError()
+          TaskSortField.completedAt -> "completed_at"
+          TaskSortField.taskType -> "type"
+          TaskSortField.decision -> "decision"
         },
       ),
     )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -305,6 +305,9 @@ components:
         - dueAt
         - person
         - allocatedTo
+        - completedAt
+        - taskType
+        - decision
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4941,6 +4941,9 @@ components:
         - dueAt
         - person
         - allocatedTo
+        - completedAt
+        - taskType
+        - decision
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -870,6 +870,9 @@ components:
         - dueAt
         - person
         - allocatedTo
+        - completedAt
+        - taskType
+        - decision
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -396,6 +396,9 @@ components:
         - dueAt
         - person
         - allocatedTo
+        - completedAt
+        - taskType
+        - decision
     AssessmentTask:
       allOf:
         - $ref: '#/components/schemas/Task'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -51,6 +51,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     this.booking = { booking }
   }
 
+  fun withBooking(configuration: BookingEntityFactory.() -> Unit) = apply {
+    this.booking = { BookingEntityFactory().apply(configuration).produce() }
+  }
+
   fun withApplication(application: ApprovedPremisesApplicationEntity) = apply {
     this.application = { application }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementRequestEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/PlacementRequestEntityTest.kt
@@ -1,12 +1,139 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestTaskOutcome
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingNotMadeEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
 
 class PlacementRequestEntityTest {
+  @Nested
+  inner class GetOutcomeDetails {
+    @Test
+    fun `When a booking not made exists, then returns its creation time as the outcome timestamp and 'unableToMatch' as the outcome`() {
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val expectedOutcomeTimestamp = OffsetDateTime.now().randomDateTimeBefore(14)
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .withCreatedAt(expectedOutcomeTimestamp.randomDateTimeBefore(14))
+        .produce()
+        .apply {
+          this.bookingNotMades = mutableListOf(
+            BookingNotMadeEntityFactory()
+              .withPlacementRequest(this)
+              .withCreatedAt(expectedOutcomeTimestamp)
+              .produce(),
+          )
+        }
+
+      val (actualOutcomeTimestamp, outcome) = placementRequest.getOutcomeDetails()
+
+      assertThat(actualOutcomeTimestamp).isEqualTo(expectedOutcomeTimestamp)
+      assertThat(outcome).isEqualTo(PlacementRequestTaskOutcome.unableToMatch)
+    }
+
+    @Test
+    fun `When an active booking exists, then returns its creation time as the outcome timestamp and 'matched' as the outcome`() {
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val expectedOutcomeTimestamp = OffsetDateTime.now().randomDateTimeBefore(14)
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .withCreatedAt(expectedOutcomeTimestamp.randomDateTimeBefore(14))
+        .withBooking {
+          withApplication(application)
+          withCreatedAt(expectedOutcomeTimestamp)
+          withDefaultPremises()
+        }
+        .produce()
+
+      val (actualOutcomeTimestamp, outcome) = placementRequest.getOutcomeDetails()
+
+      assertThat(actualOutcomeTimestamp).isEqualTo(expectedOutcomeTimestamp)
+      assertThat(outcome).isEqualTo(PlacementRequestTaskOutcome.matched)
+    }
+
+    @Test
+    fun `Returns no data otherwise`() {
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
+        .produce()
+
+      val (actualOutcomeTimestamp, outcome) = placementRequest.getOutcomeDetails()
+
+      assertThat(actualOutcomeTimestamp).isNull()
+      assertThat(outcome).isNull()
+    }
+  }
+
   @ParameterizedTest
   @CsvSource(
     value = [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -319,6 +319,8 @@ class TaskServiceTest {
         TaskEntityType.ASSESSMENT,
         (it.application as ApprovedPremisesApplicationEntity).name,
         it.allocatedToUser?.name,
+        it.submittedAt?.toLocalDateTime(),
+        it.decision?.name,
       )
     }
     val placementApplicationTasks = placementApplications.map {
@@ -328,15 +330,20 @@ class TaskServiceTest {
         TaskEntityType.PLACEMENT_APPLICATION,
         it.application.name,
         it.allocatedToUser?.name,
+        it.submittedAt?.toLocalDateTime(),
+        it.decision?.name,
       )
     }
     val placementRequestTasks = placementRequests.map {
+      val (outcomeRecordedAt, outcome) = it.getOutcomeDetails()
       Task(
         it.id,
         it.createdAt.toLocalDateTime(),
         TaskEntityType.PLACEMENT_REQUEST,
         it.application.name,
         it.allocatedToUser?.name,
+        outcomeRecordedAt?.toLocalDateTime(),
+        outcome?.name,
       )
     }
 


### PR DESCRIPTION
> See [APS-707 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-707).

This PR introduces three new ways to sort the results provided by the `GET /tasks` endpoint. Sorting is performed using the `sortBy` and `sortDirection` query parameters. The `sortBy` parameter has been updated by adding new variants to the `TaskSortField` enum defined in the OpenAPI specification:
- `completedAt`
- `taskType`
- `decision`

The corresponding SQL query in the `TaskRepository` has been modified in order to support these new sorting options.

Additionally, a set of integration tests has been introduced to verify that sorting works as expected for both existing and new sort fields in both directions.